### PR TITLE
Fix for building with nightly compiler.

### DIFF
--- a/serde_codegen/src/de.rs
+++ b/serde_codegen/src/de.rs
@@ -24,11 +24,11 @@ pub fn expand_derive_deserialize(
     cx: &mut ExtCtxt,
     span: Span,
     meta_item: &MetaItem,
-    annotatable: Annotatable,
+    annotatable: &Annotatable,
     push: &mut FnMut(Annotatable)
 ) {
     let item = match annotatable {
-        Annotatable::Item(item) => item,
+        &Annotatable::Item(ref item) => item,
         _ => {
             cx.span_err(
                 meta_item.span,

--- a/serde_codegen/src/ser.rs
+++ b/serde_codegen/src/ser.rs
@@ -19,11 +19,11 @@ pub fn expand_derive_serialize(
     cx: &mut ExtCtxt,
     span: Span,
     meta_item: &MetaItem,
-    annotatable: Annotatable,
+    annotatable: &Annotatable,
     push: &mut FnMut(Annotatable)
 ) {
     let item = match annotatable {
-        Annotatable::Item(item) => item,
+        &Annotatable::Item(ref item) => item,
         _ => {
             cx.span_err(
                 meta_item.span,


### PR DESCRIPTION
Apparently the syntax extension API has changed a little and the build fails when compiled with nightly compiler. This PR changes the type of `annotatable` from `Annotatable` to `&Annotatable` for `expand_derive_deserialize` and `expand_derive_serialize`, making the compilation to succeed again.