### PR TITLE
Major refactor: Rename methods, variant index, struct fields, deserializing structs from seq, pulling out json, and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ impl serde::Serialize for Point {
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: serde::Serializer
     {
-        serializer.visit_named_map("Point", PointMapVisitor {
+        serializer.visit_struct("Point", PointMapVisitor {
             value: self,
             state: 0,
         })
@@ -383,7 +383,7 @@ impl serde::Deserialize for Point {
     fn deserialize<D>(deserializer: &mut D) -> Result<Point, D::Error>
         where D: serde::de::Deserializer
     {
-        deserializer.visit_named_map("Point", PointVisitor)
+        deserializer.visit_struct("Point", PointVisitor)
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ struct Point {
 ```
 
 Serde bundles a high performance JSON serializer and deserializer,
-[serde::json](http://serde-rs.github.io/serde/serde/json/index.html),
+[serde_json](http://serde-rs.github.io/serde/serde_json/index.html),
 which comes with the helper functions
 [to_string](http://serde-rs.github.io/serde/serde/json/ser/fn.to_string.html)
 and
@@ -47,7 +47,7 @@ and
 that make it easy to go to and from JSON:
 
 ```rust
-use serde::json;
+use serde_json;
 
 ...
 
@@ -59,7 +59,7 @@ println!("{}", serialized_point); // prints: {"x":1,"y":2}
 let deserialize_point: Point = json::from_str(&serialized_point).unwrap();
 ```
 
-[serde::json](http://serde-rs.github.io/serde/serde/json/index.html) also
+[serde_json](http://serde-rs.github.io/serde/serde_json/index.html) also
 supports a generic
 [Value](http://serde-rs.github.io/serde/serde/json/value/enum.Value.html)
 type, which can represent any JSON value. Also, any

--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde"
-version = "0.4.3"
+version = "0.5.0"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "A generic serialization/deserialization framework"

--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -573,6 +573,15 @@ macro_rules! tuple_impls {
 
             impl<
                 $($name: Deserialize,)+
+            > $visitor<$($name,)+> {
+                fn new() -> Self {
+                    $visitor { marker: PhantomData }
+                }
+            }
+
+
+            impl<
+                $($name: Deserialize,)+
             > Visitor for $visitor<$($name,)+> {
                 type Value = ($($name,)+);
 
@@ -601,7 +610,7 @@ macro_rules! tuple_impls {
                 fn deserialize<D>(deserializer: &mut D) -> Result<($($name,)+), D::Error>
                     where D: Deserializer,
                 {
-                    deserializer.visit_tuple($visitor { marker: PhantomData })
+                    deserializer.visit_tuple($visitor::new())
                 }
             }
         )+

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -211,25 +211,25 @@ pub trait Deserializer {
     /// This method hints that the `Deserialize` type is expecting a named unit. This allows
     /// deserializers to a named unit that aren't tagged as a named unit.
     #[inline]
-    fn visit_named_unit<V>(&mut self, _name: &str, visitor: V) -> Result<V::Value, Self::Error>
+    fn visit_unit_struct<V>(&mut self, _name: &str, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor,
     {
         self.visit(visitor)
     }
 
-    /// This method hints that the `Deserialize` type is expecting a named sequence.
-    /// This allows deserializers to parse sequences that aren't tagged as sequences.
+    /// This method hints that the `Deserialize` type is expecting a tuple struct. This allows
+    /// deserializers to parse sequences that aren't tagged as sequences.
     #[inline]
-    fn visit_named_seq<V>(&mut self, _name: &str, visitor: V) -> Result<V::Value, Self::Error>
+    fn visit_tuple_struct<V>(&mut self, _name: &str, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor,
     {
         self.visit_seq(visitor)
     }
 
-    /// This method hints that the `Deserialize` type is expecting a named map.  This allows
+    /// This method hints that the `Deserialize` type is expecting a struct. This allows
     /// deserializers to parse sequences that aren't tagged as maps.
     #[inline]
-    fn visit_named_map<V>(&mut self, _name: &str, visitor: V) -> Result<V::Value, Self::Error>
+    fn visit_struct<V>(&mut self, _name: &str, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor,
     {
         self.visit_map(visitor)
@@ -386,7 +386,7 @@ pub trait Visitor {
     }
 
     #[inline]
-    fn visit_named_unit<E>(&mut self, _name: &str) -> Result<Self::Value, E>
+    fn visit_unit_struct<E>(&mut self, _name: &str) -> Result<Self::Value, E>
         where E: Error,
     {
         self.visit_unit()

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -214,7 +214,7 @@ pub trait Deserializer {
     fn visit_unit_struct<V>(&mut self, _name: &str, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor,
     {
-        self.visit(visitor)
+        self.visit_unit(visitor)
     }
 
     /// This method hints that the `Deserialize` type is expecting a tuple struct. This allows
@@ -223,7 +223,7 @@ pub trait Deserializer {
     fn visit_tuple_struct<V>(&mut self, _name: &str, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor,
     {
-        self.visit_seq(visitor)
+        self.visit_tuple(visitor)
     }
 
     /// This method hints that the `Deserialize` type is expecting a struct. This allows
@@ -244,7 +244,7 @@ pub trait Deserializer {
     fn visit_tuple<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor,
     {
-        self.visit(visitor)
+        self.visit_seq(visitor)
     }
 
     /// This method hints that the `Deserialize` type is expecting an enum value. This allows
@@ -264,7 +264,7 @@ pub trait Deserializer {
     fn visit_bytes<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor,
     {
-        self.visit(visitor)
+        self.visit_seq(visitor)
     }
 
     /// Specify a format string for the deserializer.

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -229,7 +229,10 @@ pub trait Deserializer {
     /// This method hints that the `Deserialize` type is expecting a struct. This allows
     /// deserializers to parse sequences that aren't tagged as maps.
     #[inline]
-    fn visit_struct<V>(&mut self, _name: &str, visitor: V) -> Result<V::Value, Self::Error>
+    fn visit_struct<V>(&mut self,
+                       _name: &str,
+                       _fields: &'static [&'static str],
+                       visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor,
     {
         self.visit_map(visitor)
@@ -576,7 +579,9 @@ pub trait VariantVisitor {
     }
 
     /// `visit_map` is called when deserializing a struct-like variant.
-    fn visit_map<V>(&mut self, _visitor: V) -> Result<V::Value, Self::Error>
+    fn visit_map<V>(&mut self,
+                    _fields: &'static [&'static str],
+                    _visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor
     {
         Err(Error::syntax_error())
@@ -602,10 +607,12 @@ impl<'a, T> VariantVisitor for &'a mut T where T: VariantVisitor {
         (**self).visit_seq(visitor)
     }
 
-    fn visit_map<V>(&mut self, visitor: V) -> Result<V::Value, T::Error>
+    fn visit_map<V>(&mut self,
+                    fields: &'static [&'static str],
+                    visitor: V) -> Result<V::Value, T::Error>
         where V: Visitor,
     {
-        (**self).visit_map(visitor)
+        (**self).visit_map(fields, visitor)
     }
 }
 

--- a/serde/src/json/de.rs
+++ b/serde/src/json/de.rs
@@ -649,7 +649,9 @@ impl<Iter> de::VariantVisitor for Deserializer<Iter>
         de::Deserializer::visit(self, visitor)
     }
 
-    fn visit_map<V>(&mut self, visitor: V) -> Result<V::Value, Error>
+    fn visit_map<V>(&mut self,
+                    _fields: &'static [&'static str],
+                    visitor: V) -> Result<V::Value, Error>
         where V: de::Visitor,
     {
         try!(self.parse_object_colon());

--- a/serde/src/json/ser.rs
+++ b/serde/src/json/ser.rs
@@ -159,7 +159,10 @@ impl<W, F> ser::Serializer for Serializer<W, F>
     }
 
     #[inline]
-    fn visit_enum_unit(&mut self, _name: &str, variant: &str) -> io::Result<()> {
+    fn visit_enum_unit(&mut self,
+                       _name: &str,
+                       _variant_index: usize,
+                       variant: &str) -> io::Result<()> {
         try!(self.formatter.open(&mut self.writer, b'{'));
         try!(self.formatter.comma(&mut self.writer, true));
         try!(self.visit_str(variant));
@@ -190,7 +193,11 @@ impl<W, F> ser::Serializer for Serializer<W, F>
     }
 
     #[inline]
-    fn visit_enum_seq<V>(&mut self, _name: &str, variant: &str, visitor: V) -> io::Result<()>
+    fn visit_enum_seq<V>(&mut self,
+                         _name: &str,
+                         _variant_index: usize,
+                         variant: &str,
+                         visitor: V) -> io::Result<()>
         where V: ser::SeqVisitor,
     {
         try!(self.formatter.open(&mut self.writer, b'{'));
@@ -232,7 +239,11 @@ impl<W, F> ser::Serializer for Serializer<W, F>
     }
 
     #[inline]
-    fn visit_enum_map<V>(&mut self, _name: &str, variant: &str, visitor: V) -> io::Result<()>
+    fn visit_enum_map<V>(&mut self,
+                         _name: &str,
+                         _variant_index: usize,
+                         variant: &str,
+                         visitor: V) -> io::Result<()>
         where V: ser::MapVisitor,
     {
         try!(self.formatter.open(&mut self.writer, b'{'));

--- a/serde/src/json/value.rs
+++ b/serde/src/json/value.rs
@@ -792,7 +792,9 @@ impl<'a> de::VariantVisitor for SeqDeserializer<'a> {
         de::Deserializer::visit(self, visitor)
     }
 
-    fn visit_map<V>(&mut self, visitor: V) -> Result<V::Value, Error>
+    fn visit_map<V>(&mut self,
+                    _fields: &'static [&'static str],
+                    visitor: V) -> Result<V::Value, Error>
         where V: de::Visitor,
     {
         de::Deserializer::visit(self, visitor)
@@ -901,7 +903,9 @@ impl<'a> de::VariantVisitor for MapDeserializer<'a> {
         de::Deserializer::visit(self, visitor)
     }
 
-    fn visit_map<V>(&mut self, visitor: V) -> Result<V::Value, Error>
+    fn visit_map<V>(&mut self,
+                    _fields: &'static [&'static str],
+                    visitor: V) -> Result<V::Value, Error>
         where V: de::Visitor,
     {
         de::Deserializer::visit(self, visitor)

--- a/serde/src/json/value.rs
+++ b/serde/src/json/value.rs
@@ -458,7 +458,10 @@ impl ser::Serializer for Serializer {
     }
 
     #[inline]
-    fn visit_enum_unit(&mut self, _name: &str, variant: &str) -> Result<(), ()> {
+    fn visit_enum_unit(&mut self,
+                       _name: &str,
+                       _variant_index: usize,
+                       variant: &str) -> Result<(), ()> {
         let mut values = BTreeMap::new();
         values.insert(variant.to_string(), Value::Array(vec![]));
 
@@ -489,7 +492,11 @@ impl ser::Serializer for Serializer {
     }
 
     #[inline]
-    fn visit_enum_seq<V>(&mut self, _name: &str, variant: &str, visitor: V) -> Result<(), ()>
+    fn visit_enum_seq<V>(&mut self,
+                         _name: &str,
+                         _variant_index: usize,
+                         variant: &str,
+                         visitor: V) -> Result<(), ()>
         where V: ser::SeqVisitor,
     {
         try!(self.visit_seq(visitor));
@@ -548,7 +555,11 @@ impl ser::Serializer for Serializer {
     }
 
     #[inline]
-    fn visit_enum_map<V>(&mut self, _name: &str, variant: &str, visitor: V) -> Result<(), ()>
+    fn visit_enum_map<V>(&mut self,
+                         _name: &str,
+                         _variant_index: usize,
+                         variant: &str,
+                         visitor: V) -> Result<(), ()>
         where V: ser::MapVisitor,
     {
         try!(self.visit_map(visitor));

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -22,5 +22,4 @@ pub use de::{Deserialize, Deserializer, Error};
 pub mod bytes;
 pub mod de;
 pub mod iter;
-pub mod json;
 pub mod ser;

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -613,7 +613,10 @@ impl<T, E> Serialize for Result<T, E> where T: Serialize, E: Serialize {
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error> where S: Serializer {
         match *self {
             Result::Ok(ref field0) => {
-                struct Visitor<'a, T, E> where T: Serialize + 'a, E: Serialize + 'a {
+                struct Visitor<'a, T, E>
+                    where T: Serialize + 'a,
+                          E: Serialize + 'a
+                {
                     state: usize,
                     value: (&'a T,),
                     _structure_ty: PhantomData<&'a Result<T, E>>,
@@ -653,7 +656,10 @@ impl<T, E> Serialize for Result<T, E> where T: Serialize, E: Serialize {
                 serializer.visit_enum_seq("Result", 0, "Ok", visitor)
             }
             Result::Err(ref field0) => {
-                struct Visitor<'a, T, E> where T: Serialize + 'a, E: Serialize + 'a {
+                struct Visitor<'a, T, E>
+                    where T: Serialize + 'a,
+                          E: Serialize + 'a
+                {
                     state: usize,
                     value: (&'a E,),
                     _structure_ty: PhantomData<&'a Result<T, E>>,

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -15,7 +15,6 @@ use std::collections::vec_map::VecMap;
 use std::hash::Hash;
 #[cfg(feature = "nightly")]
 use std::iter;
-use std::marker::PhantomData;
 #[cfg(feature = "nightly")]
 use std::num;
 #[cfg(feature = "nightly")]
@@ -612,31 +611,17 @@ impl<'a, T: ?Sized> Serialize for Cow<'a, T> where T: Serialize + ToOwned, {
 impl<T, E> Serialize for Result<T, E> where T: Serialize, E: Serialize {
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error> where S: Serializer {
         match *self {
-            Result::Ok(ref field0) => {
-                struct Visitor<'a, T, E>
-                    where T: Serialize + 'a,
-                          E: Serialize + 'a
-                {
-                    state: usize,
-                    value: (&'a T,),
-                    _structure_ty: PhantomData<&'a Result<T, E>>,
-                }
+            Result::Ok(ref value) => {
+                struct Visitor<'a, T: 'a>(Option<&'a T>);
 
-                impl<'a, T, E> SeqVisitor for Visitor<'a, T, E> where T: Serialize + 'a,
-                                                                      E: Serialize + 'a {
+                impl<'a, T> SeqVisitor for Visitor<'a, T> where T: Serialize + 'a {
                     #[inline]
                     fn visit<S>(&mut self, serializer: &mut S) -> Result<Option<()>, S::Error>
-                                where S: Serializer {
-                        match self.state {
-                            0 => {
-                                self.state += 1;
-                                let v = match serializer.visit_seq_elt(&self.value.0) {
-                                    Ok(val) => val,
-                                    Err(err) => return Err(From::from(err)),
-                                };
-                                Ok(Some(v))
-                            }
-                            _ => Ok(None),
+                        where S: Serializer
+                    {
+                        match self.0.take() {
+                            Some(value) => Ok(Some(try!(serializer.visit_seq_elt(value)))),
+                            None => Ok(None),
                         }
                     }
 
@@ -646,40 +631,18 @@ impl<T, E> Serialize for Result<T, E> where T: Serialize, E: Serialize {
                     }
                 }
 
-                let field0: &T = field0;
-                let data: PhantomData<&Result<&T,E>> = PhantomData;
-                let visitor = Visitor {
-                    value: (&field0,),
-                    state: 0,
-                    _structure_ty: data
-                };
-                serializer.visit_enum_seq("Result", 0, "Ok", visitor)
+                serializer.visit_enum_seq("Result", 0, "Ok", Visitor(Some(value)))
             }
-            Result::Err(ref field0) => {
-                struct Visitor<'a, T, E>
-                    where T: Serialize + 'a,
-                          E: Serialize + 'a
-                {
-                    state: usize,
-                    value: (&'a E,),
-                    _structure_ty: PhantomData<&'a Result<T, E>>,
-                }
+            Result::Err(ref value) => {
+                struct Visitor<'a, E: 'a>(Option<&'a E>);
 
-                impl<'a, T, E> SeqVisitor for Visitor<'a, T, E> where T: Serialize + 'a,
-                                                                      E: Serialize + 'a {
+                impl<'a, E> SeqVisitor for Visitor<'a, E> where E: Serialize + 'a {
                     #[inline]
                     fn visit<S>(&mut self, serializer: &mut S) -> Result<Option<()>, S::Error>
                                 where S: Serializer {
-                        match self.state {
-                            0 => {
-                                self.state += 1;
-                                let v = match serializer.visit_seq_elt(&self.value.0) {
-                                    Ok(val) => val,
-                                    Err(err) => return Err(From::from(err)),
-                                };
-                                Ok(Some(v))
-                            }
-                            _ => Ok(None),
+                        match self.0.take() {
+                            Some(value) => Ok(Some(try!(serializer.visit_seq_elt(value)))),
+                            None => Ok(None),
                         }
                     }
 
@@ -689,14 +652,7 @@ impl<T, E> Serialize for Result<T, E> where T: Serialize, E: Serialize {
                     }
                 }
 
-                let field0: &E = field0;
-                let data: PhantomData<&Result<T,&E>> = PhantomData;
-                let visitor = Visitor {
-                    value: (&field0,),
-                    state: 0,
-                    _structure_ty: data
-                };
-                serializer.visit_enum_seq("Result", 1, "Err", visitor)
+                serializer.visit_enum_seq("Result", 1, "Err", Visitor(Some(value)))
             }
         }
     }

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -650,7 +650,7 @@ impl<T, E> Serialize for Result<T, E> where T: Serialize, E: Serialize {
                     state: 0,
                     _structure_ty: data
                 };
-                serializer.visit_enum_seq("Result", "Ok", visitor)
+                serializer.visit_enum_seq("Result", 0, "Ok", visitor)
             }
             Result::Err(ref field0) => {
                 struct Visitor<'a, T, E> where T: Serialize + 'a, E: Serialize + 'a {
@@ -690,7 +690,7 @@ impl<T, E> Serialize for Result<T, E> where T: Serialize, E: Serialize {
                     state: 0,
                     _structure_ty: data
                 };
-                serializer.visit_enum_seq("Result", "Err", visitor)
+                serializer.visit_enum_seq("Result", 1, "Err", visitor)
             }
         }
     }

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -113,7 +113,7 @@ pub trait Serializer {
     fn visit_unit(&mut self) -> Result<(), Self::Error>;
 
     #[inline]
-    fn visit_named_unit(&mut self, _name: &str) -> Result<(), Self::Error> {
+    fn visit_unit_struct(&mut self, _name: &str) -> Result<(), Self::Error> {
         self.visit_unit()
     }
 
@@ -150,7 +150,7 @@ pub trait Serializer {
     }
 
     #[inline]
-    fn visit_named_seq<V>(&mut self,
+    fn visit_tuple_struct<V>(&mut self,
                           _name: &'static str,
                           visitor: V) -> Result<(), Self::Error>
         where V: SeqVisitor,
@@ -159,7 +159,7 @@ pub trait Serializer {
     }
 
     #[inline]
-    fn visit_named_seq_elt<T>(&mut self, value: T) -> Result<(), Self::Error>
+    fn visit_tuple_struct_elt<T>(&mut self, value: T) -> Result<(), Self::Error>
         where T: Serialize
     {
         self.visit_tuple_elt(value)
@@ -172,14 +172,14 @@ pub trait Serializer {
                          visitor: V) -> Result<(), Self::Error>
         where V: SeqVisitor,
     {
-        self.visit_named_seq(variant, visitor)
+        self.visit_tuple_struct(variant, visitor)
     }
 
     #[inline]
     fn visit_enum_seq_elt<T>(&mut self, value: T) -> Result<(), Self::Error>
         where T: Serialize
     {
-        self.visit_named_seq_elt(value)
+        self.visit_tuple_struct_elt(value)
     }
 
     fn visit_map<V>(&mut self, visitor: V) -> Result<(), Self::Error>
@@ -190,7 +190,7 @@ pub trait Serializer {
               V: Serialize;
 
     #[inline]
-    fn visit_named_map<V>(&mut self,
+    fn visit_struct<V>(&mut self,
                           _name: &'static str,
                           visitor: V) -> Result<(), Self::Error>
         where V: MapVisitor,
@@ -199,7 +199,7 @@ pub trait Serializer {
     }
 
     #[inline]
-    fn visit_named_map_elt<K, V>(&mut self, key: K, value: V) -> Result<(), Self::Error>
+    fn visit_struct_elt<K, V>(&mut self, key: K, value: V) -> Result<(), Self::Error>
         where K: Serialize,
               V: Serialize,
     {
@@ -213,7 +213,7 @@ pub trait Serializer {
                          visitor: V) -> Result<(), Self::Error>
         where V: MapVisitor,
     {
-        self.visit_named_map(variant, visitor)
+        self.visit_struct(variant, visitor)
     }
 
     #[inline]
@@ -221,7 +221,7 @@ pub trait Serializer {
         where K: Serialize,
               V: Serialize,
     {
-        self.visit_named_map_elt(key, value)
+        self.visit_struct_elt(key, value)
     }
 
     /// Specify a format string for the serializer.

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -120,6 +120,7 @@ pub trait Serializer {
     #[inline]
     fn visit_enum_unit(&mut self,
                        _name: &str,
+                       _variant_index: usize,
                        _variant: &str) -> Result<(), Self::Error> {
         self.visit_unit()
     }
@@ -168,6 +169,7 @@ pub trait Serializer {
     #[inline]
     fn visit_enum_seq<V>(&mut self,
                          _name: &'static str,
+                         _variant_index: usize,
                          variant: &'static str,
                          visitor: V) -> Result<(), Self::Error>
         where V: SeqVisitor,
@@ -209,6 +211,7 @@ pub trait Serializer {
     #[inline]
     fn visit_enum_map<V>(&mut self,
                          _name: &'static str,
+                         _variant_index: usize,
                          variant: &'static str,
                          visitor: V) -> Result<(), Self::Error>
         where V: MapVisitor,

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -168,18 +168,18 @@ pub trait Serializer {
     #[inline]
     fn visit_enum_seq<V>(&mut self,
                          _name: &'static str,
-                         _variant: &'static str,
+                         variant: &'static str,
                          visitor: V) -> Result<(), Self::Error>
         where V: SeqVisitor,
     {
-        self.visit_tuple(visitor)
+        self.visit_named_seq(variant, visitor)
     }
 
     #[inline]
     fn visit_enum_seq_elt<T>(&mut self, value: T) -> Result<(), Self::Error>
         where T: Serialize
     {
-        self.visit_tuple_elt(value)
+        self.visit_named_seq_elt(value)
     }
 
     fn visit_map<V>(&mut self, visitor: V) -> Result<(), Self::Error>

--- a/serde_codegen/Cargo.toml
+++ b/serde_codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_codegen"
-version = "0.4.3"
+version = "0.5.0"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Macros to auto-generate implementations for the serde framework"

--- a/serde_codegen/src/attr.rs
+++ b/serde_codegen/src/attr.rs
@@ -21,7 +21,6 @@ pub struct FieldAttrs {
 }
 
 impl FieldAttrs {
-
     /// Create a FieldAttr with a single default field name
     pub fn new(default_value: bool, name: P<ast::Expr>) -> FieldAttrs {
         FieldAttrs {
@@ -35,7 +34,7 @@ impl FieldAttrs {
         default_value: bool,
         default_name: P<ast::Expr>,
         formats: HashMap<P<ast::Expr>, P<ast::Expr>>,
-        ) -> FieldAttrs {
+    ) -> FieldAttrs {
         FieldAttrs {
             names:  FieldNames::Format {
                 formats: formats,

--- a/serde_codegen/src/de.rs
+++ b/serde_codegen/src/de.rs
@@ -676,6 +676,7 @@ fn deserialize_struct_variant(
                 $visit_seq_expr
             }
 
+            #[inline]
             fn visit_map<__V>(&mut self, mut visitor: __V) -> ::std::result::Result<$ty, __V::Error>
                 where __V: ::serde::de::MapVisitor,
             {

--- a/serde_codegen/src/de.rs
+++ b/serde_codegen/src/de.rs
@@ -260,7 +260,7 @@ fn deserialize_unit_struct(
             }
         }
 
-        deserializer.visit_named_unit($type_name, __Visitor)
+        deserializer.visit_unit_struct($type_name, __Visitor)
     })
 }
 
@@ -304,7 +304,7 @@ fn deserialize_tuple_struct(
             }
         }
 
-        deserializer.visit_named_seq($type_name, $visitor_expr)
+        deserializer.visit_tuple_struct($type_name, $visitor_expr)
     })
 }
 
@@ -385,7 +385,7 @@ fn deserialize_struct(
             }
         }
 
-        deserializer.visit_named_map($type_name, $visitor_expr)
+        deserializer.visit_struct($type_name, $visitor_expr)
     })
 }
 

--- a/serde_codegen/src/ser.rs
+++ b/serde_codegen/src/ser.rs
@@ -169,7 +169,7 @@ fn serialize_unit_struct(
 ) -> P<ast::Expr> {
     let type_name = builder.expr().str(type_ident);
 
-    quote_expr!(cx, serializer.visit_named_unit($type_name))
+    quote_expr!(cx, serializer.visit_unit_struct($type_name))
 }
 
 fn serialize_tuple_struct(
@@ -194,7 +194,7 @@ fn serialize_tuple_struct(
     quote_expr!(cx, {
         $visitor_struct
         $visitor_impl
-        serializer.visit_named_seq($type_name, Visitor {
+        serializer.visit_tuple_struct($type_name, Visitor {
             value: self,
             state: 0,
             _structure_ty: ::std::marker::PhantomData,
@@ -226,7 +226,7 @@ fn serialize_struct(
     quote_expr!(cx, {
         $visitor_struct
         $visitor_impl
-        serializer.visit_named_map($type_name, Visitor {
+        serializer.visit_struct($type_name, Visitor {
             value: self,
             state: 0,
             _structure_ty: ::std::marker::PhantomData,
@@ -476,7 +476,7 @@ fn serialize_tuple_struct_visitor(
             quote_arm!(cx,
                 $i => {
                     self.state += 1;
-                    let v = try!(serializer.visit_named_seq_elt(&$expr));
+                    let v = try!(serializer.visit_tuple_struct_elt(&$expr));
                     Ok(Some(v))
                 }
             )
@@ -559,7 +559,7 @@ fn serialize_struct_visitor<I>(
                     Ok(
                         Some(
                             try!(
-                                serializer.visit_named_map_elt(
+                                serializer.visit_struct_elt(
                                     $key_expr,
                                     $value_expr,
                                 )

--- a/serde_json/Cargo.toml
+++ b/serde_json/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "serde_json"
+version = "0.5.0"
+authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
+license = "MIT/Apache-2.0"
+description = "A JSON serialization file format"
+repository = "https://github.com/serde-rs/serde"
+documentation = "http://serde-rs.github.io/serde/serde"
+readme = "README.md"
+keywords = ["serialization", "json"]
+
+[dependencies]
+num = "*"
+serde = { version = "*", path = "../serde" }

--- a/serde_json/src/builder.rs
+++ b/serde_json/src/builder.rs
@@ -10,8 +10,9 @@
 
 use std::collections::BTreeMap;
 
-use ser::{self, Serialize};
-use json::value::{self, Value};
+use serde::ser::{self, Serialize};
+
+use value::{self, Value};
 
 pub struct ArrayBuilder {
     array: Vec<Value>,

--- a/serde_json/src/de.rs
+++ b/serde_json/src/de.rs
@@ -3,8 +3,8 @@ use std::i32;
 use std::io;
 use std::str;
 
-use de;
-use iter::LineColIterator;
+use serde::de;
+use serde::iter::LineColIterator;
 
 use super::error::{Error, ErrorCode};
 

--- a/serde_json/src/error.rs
+++ b/serde_json/src/error.rs
@@ -2,7 +2,7 @@ use std::error;
 use std::fmt;
 use std::io;
 
-use de;
+use serde::de;
 
 /// The errors that can arise while parsing a JSON stream.
 #[derive(Clone, PartialEq)]

--- a/serde_json/src/lib.rs
+++ b/serde_json/src/lib.rs
@@ -92,6 +92,9 @@
 //! }
 //! ```
 
+extern crate num;
+extern crate serde;
+
 pub use self::de::{Deserializer, from_str};
 pub use self::error::{Error, ErrorCode};
 pub use self::ser::{

--- a/serde_json/src/lib.rs
+++ b/serde_json/src/lib.rs
@@ -6,7 +6,7 @@
 //! encode structured data in a text format that can be easily read by humans.  Its simple syntax
 //! and native compatibility with JavaScript have made it a widely used format.
 //!
-//! Data types that can be encoded are JavaScript types (see the `serde::json:Value` enum for more
+//! Data types that can be encoded are JavaScript types (see the `serde_json:Value` enum for more
 //! details):
 //!
 //! * `Boolean`: equivalent to rust's `bool`
@@ -16,7 +16,7 @@
 //! * `String`: equivalent to rust's `String`
 //! * `Array`: equivalent to rust's `Vec<T>`, but also allowing objects of different types in the
 //!    same array
-//! * `Object`: equivalent to rust's `BTreeMap<String, serde::json::Value>`
+//! * `Object`: equivalent to rust's `BTreeMap<String, serde_json::Value>`
 //! * `Null`
 //!
 //! An object is a series of string keys mapping to values, in `"key": value` format.  Arrays are
@@ -48,8 +48,8 @@
 //! `serde::Deserialize` trait.  Serde provides provides an annotation to automatically generate
 //! the code for these traits: `#[derive(Serialize, Deserialize)]`.
 //!
-//! The JSON API also provides an enum `serde::json::Value` and a method `to_value` to serialize
-//! objects.  A `serde::json::Value` value can be serialized as a string or buffer using the
+//! The JSON API also provides an enum `serde_json::Value` and a method `to_value` to serialize
+//! objects.  A `serde_json::Value` value can be serialized as a string or buffer using the
 //! functions described above.  You can also use the `json::Serializer` object, which implements the
 //! `Serializer` trait.
 //!
@@ -63,7 +63,7 @@
 //!
 //! extern crate serde;
 //!
-//! use serde::json::{self, Value};
+//! use serde_json::{self, Value};
 //!
 //! fn main() {
 //!     let data: Value = json::from_str("{\"foo\": 13, \"bar\": \"baz\"}").unwrap();

--- a/serde_json/src/ser.rs
+++ b/serde_json/src/ser.rs
@@ -2,7 +2,7 @@ use std::io;
 use std::num::FpCategory;
 use std::string::FromUtf8Error;
 
-use ser;
+use serde::ser;
 
 /// A structure for implementing serialization to JSON.
 pub struct Serializer<W, F=CompactFormatter> {

--- a/serde_json/src/ser.rs
+++ b/serde_json/src/ser.rs
@@ -213,9 +213,11 @@ impl<W, F> ser::Serializer for Serializer<W, F>
         where T: ser::Serialize,
     {
         try!(self.formatter.comma(&mut self.writer, self.first));
+        try!(value.serialize(self));
+
         self.first = false;
 
-        value.serialize(self)
+        Ok(())
     }
 
     #[inline]
@@ -261,11 +263,14 @@ impl<W, F> ser::Serializer for Serializer<W, F>
               V: ser::Serialize,
     {
         try!(self.formatter.comma(&mut self.writer, self.first));
-        self.first = false;
 
         try!(key.serialize(self));
         try!(self.formatter.colon(&mut self.writer));
-        value.serialize(self)
+        try!(value.serialize(self));
+
+        self.first = false;
+
+        Ok(())
     }
 
     #[inline]

--- a/serde_json/src/value.rs
+++ b/serde_json/src/value.rs
@@ -6,9 +6,10 @@ use std::vec;
 
 use num::NumCast;
 
-use de;
-use ser;
-use super::error::Error;
+use serde::de;
+use serde::ser;
+
+use error::Error;
 
 #[derive(Clone, PartialEq)]
 pub enum Value {

--- a/serde_macros/Cargo.toml
+++ b/serde_macros/Cargo.toml
@@ -17,3 +17,4 @@ serde_codegen = { version = "*", path = "../serde_codegen", default-features = f
 num = "*"
 rustc-serialize = "*"
 serde = { version = "*", path = "../serde", features = ["nightly"] }
+serde_json = { version = "*", path = "../serde_json" }

--- a/serde_macros/Cargo.toml
+++ b/serde_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_macros"
-version = "0.4.4"
+version = "0.5.0"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Macros to auto-generate implementations for the serde framework"

--- a/serde_macros/benches/bench.rs
+++ b/serde_macros/benches/bench.rs
@@ -4,6 +4,7 @@
 extern crate num;
 extern crate rustc_serialize;
 extern crate serde;
+extern crate serde_json;
 extern crate test;
 
 include!("../../serde_tests/benches/bench.rs.in");

--- a/serde_macros/examples/json.rs
+++ b/serde_macros/examples/json.rs
@@ -2,9 +2,9 @@
 #![plugin(serde_macros)]
 
 extern crate serde;
+extern crate serde_json;
 
 use std::collections::BTreeMap;
-use serde::json;
 
 // Creating serializable types with serde is quite simple with `serde_macros`. It implements a
 // syntax extension that automatically generates the necessary serde trait implementations.
@@ -18,7 +18,7 @@ fn main() {
     let point = Point { x: 5, y: 6 };
 
     // Serializing to JSON is pretty simple by using the `to_string` method:
-    let serialized_point = json::to_string(&point).unwrap();
+    let serialized_point = serde_json::to_string(&point).unwrap();
 
     println!("{}", serialized_point);
     // prints:
@@ -26,7 +26,7 @@ fn main() {
     // {"x":5,"y":6}
 
     // There is also support for pretty printing using `to_string_pretty`:
-    let serialized_point = json::to_string_pretty(&point).unwrap();
+    let serialized_point = serde_json::to_string_pretty(&point).unwrap();
 
     println!("{}", serialized_point);
     // prints:
@@ -37,7 +37,7 @@ fn main() {
     // }
 
     // Values can also be deserialized with the same style using `from_str`:
-    let deserialized_point: Point = json::from_str(&serialized_point).unwrap();
+    let deserialized_point: Point = serde_json::from_str(&serialized_point).unwrap();
 
     println!("{:?}", deserialized_point);
     // prints:
@@ -46,16 +46,18 @@ fn main() {
 
     // `Point`s aren't the only type that can be serialized to. Because `Point` members have the
     // same type, they can be also serialized into a map. Also, 
-    let deserialized_map: BTreeMap<String, i64> = json::from_str(&serialized_point).unwrap();
+    let deserialized_map: BTreeMap<String, i64> =
+        serde_json::from_str(&serialized_point).unwrap();
 
     println!("{:?}", deserialized_map);
     // prints:
     //
     // {"x": 5, "y": 6}
 
-    // If you need to accept arbitrary data, you can also deserialize into `json::Value`, which
-    // can represent all JSON values.
-    let deserialized_value: json::Value = json::from_str(&serialized_point).unwrap();
+    // If you need to accept arbitrary data, you can also deserialize into `serde_json::Value`,
+    // which can represent all JSON values.
+    let deserialized_value: serde_json::Value =
+        serde_json::from_str(&serialized_point).unwrap();
 
     println!("{:?}", deserialized_value);
     // prints:

--- a/serde_macros/tests/test.rs
+++ b/serde_macros/tests/test.rs
@@ -2,6 +2,7 @@
 #![plugin(serde_macros)]
 
 extern crate serde;
+extern crate serde_json;
 extern crate test;
 
 include!("../../serde_tests/tests/test.rs.in");

--- a/serde_tests/Cargo.toml
+++ b/serde_tests/Cargo.toml
@@ -19,6 +19,7 @@ serde_codegen = { version = "*", path = "../serde_codegen", features = ["with-sy
 num = "*"
 rustc-serialize = "*"
 serde = { version = "*", path = "../serde" }
+serde_json = { version = "*", path = "../serde_json" }
 syntex = "*"
 
 [[test]]

--- a/serde_tests/Cargo.toml
+++ b/serde_tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_tests"
-version = "0.4.3"
+version = "0.5.0"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "A generic serialization/deserialization framework"

--- a/serde_tests/benches/bench.rs
+++ b/serde_tests/benches/bench.rs
@@ -3,6 +3,7 @@
 extern crate num;
 extern crate rustc_serialize;
 extern crate serde;
+extern crate serde_json;
 extern crate test;
 
 include!(concat!(env!("OUT_DIR"), "/bench.rs"));

--- a/serde_tests/benches/bench_log.rs
+++ b/serde_tests/benches/bench_log.rs
@@ -5,9 +5,9 @@ use test::Bencher;
 use rustc_serialize;
 
 use serde::de::{self, Deserialize, Deserializer};
-use serde::json::ser::escape_str;
-use serde::json;
 use serde::ser::{self, Serialize, Serializer};
+use serde_json::ser::escape_str;
+use serde_json;
 use std::str::FromStr;
 
 use rustc_serialize::Encodable;
@@ -1123,18 +1123,18 @@ fn bench_encoder(b: &mut Bencher) {
 #[test]
 fn test_serializer() {
     let log = Log::new();
-    let json = json::to_vec(&log);
+    let json = serde_json::to_vec(&log);
     assert_eq!(json, JSON_STR.as_bytes());
 }
 
 #[bench]
 fn bench_serializer(b: &mut Bencher) {
     let log = Log::new();
-    let json = json::to_vec(&log);
+    let json = serde_json::to_vec(&log);
     b.bytes = json.len() as u64;
 
     b.iter(|| {
-        let _ = json::to_vec(&log);
+        let _ = serde_json::to_vec(&log);
     });
 }
 
@@ -1142,7 +1142,7 @@ fn bench_serializer(b: &mut Bencher) {
 fn test_serializer_vec() {
     let log = Log::new();
     let wr = Vec::with_capacity(1024);
-    let mut serializer = json::Serializer::new(wr);
+    let mut serializer = serde_json::Serializer::new(wr);
     log.serialize(&mut serializer).unwrap();
 
     let json = serializer.into_inner();
@@ -1152,7 +1152,7 @@ fn test_serializer_vec() {
 #[bench]
 fn bench_serializer_vec(b: &mut Bencher) {
     let log = Log::new();
-    let json = json::to_vec(&log);
+    let json = serde_json::to_vec(&log);
     b.bytes = json.len() as u64;
 
     let mut wr = Vec::with_capacity(1024);
@@ -1160,7 +1160,7 @@ fn bench_serializer_vec(b: &mut Bencher) {
     b.iter(|| {
         wr.clear();
 
-        let mut serializer = json::Serializer::new(wr.by_ref());
+        let mut serializer = serde_json::Serializer::new(wr.by_ref());
         log.serialize(&mut serializer).unwrap();
         let _json = serializer.into_inner();
     });
@@ -1169,7 +1169,7 @@ fn bench_serializer_vec(b: &mut Bencher) {
 #[bench]
 fn bench_serializer_slice(b: &mut Bencher) {
     let log = Log::new();
-    let json = json::to_vec(&log);
+    let json = serde_json::to_vec(&log);
     b.bytes = json.len() as u64;
 
     let mut buf = [0; 1024];
@@ -1178,7 +1178,7 @@ fn bench_serializer_slice(b: &mut Bencher) {
         for item in buf.iter_mut(){ *item = 0; }
         let mut wr = &mut buf[..];
 
-        let mut serializer = json::Serializer::new(wr.by_ref());
+        let mut serializer = serde_json::Serializer::new(wr.by_ref());
         log.serialize(&mut serializer).unwrap();
         let _json = serializer.into_inner();
     });
@@ -1191,7 +1191,7 @@ fn test_serializer_my_mem_writer0() {
     let mut wr = MyMemWriter0::with_capacity(1024);
 
     {
-        let mut serializer = json::Serializer::new(wr.by_ref());
+        let mut serializer = serde_json::Serializer::new(wr.by_ref());
         log.serialize(&mut serializer).unwrap();
         let _json = serializer.into_inner();
     }
@@ -1202,7 +1202,7 @@ fn test_serializer_my_mem_writer0() {
 #[bench]
 fn bench_serializer_my_mem_writer0(b: &mut Bencher) {
     let log = Log::new();
-    let json = json::to_vec(&log);
+    let json = serde_json::to_vec(&log);
     b.bytes = json.len() as u64;
 
     let mut wr = MyMemWriter0::with_capacity(1024);
@@ -1210,7 +1210,7 @@ fn bench_serializer_my_mem_writer0(b: &mut Bencher) {
     b.iter(|| {
         wr.buf.clear();
 
-        let mut serializer = json::Serializer::new(wr.by_ref());
+        let mut serializer = serde_json::Serializer::new(wr.by_ref());
         log.serialize(&mut serializer).unwrap();
         let _json = serializer.into_inner();
     });
@@ -1223,7 +1223,7 @@ fn test_serializer_my_mem_writer1() {
     let mut wr = MyMemWriter1::with_capacity(1024);
 
     {
-        let mut serializer = json::Serializer::new(wr.by_ref());
+        let mut serializer = serde_json::Serializer::new(wr.by_ref());
         log.serialize(&mut serializer).unwrap();
         let _json = serializer.into_inner();
     }
@@ -1234,7 +1234,7 @@ fn test_serializer_my_mem_writer1() {
 #[bench]
 fn bench_serializer_my_mem_writer1(b: &mut Bencher) {
     let log = Log::new();
-    let json = json::to_vec(&log);
+    let json = serde_json::to_vec(&log);
     b.bytes = json.len() as u64;
 
     let mut wr = MyMemWriter1::with_capacity(1024);
@@ -1242,7 +1242,7 @@ fn bench_serializer_my_mem_writer1(b: &mut Bencher) {
     b.iter(|| {
         wr.buf.clear();
 
-        let mut serializer = json::Serializer::new(wr.by_ref());
+        let mut serializer = serde_json::Serializer::new(wr.by_ref());
         log.serialize(&mut serializer).unwrap();
         let _json = serializer.into_inner();
     });
@@ -1593,6 +1593,6 @@ fn bench_deserializer(b: &mut Bencher) {
     b.bytes = JSON_STR.len() as u64;
 
     b.iter(|| {
-        let _log: Log = json::from_str(JSON_STR).unwrap();
+        let _log: Log = serde_json::from_str(JSON_STR).unwrap();
     });
 }

--- a/serde_tests/benches/bench_struct.rs
+++ b/serde_tests/benches/bench_struct.rs
@@ -398,7 +398,7 @@ mod deserializer {
             }
         }
 
-        fn visit_named_map<V>(&mut self, name: &str, mut visitor: V) -> Result<V::Value, Error>
+        fn visit_struct<V>(&mut self, name: &str, mut visitor: V) -> Result<V::Value, Error>
             where V: de::Visitor,
         {
             match self.stack.pop() {

--- a/serde_tests/benches/bench_struct.rs
+++ b/serde_tests/benches/bench_struct.rs
@@ -398,7 +398,10 @@ mod deserializer {
             }
         }
 
-        fn visit_struct<V>(&mut self, name: &str, mut visitor: V) -> Result<V::Value, Error>
+        fn visit_struct<V>(&mut self,
+                           name: &str,
+                           _fields: &'static [&'static str],
+                           mut visitor: V) -> Result<V::Value, Error>
             where V: de::Visitor,
         {
             match self.stack.pop() {

--- a/serde_tests/tests/test.rs
+++ b/serde_tests/tests/test.rs
@@ -1,3 +1,4 @@
 extern crate serde;
+extern crate serde_json;
 
 include!(concat!(env!("OUT_DIR"), "/test.rs"));

--- a/serde_tests/tests/test_annotations.rs
+++ b/serde_tests/tests/test_annotations.rs
@@ -1,4 +1,4 @@
-use serde::json;
+use serde_json;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 struct Default {
@@ -33,30 +33,30 @@ enum SerEnum<A> {
 
 #[test]
 fn test_default() {
-    let deserialized_value: Default = json::from_str(&"{\"a1\":1,\"a2\":2}").unwrap();
+    let deserialized_value: Default = serde_json::from_str(&"{\"a1\":1,\"a2\":2}").unwrap();
     assert_eq!(deserialized_value, Default { a1: 1, a2: 2 });
 
-    let deserialized_value: Default = json::from_str(&"{\"a1\":1}").unwrap();
+    let deserialized_value: Default = serde_json::from_str(&"{\"a1\":1}").unwrap();
     assert_eq!(deserialized_value, Default { a1: 1, a2: 0 });
 }
 
 #[test]
 fn test_rename() {
     let value = Rename { a1: 1, a2: 2 };
-    let serialized_value = json::to_string(&value).unwrap();
+    let serialized_value = serde_json::to_string(&value).unwrap();
     assert_eq!(serialized_value, "{\"a1\":1,\"a3\":2}");
 
-    let deserialized_value: Rename = json::from_str(&serialized_value).unwrap();
+    let deserialized_value: Rename = serde_json::from_str(&serialized_value).unwrap();
     assert_eq!(value, deserialized_value);
 }
 
 #[test]
 fn test_format_rename() {
     let value = FormatRename { a1: 1, a2: 2 };
-    let serialized_value = json::to_string(&value).unwrap();
+    let serialized_value = serde_json::to_string(&value).unwrap();
     assert_eq!(serialized_value, "{\"a1\":1,\"a5\":2}");
 
-    let deserialized_value = json::from_str("{\"a1\":1,\"a5\":2}").unwrap();
+    let deserialized_value = serde_json::from_str("{\"a1\":1,\"a5\":2}").unwrap();
     assert_eq!(value, deserialized_value);
 }
 
@@ -64,10 +64,10 @@ fn test_format_rename() {
 fn test_enum_format_rename() {
     let s1 = String::new();
     let value = SerEnum::Map { a: 0i8, b: s1 };
-    let serialized_value = json::to_string(&value).unwrap();
+    let serialized_value = serde_json::to_string(&value).unwrap();
     let ans = "{\"Map\":{\"a\":0,\"d\":\"\"}}";
     assert_eq!(serialized_value, ans);
 
-    let deserialized_value = json::from_str(ans).unwrap();
+    let deserialized_value = serde_json::from_str(ans).unwrap();
     assert_eq!(value, deserialized_value);
 }

--- a/serde_tests/tests/test_bytes.rs
+++ b/serde_tests/tests/test_bytes.rs
@@ -1,7 +1,7 @@
 use serde;
 use serde::Serialize;
 use serde::bytes::{ByteBuf, Bytes};
-use serde::json;
+use serde_json;
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -144,11 +144,11 @@ impl serde::Deserializer for BytesDeserializer {
 fn test_bytes_ser_json() {
     let buf = vec![];
     let bytes = Bytes::from(&buf);
-    assert_eq!(json::to_string(&bytes).unwrap(), "[]".to_string());
+    assert_eq!(serde_json::to_string(&bytes).unwrap(), "[]".to_string());
 
     let buf = vec![1, 2, 3];
     let bytes = Bytes::from(&buf);
-    assert_eq!(json::to_string(&bytes).unwrap(), "[1,2,3]".to_string());
+    assert_eq!(serde_json::to_string(&bytes).unwrap(), "[1,2,3]".to_string());
 }
 
 #[test]
@@ -167,10 +167,10 @@ fn test_bytes_ser_bytes() {
 #[test]
 fn test_byte_buf_ser_json() {
     let bytes = ByteBuf::new();
-    assert_eq!(json::to_string(&bytes).unwrap(), "[]".to_string());
+    assert_eq!(serde_json::to_string(&bytes).unwrap(), "[]".to_string());
 
     let bytes = ByteBuf::from(vec![1, 2, 3]);
-    assert_eq!(json::to_string(&bytes).unwrap(), "[1,2,3]".to_string());
+    assert_eq!(serde_json::to_string(&bytes).unwrap(), "[1,2,3]".to_string());
 }
 
 #[test]
@@ -189,11 +189,11 @@ fn test_byte_buf_ser_bytes() {
 #[test]
 fn test_byte_buf_de_json() {
     let bytes = ByteBuf::new();
-    let v: ByteBuf = json::from_str("[]").unwrap();
+    let v: ByteBuf = serde_json::from_str("[]").unwrap();
     assert_eq!(v, bytes);
 
     let bytes = ByteBuf::from(vec![1, 2, 3]);
-    let v: ByteBuf = json::from_str("[1, 2, 3]").unwrap();
+    let v: ByteBuf = serde_json::from_str("[1, 2, 3]").unwrap();
     assert_eq!(v, bytes);
 }
 

--- a/serde_tests/tests/test_de.rs
+++ b/serde_tests/tests/test_de.rs
@@ -491,6 +491,26 @@ declare_tests! {
             Token::I32(1),
         ],
     }
+    test_result {
+        Ok::<i32, i32>(0) => vec![
+            Token::EnumStart("Result"),
+                Token::Str("Ok"),
+                Token::SeqStart(1),
+                    Token::SeqSep,
+                    Token::I32(0),
+                Token::SeqEnd,
+            Token::EnumEnd,
+        ],
+        Err::<i32, i32>(1) => vec![
+            Token::EnumStart("Result"),
+                Token::Str("Err"),
+                Token::SeqStart(1),
+                    Token::SeqSep,
+                    Token::I32(1),
+                Token::SeqEnd,
+            Token::EnumEnd,
+        ],
+    }
     test_unit {
         () => vec![Token::Unit],
         () => vec![

--- a/serde_tests/tests/test_de.rs
+++ b/serde_tests/tests/test_de.rs
@@ -161,7 +161,7 @@ impl Deserializer for TokenDeserializer {
         }
     }
 
-    fn visit_named_unit<V>(&mut self, name: &str, visitor: V) -> Result<V::Value, Error>
+    fn visit_unit_struct<V>(&mut self, name: &str, visitor: V) -> Result<V::Value, Error>
         where V: de::Visitor,
     {
         match self.tokens.peek() {
@@ -178,7 +178,7 @@ impl Deserializer for TokenDeserializer {
         }
     }
 
-    fn visit_named_seq<V>(&mut self, name: &str, visitor: V) -> Result<V::Value, Error>
+    fn visit_tuple_struct<V>(&mut self, name: &str, visitor: V) -> Result<V::Value, Error>
         where V: de::Visitor,
     {
         match self.tokens.peek() {
@@ -195,7 +195,7 @@ impl Deserializer for TokenDeserializer {
         }
     }
 
-    fn visit_named_map<V>(&mut self, name: &str, visitor: V) -> Result<V::Value, Error>
+    fn visit_struct<V>(&mut self, name: &str, visitor: V) -> Result<V::Value, Error>
         where V: de::Visitor,
     {
         match self.tokens.peek() {
@@ -334,13 +334,13 @@ impl<'a> de::VariantVisitor for TokenDeserializerVariantVisitor<'a> {
 //////////////////////////////////////////////////////////////////////////
 
 #[derive(Copy, Clone, PartialEq, Debug, Deserialize)]
-struct NamedUnit;
+struct UnitStruct;
 
 #[derive(PartialEq, Debug, Deserialize)]
-struct NamedSeq(i32, i32, i32);
+struct TupleStruct(i32, i32, i32);
 
 #[derive(PartialEq, Debug, Deserialize)]
-struct NamedMap {
+struct Struct {
     a: i32,
     b: i32,
     c: i32,
@@ -498,19 +498,19 @@ declare_tests! {
             Token::SeqEnd,
         ],
     }
-    test_named_unit {
-        NamedUnit => vec![Token::Unit],
-        NamedUnit => vec![
-            Token::Name("NamedUnit"),
+    test_unit_struct {
+        UnitStruct => vec![Token::Unit],
+        UnitStruct => vec![
+            Token::Name("UnitStruct"),
             Token::Unit,
         ],
-        NamedUnit => vec![
+        UnitStruct => vec![
             Token::SeqStart(0),
             Token::SeqEnd,
         ],
     }
-    test_named_seq {
-        NamedSeq(1, 2, 3) => vec![
+    test_tuple_struct {
+        TupleStruct(1, 2, 3) => vec![
             Token::SeqStart(3),
                 Token::SeqSep,
                 Token::I32(1),
@@ -522,8 +522,8 @@ declare_tests! {
                 Token::I32(3),
             Token::SeqEnd,
         ],
-        NamedSeq(1, 2, 3) => vec![
-            Token::Name("NamedSeq"),
+        TupleStruct(1, 2, 3) => vec![
+            Token::Name("TupleStruct"),
             Token::SeqStart(3),
                 Token::SeqSep,
                 Token::I32(1),
@@ -818,8 +818,8 @@ declare_tests! {
             Token::MapEnd,
         ],
     }
-    test_named_map {
-        NamedMap { a: 1, b: 2, c: 3 } => vec![
+    test_struct {
+        Struct { a: 1, b: 2, c: 3 } => vec![
             Token::MapStart(3),
                 Token::MapSep,
                 Token::Str("a"),
@@ -834,8 +834,8 @@ declare_tests! {
                 Token::I32(3),
             Token::MapEnd,
         ],
-        NamedMap { a: 1, b: 2, c: 3 } => vec![
-            Token::Name("NamedMap"),
+        Struct { a: 1, b: 2, c: 3 } => vec![
+            Token::Name("Struct"),
             Token::MapStart(3),
                 Token::MapSep,
                 Token::Str("a"),

--- a/serde_tests/tests/test_de.rs
+++ b/serde_tests/tests/test_de.rs
@@ -195,7 +195,10 @@ impl Deserializer for TokenDeserializer {
         }
     }
 
-    fn visit_struct<V>(&mut self, name: &str, visitor: V) -> Result<V::Value, Error>
+    fn visit_struct<V>(&mut self,
+                       name: &str,
+                       _fields: &'static [&'static str],
+                       visitor: V) -> Result<V::Value, Error>
         where V: de::Visitor,
     {
         match self.tokens.peek() {
@@ -324,7 +327,9 @@ impl<'a> de::VariantVisitor for TokenDeserializerVariantVisitor<'a> {
         de::Deserializer::visit(self.de, visitor)
     }
 
-    fn visit_map<V>(&mut self, visitor: V) -> Result<V::Value, Error>
+    fn visit_map<V>(&mut self,
+                    _fields: &'static [&'static str],
+                    visitor: V) -> Result<V::Value, Error>
         where V: de::Visitor,
     {
         de::Deserializer::visit(self.de, visitor)

--- a/serde_tests/tests/test_json.rs
+++ b/serde_tests/tests/test_json.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 use serde::de;
 use serde::ser;
 
-use serde::json::{
+use serde_json::{
     self,
     Value,
     from_str,
@@ -12,7 +12,7 @@ use serde::json::{
     to_value,
 };
 
-use serde::json::error::{Error, ErrorCode};
+use serde_json::error::{Error, ErrorCode};
 
 macro_rules! treemap {
     ($($k:expr => $v:expr),*) => ({
@@ -48,11 +48,11 @@ fn test_encode_ok<T>(errors: &[(T, &str)])
     for &(ref value, out) in errors {
         let out = out.to_string();
 
-        let s = json::to_string(value).unwrap();
+        let s = serde_json::to_string(value).unwrap();
         assert_eq!(s, out);
 
         let v = to_value(&value);
-        let s = json::to_string(&v).unwrap();
+        let s = serde_json::to_string(&v).unwrap();
         assert_eq!(s, out);
     }
 }
@@ -63,11 +63,11 @@ fn test_pretty_encode_ok<T>(errors: &[(T, &str)])
     for &(ref value, out) in errors {
         let out = out.to_string();
 
-        let s = json::to_string_pretty(value).unwrap();
+        let s = serde_json::to_string_pretty(value).unwrap();
         assert_eq!(s, out);
 
         let v = to_value(&value);
-        let s = json::to_string_pretty(&v).unwrap();
+        let s = serde_json::to_string_pretty(&v).unwrap();
         assert_eq!(s, out);
     }
 }
@@ -1080,7 +1080,7 @@ fn test_missing_fmt_renamed_field() {
 
 #[test]
 fn test_find_path() {
-    let obj: Value = json::from_str(r#"{"x": {"a": 1}, "y": 2}"#).unwrap();
+    let obj: Value = serde_json::from_str(r#"{"x": {"a": 1}, "y": 2}"#).unwrap();
 
     assert!(obj.find_path(&["x", "a"]).unwrap() == &Value::U64(1));
     assert!(obj.find_path(&["y"]).unwrap() == &Value::U64(2));
@@ -1089,7 +1089,7 @@ fn test_find_path() {
 
 #[test]
 fn test_lookup() {
-    let obj: Value = json::from_str(r#"{"x": {"a": 1}, "y": 2}"#).unwrap();
+    let obj: Value = serde_json::from_str(r#"{"x": {"a": 1}, "y": 2}"#).unwrap();
 
     assert!(obj.lookup("x.a").unwrap() == &Value::U64(1));
     assert!(obj.lookup("y").unwrap() == &Value::U64(2));

--- a/serde_tests/tests/test_json.rs
+++ b/serde_tests/tests/test_json.rs
@@ -1,5 +1,6 @@
-use std::fmt::Debug;
 use std::collections::BTreeMap;
+use std::fmt::Debug;
+use std::marker::PhantomData;
 
 use serde::de;
 use serde::ser;
@@ -1094,4 +1095,175 @@ fn test_lookup() {
     assert!(obj.lookup("x.a").unwrap() == &Value::U64(1));
     assert!(obj.lookup("y").unwrap() == &Value::U64(2));
     assert!(obj.lookup("z").is_none());
+}
+
+#[test]
+fn test_serialize_seq_with_no_len() {
+    #[derive(Clone, Debug, PartialEq)]
+    struct MyVec<T>(Vec<T>);
+
+    impl<T> ser::Serialize for MyVec<T>
+        where T: ser::Serialize,
+    {
+        #[inline]
+        fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
+            where S: ser::Serializer,
+        {
+            serializer.visit_seq(ser::impls::SeqIteratorVisitor::new(self.0.iter(), None))
+        }
+    }
+
+    struct Visitor<T> {
+        marker: PhantomData<MyVec<T>>,
+    }
+
+    impl<T> de::Visitor for Visitor<T>
+        where T: de::Deserialize,
+    {
+        type Value = MyVec<T>;
+
+        #[inline]
+        fn visit_unit<E>(&mut self) -> Result<MyVec<T>, E>
+            where E: de::Error,
+        {
+            Ok(MyVec(Vec::new()))
+        }
+
+        #[inline]
+        fn visit_seq<V>(&mut self, mut visitor: V) -> Result<MyVec<T>, V::Error>
+            where V: de::SeqVisitor,
+        {
+            let mut values = Vec::new();
+
+            while let Some(value) = try!(visitor.visit()) {
+                values.push(value);
+            }
+
+            try!(visitor.end());
+
+            Ok(MyVec(values))
+        }
+    }
+
+    impl<T> de::Deserialize for MyVec<T>
+        where T: de::Deserialize,
+    {
+        fn deserialize<D>(deserializer: &mut D) -> Result<MyVec<T>, D::Error>
+            where D: de::Deserializer,
+        {
+            deserializer.visit_map(Visitor { marker: PhantomData })
+        }
+    }
+
+    let mut vec = Vec::new();
+    vec.push(MyVec(Vec::new()));
+    vec.push(MyVec(Vec::new()));
+    let vec: MyVec<MyVec<u32>> = MyVec(vec);
+
+    test_encode_ok(&[
+        (
+            vec.clone(),
+            "[[],[]]",
+        ),
+    ]);
+
+    let s = serde_json::to_string_pretty(&vec).unwrap();
+    assert_eq!(
+        s,
+        concat!(
+            "[\n",
+            "  [\n",
+            "  ],\n",
+            "  [\n",
+            "  ]\n",
+            "]"
+        )
+    );
+}
+
+#[test]
+fn test_serialize_map_with_no_len() {
+    #[derive(Clone, Debug, PartialEq)]
+    struct Map<K, V>(BTreeMap<K, V>);
+
+    impl<K, V> ser::Serialize for Map<K, V>
+        where K: ser::Serialize + Ord,
+              V: ser::Serialize,
+    {
+        #[inline]
+        fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
+            where S: ser::Serializer,
+        {
+            serializer.visit_map(ser::impls::MapIteratorVisitor::new(self.0.iter(), None))
+        }
+    }
+
+    struct Visitor<K, V> {
+        marker: PhantomData<Map<K, V>>,
+    }
+
+    impl<K, V> de::Visitor for Visitor<K, V>
+        where K: de::Deserialize + Eq + Ord,
+              V: de::Deserialize,
+    {
+        type Value = Map<K, V>;
+
+        #[inline]
+        fn visit_unit<E>(&mut self) -> Result<Map<K, V>, E>
+            where E: de::Error,
+        {
+            Ok(Map(BTreeMap::new()))
+        }
+
+        #[inline]
+        fn visit_map<Visitor>(&mut self, mut visitor: Visitor) -> Result<Map<K, V>, Visitor::Error>
+            where Visitor: de::MapVisitor,
+        {
+            let mut values = BTreeMap::new();
+
+            while let Some((key, value)) = try!(visitor.visit()) {
+                values.insert(key, value);
+            }
+
+            try!(visitor.end());
+
+            Ok(Map(values))
+        }
+    }
+
+    impl<K, V> de::Deserialize for Map<K, V>
+        where K: de::Deserialize + Eq + Ord,
+              V: de::Deserialize,
+    {
+        fn deserialize<D>(deserializer: &mut D) -> Result<Map<K, V>, D::Error>
+            where D: de::Deserializer,
+        {
+            deserializer.visit_map(Visitor { marker: PhantomData })
+        }
+    }
+
+    let mut map = BTreeMap::new();
+    map.insert("a", Map(BTreeMap::new()));
+    map.insert("b", Map(BTreeMap::new()));
+    let map: Map<_, Map<u32, u32>> = Map(map);
+
+    test_encode_ok(&[
+        (
+            map.clone(),
+            "{\"a\":{},\"b\":{}}",
+        ),
+    ]);
+
+    let s = serde_json::to_string_pretty(&map).unwrap();
+    assert_eq!(
+        s,
+        concat!(
+            "{\n",
+            "  \"a\": {\n",
+            "  },\n",
+            "  \"b\": {\n",
+            "  }\n",
+            "}"
+        )
+    );
 }

--- a/serde_tests/tests/test_json.rs
+++ b/serde_tests/tests/test_json.rs
@@ -891,7 +891,7 @@ fn test_parse_struct() {
                     Inner { a: (), b: 2, c: vec!["abc".to_string(), "xyz".to_string()] }
                 ]
             },
-        )
+        ),
     ]);
 
     let v: Outer = from_str("{}").unwrap();
@@ -900,6 +900,22 @@ fn test_parse_struct() {
         v,
         Outer {
             inner: vec![],
+        }
+    );
+
+    let v: Outer = from_str(
+        "[
+            [
+                [ null, 2, [\"abc\", \"xyz\"] ]
+            ]
+        ]").unwrap();
+
+    assert_eq!(
+        v,
+        Outer {
+            inner: vec![
+                Inner { a: (), b: 2, c: vec!["abc".to_string(), "xyz".to_string()] }
+            ],
         }
     );
 }
@@ -934,7 +950,7 @@ fn test_parse_enum_errors() {
         ("{\"unknown\":[]}", Error::SyntaxError(ErrorCode::UnknownField("unknown".to_string()), 1, 11)),
         ("{\"Dog\":{}}", Error::SyntaxError(ErrorCode::ExpectedSomeValue, 1, 9)),
         ("{\"Frog\":{}}", Error::SyntaxError(ErrorCode::ExpectedSomeValue, 1, 10)),
-        ("{\"Cat\":[]}", Error::SyntaxError(ErrorCode::ExpectedSomeValue, 1, 9)),
+        ("{\"Cat\":[]}", Error::SyntaxError(ErrorCode::EOFWhileParsingValue, 1, 9)),
     ]);
 }
 

--- a/serde_tests/tests/test_json_builder.rs
+++ b/serde_tests/tests/test_json_builder.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
-use serde::json::value::Value;
-use serde::json::builder::{ArrayBuilder, ObjectBuilder};
+use serde_json::value::Value;
+use serde_json::builder::{ArrayBuilder, ObjectBuilder};
 
 #[test]
 fn test_array_builder() {

--- a/serde_tests/tests/test_macros.rs
+++ b/serde_tests/tests/test_macros.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use serde::json::{self, Value};
+use serde_json::{self, Value};
 
 macro_rules! btreemap {
     () => {
@@ -136,19 +136,19 @@ fn test_named_unit() {
     let named_unit = NamedUnit;
 
     assert_eq!(
-        json::to_string(&named_unit).unwrap(),
+        serde_json::to_string(&named_unit).unwrap(),
         "null".to_string()
     );
 
     assert_eq!(
-        json::to_value(&named_unit),
+        serde_json::to_value(&named_unit),
         Value::Null
     );
 
-    let v: NamedUnit = json::from_str("null").unwrap();
+    let v: NamedUnit = serde_json::from_str("null").unwrap();
     assert_eq!(v, named_unit);
 
-    let v: NamedUnit = json::from_value(Value::Null).unwrap();
+    let v: NamedUnit = serde_json::from_value(Value::Null).unwrap();
     assert_eq!(v, named_unit);
 }
 
@@ -160,25 +160,25 @@ fn test_ser_named_tuple() {
     let named_tuple = SerNamedTuple(&a, &mut b, c);
 
     assert_eq!(
-        json::to_string(&named_tuple).unwrap(),
+        serde_json::to_string(&named_tuple).unwrap(),
         "[5,6,7]"
     );
 
     assert_eq!(
-        json::to_value(&named_tuple),
+        serde_json::to_value(&named_tuple),
         Value::Array(vec![Value::U64(5), Value::U64(6), Value::U64(7)])
     );
 }
 
 #[test]
 fn test_de_named_tuple() {
-    let v: DeNamedTuple<i32, i32, i32> = json::from_str("[1,2,3]").unwrap();
+    let v: DeNamedTuple<i32, i32, i32> = serde_json::from_str("[1,2,3]").unwrap();
     assert_eq!(
         v,
         DeNamedTuple(1, 2, 3)
     );
 
-    let v: Value = json::from_str("[1,2,3]").unwrap();
+    let v: Value = serde_json::from_str("[1,2,3]").unwrap();
     assert_eq!(
         v,
         Value::Array(vec![
@@ -201,12 +201,12 @@ fn test_ser_named_map() {
     };
 
     assert_eq!(
-        json::to_string(&named_map).unwrap(),
+        serde_json::to_string(&named_map).unwrap(),
         "{\"a\":5,\"b\":6,\"c\":7}"
     );
 
     assert_eq!(
-        json::to_value(&named_map),
+        serde_json::to_value(&named_map),
         Value::Object(btreemap![
             "a".to_string() => Value::U64(5),
             "b".to_string() => Value::U64(6),
@@ -223,12 +223,12 @@ fn test_de_named_map() {
         c: 7,
     };
 
-    let v2: DeNamedMap<i32, i32, i32> = json::from_str(
+    let v2: DeNamedMap<i32, i32, i32> = serde_json::from_str(
         "{\"a\":5,\"b\":6,\"c\":7}"
     ).unwrap();
     assert_eq!(v, v2);
 
-    let v2 = json::from_value(Value::Object(btreemap![
+    let v2 = serde_json::from_value(Value::Object(btreemap![
         "a".to_string() => Value::U64(5),
         "b".to_string() => Value::U64(6),
         "c".to_string() => Value::U64(7)
@@ -239,12 +239,12 @@ fn test_de_named_map() {
 #[test]
 fn test_ser_enum_unit() {
     assert_eq!(
-        json::to_string(&SerEnum::Unit::<u32, u32, u32>).unwrap(),
+        serde_json::to_string(&SerEnum::Unit::<u32, u32, u32>).unwrap(),
         "{\"Unit\":[]}"
     );
 
     assert_eq!(
-        json::to_value(&SerEnum::Unit::<u32, u32, u32>),
+        serde_json::to_value(&SerEnum::Unit::<u32, u32, u32>),
         Value::Object(btreemap!(
             "Unit".to_string() => Value::Array(vec![]))
         )
@@ -261,7 +261,7 @@ fn test_ser_enum_seq() {
     //let f = 6;
 
     assert_eq!(
-        json::to_string(&SerEnum::Seq(
+        serde_json::to_string(&SerEnum::Seq(
             a,
             b,
             &c,
@@ -273,7 +273,7 @@ fn test_ser_enum_seq() {
     );
 
     assert_eq!(
-        json::to_value(&SerEnum::Seq(
+        serde_json::to_value(&SerEnum::Seq(
             a,
             b,
             &c,
@@ -304,7 +304,7 @@ fn test_ser_enum_map() {
     //let f = 6;
 
     assert_eq!(
-        json::to_string(&SerEnum::Map {
+        serde_json::to_string(&SerEnum::Map {
             a: a,
             b: b,
             c: &c,
@@ -316,7 +316,7 @@ fn test_ser_enum_map() {
     );
 
     assert_eq!(
-        json::to_value(&SerEnum::Map {
+        serde_json::to_value(&SerEnum::Map {
             a: a,
             b: b,
             c: &c,
@@ -339,13 +339,13 @@ fn test_ser_enum_map() {
 
 #[test]
 fn test_de_enum_unit() {
-    let v: DeEnum<_, _, _> = json::from_str("{\"Unit\":[]}").unwrap();
+    let v: DeEnum<_, _, _> = serde_json::from_str("{\"Unit\":[]}").unwrap();
     assert_eq!(
         v,
         DeEnum::Unit::<u32, u32, u32>
     );
 
-    let v: DeEnum<_, _, _> = json::from_value(Value::Object(btreemap!(
+    let v: DeEnum<_, _, _> = serde_json::from_value(Value::Object(btreemap!(
         "Unit".to_string() => Value::Array(vec![]))
     )).unwrap();
     assert_eq!(
@@ -363,7 +363,7 @@ fn test_de_enum_seq() {
     let e = 5;
     //let f = 6;
 
-    let v: DeEnum<_, _, _> = json::from_str("{\"Seq\":[1,2,3,5]}").unwrap();
+    let v: DeEnum<_, _, _> = serde_json::from_str("{\"Seq\":[1,2,3,5]}").unwrap();
     assert_eq!(
         v,
         DeEnum::Seq(
@@ -376,7 +376,7 @@ fn test_de_enum_seq() {
         )
     );
 
-    let v: DeEnum<_, _, _> = json::from_value(Value::Object(btreemap!(
+    let v: DeEnum<_, _, _> = serde_json::from_value(Value::Object(btreemap!(
         "Seq".to_string() => Value::Array(vec![
             Value::U64(1),
             Value::U64(2),
@@ -408,7 +408,7 @@ fn test_de_enum_map() {
     let e = 5;
     //let f = 6;
 
-    let v: DeEnum<_, _, _> = json::from_str(
+    let v: DeEnum<_, _, _> = serde_json::from_str(
         "{\"Map\":{\"a\":1,\"b\":2,\"c\":3,\"e\":5}}"
     ).unwrap();
     assert_eq!(
@@ -423,7 +423,7 @@ fn test_de_enum_map() {
         }
     );
 
-    let v: DeEnum<_, _, _> = json::from_value(Value::Object(btreemap!(
+    let v: DeEnum<_, _, _> = serde_json::from_value(Value::Object(btreemap!(
         "Map".to_string() => Value::Object(btreemap![
             "a".to_string() => Value::U64(1),
             "b".to_string() => Value::U64(2),
@@ -452,26 +452,26 @@ fn test_lifetimes() {
     let value = 5;
     let lifetime = Lifetimes::LifetimeSeq(&value);
     assert_eq!(
-        json::to_string(&lifetime).unwrap(),
+        serde_json::to_string(&lifetime).unwrap(),
         "{\"LifetimeSeq\":[5]}"
     );
 
     let lifetime = Lifetimes::NoLifetimeSeq(5);
     assert_eq!(
-        json::to_string(&lifetime).unwrap(),
+        serde_json::to_string(&lifetime).unwrap(),
         "{\"NoLifetimeSeq\":[5]}"
     );
 
     let value = 5;
     let lifetime = Lifetimes::LifetimeMap { a: &value };
     assert_eq!(
-        json::to_string(&lifetime).unwrap(),
+        serde_json::to_string(&lifetime).unwrap(),
         "{\"LifetimeMap\":{\"a\":5}}"
     );
 
     let lifetime = Lifetimes::NoLifetimeMap { a: 5 };
     assert_eq!(
-        json::to_string(&lifetime).unwrap(),
+        serde_json::to_string(&lifetime).unwrap(),
         "{\"NoLifetimeMap\":{\"a\":5}}"
     );
 }

--- a/serde_tests/tests/test_ser.rs
+++ b/serde_tests/tests/test_ser.rs
@@ -24,17 +24,17 @@ pub enum Token<'a> {
     Option(bool),
 
     Unit,
-    NamedUnit(&'a str),
+    UnitStruct(&'a str),
     EnumUnit(&'a str, &'a str),
 
     SeqStart(Option<usize>),
-    NamedSeqStart(&'a str, Option<usize>),
+    TupleStructStart(&'a str, Option<usize>),
     EnumSeqStart(&'a str, &'a str, Option<usize>),
     SeqSep,
     SeqEnd,
 
     MapStart(Option<usize>),
-    NamedMapStart(&'a str, Option<usize>),
+    StructStart(&'a str, Option<usize>),
     EnumMapStart(&'a str, &'a str, Option<usize>),
     MapSep,
     MapEnd,
@@ -80,8 +80,8 @@ impl<'a> Serializer for AssertSerializer<'a> {
         Ok(())
     }
 
-    fn visit_named_unit(&mut self, name: &str) -> Result<(), ()> {
-        assert_eq!(self.iter.next().unwrap(), Token::NamedUnit(name));
+    fn visit_unit_struct(&mut self, name: &str) -> Result<(), ()> {
+        assert_eq!(self.iter.next().unwrap(), Token::UnitStruct(name));
         Ok(())
     }
 
@@ -188,12 +188,12 @@ impl<'a> Serializer for AssertSerializer<'a> {
         self.visit_sequence(visitor)
     }
 
-    fn visit_named_seq<V>(&mut self, name: &str, visitor: V) -> Result<(), ()>
+    fn visit_tuple_struct<V>(&mut self, name: &str, visitor: V) -> Result<(), ()>
         where V: SeqVisitor
     {
         let len = visitor.len();
 
-        assert_eq!(self.iter.next().unwrap(), Token::NamedSeqStart(name, len));
+        assert_eq!(self.iter.next().unwrap(), Token::TupleStructStart(name, len));
 
         self.visit_sequence(visitor)
     }
@@ -228,12 +228,12 @@ impl<'a> Serializer for AssertSerializer<'a> {
         self.visit_mapping(visitor)
     }
 
-    fn visit_named_map<V>(&mut self, name: &str, visitor: V) -> Result<(), ()>
+    fn visit_struct<V>(&mut self, name: &str, visitor: V) -> Result<(), ()>
         where V: MapVisitor
     {
         let len = visitor.len();
 
-        assert_eq!(self.iter.next().unwrap(), Token::NamedMapStart(name, len));
+        assert_eq!(self.iter.next().unwrap(), Token::StructStart(name, len));
 
         self.visit_mapping(visitor)
     }
@@ -262,13 +262,13 @@ impl<'a> Serializer for AssertSerializer<'a> {
 //////////////////////////////////////////////////////////////////////////
 
 #[derive(Serialize)]
-struct NamedUnit;
+struct UnitStruct;
 
 #[derive(Serialize)]
-struct NamedSeq(i32, i32, i32);
+struct TupleStruct(i32, i32, i32);
 
 #[derive(Serialize)]
-struct NamedMap {
+struct Struct {
     a: i32,
     b: i32,
     c: i32,
@@ -480,12 +480,12 @@ declare_tests! {
             Token::MapEnd,
         ],
     }
-    test_named_unit {
-        NamedUnit => vec![Token::NamedUnit("NamedUnit")],
+    test_unit_struct {
+        UnitStruct => vec![Token::UnitStruct("UnitStruct")],
     }
-    test_named_seq {
-        NamedSeq(1, 2, 3) => vec![
-            Token::NamedSeqStart("NamedSeq", Some(3)),
+    test_tuple_struct {
+        TupleStruct(1, 2, 3) => vec![
+            Token::TupleStructStart("TupleStruct", Some(3)),
                 Token::SeqSep,
                 Token::I32(1),
 
@@ -497,9 +497,9 @@ declare_tests! {
             Token::SeqEnd,
         ],
     }
-    test_named_map {
-        NamedMap { a: 1, b: 2, c: 3 } => vec![
-            Token::NamedMapStart("NamedMap", Some(3)),
+    test_struct {
+        Struct { a: 1, b: 2, c: 3 } => vec![
+            Token::StructStart("Struct", Some(3)),
                 Token::MapSep,
                 Token::Str("a"),
                 Token::I32(1),

--- a/serde_tests/tests/test_ser.rs
+++ b/serde_tests/tests/test_ser.rs
@@ -380,6 +380,20 @@ declare_tests! {
             Token::I32(1),
         ],
     }
+    test_result {
+        Ok::<i32, i32>(0) => vec![
+            Token::EnumSeqStart("Result", "Ok", Some(1)),
+            Token::SeqSep,
+            Token::I32(0),
+            Token::SeqEnd,
+        ],
+        Err::<i32, i32>(1) => vec![
+            Token::EnumSeqStart("Result", "Err", Some(1)),
+            Token::SeqSep,
+            Token::I32(1),
+            Token::SeqEnd,
+        ],
+    }
     test_slice {
         &[0][..0] => vec![
             Token::SeqStart(Some(0)),

--- a/serde_tests/tests/test_ser.rs
+++ b/serde_tests/tests/test_ser.rs
@@ -85,7 +85,10 @@ impl<'a> Serializer for AssertSerializer<'a> {
         Ok(())
     }
 
-    fn visit_enum_unit(&mut self, name: &str, variant: &str) -> Result<(), ()> {
+    fn visit_enum_unit(&mut self,
+                       name: &str,
+                       _variant_index: usize,
+                       variant: &str) -> Result<(), ()> {
         assert_eq!(self.iter.next().unwrap(), Token::EnumUnit(name, variant));
         Ok(())
     }
@@ -200,6 +203,7 @@ impl<'a> Serializer for AssertSerializer<'a> {
 
     fn visit_enum_seq<V>(&mut self,
                          name: &str,
+                         _variant_index: usize,
                          variant: &str,
                          visitor: V) -> Result<(), ()>
         where V: SeqVisitor
@@ -238,7 +242,11 @@ impl<'a> Serializer for AssertSerializer<'a> {
         self.visit_mapping(visitor)
     }
 
-    fn visit_enum_map<V>(&mut self, name: &str, variant: &str, visitor: V) -> Result<(), ()>
+    fn visit_enum_map<V>(&mut self,
+                         name: &str,
+                         _variant_index: usize,
+                         variant: &str,
+                         visitor: V) -> Result<(), ()>
         where V: MapVisitor
     {
         let len = visitor.len();

--- a/serde_tests/tests/test_ser.rs
+++ b/serde_tests/tests/test_ser.rs
@@ -89,7 +89,11 @@ impl<'a> Serializer for AssertSerializer<'a> {
                        name: &str,
                        _variant_index: usize,
                        variant: &str) -> Result<(), ()> {
-        assert_eq!(self.iter.next().unwrap(), Token::EnumUnit(name, variant));
+        assert_eq!(
+            self.iter.next().unwrap(),
+            Token::EnumUnit(name, variant)
+        );
+
         Ok(())
     }
 
@@ -196,7 +200,10 @@ impl<'a> Serializer for AssertSerializer<'a> {
     {
         let len = visitor.len();
 
-        assert_eq!(self.iter.next().unwrap(), Token::TupleStructStart(name, len));
+        assert_eq!(
+            self.iter.next().unwrap(),
+            Token::TupleStructStart(name, len)
+        );
 
         self.visit_sequence(visitor)
     }
@@ -210,7 +217,10 @@ impl<'a> Serializer for AssertSerializer<'a> {
     {
         let len = visitor.len();
 
-        assert_eq!(self.iter.next().unwrap(), Token::EnumSeqStart(name, variant, len));
+        assert_eq!(
+            self.iter.next().unwrap(),
+            Token::EnumSeqStart(name, variant, len)
+        );
 
         self.visit_sequence(visitor)
     }
@@ -237,7 +247,10 @@ impl<'a> Serializer for AssertSerializer<'a> {
     {
         let len = visitor.len();
 
-        assert_eq!(self.iter.next().unwrap(), Token::StructStart(name, len));
+        assert_eq!(
+            self.iter.next().unwrap(),
+            Token::StructStart(name, len)
+        );
 
         self.visit_mapping(visitor)
     }
@@ -251,7 +264,10 @@ impl<'a> Serializer for AssertSerializer<'a> {
     {
         let len = visitor.len();
 
-        assert_eq!(self.iter.next().unwrap(), Token::EnumMapStart(name, variant, len));
+        assert_eq!(
+            self.iter.next().unwrap(),
+            Token::EnumMapStart(name, variant, len)
+        );
 
         self.visit_mapping(visitor)
     }


### PR DESCRIPTION
This is a series of breaking changes in order to better support formats like bincode:

* Bump version number to 0.5.0
* Renames methods like `visit_named_{map,seq}` to `visit_{struct,tuple,tuple_struct}`. This better reflects how their used.
* Passes the struct fields names to the deserializer.
* Allow structs to be deserialized from sequences.
* Added constructor to tuple deserializer visitor
* Moved json into it's own crate
* Other minor cleanup

Closes #110

cc @pcwalton