### PR TITLE
Improved support for byte strings

### DIFF
--- a/serde_macros/src/de.rs
+++ b/serde_macros/src/de.rs
@@ -578,6 +578,16 @@ fn deserialize_field_visitor(
                                 _ => Err(::serde::de::Error::unknown_field_error(value)),
                             }
                         }
+
+                        fn visit_bytes<E>(&mut self, value: &[u8]) -> ::std::result::Result<__Field, E>
+                            where E: ::serde::de::Error,
+                        {
+                            // TODO: would be better to generate a byte string literal match
+                            match ::std::str::from_utf8(value) {
+                                Ok(s) => self.visit_str(s),
+                                _ => Err(::serde::de::Error::syntax_error()),
+                            }
+                        }
                     }
 
                     deserializer.visit(__FieldVisitor)

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -3,7 +3,6 @@
 use std::ops;
 use std::fmt;
 use std::ascii;
-use std::char;
 
 use ser;
 use de;
@@ -90,6 +89,15 @@ impl fmt::Debug for ByteBuf {
         write!(f, "b\"{}\"", escape_bytestring(self.bytes.as_ref()))
     }
 }
+
+/*
+// Disabled: triggers conflict with From implementation below
+impl Into<Vec<u8>> for ByteBuf {
+    fn into(self) -> Vec<u8> {
+        self.bytes
+    }
+}
+*/
 
 impl<T> From<T> for ByteBuf where T: Into<Vec<u8>> {
     fn from(bytes: T) -> Self {
@@ -205,7 +213,7 @@ fn escape_bytestring(bytes: &[u8]) -> String {
     let mut result = String::new();
     for &b in bytes {
         for esc in ascii::escape_default(b) {
-            result.push(char::from_u32(esc as u32).unwrap());
+            result.push(esc as char);
         }
     }
     result

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -78,10 +78,6 @@ impl ByteBuf {
             bytes: Vec::with_capacity(cap)
         }
     }
-
-    pub fn as_vec(self) -> Vec<u8> {
-        self.bytes
-    }
 }
 
 impl fmt::Debug for ByteBuf {
@@ -90,19 +86,16 @@ impl fmt::Debug for ByteBuf {
     }
 }
 
-/*
-// Disabled: triggers conflict with From implementation below
 impl Into<Vec<u8>> for ByteBuf {
     fn into(self) -> Vec<u8> {
         self.bytes
     }
 }
-*/
 
-impl<T> From<T> for ByteBuf where T: Into<Vec<u8>> {
-    fn from(bytes: T) -> Self {
+impl From<Vec<u8>> for ByteBuf {
+    fn from(bytes: Vec<u8>) -> Self {
         ByteBuf {
-            bytes: bytes.into(),
+            bytes: bytes,
         }
     }
 }

--- a/src/de/impls.rs
+++ b/src/de/impls.rs
@@ -3,6 +3,7 @@ use std::hash::Hash;
 use std::marker::PhantomData;
 use std::path;
 use std::rc::Rc;
+use std::str;
 use std::sync::Arc;
 
 use num::FromPrimitive;
@@ -197,6 +198,24 @@ impl Visitor for StringVisitor {
         where E: Error,
     {
         Ok(v)
+    }
+
+    fn visit_bytes<E>(&mut self, v: &[u8]) -> Result<String, E>
+        where E: Error,
+    {
+        match str::from_utf8(v) {
+            Ok(s) => Ok(s.to_string()),
+            Err(_) => Err(Error::syntax_error()),
+        }
+    }
+
+    fn visit_byte_buf<'a, E>(&mut self, v: Vec<u8>) -> Result<String, E>
+        where E: Error,
+    {
+        match String::from_utf8(v) {
+            Ok(s) => Ok(s),
+            Err(_) => Err(Error::syntax_error()),
+        }
     }
 }
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -263,10 +263,10 @@ pub trait Visitor {
         Err(Error::syntax_error())
     }
 
-    fn visit_byte_buf<E>(&mut self, _v: Vec<u8>) -> Result<Self::Value, E>
+    fn visit_byte_buf<E>(&mut self, v: Vec<u8>) -> Result<Self::Value, E>
         where E: Error,
     {
-        Err(Error::syntax_error())
+        self.visit_bytes(&v)
     }
 }
 

--- a/src/de/value.rs
+++ b/src/de/value.rs
@@ -445,7 +445,7 @@ impl ValueDeserializer for bytes::ByteBuf
     type Deserializer = ByteBufDeserializer;
 
     fn into_deserializer(self) -> Self::Deserializer {
-        ByteBufDeserializer(Some(self.as_vec()))
+        ByteBufDeserializer(Some(self.into()))
     }
 }
 


### PR DESCRIPTION
Currently working on a serialization library for a format where all strings are byte strings. Thus, I find byte string support requiring some attention.

The proposed changes are:

1. Allow to disassemble `Bytes`/`ByteBuf` into underlying representation
2. Add a nice-looking `Debug` implementation for `Bytes`/`ByteBuf`
3. Add methods to construct strings from byte strings via str::from_utf8
4. Add default `visit_byte_buf` implementation as a fallback to `visit_bytes`
5. Implement `ValueDeserializer` for `Bytes`/`ByteBuf`
6. Recognize struct field names as byte strings.