### PR TITLE
Make the TupleVisitors public

### DIFF
--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -567,7 +567,7 @@ macro_rules! tuple_impls {
     () => {};
     ($($visitor:ident => ($($name:ident),+),)+) => {
         $(
-            struct $visitor<$($name,)+> {
+            pub struct $visitor<$($name,)+> {
                 marker: PhantomData<($($name,)+)>,
             }
 


### PR DESCRIPTION
This change is needed to use the TupleVisitor to implement a VariantVisitor