### PR TITLE
Make BoolVisitor public so it is documented as being in existence

### DIFF
--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -48,7 +48,7 @@ impl Deserialize for () {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-struct BoolVisitor;
+pub struct BoolVisitor;
 
 impl Visitor for BoolVisitor {
     type Value = bool;


### PR DESCRIPTION
This is consistent with the other visitors.  Even though they technically do not need to be public, it's handy to have it public for 1) documentation and 2) custom deserializer implementations that can pick and choose existing visitors a la carte.