### PR TITLE
Fix #77, integer overflow when parsing JSON scientific notation number.

### DIFF
--- a/serde_tests/tests/test_json.rs
+++ b/serde_tests/tests/test_json.rs
@@ -703,6 +703,7 @@ fn test_parse_number_errors() {
         ("1e+", Error::SyntaxError(ErrorCode::InvalidNumber, 1, 3)),
         ("1a", Error::SyntaxError(ErrorCode::TrailingCharacters, 1, 2)),
         ("777777777777777777777777777", Error::SyntaxError(ErrorCode::InvalidNumber, 1, 20)),
+        ("1e777777777777777777777777777", Error::SyntaxError(ErrorCode::InvalidNumber, 1, 22)),
     ]);
 }
 


### PR DESCRIPTION
I think this should fix it, but make sure to review it. :smiley: 