### PR TITLE
Implement serialization for `NonZero` values in nightly.

### DIFF
--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -11,3 +11,7 @@ keywords = ["serialization"]
 
 [dependencies]
 num = "*"
+
+[features]
+nightly = []
+

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -6,8 +6,12 @@
 //! leaving serde to perform roughly the same speed as a hand written serializer for a specific
 //! type.
 #![doc(html_root_url="http://erickt.github.io/rust-serde")]
+#![cfg_attr(feature = "nightly", feature(core, nonzero, zero_one))]
 
 extern crate num;
+
+#[cfg(feature = "nightly")]
+extern crate core;
 
 pub use ser::{Serialize, Serializer};
 pub use de::{Deserialize, Deserializer, Error};

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -5,6 +5,9 @@ use std::path;
 use std::rc::Rc;
 use std::sync::Arc;
 
+#[cfg(feature = "nightly")]
+use core::nonzero::{NonZero, Zeroable};
+
 use super::{
     Serialize,
     Serializer,
@@ -545,3 +548,10 @@ impl Serialize for path::PathBuf {
         self.to_str().unwrap().serialize(serializer)
     }
 }
+
+impl<T> Serialize for NonZero<T> where T: Serialize + Zeroable {
+    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error> where S: Serializer {
+        (**self).serialize(serializer)
+    }
+}
+


### PR DESCRIPTION
This adds a new Cargo feature so that you can opt into this feature on nightly if you need it while maintaining compatibility with stable Rust.