### PR TITLE
Make enum variants generic

### DIFF
--- a/serde/src/json/value.rs
+++ b/serde/src/json/value.rs
@@ -8,6 +8,7 @@ use num::NumCast;
 
 use de;
 use ser;
+use ser::Serialize;
 use super::error::Error;
 
 #[derive(Clone, PartialEq)]
@@ -398,6 +399,7 @@ impl Serializer {
 
 impl ser::Serializer for Serializer {
     type Error = ();
+    type Variant = String;
 
     #[inline]
     fn visit_bool(&mut self, value: bool) -> Result<(), ()> {
@@ -458,9 +460,9 @@ impl ser::Serializer for Serializer {
     }
 
     #[inline]
-    fn visit_enum_unit(&mut self, _name: &str, variant: &str) -> Result<(), ()> {
+    fn visit_enum_unit(&mut self, _name: &str, variant: Self::Variant) -> Result<(), ()> {
         let mut values = BTreeMap::new();
-        values.insert(variant.to_string(), Value::Array(vec![]));
+        values.insert(variant, Value::Array(vec![]));
 
         self.state.push(State::Value(Value::Object(values)));
 
@@ -489,7 +491,7 @@ impl ser::Serializer for Serializer {
     }
 
     #[inline]
-    fn visit_enum_seq<V>(&mut self, _name: &str, variant: &str, visitor: V) -> Result<(), ()>
+    fn visit_enum_seq<V>(&mut self, _name: &str, variant: Self::Variant, visitor: V) -> Result<(), ()>
         where V: ser::SeqVisitor,
     {
         try!(self.visit_seq(visitor));
@@ -501,7 +503,7 @@ impl ser::Serializer for Serializer {
 
         let mut object = BTreeMap::new();
 
-        object.insert(variant.to_string(), value);
+        object.insert(variant, value);
 
         self.state.push(State::Value(Value::Object(object)));
 
@@ -548,7 +550,7 @@ impl ser::Serializer for Serializer {
     }
 
     #[inline]
-    fn visit_enum_map<V>(&mut self, _name: &str, variant: &str, visitor: V) -> Result<(), ()>
+    fn visit_enum_map<V>(&mut self, _name: &str, variant: Self::Variant, visitor: V) -> Result<(), ()>
         where V: ser::MapVisitor,
     {
         try!(self.visit_map(visitor));
@@ -560,7 +562,7 @@ impl ser::Serializer for Serializer {
 
         let mut object = BTreeMap::new();
 
-        object.insert(variant.to_string(), value);
+        object.insert(variant, value);
 
         self.state.push(State::Value(Value::Object(object)));
 
@@ -597,6 +599,16 @@ impl ser::Serializer for Serializer {
     #[inline]
     fn format() -> &'static str {
         "json"
+    }
+    
+    #[inline]
+    fn result_variant_ok(&self) -> Self::Variant {
+      "Ok".to_string()
+    }
+    
+    #[inline]
+    fn result_variant_err(&self) -> Self::Variant {
+      "Err".to_string()
     }
 }
 

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -650,7 +650,8 @@ impl<T, E> Serialize for Result<T, E> where T: Serialize, E: Serialize {
                     state: 0,
                     _structure_ty: data
                 };
-                serializer.visit_enum_seq("Result", "Ok", visitor)
+                let ok = serializer.result_variant_ok();
+                serializer.visit_enum_seq("Result", ok, visitor)
             }
             Result::Err(ref field0) => {
                 struct Visitor<'a, T, E> where T: Serialize + 'a, E: Serialize + 'a {
@@ -690,7 +691,8 @@ impl<T, E> Serialize for Result<T, E> where T: Serialize, E: Serialize {
                     state: 0,
                     _structure_ty: data
                 };
-                serializer.visit_enum_seq("Result", "Err", visitor)
+                let err = serializer.result_variant_err();
+                serializer.visit_enum_seq("Result", err, visitor)
             }
         }
     }

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -13,6 +13,7 @@ pub trait Serialize {
 
 pub trait Serializer {
     type Error;
+    type Variant: Serialize;
 
     /// `visit_bool` serializes a `bool` value.
     fn visit_bool(&mut self, v: bool) -> Result<(), Self::Error>;
@@ -118,9 +119,9 @@ pub trait Serializer {
     }
 
     #[inline]
-    fn visit_enum_unit<V>(&mut self,
+    fn visit_enum_unit(&mut self,
                        _name: &str,
-                       _variant: V) -> Result<(), Self::Error> {
+                       _variant: Self::Variant) -> Result<(), Self::Error> {
         self.visit_unit()
     }
 
@@ -166,9 +167,9 @@ pub trait Serializer {
     }
 
     #[inline]
-    fn visit_enum_seq<V, T>(&mut self,
+    fn visit_enum_seq<V>(&mut self,
                          _name: &'static str,
-                         _variant: T,
+                         _variant: Self::Variant,
                          visitor: V) -> Result<(), Self::Error>
         where V: SeqVisitor,
     {
@@ -207,13 +208,13 @@ pub trait Serializer {
     }
 
     #[inline]
-    fn visit_enum_map<V, T>(&mut self,
+    fn visit_enum_map<V>(&mut self,
                          _name: &'static str,
-                         variant: T,
+                         _variant: Self::Variant,
                          visitor: V) -> Result<(), Self::Error>
         where V: MapVisitor,
     {
-        self.visit_named_map(variant, visitor)
+        self.visit_map(visitor)
     }
 
     #[inline]
@@ -223,6 +224,10 @@ pub trait Serializer {
     {
         self.visit_named_map_elt(key, value)
     }
+
+    fn result_variant_ok(&self) -> Self::Variant;
+    
+    fn result_variant_err(&self) -> Self::Variant;
 
     /// Specify a format string for the serializer.
     ///

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -118,9 +118,9 @@ pub trait Serializer {
     }
 
     #[inline]
-    fn visit_enum_unit(&mut self,
+    fn visit_enum_unit<V>(&mut self,
                        _name: &str,
-                       _variant: &str) -> Result<(), Self::Error> {
+                       _variant: V) -> Result<(), Self::Error> {
         self.visit_unit()
     }
 
@@ -166,9 +166,9 @@ pub trait Serializer {
     }
 
     #[inline]
-    fn visit_enum_seq<V>(&mut self,
+    fn visit_enum_seq<V, T>(&mut self,
                          _name: &'static str,
-                         _variant: &'static str,
+                         _variant: T,
                          visitor: V) -> Result<(), Self::Error>
         where V: SeqVisitor,
     {
@@ -207,9 +207,9 @@ pub trait Serializer {
     }
 
     #[inline]
-    fn visit_enum_map<V>(&mut self,
+    fn visit_enum_map<V, T>(&mut self,
                          _name: &'static str,
-                         variant: &'static str,
+                         variant: T,
                          visitor: V) -> Result<(), Self::Error>
         where V: MapVisitor,
     {


### PR DESCRIPTION
I am working on Msgpack implementation for serde and for this, I want to be able to map variants to numbers rather than strings.