### PR TITLE
Update json number parsing to switch to floats if the number gets too big

### DIFF
--- a/serde_json/src/de.rs
+++ b/serde_json/src/de.rs
@@ -259,7 +259,9 @@ impl<Iter> Deserializer<Iter>
                 if pos {
                     visitor.visit_u64(res)
                 } else {
-                    let res_i64 = (res as i64).wrapping_neg();
+                    // FIXME: `wrapping_neg` will be stable in Rust 1.2
+                    //let res_i64 = (res as i64).wrapping_neg();
+                    let res_i64 = (!res + 1) as i64;
 
                     // Convert into a float if we underflow.
                     if res_i64 > 0 {

--- a/serde_json/src/de.rs
+++ b/serde_json/src/de.rs
@@ -167,7 +167,7 @@ impl<Iter> Deserializer<Iter>
                 if pos {
                     visitor.visit_u64(res)
                 } else {
-                    let res = -(res as i64);
+                    let res = (res as i64).wrapping_neg();
 
                     // Make sure we didn't underflow.
                     if res > 0 {

--- a/serde_json/src/de.rs
+++ b/serde_json/src/de.rs
@@ -183,19 +183,8 @@ impl<Iter> Deserializer<Iter>
                             // We need to be careful with overflow. If we can, try to keep the
                             // number as a `u64` until we grow too large. At that point, switch to
                             // parsing the value as a `f64`.
-                            match res.checked_mul(10) {
-                                Some(res_) => {
-                                    res = res_;
-                                    match res.checked_add(digit) {
-                                        Some(res_) => { res = res_; }
-                                        None => {
-                                            return self.parse_float(
-                                                pos,
-                                                (res as f64) + (digit as f64),
-                                                visitor);
-                                        }
-                                    }
-                                }
+                            match res.checked_mul(10).and_then(|val| val.checked_add(digit)) {
+                                Some(res_) => { res = res_; }
                                 None => {
                                     return self.parse_float(
                                         pos,

--- a/serde_json/src/error.rs
+++ b/serde_json/src/error.rs
@@ -1,6 +1,7 @@
 use std::error;
 use std::fmt;
 use std::io;
+use std::result;
 
 use serde::de;
 
@@ -183,3 +184,6 @@ impl de::Error for Error {
         Error::MissingFieldError(field)
     }
 }
+
+/// Helper alias for `Result` objects that return a JSON `Error`.
+pub type Result<T> = result::Result<T, Error>;

--- a/serde_json/src/lib.rs
+++ b/serde_json/src/lib.rs
@@ -96,7 +96,7 @@ extern crate num;
 extern crate serde;
 
 pub use self::de::{Deserializer, from_str};
-pub use self::error::{Error, ErrorCode};
+pub use self::error::{Error, ErrorCode, Result};
 pub use self::ser::{
     Serializer,
     to_writer,

--- a/serde_json/src/ser.rs
+++ b/serde_json/src/ser.rs
@@ -465,12 +465,7 @@ fn fmt_f32_or_null<W>(wr: &mut W, value: f32) -> io::Result<()>
     match value.classify() {
         FpCategory::Nan | FpCategory::Infinite => wr.write_all(b"null"),
         _ => {
-            let s = format!("{:?}", value);
-            try!(wr.write_all(s.as_bytes()));
-            if !s.contains('.') {
-                try!(wr.write_all(b".0"))
-            }
-            Ok(())
+            write!(wr, "{:?}", value)
         }
     }
 }
@@ -481,12 +476,7 @@ fn fmt_f64_or_null<W>(wr: &mut W, value: f64) -> io::Result<()>
     match value.classify() {
         FpCategory::Nan | FpCategory::Infinite => wr.write_all(b"null"),
         _ => {
-            let s = format!("{:?}", value);
-            try!(wr.write_all(s.as_bytes()));
-            if !s.contains('.') {
-                try!(wr.write_all(b".0"))
-            }
-            Ok(())
+            write!(wr, "{:?}", value)
         }
     }
 }

--- a/serde_tests/tests/test_json.rs
+++ b/serde_tests/tests/test_json.rs
@@ -708,7 +708,7 @@ fn test_parse_number_errors() {
         ("1e+", Error::SyntaxError(ErrorCode::InvalidNumber, 1, 3)),
         ("1a", Error::SyntaxError(ErrorCode::TrailingCharacters, 1, 2)),
         ("777777777777777777777777777", Error::SyntaxError(ErrorCode::InvalidNumber, 1, 20)),
-        ("1e777777777777777777777777777", Error::SyntaxError(ErrorCode::InvalidNumber, 1, 22)),
+        ("1e777777777777777777777777777", Error::SyntaxError(ErrorCode::InvalidNumber, 1, 23)),
     ]);
 }
 
@@ -735,13 +735,21 @@ fn test_parse_f64() {
     test_parse_ok(vec![
         ("0.0", 0.0f64),
         ("3.0", 3.0f64),
+        ("3.00", 3.0f64),
         ("3.1", 3.1),
         ("-1.2", -1.2),
         ("0.4", 0.4),
         ("0.4e5", 0.4e5),
+        ("0.4e+5", 0.4e5),
         ("0.4e15", 0.4e15),
-        ("0.4e-01", 0.4e-01),
-        (" 0.4e-01 ", 0.4e-01),
+        ("0.4e+15", 0.4e15),
+        ("0.4e-01", 0.4e-1),
+        (" 0.4e-01 ", 0.4e-1),
+        ("0.4e-001", 0.4e-1),
+        ("0.4e-0", 0.4e0),
+        ("0.00e00", 0.0),
+        ("0.00e+00", 0.0),
+        ("0.00e-00", 0.0),
     ]);
 }
 

--- a/serde_tests/tests/test_json.rs
+++ b/serde_tests/tests/test_json.rs
@@ -724,6 +724,7 @@ fn test_parse_i64() {
 #[test]
 fn test_parse_u64() {
     test_parse_ok(vec![
+        ("0", 0u64),
         ("3", 3u64),
         ("1234", 1234),
     ]);
@@ -732,6 +733,7 @@ fn test_parse_u64() {
 #[test]
 fn test_parse_f64() {
     test_parse_ok(vec![
+        ("0.0", 0.0f64),
         ("3.0", 3.0f64),
         ("3.1", 3.1),
         ("-1.2", -1.2),

--- a/serde_tests/tests/test_json.rs
+++ b/serde_tests/tests/test_json.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeMap;
 use std::fmt::Debug;
+use std::i64;
 use std::marker::PhantomData;
+use std::u64;
 
 use serde::de;
 use serde::ser;
@@ -83,11 +85,22 @@ fn test_write_null() {
 }
 
 #[test]
+fn test_write_u64() {
+    let tests = &[
+        (3u64, "3"),
+        (u64::MAX, &u64::MAX.to_string()),
+    ];
+    test_encode_ok(tests);
+    test_pretty_encode_ok(tests);
+}
+
+#[test]
 fn test_write_i64() {
     let tests = &[
         (3i64, "3"),
         (-2i64, "-2"),
         (-1234i64, "-1234"),
+        (i64::MIN, &i64::MIN.to_string()),
     ];
     test_encode_ok(tests);
     test_pretty_encode_ok(tests);
@@ -95,11 +108,18 @@ fn test_write_i64() {
 
 #[test]
 fn test_write_f64() {
+    let min_string = f64::MIN.to_string();
+    let max_string = f64::MAX.to_string();
+    let epsilon_string = f64::EPSILON.to_string();
+
     let tests = &[
         (3.0, "3.0"),
         (3.1, "3.1"),
         (-1.5, "-1.5"),
         (0.5, "0.5"),
+        (f64::MIN, &min_string),
+        (f64::MAX, &max_string),
+        (f64::EPSILON, &epsilon_string),
     ];
     test_encode_ok(tests);
     test_pretty_encode_ok(tests);
@@ -621,7 +641,7 @@ fn test_write_option() {
     ]);
 }
 
-fn test_parse_ok<T>(errors: Vec<(&'static str, T)>)
+fn test_parse_ok<T>(errors: Vec<(&str, T)>)
     where T: Clone + Debug + PartialEq + ser::Serialize + de::Deserialize,
 {
     for (s, value) in errors {
@@ -718,6 +738,8 @@ fn test_parse_i64() {
         ("-2", -2),
         ("-1234", -1234),
         (" -1234 ", -1234),
+        (&i64::MIN.to_string(), i64::MIN),
+        (&i64::MAX.to_string(), i64::MAX),
     ]);
 }
 
@@ -727,6 +749,7 @@ fn test_parse_u64() {
         ("0", 0u64),
         ("3", 3u64),
         ("1234", 1234),
+        (&u64::MAX.to_string(), u64::MAX),
     ]);
 }
 

--- a/serde_tests/tests/test_json.rs
+++ b/serde_tests/tests/test_json.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::f64;
 use std::fmt::Debug;
 use std::i64;
 use std::marker::PhantomData;
@@ -108,12 +109,12 @@ fn test_write_i64() {
 
 #[test]
 fn test_write_f64() {
-    let min_string = f64::MIN.to_string();
-    let max_string = f64::MAX.to_string();
-    let epsilon_string = f64::EPSILON.to_string();
+    let min_string = format!("{:?}", f64::MIN);
+    let max_string = format!("{:?}", f64::MAX);
+    let epsilon_string = format!("{:?}", f64::EPSILON);
 
     let tests = &[
-        (3.0, "3.0"),
+        (3.0, "3"),
         (3.1, "3.1"),
         (-1.5, "-1.5"),
         (0.5, "0.5"),
@@ -727,7 +728,6 @@ fn test_parse_number_errors() {
         ("1e", Error::SyntaxError(ErrorCode::InvalidNumber, 1, 2)),
         ("1e+", Error::SyntaxError(ErrorCode::InvalidNumber, 1, 3)),
         ("1a", Error::SyntaxError(ErrorCode::TrailingCharacters, 1, 2)),
-        ("777777777777777777777777777", Error::SyntaxError(ErrorCode::InvalidNumber, 1, 20)),
         ("1e777777777777777777777777777", Error::SyntaxError(ErrorCode::InvalidNumber, 1, 23)),
     ]);
 }
@@ -773,6 +773,9 @@ fn test_parse_f64() {
         ("0.00e00", 0.0),
         ("0.00e+00", 0.0),
         ("0.00e-00", 0.0),
+        (&format!("{:?}", (i64::MIN as f64) - 1.0), (i64::MIN as f64) - 1.0),
+        (&format!("{:?}", (u64::MAX as f64) + 1.0), (u64::MAX as f64) + 1.0),
+        (&format!("{:?}", f64::EPSILON), f64::EPSILON),
     ]);
 }
 


### PR DESCRIPTION
This patch switches json to parse a large number as a `f64` if it grows bigger than one that can fit into `i64`.

Along the way it also adds a `json::Result` helper type as well.