### PR TITLE
Add enum fields and tuple length to deserialization visitor methods, renamed some more methods

### DIFF
--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -565,7 +565,7 @@ array_impls! {
 
 macro_rules! tuple_impls {
     () => {};
-    ($($visitor:ident => ($($name:ident),+),)+) => {
+    ($($len:expr => $visitor:ident => ($($name:ident),+),)+) => {
         $(
             pub struct $visitor<$($name,)+> {
                 marker: PhantomData<($($name,)+)>,
@@ -610,7 +610,7 @@ macro_rules! tuple_impls {
                 fn deserialize<D>(deserializer: &mut D) -> Result<($($name,)+), D::Error>
                     where D: Deserializer,
                 {
-                    deserializer.visit_tuple($visitor::new())
+                    deserializer.visit_tuple($len, $visitor::new())
                 }
             }
         )+
@@ -618,18 +618,18 @@ macro_rules! tuple_impls {
 }
 
 tuple_impls! {
-    TupleVisitor1 => (T0),
-    TupleVisitor2 => (T0, T1),
-    TupleVisitor3 => (T0, T1, T2),
-    TupleVisitor4 => (T0, T1, T2, T3),
-    TupleVisitor5 => (T0, T1, T2, T3, T4),
-    TupleVisitor6 => (T0, T1, T2, T3, T4, T5),
-    TupleVisitor7 => (T0, T1, T2, T3, T4, T5, T6),
-    TupleVisitor8 => (T0, T1, T2, T3, T4, T5, T6, T7),
-    TupleVisitor9 => (T0, T1, T2, T3, T4, T5, T6, T7, T8),
-    TupleVisitor10 => (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9),
-    TupleVisitor11 => (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10),
-    TupleVisitor12 => (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11),
+    1 => TupleVisitor1 => (T0),
+    2 => TupleVisitor2 => (T0, T1),
+    3 => TupleVisitor3 => (T0, T1, T2),
+    4 => TupleVisitor4 => (T0, T1, T2, T3),
+    5 => TupleVisitor5 => (T0, T1, T2, T3, T4),
+    6 => TupleVisitor6 => (T0, T1, T2, T3, T4, T5),
+    7 => TupleVisitor7 => (T0, T1, T2, T3, T4, T5, T6),
+    8 => TupleVisitor8 => (T0, T1, T2, T3, T4, T5, T6, T7),
+    9 => TupleVisitor9 => (T0, T1, T2, T3, T4, T5, T6, T7, T8),
+    10 => TupleVisitor10 => (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9),
+    11 => TupleVisitor11 => (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10),
+    12 => TupleVisitor12 => (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11),
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -916,17 +916,19 @@ impl<T, E> Deserialize for Result<T, E> where T: Deserialize, E: Deserialize {
             {
                 match try!(visitor.visit_variant()) {
                     Field::Ok => {
-                        let (value,) = try!(visitor.visit_seq(TupleVisitor1::new()));
+                        let (value,) = try!(visitor.visit_seq(1, TupleVisitor1::new()));
                         Ok(Ok(value))
                     }
                     Field::Err => {
-                        let (value,) = try!(visitor.visit_seq(TupleVisitor1::new()));
+                        let (value,) = try!(visitor.visit_seq(1, TupleVisitor1::new()));
                         Ok(Err(value))
                     }
                 }
             }
         }
 
-        deserializer.visit_enum("Result", Visitor(PhantomData))
+        const VARIANTS: &'static [&'static str] = &["Ok", "Err"];
+
+        deserializer.visit_enum("Result", VARIANTS, Visitor(PhantomData))
     }
 }

--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -877,6 +877,14 @@ impl<T, E> Deserialize for Result<T, E> where T: Deserialize, E: Deserialize {
                 impl ::de::Visitor for FieldVisitor {
                     type Value = Field;
 
+                    fn visit_usize<E>(&mut self, value: usize) -> Result<Field, E> where E: Error {
+                        match value {
+                            0 => Ok(Field::Ok),
+                            1 => Ok(Field::Err),
+                            _ => Err(Error::unknown_field_error(&value.to_string())),
+                        }
+                    }
+
                     fn visit_str<E>(&mut self, value: &str) -> Result<Field, E> where E: Error {
                         match value {
                             "Ok" => Ok(Field::Ok),

--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -916,11 +916,11 @@ impl<T, E> Deserialize for Result<T, E> where T: Deserialize, E: Deserialize {
             {
                 match try!(visitor.visit_variant()) {
                     Field::Ok => {
-                        let (value,) = try!(visitor.visit_tuple(1, TupleVisitor1::new()));
+                        let value = try!(visitor.visit_simple());
                         Ok(Ok(value))
                     }
                     Field::Err => {
-                        let (value,) = try!(visitor.visit_tuple(1, TupleVisitor1::new()));
+                        let value = try!(visitor.visit_simple());
                         Ok(Err(value))
                     }
                 }

--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -916,11 +916,11 @@ impl<T, E> Deserialize for Result<T, E> where T: Deserialize, E: Deserialize {
             {
                 match try!(visitor.visit_variant()) {
                     Field::Ok => {
-                        let (value,) = try!(visitor.visit_seq(1, TupleVisitor1::new()));
+                        let (value,) = try!(visitor.visit_tuple(1, TupleVisitor1::new()));
                         Ok(Ok(value))
                     }
                     Field::Err => {
-                        let (value,) = try!(visitor.visit_seq(1, TupleVisitor1::new()));
+                        let (value,) = try!(visitor.visit_tuple(1, TupleVisitor1::new()));
                         Ok(Err(value))
                     }
                 }

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -584,17 +584,19 @@ pub trait VariantVisitor {
         Err(Error::syntax_error())
     }
 
-    /// `visit_seq` is called when deserializing a tuple-like variant.
-    fn visit_seq<V>(&mut self, _len: usize, _visitor: V) -> Result<V::Value, Self::Error>
+    /// `visit_tuple` is called when deserializing a tuple-like variant.
+    fn visit_tuple<V>(&mut self,
+                      _len: usize,
+                      _visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor
     {
         Err(Error::syntax_error())
     }
 
-    /// `visit_map` is called when deserializing a struct-like variant.
-    fn visit_map<V>(&mut self,
-                    _fields: &'static [&'static str],
-                    _visitor: V) -> Result<V::Value, Self::Error>
+    /// `visit_struct` is called when deserializing a struct-like variant.
+    fn visit_struct<V>(&mut self,
+                       _fields: &'static [&'static str],
+                       _visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor
     {
         Err(Error::syntax_error())
@@ -618,18 +620,20 @@ impl<'a, T> VariantVisitor for &'a mut T where T: VariantVisitor {
         (**self).visit_simple()
     }
 
-    fn visit_seq<V>(&mut self, len: usize, visitor: V) -> Result<V::Value, T::Error>
+    fn visit_tuple<V>(&mut self,
+                      len: usize,
+                      visitor: V) -> Result<V::Value, T::Error>
         where V: Visitor,
     {
-        (**self).visit_seq(len, visitor)
+        (**self).visit_tuple(len, visitor)
     }
 
-    fn visit_map<V>(&mut self,
+    fn visit_struct<V>(&mut self,
                     fields: &'static [&'static str],
                     visitor: V) -> Result<V::Value, T::Error>
         where V: Visitor,
     {
-        (**self).visit_map(fields, visitor)
+        (**self).visit_struct(fields, visitor)
     }
 }
 

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -580,7 +580,9 @@ pub trait VariantVisitor {
     }
 
     /// `visit_simple` is called when deserializing a variant with a single value.
-    fn visit_simple<T: Deserialize>(&mut self) -> Result<T, Self::Error> {
+    fn visit_simple<T>(&mut self) -> Result<T, Self::Error>
+        where T: Deserialize,
+    {
         Err(Error::syntax_error())
     }
 
@@ -616,7 +618,9 @@ impl<'a, T> VariantVisitor for &'a mut T where T: VariantVisitor {
         (**self).visit_unit()
     }
 
-    fn visit_simple<D: Deserialize>(&mut self) -> Result<D, T::Error> {
+    fn visit_simple<D>(&mut self) -> Result<D, T::Error>
+        where D: Deserialize,
+    {
         (**self).visit_simple()
     }
 

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -211,7 +211,9 @@ pub trait Deserializer {
     /// This method hints that the `Deserialize` type is expecting a named unit. This allows
     /// deserializers to a named unit that aren't tagged as a named unit.
     #[inline]
-    fn visit_unit_struct<V>(&mut self, _name: &str, visitor: V) -> Result<V::Value, Self::Error>
+    fn visit_unit_struct<V>(&mut self,
+                            _name: &'static str,
+                            visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor,
     {
         self.visit_unit(visitor)
@@ -221,7 +223,7 @@ pub trait Deserializer {
     /// deserializers to parse sequences that aren't tagged as sequences.
     #[inline]
     fn visit_tuple_struct<V>(&mut self,
-                             _name: &str,
+                             _name: &'static str,
                              len: usize,
                              visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor,
@@ -233,7 +235,7 @@ pub trait Deserializer {
     /// deserializers to parse sequences that aren't tagged as maps.
     #[inline]
     fn visit_struct<V>(&mut self,
-                       _name: &str,
+                       _name: &'static str,
                        _fields: &'static [&'static str],
                        visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor,
@@ -255,7 +257,7 @@ pub trait Deserializer {
     /// type.
     #[inline]
     fn visit_enum<V>(&mut self,
-                     _enum: &str,
+                     _enum: &'static str,
                      _variants: &'static [&'static str],
                      _visitor: V) -> Result<V::Value, Self::Error>
         where V: EnumVisitor,
@@ -395,7 +397,7 @@ pub trait Visitor {
     }
 
     #[inline]
-    fn visit_unit_struct<E>(&mut self, _name: &str) -> Result<Self::Value, E>
+    fn visit_unit_struct<E>(&mut self, _name: &'static str) -> Result<Self::Value, E>
         where E: Error,
     {
         self.visit_unit()

--- a/serde/src/de/value.rs
+++ b/serde/src/de/value.rs
@@ -136,7 +136,10 @@ impl<'a> de::Deserializer for StrDeserializer<'a> {
         }
     }
 
-    fn visit_enum<V>(&mut self, _name: &str, mut visitor: V) -> Result<V::Value, Error>
+    fn visit_enum<V>(&mut self,
+                     _name: &str,
+                     _variants: &'static [&'static str],
+                     mut visitor: V) -> Result<V::Value, Error>
         where V: de::EnumVisitor,
     {
         visitor.visit(self)
@@ -182,7 +185,10 @@ impl de::Deserializer for StringDeserializer {
         }
     }
 
-    fn visit_enum<V>(&mut self, _name: &str, mut visitor: V) -> Result<V::Value, Error>
+    fn visit_enum<V>(&mut self,
+                     _name: &str,
+                     _variants: &'static [&'static str],
+                     mut visitor: V) -> Result<V::Value, Error>
         where V: de::EnumVisitor,
     {
         visitor.visit(self)

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -126,8 +126,8 @@ impl<T, Iter> SeqVisitor for SeqIteratorVisitor<Iter>
     {
         match self.iter.next() {
             Some(value) => {
-                let value = try!(serializer.visit_seq_elt(value));
-                Ok(Some(value))
+                try!(serializer.visit_seq_elt(value));
+                Ok(Some(()))
             }
             None => Ok(None),
         }

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -632,47 +632,10 @@ impl<T, E> Serialize for Result<T, E> where T: Serialize, E: Serialize {
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error> where S: Serializer {
         match *self {
             Result::Ok(ref value) => {
-                struct Visitor<'a, T: 'a>(Option<&'a T>);
-
-                impl<'a, T> SeqVisitor for Visitor<'a, T> where T: Serialize + 'a {
-                    #[inline]
-                    fn visit<S>(&mut self, serializer: &mut S) -> Result<Option<()>, S::Error>
-                        where S: Serializer
-                    {
-                        match self.0.take() {
-                            Some(value) => Ok(Some(try!(serializer.visit_seq_elt(value)))),
-                            None => Ok(None),
-                        }
-                    }
-
-                    #[inline]
-                    fn len(&self) -> Option<usize> {
-                        Some(1)
-                    }
-                }
-
-                serializer.visit_tuple_variant("Result", 0, "Ok", Visitor(Some(value)))
+                serializer.visit_enum_simple("Result", 0, "Ok", value)
             }
             Result::Err(ref value) => {
-                struct Visitor<'a, E: 'a>(Option<&'a E>);
-
-                impl<'a, E> SeqVisitor for Visitor<'a, E> where E: Serialize + 'a {
-                    #[inline]
-                    fn visit<S>(&mut self, serializer: &mut S) -> Result<Option<()>, S::Error>
-                                where S: Serializer {
-                        match self.0.take() {
-                            Some(value) => Ok(Some(try!(serializer.visit_seq_elt(value)))),
-                            None => Ok(None),
-                        }
-                    }
-
-                    #[inline]
-                    fn len(&self) -> Option<usize> {
-                        Some(1)
-                    }
-                }
-
-                serializer.visit_tuple_variant("Result", 1, "Err", Visitor(Some(value)))
+                serializer.visit_enum_simple("Result", 1, "Err", value)
             }
         }
     }

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -631,7 +631,7 @@ impl<T, E> Serialize for Result<T, E> where T: Serialize, E: Serialize {
                     }
                 }
 
-                serializer.visit_enum_seq("Result", 0, "Ok", Visitor(Some(value)))
+                serializer.visit_tuple_variant("Result", 0, "Ok", Visitor(Some(value)))
             }
             Result::Err(ref value) => {
                 struct Visitor<'a, E: 'a>(Option<&'a E>);
@@ -652,7 +652,7 @@ impl<T, E> Serialize for Result<T, E> where T: Serialize, E: Serialize {
                     }
                 }
 
-                serializer.visit_enum_seq("Result", 1, "Err", Visitor(Some(value)))
+                serializer.visit_tuple_variant("Result", 1, "Err", Visitor(Some(value)))
             }
         }
     }

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -97,6 +97,26 @@ impl<T> Serialize for Option<T> where T: Serialize {
     }
 }
 
+impl<T> SeqVisitor for Option<T> where T: Serialize {
+    #[inline]
+    fn visit<S>(&mut self, serializer: &mut S) -> Result<Option<()>, S::Error>
+        where S: Serializer,
+    {
+        match self.take() {
+            Some(value) => {
+                try!(serializer.visit_seq_elt(value));
+                Ok(Some(()))
+            }
+            None => Ok(None),
+        }
+    }
+
+    #[inline]
+    fn len(&self) -> Option<usize> {
+        Some(if self.is_some() { 1 } else { 0 })
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 pub struct SeqIteratorVisitor<Iter> {

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -118,10 +118,10 @@ pub trait Serializer {
     }
 
     #[inline]
-    fn visit_enum_unit(&mut self,
-                       _name: &'static str,
-                       _variant_index: usize,
-                       _variant: &'static str) -> Result<(), Self::Error> {
+    fn visit_unit_variant(&mut self,
+                          _name: &'static str,
+                          _variant_index: usize,
+                          _variant: &'static str) -> Result<(), Self::Error> {
         self.visit_unit()
     }
 
@@ -175,18 +175,18 @@ pub trait Serializer {
     }
 
     #[inline]
-    fn visit_enum_seq<V>(&mut self,
-                         _name: &'static str,
-                         _variant_index: usize,
-                         variant: &'static str,
-                         visitor: V) -> Result<(), Self::Error>
+    fn visit_tuple_variant<V>(&mut self,
+                              _name: &'static str,
+                              _variant_index: usize,
+                              variant: &'static str,
+                              visitor: V) -> Result<(), Self::Error>
         where V: SeqVisitor,
     {
         self.visit_tuple_struct(variant, visitor)
     }
 
     #[inline]
-    fn visit_enum_seq_elt<T>(&mut self, value: T) -> Result<(), Self::Error>
+    fn visit_tuple_variant_elt<T>(&mut self, value: T) -> Result<(), Self::Error>
         where T: Serialize
     {
         self.visit_tuple_struct_elt(value)
@@ -209,7 +209,9 @@ pub trait Serializer {
     }
 
     #[inline]
-    fn visit_struct_elt<K, V>(&mut self, key: K, value: V) -> Result<(), Self::Error>
+    fn visit_struct_elt<K, V>(&mut self,
+                              key: K,
+                              value: V) -> Result<(), Self::Error>
         where K: Serialize,
               V: Serialize,
     {
@@ -217,18 +219,20 @@ pub trait Serializer {
     }
 
     #[inline]
-    fn visit_enum_map<V>(&mut self,
-                         _name: &'static str,
-                         _variant_index: usize,
-                         variant: &'static str,
-                         visitor: V) -> Result<(), Self::Error>
+    fn visit_struct_variant<V>(&mut self,
+                               _name: &'static str,
+                               _variant_index: usize,
+                               variant: &'static str,
+                               visitor: V) -> Result<(), Self::Error>
         where V: MapVisitor,
     {
         self.visit_struct(variant, visitor)
     }
 
     #[inline]
-    fn visit_enum_map_elt<K, V>(&mut self, key: K, value: V) -> Result<(), Self::Error>
+    fn visit_struct_variant_elt<K, V>(&mut self,
+                                      key: K,
+                                      value: V) -> Result<(), Self::Error>
         where K: Serialize,
               V: Serialize,
     {

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -129,8 +129,7 @@ pub trait Serializer {
     fn visit_enum_simple<T>(&mut self,
                             _name: &str,
                             _variant: &str,
-                            _value: T,
-                            ) -> Result<(), Self::Error>
+                            _value: T) -> Result<(), Self::Error>
         where T: Serialize;
 
     fn visit_none(&mut self) -> Result<(), Self::Error>;

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -131,7 +131,14 @@ pub trait Serializer {
                             variant_index: usize,
                             variant: &'static str,
                             value: T) -> Result<(), Self::Error>
-        where T: Serialize;
+        where T: Serialize,
+    {
+        self.visit_tuple_variant(
+            name,
+            variant_index,
+            variant,
+            Some(value))
+    }
 
     fn visit_none(&mut self) -> Result<(), Self::Error>;
 

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -160,8 +160,8 @@ pub trait Serializer {
 
     #[inline]
     fn visit_tuple_struct<V>(&mut self,
-                          _name: &'static str,
-                          visitor: V) -> Result<(), Self::Error>
+                             _name: &'static str,
+                             visitor: V) -> Result<(), Self::Error>
         where V: SeqVisitor,
     {
         self.visit_tuple(visitor)
@@ -201,8 +201,8 @@ pub trait Serializer {
 
     #[inline]
     fn visit_struct<V>(&mut self,
-                          _name: &'static str,
-                          visitor: V) -> Result<(), Self::Error>
+                       _name: &'static str,
+                       visitor: V) -> Result<(), Self::Error>
         where V: MapVisitor,
     {
         self.visit_map(visitor)

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -127,9 +127,10 @@ pub trait Serializer {
 
     #[inline]
     fn visit_enum_simple<T>(&mut self,
-                            _name: &str,
-                            _variant: &str,
-                            _value: T) -> Result<(), Self::Error>
+                            name: &'static str,
+                            variant_index: usize,
+                            variant: &'static str,
+                            value: T) -> Result<(), Self::Error>
         where T: Serialize;
 
     fn visit_none(&mut self) -> Result<(), Self::Error>;

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -113,15 +113,15 @@ pub trait Serializer {
     fn visit_unit(&mut self) -> Result<(), Self::Error>;
 
     #[inline]
-    fn visit_unit_struct(&mut self, _name: &str) -> Result<(), Self::Error> {
+    fn visit_unit_struct(&mut self, _name: &'static str) -> Result<(), Self::Error> {
         self.visit_unit()
     }
 
     #[inline]
     fn visit_enum_unit(&mut self,
-                       _name: &str,
+                       _name: &'static str,
                        _variant_index: usize,
-                       _variant: &str) -> Result<(), Self::Error> {
+                       _variant: &'static str) -> Result<(), Self::Error> {
         self.visit_unit()
     }
 

--- a/serde_codegen/src/de.rs
+++ b/serde_codegen/src/de.rs
@@ -765,10 +765,10 @@ fn deserialize_field_visitor(
     let str_body = if formats.is_empty() {
         // No formats specific attributes, so no match on format required
         quote_expr!(cx,
-                    match value {
-                        $default_field_arms
-                        _ => { Err(::serde::de::Error::unknown_field_error(value)) }
-                    })
+            match value {
+                $default_field_arms
+                _ => { Err(::serde::de::Error::unknown_field_error(value)) }
+            })
     } else {
         let field_arms: Vec<_> = formats.iter()
             .map(|fmt| {

--- a/serde_codegen/src/de.rs
+++ b/serde_codegen/src/de.rs
@@ -641,7 +641,7 @@ fn deserialize_tuple_variant(
             }
         }
 
-        visitor.visit_seq($fields, $visitor_expr)
+        visitor.visit_tuple($fields, $visitor_expr)
     })
 }
 
@@ -708,7 +708,7 @@ fn deserialize_struct_variant(
 
         $fields_stmt
 
-        visitor.visit_map(FIELDS, $visitor_expr)
+        visitor.visit_struct(FIELDS, $visitor_expr)
     })
 }
 

--- a/serde_codegen/src/ser.rs
+++ b/serde_codegen/src/ser.rs
@@ -288,7 +288,7 @@ fn serialize_variant(
 
             quote_arm!(cx,
                 $pat => {
-                    ::serde::ser::Serializer::visit_enum_unit(
+                    ::serde::ser::Serializer::visit_unit_variant(
                         serializer,
                         $type_name,
                         $variant_index,
@@ -421,7 +421,7 @@ fn serialize_tuple_variant(
     quote_expr!(cx, {
         $visitor_struct
         $visitor_impl
-        serializer.visit_enum_seq($type_name, $variant_index, $variant_name, Visitor {
+        serializer.visit_tuple_variant($type_name, $variant_index, $variant_name, Visitor {
             value: $value_expr,
             state: 0,
             _structure_ty: ::std::marker::PhantomData::<&$structure_ty>,
@@ -476,7 +476,7 @@ fn serialize_struct_variant(
     quote_expr!(cx, {
         $visitor_struct
         $visitor_impl
-        serializer.visit_enum_map($type_name, $variant_index, $variant_name, Visitor {
+        serializer.visit_struct_variant($type_name, $variant_index, $variant_name, Visitor {
             value: $value_expr,
             state: 0,
             _structure_ty: ::std::marker::PhantomData::<&$structure_ty>,

--- a/serde_codegen/src/ser.rs
+++ b/serde_codegen/src/ser.rs
@@ -309,6 +309,7 @@ fn serialize_variant(
                     ::serde::ser::Serializer::visit_enum_simple(
                         serializer,
                         $type_name,
+                        $variant_index,
                         $variant_name,
                         __simple_value,
                     )

--- a/serde_json/src/de.rs
+++ b/serde_json/src/de.rs
@@ -454,7 +454,10 @@ impl<Iter> de::Deserializer for Deserializer<Iter>
     }
 
     #[inline]
-    fn visit_enum<V>(&mut self, _name: &str, mut visitor: V) -> Result<V::Value, Error>
+    fn visit_enum<V>(&mut self,
+                     _name: &str,
+                     _variants: &'static [&'static str],
+                     mut visitor: V) -> Result<V::Value, Error>
         where V: de::EnumVisitor,
     {
         try!(self.parse_whitespace());
@@ -645,7 +648,9 @@ impl<Iter> de::VariantVisitor for Deserializer<Iter>
         de::Deserialize::deserialize(self)
     }
 
-    fn visit_seq<V>(&mut self, visitor: V) -> Result<V::Value, Error>
+    fn visit_seq<V>(&mut self,
+                    _len: usize,
+                    visitor: V) -> Result<V::Value, Error>
         where V: de::Visitor,
     {
         de::Deserializer::visit(self, visitor)

--- a/serde_json/src/de.rs
+++ b/serde_json/src/de.rs
@@ -648,17 +648,17 @@ impl<Iter> de::VariantVisitor for Deserializer<Iter>
         de::Deserialize::deserialize(self)
     }
 
-    fn visit_seq<V>(&mut self,
-                    _len: usize,
-                    visitor: V) -> Result<V::Value, Error>
+    fn visit_tuple<V>(&mut self,
+                      _len: usize,
+                      visitor: V) -> Result<V::Value, Error>
         where V: de::Visitor,
     {
         de::Deserializer::visit(self, visitor)
     }
 
-    fn visit_map<V>(&mut self,
-                    _fields: &'static [&'static str],
-                    visitor: V) -> Result<V::Value, Error>
+    fn visit_struct<V>(&mut self,
+                       _fields: &'static [&'static str],
+                       visitor: V) -> Result<V::Value, Error>
         where V: de::Visitor,
     {
         de::Deserializer::visit(self, visitor)

--- a/serde_json/src/ser.rs
+++ b/serde_json/src/ser.rs
@@ -174,6 +174,7 @@ impl<W, F> ser::Serializer for Serializer<W, F>
     #[inline]
     fn visit_enum_simple<T>(&mut self,
                             _name: &str,
+                            _variant_index: usize,
                             variant: &str,
                             value: T,
                             ) -> io::Result<()>

--- a/serde_json/src/ser.rs
+++ b/serde_json/src/ser.rs
@@ -159,10 +159,10 @@ impl<W, F> ser::Serializer for Serializer<W, F>
     }
 
     #[inline]
-    fn visit_enum_unit(&mut self,
-                       _name: &str,
-                       _variant_index: usize,
-                       variant: &str) -> io::Result<()> {
+    fn visit_unit_variant(&mut self,
+                          _name: &str,
+                          _variant_index: usize,
+                          variant: &str) -> io::Result<()> {
         try!(self.formatter.open(&mut self.writer, b'{'));
         try!(self.formatter.comma(&mut self.writer, true));
         try!(self.visit_str(variant));
@@ -209,11 +209,11 @@ impl<W, F> ser::Serializer for Serializer<W, F>
     }
 
     #[inline]
-    fn visit_enum_seq<V>(&mut self,
-                         _name: &str,
-                         _variant_index: usize,
-                         variant: &str,
-                         visitor: V) -> io::Result<()>
+    fn visit_tuple_variant<V>(&mut self,
+                              _name: &str,
+                              _variant_index: usize,
+                              variant: &str,
+                              visitor: V) -> io::Result<()>
         where V: ser::SeqVisitor,
     {
         try!(self.formatter.open(&mut self.writer, b'{'));
@@ -257,11 +257,11 @@ impl<W, F> ser::Serializer for Serializer<W, F>
     }
 
     #[inline]
-    fn visit_enum_map<V>(&mut self,
-                         _name: &str,
-                         _variant_index: usize,
-                         variant: &str,
-                         visitor: V) -> io::Result<()>
+    fn visit_struct_variant<V>(&mut self,
+                               _name: &str,
+                               _variant_index: usize,
+                               variant: &str,
+                               visitor: V) -> io::Result<()>
         where V: ser::MapVisitor,
     {
         try!(self.formatter.open(&mut self.writer, b'{'));

--- a/serde_json/src/value.rs
+++ b/serde_json/src/value.rs
@@ -459,10 +459,10 @@ impl ser::Serializer for Serializer {
     }
 
     #[inline]
-    fn visit_enum_unit(&mut self,
-                       _name: &str,
-                       _variant_index: usize,
-                       variant: &str) -> Result<(), ()> {
+    fn visit_unit_variant(&mut self,
+                          _name: &str,
+                          _variant_index: usize,
+                          variant: &str) -> Result<(), ()> {
         let mut values = BTreeMap::new();
         values.insert(variant.to_string(), Value::Array(vec![]));
 
@@ -509,11 +509,11 @@ impl ser::Serializer for Serializer {
     }
 
     #[inline]
-    fn visit_enum_seq<V>(&mut self,
-                         _name: &str,
-                         _variant_index: usize,
-                         variant: &str,
-                         visitor: V) -> Result<(), ()>
+    fn visit_tuple_variant<V>(&mut self,
+                              _name: &str,
+                              _variant_index: usize,
+                              variant: &str,
+                              visitor: V) -> Result<(), ()>
         where V: ser::SeqVisitor,
     {
         try!(self.visit_seq(visitor));
@@ -572,11 +572,11 @@ impl ser::Serializer for Serializer {
     }
 
     #[inline]
-    fn visit_enum_map<V>(&mut self,
-                         _name: &str,
-                         _variant_index: usize,
-                         variant: &str,
-                         visitor: V) -> Result<(), ()>
+    fn visit_struct_variant<V>(&mut self,
+                               _name: &str,
+                               _variant_index: usize,
+                               variant: &str,
+                               visitor: V) -> Result<(), ()>
         where V: ser::MapVisitor,
     {
         try!(self.visit_map(visitor));

--- a/serde_json/src/value.rs
+++ b/serde_json/src/value.rs
@@ -743,12 +743,12 @@ impl<'a> de::VariantVisitor for VariantDeserializer<'a> {
         de::Deserialize::deserialize(&mut Deserializer::new(self.variant.take().unwrap()))
     }
 
-    fn visit_unit(&mut self) -> Result<(), Error>
-    {
+    fn visit_unit(&mut self) -> Result<(), Error> {
         de::Deserialize::deserialize(&mut Deserializer::new(self.val.take().unwrap()))
     }
 
-    fn visit_simple<D: de::Deserialize>(&mut self) -> Result<D, Error>
+    fn visit_simple<T>(&mut self) -> Result<T, Error>
+        where T: de::Deserialize,
     {
         de::Deserialize::deserialize(&mut Deserializer::new(self.val.take().unwrap()))
     }

--- a/serde_json/src/value.rs
+++ b/serde_json/src/value.rs
@@ -474,6 +474,7 @@ impl ser::Serializer for Serializer {
     #[inline]
     fn visit_enum_simple<T>(&mut self,
                             _name: &str,
+                            _variant_index: usize,
                             variant: &str,
                             value: T,
                             ) -> Result<(), ()>

--- a/serde_json/src/value.rs
+++ b/serde_json/src/value.rs
@@ -753,9 +753,9 @@ impl<'a> de::VariantVisitor for VariantDeserializer<'a> {
         de::Deserialize::deserialize(&mut Deserializer::new(self.val.take().unwrap()))
     }
 
-    fn visit_seq<V>(&mut self,
-                    _len: usize,
-                    visitor: V) -> Result<V::Value, Error>
+    fn visit_tuple<V>(&mut self,
+                      _len: usize,
+                      visitor: V) -> Result<V::Value, Error>
         where V: de::Visitor,
     {
         if let Value::Array(fields) = self.val.take().unwrap() {
@@ -772,9 +772,9 @@ impl<'a> de::VariantVisitor for VariantDeserializer<'a> {
         }
     }
 
-    fn visit_map<V>(&mut self,
-                    _fields: &'static[&'static str],
-                    visitor: V) -> Result<V::Value, Error>
+    fn visit_struct<V>(&mut self,
+                       _fields: &'static[&'static str],
+                       visitor: V) -> Result<V::Value, Error>
         where V: de::Visitor,
     {
         if let Value::Object(fields) = self.val.take().unwrap() {

--- a/serde_json/src/value.rs
+++ b/serde_json/src/value.rs
@@ -692,7 +692,10 @@ impl de::Deserializer for Deserializer {
     }
 
     #[inline]
-    fn visit_enum<V>(&mut self, _name: &str, mut visitor: V) -> Result<V::Value, Error>
+    fn visit_enum<V>(&mut self,
+                     _name: &str,
+                     _variants: &'static [&'static str],
+                     mut visitor: V) -> Result<V::Value, Error>
         where V: de::EnumVisitor,
     {
         let value = match self.value.take() {
@@ -750,7 +753,9 @@ impl<'a> de::VariantVisitor for VariantDeserializer<'a> {
         de::Deserialize::deserialize(&mut Deserializer::new(self.val.take().unwrap()))
     }
 
-    fn visit_seq<V>(&mut self, visitor: V) -> Result<V::Value, Error>
+    fn visit_seq<V>(&mut self,
+                    _len: usize,
+                    visitor: V) -> Result<V::Value, Error>
         where V: de::Visitor,
     {
         if let Value::Array(fields) = self.val.take().unwrap() {
@@ -767,7 +772,9 @@ impl<'a> de::VariantVisitor for VariantDeserializer<'a> {
         }
     }
 
-    fn visit_map<V>(&mut self, _fields: &'static[&'static str], visitor: V) -> Result<V::Value, Error>
+    fn visit_map<V>(&mut self,
+                    _fields: &'static[&'static str],
+                    visitor: V) -> Result<V::Value, Error>
         where V: de::Visitor,
     {
         if let Value::Object(fields) = self.val.take().unwrap() {

--- a/serde_tests/benches/bench_enum.rs
+++ b/serde_tests/benches/bench_enum.rs
@@ -288,7 +288,10 @@ mod deserializer {
         }
 
         #[inline]
-        fn visit_enum<V>(&mut self, _name: &str, mut visitor: V) -> Result<V::Value, Error>
+        fn visit_enum<V>(&mut self,
+                         _name: &str,
+                         _variants: &[&str],
+                         mut visitor: V) -> Result<V::Value, Error>
             where V: de::EnumVisitor,
         {
             match self.stack.pop() {
@@ -350,7 +353,9 @@ mod deserializer {
             de::Deserialize::deserialize(self.de)
         }
 
-        fn visit_seq<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
+        fn visit_tuple<V>(&mut self,
+                          _len: usize,
+                          mut visitor: V) -> Result<V::Value, Error>
             where V: de::Visitor,
         {
             visitor.visit_seq(self)

--- a/serde_tests/tests/test_bytes.rs
+++ b/serde_tests/tests/test_bytes.rs
@@ -41,6 +41,7 @@ impl serde::Serializer for BytesSerializer {
 
     fn visit_enum_simple<T>(&mut self,
                             _name: &str,
+                            _variant_index: usize,
                             _variant: &str,
                             _value: T) -> Result<(), Error>
     {

--- a/serde_tests/tests/test_bytes.rs
+++ b/serde_tests/tests/test_bytes.rs
@@ -39,15 +39,6 @@ impl serde::Serializer for BytesSerializer {
         Err(Error)
     }
 
-    fn visit_enum_simple<T>(&mut self,
-                            _name: &str,
-                            _variant_index: usize,
-                            _variant: &str,
-                            _value: T) -> Result<(), Error>
-    {
-        Err(Error)
-    }
-
     fn visit_bool(&mut self, _v: bool) -> Result<(), Error> {
         Err(Error)
     }

--- a/serde_tests/tests/test_bytes.rs
+++ b/serde_tests/tests/test_bytes.rs
@@ -42,8 +42,7 @@ impl serde::Serializer for BytesSerializer {
     fn visit_enum_simple<T>(&mut self,
                             _name: &str,
                             _variant: &str,
-                            _value: T,
-                            ) -> Result<(), Error>
+                            _value: T) -> Result<(), Error>
     {
         Err(Error)
     }

--- a/serde_tests/tests/test_de.rs
+++ b/serde_tests/tests/test_de.rs
@@ -22,6 +22,7 @@ enum Token {
     Char(char),
     Str(&'static str),
     String(String),
+    Bytes(&'static [u8]),
 
     Option(bool),
 
@@ -103,6 +104,7 @@ impl Deserializer for TokenDeserializer {
             Some(Token::Char(v)) => visitor.visit_char(v),
             Some(Token::Str(v)) => visitor.visit_str(v),
             Some(Token::String(v)) => visitor.visit_string(v),
+            Some(Token::Bytes(v)) => visitor.visit_bytes(v),
             Some(Token::Option(false)) => visitor.visit_none(),
             Some(Token::Option(true)) => visitor.visit_some(self),
             Some(Token::Unit) => visitor.visit_unit(),
@@ -975,6 +977,26 @@ declare_tests! {
                     Token::Str("c"),
                     Token::I32(3),
                 Token::MapEnd,
+            Token::EnumEnd,
+        ],
+    }
+    test_enum_unit_usize {
+        Enum::Unit => vec![
+            Token::EnumStart("Enum"),
+                Token::Usize(0),
+
+                Token::EnumUnit,
+                Token::Unit,
+            Token::EnumEnd,
+        ],
+    }
+    test_enum_unit_bytes {
+        Enum::Unit => vec![
+            Token::EnumStart("Enum"),
+                Token::Bytes(b"Unit"),
+
+                Token::EnumUnit,
+                Token::Unit,
             Token::EnumEnd,
         ],
     }

--- a/serde_tests/tests/test_de.rs
+++ b/serde_tests/tests/test_de.rs
@@ -143,7 +143,10 @@ impl Deserializer for TokenDeserializer {
         }
     }
 
-    fn visit_enum<V>(&mut self, name: &str, mut visitor: V) -> Result<V::Value, Error>
+    fn visit_enum<V>(&mut self,
+                     name: &str,
+                     _variants: &'static [&'static str],
+                     mut visitor: V) -> Result<V::Value, Error>
         where V: de::EnumVisitor,
     {
         match self.tokens.next() {
@@ -178,7 +181,10 @@ impl Deserializer for TokenDeserializer {
         }
     }
 
-    fn visit_tuple_struct<V>(&mut self, name: &str, visitor: V) -> Result<V::Value, Error>
+    fn visit_tuple_struct<V>(&mut self,
+                             name: &str,
+                             _len: usize,
+                             visitor: V) -> Result<V::Value, Error>
         where V: de::Visitor,
     {
         match self.tokens.peek() {
@@ -321,7 +327,9 @@ impl<'a> de::VariantVisitor for TokenDeserializerVariantVisitor<'a> {
         de::Deserialize::deserialize(self.de)
     }
 
-    fn visit_seq<V>(&mut self, visitor: V) -> Result<V::Value, Error>
+    fn visit_seq<V>(&mut self,
+                    _len: usize,
+                    visitor: V) -> Result<V::Value, Error>
         where V: de::Visitor,
     {
         de::Deserializer::visit(self.de, visitor)

--- a/serde_tests/tests/test_de.rs
+++ b/serde_tests/tests/test_de.rs
@@ -539,23 +539,17 @@ declare_tests! {
             Token::EnumStart("Result"),
                 Token::Str("Ok"),
 
-                Token::EnumSeq,
-                Token::SeqStart(1),
-                    Token::SeqSep,
-                    Token::I32(0),
-                Token::SeqEnd,
-            Token::EnumEnd,
+                Token::EnumSimple,
+                Token::I32(0),
+            Token::SeqEnd,
         ],
         Err::<i32, i32>(1) => vec![
             Token::EnumStart("Result"),
                 Token::Str("Err"),
 
-                Token::EnumSeq,
-                Token::SeqStart(1),
-                    Token::SeqSep,
-                    Token::I32(1),
-                Token::SeqEnd,
-            Token::EnumEnd,
+                Token::EnumSimple,
+                Token::I32(1),
+            Token::SeqEnd,
         ],
     }
     test_unit {

--- a/serde_tests/tests/test_de.rs
+++ b/serde_tests/tests/test_de.rs
@@ -327,17 +327,17 @@ impl<'a> de::VariantVisitor for TokenDeserializerVariantVisitor<'a> {
         de::Deserialize::deserialize(self.de)
     }
 
-    fn visit_seq<V>(&mut self,
-                    _len: usize,
-                    visitor: V) -> Result<V::Value, Error>
+    fn visit_tuple<V>(&mut self,
+                      _len: usize,
+                      visitor: V) -> Result<V::Value, Error>
         where V: de::Visitor,
     {
         de::Deserializer::visit(self.de, visitor)
     }
 
-    fn visit_map<V>(&mut self,
-                    _fields: &'static [&'static str],
-                    visitor: V) -> Result<V::Value, Error>
+    fn visit_struct<V>(&mut self,
+                       _fields: &'static [&'static str],
+                       visitor: V) -> Result<V::Value, Error>
         where V: de::Visitor,
     {
         de::Deserializer::visit(self.de, visitor)

--- a/serde_tests/tests/test_ser.rs
+++ b/serde_tests/tests/test_ser.rs
@@ -396,16 +396,12 @@ declare_tests! {
     }
     test_result {
         Ok::<i32, i32>(0) => vec![
-            Token::EnumSeqStart("Result", "Ok", Some(1)),
-            Token::SeqSep,
+            Token::EnumSimple("Result", "Ok"),
             Token::I32(0),
-            Token::SeqEnd,
         ],
         Err::<i32, i32>(1) => vec![
-            Token::EnumSeqStart("Result", "Err", Some(1)),
-            Token::SeqSep,
+            Token::EnumSimple("Result", "Err"),
             Token::I32(1),
-            Token::SeqEnd,
         ],
     }
     test_slice {

--- a/serde_tests/tests/test_ser.rs
+++ b/serde_tests/tests/test_ser.rs
@@ -84,6 +84,7 @@ impl<'a> Serializer for AssertSerializer<'a> {
 
     fn visit_enum_simple<T>(&mut self,
                             name: &str,
+                            _variant_index: usize,
                             variant: &str,
                             value: T,
                             ) -> Result<(), ()>

--- a/serde_tests/tests/test_ser.rs
+++ b/serde_tests/tests/test_ser.rs
@@ -98,10 +98,10 @@ impl<'a> Serializer for AssertSerializer<'a> {
         Ok(())
     }
 
-    fn visit_enum_unit(&mut self,
-                       name: &str,
-                       _variant_index: usize,
-                       variant: &str) -> Result<(), ()> {
+    fn visit_unit_variant(&mut self,
+                          name: &str,
+                          _variant_index: usize,
+                          variant: &str) -> Result<(), ()> {
         assert_eq!(
             self.iter.next().unwrap(),
             Token::EnumUnit(name, variant)
@@ -221,11 +221,11 @@ impl<'a> Serializer for AssertSerializer<'a> {
         self.visit_sequence(visitor)
     }
 
-    fn visit_enum_seq<V>(&mut self,
-                         name: &str,
-                         _variant_index: usize,
-                         variant: &str,
-                         visitor: V) -> Result<(), ()>
+    fn visit_tuple_variant<V>(&mut self,
+                              name: &str,
+                              _variant_index: usize,
+                              variant: &str,
+                              visitor: V) -> Result<(), ()>
         where V: SeqVisitor
     {
         let len = visitor.len();
@@ -268,11 +268,11 @@ impl<'a> Serializer for AssertSerializer<'a> {
         self.visit_mapping(visitor)
     }
 
-    fn visit_enum_map<V>(&mut self,
-                         name: &str,
-                         _variant_index: usize,
-                         variant: &str,
-                         visitor: V) -> Result<(), ()>
+    fn visit_struct_variant<V>(&mut self,
+                               name: &str,
+                               _variant_index: usize,
+                               variant: &str,
+                               visitor: V) -> Result<(), ()>
         where V: MapVisitor
     {
         let len = visitor.len();


### PR DESCRIPTION
Some more bits inspired by #114.

This adds the expected length of tuples, tuple structs, and tuple variants to the visitors as well as adds the variant names to the `visit_enum` method. Also renames `VariantVisitor::visit_{map,seq}` to `visit_{struct,tuple}` as well as renaming `Serializer::visit_enum_{unit,map,seq}` to `visit_{unit,struct,tuple}_variant` to be consistent with the other methods.

cc @oli-obk, @tomprogrammer, @hugoduncan 