### PR TITLE
Rename *enum_simple to enum_newtype, add hooks for serializing newtype structs

### DIFF
--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -924,11 +924,11 @@ impl<T, E> Deserialize for Result<T, E> where T: Deserialize, E: Deserialize {
             {
                 match try!(visitor.visit_variant()) {
                     Field::Ok => {
-                        let value = try!(visitor.visit_simple());
+                        let value = try!(visitor.visit_newtype());
                         Ok(Ok(value))
                     }
                     Field::Err => {
-                        let value = try!(visitor.visit_simple());
+                        let value = try!(visitor.visit_newtype());
                         Ok(Err(value))
                     }
                 }

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -208,8 +208,8 @@ pub trait Deserializer {
         self.visit(visitor)
     }
 
-    /// This method hints that the `Deserialize` type is expecting a named unit. This allows
-    /// deserializers to a named unit that aren't tagged as a named unit.
+    /// This method hints that the `Deserialize` type is expecting a unit struct. This allows
+    /// deserializers to a unit struct that aren't tagged as a unit struct.
     #[inline]
     fn visit_unit_struct<V>(&mut self,
                             _name: &'static str,
@@ -217,6 +217,17 @@ pub trait Deserializer {
         where V: Visitor,
     {
         self.visit_unit(visitor)
+    }
+
+    /// This method hints that the `Deserialize` type is expecting a . This allows
+    /// deserializers to a named unit that aren't tagged as a named unit.
+    #[inline]
+    fn visit_newtype_struct<V>(&mut self,
+                               name: &'static str,
+                               visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor,
+    {
+        self.visit_tuple_struct(name, 1, visitor)
     }
 
     /// This method hints that the `Deserialize` type is expecting a tuple struct. This allows
@@ -410,6 +421,12 @@ pub trait Visitor {
     }
 
     fn visit_some<D>(&mut self, _deserializer: &mut D) -> Result<Self::Value, D::Error>
+        where D: Deserializer,
+    {
+        Err(Error::syntax_error())
+    }
+
+    fn visit_newtype_struct<D>(&mut self, _deserializer: &mut D) -> Result<Self::Value, D::Error>
         where D: Deserializer,
     {
         Err(Error::syntax_error())

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -579,8 +579,8 @@ pub trait VariantVisitor {
         Err(Error::syntax_error())
     }
 
-    /// `visit_simple` is called when deserializing a variant with a single value.
-    fn visit_simple<T>(&mut self) -> Result<T, Self::Error>
+    /// `visit_newtype` is called when deserializing a variant with a single value.
+    fn visit_newtype<T>(&mut self) -> Result<T, Self::Error>
         where T: Deserialize,
     {
         Err(Error::syntax_error())
@@ -618,10 +618,10 @@ impl<'a, T> VariantVisitor for &'a mut T where T: VariantVisitor {
         (**self).visit_unit()
     }
 
-    fn visit_simple<D>(&mut self) -> Result<D, T::Error>
+    fn visit_newtype<D>(&mut self) -> Result<D, T::Error>
         where D: Deserialize,
     {
-        (**self).visit_simple()
+        (**self).visit_newtype()
     }
 
     fn visit_tuple<V>(&mut self,

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -632,10 +632,10 @@ impl<T, E> Serialize for Result<T, E> where T: Serialize, E: Serialize {
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error> where S: Serializer {
         match *self {
             Result::Ok(ref value) => {
-                serializer.visit_enum_simple("Result", 0, "Ok", value)
+                serializer.visit_newtype_variant("Result", 0, "Ok", value)
             }
             Result::Err(ref value) => {
-                serializer.visit_enum_simple("Result", 1, "Err", value)
+                serializer.visit_newtype_variant("Result", 1, "Err", value)
             }
         }
     }

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -125,6 +125,18 @@ pub trait Serializer {
         self.visit_unit()
     }
 
+    /// The `visit_newtype_struct` allows a tuple struct with a single element, also known as a
+    /// newtyped value, to be more efficiently serialized than a tuple struct with multiple items.
+    /// By default it just serializes the value as a tuple struct sequence.
+    #[inline]
+    fn visit_newtype_struct<T>(&mut self,
+                               name: &'static str,
+                               value: T) -> Result<(), Self::Error>
+        where T: Serialize,
+    {
+        self.visit_tuple_struct(name, Some(value))
+    }
+
     /// The `visit_newtype_variant` allows a variant with a single item to be more efficiently
     /// serialized than a variant with multiple items. By default it just serializes the value as a
     /// tuple variant sequence.

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -125,12 +125,15 @@ pub trait Serializer {
         self.visit_unit()
     }
 
+    /// The `visit_newtype_variant` allows a variant with a single item to be more efficiently
+    /// serialized than a variant with multiple items. By default it just serializes the value as a
+    /// tuple variant sequence.
     #[inline]
-    fn visit_enum_simple<T>(&mut self,
-                            name: &'static str,
-                            variant_index: usize,
-                            variant: &'static str,
-                            value: T) -> Result<(), Self::Error>
+    fn visit_newtype_variant<T>(&mut self,
+                                name: &'static str,
+                                variant_index: usize,
+                                variant: &'static str,
+                                value: T) -> Result<(), Self::Error>
         where T: Serialize,
     {
         self.visit_tuple_variant(

--- a/serde_codegen/src/de.rs
+++ b/serde_codegen/src/de.rs
@@ -129,15 +129,24 @@ fn deserialize_item_struct(
         }
     }
 
-    match (named_fields.is_empty(), unnamed_fields == 0) {
-        (true, true) => {
+    match (named_fields.is_empty(), unnamed_fields) {
+        (true, 0) => {
             deserialize_unit_struct(
                 cx,
                 &builder,
                 item.ident,
             )
         }
-        (true, false) => {
+        (true, 1) => {
+            deserialize_newtype_struct(
+                cx,
+                &builder,
+                item.ident,
+                impl_generics,
+                ty,
+            )
+        }
+        (true, _) => {
             deserialize_tuple_struct(
                 cx,
                 &builder,
@@ -147,7 +156,7 @@ fn deserialize_item_struct(
                 unnamed_fields,
             )
         }
-        (false, true) => {
+        (false, 0) => {
             deserialize_struct(
                 cx,
                 &builder,
@@ -157,7 +166,7 @@ fn deserialize_item_struct(
                 struct_def,
             )
         }
-        (false, false) => {
+        (false, _) => {
             cx.bug("struct has named and unnamed fields")
         }
     }
@@ -275,6 +284,58 @@ fn deserialize_unit_struct(
         }
 
         deserializer.visit_unit_struct($type_name, __Visitor)
+    })
+}
+
+fn deserialize_newtype_struct(
+    cx: &ExtCtxt,
+    builder: &aster::AstBuilder,
+    type_ident: Ident,
+    impl_generics: &ast::Generics,
+    ty: P<ast::Ty>,
+) -> P<ast::Expr> {
+    let where_clause = &impl_generics.where_clause;
+
+    let (visitor_item, visitor_ty, visitor_expr, visitor_generics) =
+        deserialize_visitor(
+            builder,
+            impl_generics,
+            vec![deserializer_ty_param(builder)],
+            vec![deserializer_ty_arg(builder)],
+        );
+
+    let visit_seq_expr = deserialize_seq(
+        cx,
+        builder,
+        builder.path().id(type_ident).build(),
+        1,
+    );
+
+    let type_name = builder.expr().str(type_ident);
+
+    quote_expr!(cx, {
+        $visitor_item
+
+        impl $visitor_generics ::serde::de::Visitor for $visitor_ty $where_clause {
+            type Value = $ty;
+
+            #[inline]
+            fn visit_newtype_struct<D>(&mut self, deserializer: &mut D) -> Result<Self::Value, D::Error>
+                where D: ::serde::de::Deserializer,
+            {
+                let value = try!(::serde::de::Deserialize::deserialize(deserializer));
+                Ok($type_ident(value))
+            }
+
+            #[inline]
+            fn visit_seq<__V>(&mut self, mut visitor: __V) -> ::std::result::Result<$ty, __V::Error>
+                where __V: ::serde::de::SeqVisitor,
+            {
+                $visit_seq_expr
+            }
+        }
+
+        deserializer.visit_newtype_struct($type_name, $visitor_expr)
     })
 }
 

--- a/serde_codegen/src/de.rs
+++ b/serde_codegen/src/de.rs
@@ -311,6 +311,7 @@ fn deserialize_tuple_struct(
         impl $visitor_generics ::serde::de::Visitor for $visitor_ty $where_clause {
             type Value = $ty;
 
+            #[inline]
             fn visit_seq<__V>(&mut self, mut visitor: __V) -> ::std::result::Result<$ty, __V::Error>
                 where __V: ::serde::de::SeqVisitor,
             {

--- a/serde_codegen/src/de.rs
+++ b/serde_codegen/src/de.rs
@@ -574,7 +574,7 @@ fn deserialize_variant(
         }
         ast::TupleVariantKind(ref args) if args.len() == 1 => {
             quote_expr!(cx, {
-                let val = try!(visitor.visit_simple());
+                let val = try!(visitor.visit_newtype());
                 Ok($type_ident::$variant_ident(val))
             })
         }

--- a/serde_codegen/src/ser.rs
+++ b/serde_codegen/src/ser.rs
@@ -306,7 +306,7 @@ fn serialize_variant(
                 .build();
             quote_arm!(cx,
                 $pat => {
-                    ::serde::ser::Serializer::visit_enum_simple(
+                    ::serde::ser::Serializer::visit_newtype_variant(
                         serializer,
                         $type_name,
                         $variant_index,

--- a/serde_json/src/de.rs
+++ b/serde_json/src/de.rs
@@ -454,6 +454,15 @@ impl<Iter> de::Deserializer for Deserializer<Iter>
     }
 
     #[inline]
+    fn visit_newtype_struct<V>(&mut self,
+                               _name: &str,
+                               mut visitor: V) -> Result<V::Value, Error>
+        where V: de::Visitor,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    #[inline]
     fn visit_enum<V>(&mut self,
                      _name: &str,
                      _variants: &'static [&'static str],

--- a/serde_json/src/de.rs
+++ b/serde_json/src/de.rs
@@ -644,7 +644,9 @@ impl<Iter> de::VariantVisitor for Deserializer<Iter>
         de::Deserialize::deserialize(self)
     }
 
-    fn visit_simple<T: de::Deserialize>(&mut self) -> Result<T, Error> {
+    fn visit_newtype<T>(&mut self) -> Result<T, Error>
+        where T: de::Deserialize,
+    {
         de::Deserialize::deserialize(self)
     }
 

--- a/serde_json/src/ser.rs
+++ b/serde_json/src/ser.rs
@@ -158,6 +158,16 @@ impl<W, F> ser::Serializer for Serializer<W, F>
         self.writer.write_all(b"null")
     }
 
+    /// Override `visit_newtype_struct` to serialize newtypes without an object wrapper.
+    #[inline]
+    fn visit_newtype_struct<T>(&mut self,
+                               _name: &'static str,
+                               value: T) -> Result<(), Self::Error>
+        where T: ser::Serialize,
+    {
+        value.serialize(self)
+    }
+
     #[inline]
     fn visit_unit_variant(&mut self,
                           _name: &str,

--- a/serde_json/src/ser.rs
+++ b/serde_json/src/ser.rs
@@ -172,12 +172,11 @@ impl<W, F> ser::Serializer for Serializer<W, F>
     }
 
     #[inline]
-    fn visit_enum_simple<T>(&mut self,
-                            _name: &str,
-                            _variant_index: usize,
-                            variant: &str,
-                            value: T,
-                            ) -> io::Result<()>
+    fn visit_newtype_variant<T>(&mut self,
+                                _name: &str,
+                                _variant_index: usize,
+                                variant: &str,
+                                value: T) -> io::Result<()>
         where T: ser::Serialize,
     {
         try!(self.formatter.open(&mut self.writer, b'{'));

--- a/serde_json/src/value.rs
+++ b/serde_json/src/value.rs
@@ -472,12 +472,11 @@ impl ser::Serializer for Serializer {
     }
 
     #[inline]
-    fn visit_enum_simple<T>(&mut self,
-                            _name: &str,
-                            _variant_index: usize,
-                            variant: &str,
-                            value: T,
-                            ) -> Result<(), ()>
+    fn visit_newtype_variant<T>(&mut self,
+                                _name: &str,
+                                _variant_index: usize,
+                                variant: &str,
+                                value: T) -> Result<(), ()>
         where T: ser::Serialize,
     {
         let mut values = BTreeMap::new();

--- a/serde_json/src/value.rs
+++ b/serde_json/src/value.rs
@@ -747,7 +747,7 @@ impl<'a> de::VariantVisitor for VariantDeserializer<'a> {
         de::Deserialize::deserialize(&mut Deserializer::new(self.val.take().unwrap()))
     }
 
-    fn visit_simple<T>(&mut self) -> Result<T, Error>
+    fn visit_newtype<T>(&mut self) -> Result<T, Error>
         where T: de::Deserialize,
     {
         de::Deserialize::deserialize(&mut Deserializer::new(self.val.take().unwrap()))

--- a/serde_tests/tests/test_de.rs
+++ b/serde_tests/tests/test_de.rs
@@ -40,7 +40,7 @@ enum Token {
 
     EnumStart(&'static str),
     EnumUnit,
-    EnumSimple,
+    EnumNewtype,
     EnumSeq,
     EnumMap,
     EnumEnd,
@@ -339,11 +339,11 @@ impl<'a> de::VariantVisitor for TokenDeserializerVariantVisitor<'a> {
         }
     }
 
-    fn visit_simple<T>(&mut self) -> Result<T, Self::Error>
+    fn visit_newtype<T>(&mut self) -> Result<T, Self::Error>
         where T: de::Deserialize,
     {
         match self.de.tokens.next() {
-            Some(Token::EnumSimple) => {
+            Some(Token::EnumNewtype) => {
                 de::Deserialize::deserialize(self.de)
             }
             Some(_) => Err(Error::SyntaxError),
@@ -541,7 +541,7 @@ declare_tests! {
             Token::EnumStart("Result"),
                 Token::Str("Ok"),
 
-                Token::EnumSimple,
+                Token::EnumNewtype,
                 Token::I32(0),
             Token::SeqEnd,
         ],
@@ -549,7 +549,7 @@ declare_tests! {
             Token::EnumStart("Result"),
                 Token::Str("Err"),
 
-                Token::EnumSimple,
+                Token::EnumNewtype,
                 Token::I32(1),
             Token::SeqEnd,
         ],
@@ -934,7 +934,7 @@ declare_tests! {
             Token::EnumStart("Enum"),
                 Token::Str("Simple"),
 
-                Token::EnumSimple,
+                Token::EnumNewtype,
                 Token::I32(1),
             Token::EnumEnd,
         ],

--- a/serde_tests/tests/test_ser.rs
+++ b/serde_tests/tests/test_ser.rs
@@ -27,7 +27,7 @@ pub enum Token<'a> {
     UnitStruct(&'a str),
     EnumUnit(&'a str, &'a str),
 
-    EnumSimple(&'a str, &'a str),
+    EnumNewtype(&'a str, &'a str),
 
     SeqStart(Option<usize>),
     TupleStructStart(&'a str, Option<usize>),
@@ -82,15 +82,14 @@ impl<'a> Serializer for AssertSerializer<'a> {
         Ok(())
     }
 
-    fn visit_enum_simple<T>(&mut self,
-                            name: &str,
-                            _variant_index: usize,
-                            variant: &str,
-                            value: T,
-                            ) -> Result<(), ()>
+    fn visit_newtype_variant<T>(&mut self,
+                                name: &str,
+                                _variant_index: usize,
+                                variant: &str,
+                                value: T) -> Result<(), ()>
         where T: Serialize,
     {
-        assert_eq!(self.iter.next(), Some(Token::EnumSimple(name, variant)));
+        assert_eq!(self.iter.next(), Some(Token::EnumNewtype(name, variant)));
         value.serialize(self)
     }
 
@@ -397,11 +396,11 @@ declare_tests! {
     }
     test_result {
         Ok::<i32, i32>(0) => vec![
-            Token::EnumSimple("Result", "Ok"),
+            Token::EnumNewtype("Result", "Ok"),
             Token::I32(0),
         ],
         Err::<i32, i32>(1) => vec![
-            Token::EnumSimple("Result", "Err"),
+            Token::EnumNewtype("Result", "Err"),
             Token::I32(1),
         ],
     }
@@ -565,7 +564,7 @@ declare_tests! {
     }
     test_enum {
         Enum::Unit => vec![Token::EnumUnit("Enum", "Unit")],
-        Enum::One(42) => vec![Token::EnumSimple("Enum", "One"), Token::I32(42)],
+        Enum::One(42) => vec![Token::EnumNewtype("Enum", "One"), Token::I32(42)],
         Enum::Seq(1, 2) => vec![
             Token::EnumSeqStart("Enum", "Seq", Some(2)),
                 Token::SeqSep,


### PR DESCRIPTION
This enables formats like JSON to serialize newtype wrapper structs without the normal object wrapper. Consider types like:

```rust
struct Point {
    x: u32,
    y: u32,
}

struct MyPoint(Point);
```

Before this patch, `MyPoint(1,2)` would get serialized as `[{"x":1,"y":2}]`, but now it gets serialized as `{"x":1,"y"2}`.