### PR TITLE
Remove "_error" from de::Error methods, add string argument to Error::syntax()

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ to generate an error for a few common error conditions. Here's how it could be u
     fn visit_string<E>(&mut self, _: String) -> Result<i32, E>
         where E: Error,
     {
-        Err(serde::de::Error::syntax())
+        Err(serde::de::Error::syntax("expect a string"))
     }
 
     ...
@@ -366,7 +366,7 @@ impl serde::Deserialize for PointField {
                 match value {
                     "x" => Ok(Field::X),
                     "y" => Ok(Field::Y),
-                    _ => Err(serde::de::Error::syntax()),
+                    _ => Err(serde::de::Error::syntax("expected x or y")),
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ to generate an error for a few common error conditions. Here's how it could be u
     fn visit_string<E>(&mut self, _: String) -> Result<i32, E>
         where E: Error,
     {
-        Err(serde::de::Error::syntax_error())
+        Err(serde::de::Error::syntax())
     }
 
     ...
@@ -366,7 +366,7 @@ impl serde::Deserialize for PointField {
                 match value {
                     "x" => Ok(Field::X),
                     "y" => Ok(Field::Y),
-                    _ => Err(serde::de::Error::syntax_error()),
+                    _ => Err(serde::de::Error::syntax()),
                 }
             }
         }

--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -85,7 +85,7 @@ impl Visitor for BoolVisitor {
         match s.trim() {
             "true" => Ok(true),
             "false" => Ok(false),
-            _ => Err(Error::syntax_error()),
+            _ => Err(Error::syntax()),
         }
     }
 }
@@ -108,7 +108,7 @@ macro_rules! impl_deserialize_num_method {
         {
             match FromPrimitive::$from_method(v) {
                 Some(v) => Ok(v),
-                None => Err(Error::syntax_error()),
+                None => Err(Error::syntax()),
             }
         }
     }
@@ -149,7 +149,7 @@ impl<
     fn visit_str<E>(&mut self, v: &str) -> Result<T, E>
         where E: Error,
     {
-        str::FromStr::from_str(v.trim()).or(Err(Error::syntax_error()))
+        str::FromStr::from_str(v.trim()).or(Err(Error::syntax()))
     }
 }
 
@@ -200,12 +200,12 @@ impl Visitor for CharVisitor {
         let mut iter = v.chars();
         if let Some(v) = iter.next() {
             if iter.next().is_some() {
-                Err(Error::syntax_error())
+                Err(Error::syntax())
             } else {
                 Ok(v)
             }
         } else {
-            Err(Error::end_of_stream_error())
+            Err(Error::end_of_stream())
         }
     }
 }
@@ -243,7 +243,7 @@ impl Visitor for StringVisitor {
     {
         match str::from_utf8(v) {
             Ok(s) => Ok(s.to_string()),
-            Err(_) => Err(Error::syntax_error()),
+            Err(_) => Err(Error::syntax()),
         }
     }
 
@@ -252,7 +252,7 @@ impl Visitor for StringVisitor {
     {
         match String::from_utf8(v) {
             Ok(s) => Ok(s),
-            Err(_) => Err(Error::syntax_error()),
+            Err(_) => Err(Error::syntax()),
         }
     }
 }
@@ -495,7 +495,7 @@ macro_rules! array_impls {
                     $(
                         let $name = match try!(visitor.visit()) {
                             Some(val) => val,
-                            None => { return Err(Error::end_of_stream_error()); }
+                            None => { return Err(Error::end_of_stream()); }
                         };
                     )+;
 
@@ -593,7 +593,7 @@ macro_rules! tuple_impls {
                     $(
                         let $name = match try!(visitor.visit()) {
                             Some(value) => value,
-                            None => { return Err(Error::end_of_stream_error()); }
+                            None => { return Err(Error::end_of_stream()); }
                         };
                      )+;
 
@@ -848,7 +848,7 @@ impl<T> Deserialize for NonZero<T> where T: Deserialize + PartialEq + Zeroable +
     fn deserialize<D>(deserializer: &mut D) -> Result<NonZero<T>, D::Error> where D: Deserializer {
         let value = try!(Deserialize::deserialize(deserializer));
         if value == Zero::zero() {
-            return Err(Error::syntax_error())
+            return Err(Error::syntax())
         }
         unsafe {
             Ok(NonZero::new(value))
@@ -881,7 +881,7 @@ impl<T, E> Deserialize for Result<T, E> where T: Deserialize, E: Deserialize {
                         match value {
                             0 => Ok(Field::Ok),
                             1 => Ok(Field::Err),
-                            _ => Err(Error::unknown_field_error(&value.to_string())),
+                            _ => Err(Error::unknown_field(&value.to_string())),
                         }
                     }
 
@@ -889,7 +889,7 @@ impl<T, E> Deserialize for Result<T, E> where T: Deserialize, E: Deserialize {
                         match value {
                             "Ok" => Ok(Field::Ok),
                             "Err" => Ok(Field::Err),
-                            _ => Err(Error::unknown_field_error(value)),
+                            _ => Err(Error::unknown_field(value)),
                         }
                     }
 
@@ -899,8 +899,8 @@ impl<T, E> Deserialize for Result<T, E> where T: Deserialize, E: Deserialize {
                             b"Err" => Ok(Field::Err),
                             _ => {
                                 match str::from_utf8(value) {
-                                    Ok(value) => Err(Error::unknown_field_error(value)),
-                                    Err(_) => Err(Error::syntax_error()),
+                                    Ok(value) => Err(Error::unknown_field(value)),
+                                    Err(_) => Err(Error::syntax()),
                                 }
                             }
                         }

--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -85,7 +85,7 @@ impl Visitor for BoolVisitor {
         match s.trim() {
             "true" => Ok(true),
             "false" => Ok(false),
-            _ => Err(Error::syntax()),
+            _ => Err(Error::syntax("expected `true` or `false`")),
         }
     }
 }
@@ -108,7 +108,7 @@ macro_rules! impl_deserialize_num_method {
         {
             match FromPrimitive::$from_method(v) {
                 Some(v) => Ok(v),
-                None => Err(Error::syntax()),
+                None => Err(Error::syntax("expected a number")),
             }
         }
     }
@@ -149,7 +149,7 @@ impl<
     fn visit_str<E>(&mut self, v: &str) -> Result<T, E>
         where E: Error,
     {
-        str::FromStr::from_str(v.trim()).or(Err(Error::syntax()))
+        str::FromStr::from_str(v.trim()).or(Err(Error::syntax("expected a str")))
     }
 }
 
@@ -200,7 +200,7 @@ impl Visitor for CharVisitor {
         let mut iter = v.chars();
         if let Some(v) = iter.next() {
             if iter.next().is_some() {
-                Err(Error::syntax())
+                Err(Error::syntax("expected a character"))
             } else {
                 Ok(v)
             }
@@ -243,7 +243,7 @@ impl Visitor for StringVisitor {
     {
         match str::from_utf8(v) {
             Ok(s) => Ok(s.to_string()),
-            Err(_) => Err(Error::syntax()),
+            Err(_) => Err(Error::syntax("expected utf8 `&[u8]`")),
         }
     }
 
@@ -252,7 +252,7 @@ impl Visitor for StringVisitor {
     {
         match String::from_utf8(v) {
             Ok(s) => Ok(s),
-            Err(_) => Err(Error::syntax()),
+            Err(_) => Err(Error::syntax("expected utf8 `&[u8]`")),
         }
     }
 }
@@ -848,7 +848,7 @@ impl<T> Deserialize for NonZero<T> where T: Deserialize + PartialEq + Zeroable +
     fn deserialize<D>(deserializer: &mut D) -> Result<NonZero<T>, D::Error> where D: Deserializer {
         let value = try!(Deserialize::deserialize(deserializer));
         if value == Zero::zero() {
-            return Err(Error::syntax())
+            return Err(Error::syntax("expected a non-zero value"))
         }
         unsafe {
             Ok(NonZero::new(value))
@@ -900,7 +900,7 @@ impl<T, E> Deserialize for Result<T, E> where T: Deserialize, E: Deserialize {
                             _ => {
                                 match str::from_utf8(value) {
                                     Ok(value) => Err(Error::unknown_field(value)),
-                                    Err(_) => Err(Error::syntax()),
+                                    Err(_) => Err(Error::syntax("expected a `&[u8]`")),
                                 }
                             }
                         }

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -6,13 +6,13 @@ pub mod value;
 ///////////////////////////////////////////////////////////////////////////////
 
 pub trait Error {
-    fn syntax_error() -> Self;
+    fn syntax() -> Self;
 
-    fn end_of_stream_error() -> Self;
+    fn end_of_stream() -> Self;
 
-    fn unknown_field_error(field: &str) -> Self;
+    fn unknown_field(field: &str) -> Self;
 
-    fn missing_field_error(field: &'static str) -> Self;
+    fn missing_field(field: &'static str) -> Self;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -273,7 +273,7 @@ pub trait Deserializer {
                      _visitor: V) -> Result<V::Value, Self::Error>
         where V: EnumVisitor,
     {
-        Err(Error::syntax_error())
+        Err(Error::syntax())
     }
 
     /// This method hints that the `Deserialize` type is expecting a `Vec<u8>`. This allows
@@ -304,7 +304,7 @@ pub trait Visitor {
     fn visit_bool<E>(&mut self, _v: bool) -> Result<Self::Value, E>
         where E: Error,
     {
-        Err(Error::syntax_error())
+        Err(Error::syntax())
     }
 
     fn visit_isize<E>(&mut self, v: isize) -> Result<Self::Value, E>
@@ -334,7 +334,7 @@ pub trait Visitor {
     fn visit_i64<E>(&mut self, _v: i64) -> Result<Self::Value, E>
         where E: Error,
     {
-        Err(Error::syntax_error())
+        Err(Error::syntax())
     }
 
     fn visit_usize<E>(&mut self, v: usize) -> Result<Self::Value, E>
@@ -364,7 +364,7 @@ pub trait Visitor {
     fn visit_u64<E>(&mut self, _v: u64) -> Result<Self::Value, E>
         where E: Error,
     {
-        Err(Error::syntax_error())
+        Err(Error::syntax())
     }
 
     fn visit_f32<E>(&mut self, v: f32) -> Result<Self::Value, E>
@@ -376,7 +376,7 @@ pub trait Visitor {
     fn visit_f64<E>(&mut self, _v: f64) -> Result<Self::Value, E>
         where E: Error,
     {
-        Err(Error::syntax_error())
+        Err(Error::syntax())
     }
 
     #[inline]
@@ -391,7 +391,7 @@ pub trait Visitor {
     fn visit_str<E>(&mut self, _v: &str) -> Result<Self::Value, E>
         where E: Error,
     {
-        Err(Error::syntax_error())
+        Err(Error::syntax())
     }
 
     #[inline]
@@ -404,7 +404,7 @@ pub trait Visitor {
     fn visit_unit<E>(&mut self) -> Result<Self::Value, E>
         where E: Error,
     {
-        Err(Error::syntax_error())
+        Err(Error::syntax())
     }
 
     #[inline]
@@ -417,37 +417,37 @@ pub trait Visitor {
     fn visit_none<E>(&mut self) -> Result<Self::Value, E>
         where E: Error,
     {
-        Err(Error::syntax_error())
+        Err(Error::syntax())
     }
 
     fn visit_some<D>(&mut self, _deserializer: &mut D) -> Result<Self::Value, D::Error>
         where D: Deserializer,
     {
-        Err(Error::syntax_error())
+        Err(Error::syntax())
     }
 
     fn visit_newtype_struct<D>(&mut self, _deserializer: &mut D) -> Result<Self::Value, D::Error>
         where D: Deserializer,
     {
-        Err(Error::syntax_error())
+        Err(Error::syntax())
     }
 
     fn visit_seq<V>(&mut self, _visitor: V) -> Result<Self::Value, V::Error>
         where V: SeqVisitor,
     {
-        Err(Error::syntax_error())
+        Err(Error::syntax())
     }
 
     fn visit_map<V>(&mut self, _visitor: V) -> Result<Self::Value, V::Error>
         where V: MapVisitor,
     {
-        Err(Error::syntax_error())
+        Err(Error::syntax())
     }
 
     fn visit_bytes<E>(&mut self, _v: &[u8]) -> Result<Self::Value, E>
         where E: Error,
     {
-        Err(Error::syntax_error())
+        Err(Error::syntax())
     }
 
     fn visit_byte_buf<E>(&mut self, v: Vec<u8>) -> Result<Self::Value, E>
@@ -529,7 +529,7 @@ pub trait MapVisitor {
     fn missing_field<V>(&mut self, field: &'static str) -> Result<V, Self::Error>
         where V: Deserialize,
     {
-        Err(Error::missing_field_error(field))
+        Err(Error::missing_field(field))
     }
 }
 
@@ -593,7 +593,7 @@ pub trait VariantVisitor {
 
     /// `visit_unit` is called when deserializing a variant with no values.
     fn visit_unit(&mut self) -> Result<(), Self::Error> {
-        Err(Error::syntax_error())
+        Err(Error::syntax())
     }
 
     /// `visit_newtype` is called when deserializing a variant with a single value. By default this
@@ -612,7 +612,7 @@ pub trait VariantVisitor {
                       _visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor
     {
-        Err(Error::syntax_error())
+        Err(Error::syntax())
     }
 
     /// `visit_struct` is called when deserializing a struct-like variant.
@@ -621,7 +621,7 @@ pub trait VariantVisitor {
                        _visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor
     {
-        Err(Error::syntax_error())
+        Err(Error::syntax())
     }
 }
 

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -6,7 +6,7 @@ pub mod value;
 ///////////////////////////////////////////////////////////////////////////////
 
 pub trait Error {
-    fn syntax() -> Self;
+    fn syntax(msg: &str) -> Self;
 
     fn end_of_stream() -> Self;
 
@@ -273,7 +273,7 @@ pub trait Deserializer {
                      _visitor: V) -> Result<V::Value, Self::Error>
         where V: EnumVisitor,
     {
-        Err(Error::syntax())
+        Err(Error::syntax("expected an enum"))
     }
 
     /// This method hints that the `Deserialize` type is expecting a `Vec<u8>`. This allows
@@ -304,7 +304,7 @@ pub trait Visitor {
     fn visit_bool<E>(&mut self, _v: bool) -> Result<Self::Value, E>
         where E: Error,
     {
-        Err(Error::syntax())
+        Err(Error::syntax("expected a bool"))
     }
 
     fn visit_isize<E>(&mut self, v: isize) -> Result<Self::Value, E>
@@ -334,7 +334,7 @@ pub trait Visitor {
     fn visit_i64<E>(&mut self, _v: i64) -> Result<Self::Value, E>
         where E: Error,
     {
-        Err(Error::syntax())
+        Err(Error::syntax("expected a i64"))
     }
 
     fn visit_usize<E>(&mut self, v: usize) -> Result<Self::Value, E>
@@ -364,7 +364,7 @@ pub trait Visitor {
     fn visit_u64<E>(&mut self, _v: u64) -> Result<Self::Value, E>
         where E: Error,
     {
-        Err(Error::syntax())
+        Err(Error::syntax("expected a u64"))
     }
 
     fn visit_f32<E>(&mut self, v: f32) -> Result<Self::Value, E>
@@ -376,7 +376,7 @@ pub trait Visitor {
     fn visit_f64<E>(&mut self, _v: f64) -> Result<Self::Value, E>
         where E: Error,
     {
-        Err(Error::syntax())
+        Err(Error::syntax("expected a f64"))
     }
 
     #[inline]
@@ -391,7 +391,7 @@ pub trait Visitor {
     fn visit_str<E>(&mut self, _v: &str) -> Result<Self::Value, E>
         where E: Error,
     {
-        Err(Error::syntax())
+        Err(Error::syntax("expected a str"))
     }
 
     #[inline]
@@ -404,7 +404,7 @@ pub trait Visitor {
     fn visit_unit<E>(&mut self) -> Result<Self::Value, E>
         where E: Error,
     {
-        Err(Error::syntax())
+        Err(Error::syntax("expected a unit"))
     }
 
     #[inline]
@@ -417,37 +417,37 @@ pub trait Visitor {
     fn visit_none<E>(&mut self) -> Result<Self::Value, E>
         where E: Error,
     {
-        Err(Error::syntax())
+        Err(Error::syntax("expected an Option::None"))
     }
 
     fn visit_some<D>(&mut self, _deserializer: &mut D) -> Result<Self::Value, D::Error>
         where D: Deserializer,
     {
-        Err(Error::syntax())
+        Err(Error::syntax("expected an Option::Some"))
     }
 
     fn visit_newtype_struct<D>(&mut self, _deserializer: &mut D) -> Result<Self::Value, D::Error>
         where D: Deserializer,
     {
-        Err(Error::syntax())
+        Err(Error::syntax("expected a newtype struct"))
     }
 
     fn visit_seq<V>(&mut self, _visitor: V) -> Result<Self::Value, V::Error>
         where V: SeqVisitor,
     {
-        Err(Error::syntax())
+        Err(Error::syntax("expected a sequence"))
     }
 
     fn visit_map<V>(&mut self, _visitor: V) -> Result<Self::Value, V::Error>
         where V: MapVisitor,
     {
-        Err(Error::syntax())
+        Err(Error::syntax("expected a map"))
     }
 
     fn visit_bytes<E>(&mut self, _v: &[u8]) -> Result<Self::Value, E>
         where E: Error,
     {
-        Err(Error::syntax())
+        Err(Error::syntax("expected a &[u8]"))
     }
 
     fn visit_byte_buf<E>(&mut self, v: Vec<u8>) -> Result<Self::Value, E>
@@ -593,7 +593,7 @@ pub trait VariantVisitor {
 
     /// `visit_unit` is called when deserializing a variant with no values.
     fn visit_unit(&mut self) -> Result<(), Self::Error> {
-        Err(Error::syntax())
+        Err(Error::syntax("expected a univ variant"))
     }
 
     /// `visit_newtype` is called when deserializing a variant with a single value. By default this
@@ -612,7 +612,7 @@ pub trait VariantVisitor {
                       _visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor
     {
-        Err(Error::syntax())
+        Err(Error::syntax("expected a tuple variant"))
     }
 
     /// `visit_struct` is called when deserializing a struct-like variant.
@@ -621,7 +621,7 @@ pub trait VariantVisitor {
                        _visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor
     {
-        Err(Error::syntax())
+        Err(Error::syntax("expected a struct variant"))
     }
 }
 

--- a/serde/src/de/value.rs
+++ b/serde/src/de/value.rs
@@ -24,9 +24,9 @@ pub enum Error {
 }
 
 impl de::Error for Error {
-    fn syntax() -> Self { Error::SyntaxError }
+    fn syntax(_: &str) -> Self { Error::SyntaxError }
     fn end_of_stream() -> Self { Error::EndOfStreamError }
-    fn unknown_field(field: &str) -> Self { Error::UnknownFieldError(field.to_string()) }
+    fn unknown_field(field: &str) -> Self { Error::UnknownFieldError(String::from(field)) }
     fn missing_field(field: &'static str) -> Self { Error::MissingFieldError(field) }
 }
 
@@ -374,7 +374,7 @@ impl<I, K, V> de::MapVisitor for MapDeserializer<I, K, V>
                 let mut de = value.into_deserializer();
                 de::Deserialize::deserialize(&mut de)
             }
-            None => Err(de::Error::syntax())
+            None => Err(de::Error::syntax("expected a map value"))
         }
     }
 

--- a/serde/src/de/value.rs
+++ b/serde/src/de/value.rs
@@ -24,10 +24,10 @@ pub enum Error {
 }
 
 impl de::Error for Error {
-    fn syntax_error() -> Self { Error::SyntaxError }
-    fn end_of_stream_error() -> Self { Error::EndOfStreamError }
-    fn unknown_field_error(field: &str) -> Self { Error::UnknownFieldError(field.to_string()) }
-    fn missing_field_error(field: &'static str) -> Self { Error::MissingFieldError(field) }
+    fn syntax() -> Self { Error::SyntaxError }
+    fn end_of_stream() -> Self { Error::EndOfStreamError }
+    fn unknown_field(field: &str) -> Self { Error::UnknownFieldError(field.to_string()) }
+    fn missing_field(field: &'static str) -> Self { Error::MissingFieldError(field) }
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -89,7 +89,7 @@ macro_rules! primitive_deserializer {
             {
                 match self.0.take() {
                     Some(v) => visitor.$method(v),
-                    None => Err(de::Error::end_of_stream_error()),
+                    None => Err(de::Error::end_of_stream()),
                 }
             }
         }
@@ -132,7 +132,7 @@ impl<'a> de::Deserializer for StrDeserializer<'a> {
     {
         match self.0.take() {
             Some(v) => visitor.visit_str(v),
-            None => Err(de::Error::end_of_stream_error()),
+            None => Err(de::Error::end_of_stream()),
         }
     }
 
@@ -181,7 +181,7 @@ impl de::Deserializer for StringDeserializer {
     {
         match self.0.take() {
             Some(string) => visitor.visit_string(string),
-            None => Err(de::Error::end_of_stream_error()),
+            None => Err(de::Error::end_of_stream()),
         }
     }
 
@@ -261,7 +261,7 @@ impl<I, T> de::SeqVisitor for SeqDeserializer<I>
         if self.len == 0 {
             Ok(())
         } else {
-            Err(de::Error::end_of_stream_error())
+            Err(de::Error::end_of_stream())
         }
     }
 
@@ -374,7 +374,7 @@ impl<I, K, V> de::MapVisitor for MapDeserializer<I, K, V>
                 let mut de = value.into_deserializer();
                 de::Deserialize::deserialize(&mut de)
             }
-            None => Err(de::Error::syntax_error())
+            None => Err(de::Error::syntax())
         }
     }
 
@@ -382,7 +382,7 @@ impl<I, K, V> de::MapVisitor for MapDeserializer<I, K, V>
         if self.len == 0 {
             Ok(())
         } else {
-            Err(de::Error::end_of_stream_error())
+            Err(de::Error::end_of_stream())
         }
     }
 
@@ -438,7 +438,7 @@ impl<'a> de::Deserializer for BytesDeserializer<'a> {
     {
         match self.0.take() {
             Some(bytes) => visitor.visit_bytes(bytes),
-            None => Err(de::Error::end_of_stream_error()),
+            None => Err(de::Error::end_of_stream()),
         }
     }
 }
@@ -465,7 +465,7 @@ impl de::Deserializer for ByteBufDeserializer {
     {
         match self.0.take() {
             Some(bytes) => visitor.visit_byte_buf(bytes),
-            None => Err(de::Error::end_of_stream_error()),
+            None => Err(de::Error::end_of_stream()),
         }
     }
 }

--- a/serde_codegen/src/de.rs
+++ b/serde_codegen/src/de.rs
@@ -804,7 +804,7 @@ fn deserialize_field_visitor(
     let index_body = quote_expr!(cx,
         match value {
             $index_field_arms
-            _ => { Err(::serde::de::Error::syntax()) }
+            _ => { Err(::serde::de::Error::syntax("expected a field")) }
         }
     );
 
@@ -903,7 +903,13 @@ fn deserialize_field_visitor(
                         // TODO: would be better to generate a byte string literal match
                         match ::std::str::from_utf8(value) {
                             Ok(s) => self.visit_str(s),
-                            _ => Err(::serde::de::Error::syntax()),
+                            _ => {
+                                Err(
+                                    ::serde::de::Error::syntax(
+                                        "could not convert a byte string to a String"
+                                    )
+                                )
+                            }
                         }
                     }
                 }

--- a/serde_codegen/src/de.rs
+++ b/serde_codegen/src/de.rs
@@ -397,7 +397,7 @@ fn deserialize_seq(
                 let $name = match try!(visitor.visit()) {
                     Some(value) => { value },
                     None => {
-                        return Err(::serde::de::Error::end_of_stream_error());
+                        return Err(::serde::de::Error::end_of_stream());
                     }
                 };
             ).unwrap()
@@ -431,7 +431,7 @@ fn deserialize_struct_as_seq(
                 let $name = match try!(visitor.visit()) {
                     Some(value) => { value },
                     None => {
-                        return Err(::serde::de::Error::end_of_stream_error());
+                        return Err(::serde::de::Error::end_of_stream());
                     }
                 };
             ).unwrap()
@@ -804,7 +804,7 @@ fn deserialize_field_visitor(
     let index_body = quote_expr!(cx,
         match value {
             $index_field_arms
-            _ => { Err(::serde::de::Error::syntax_error()) }
+            _ => { Err(::serde::de::Error::syntax()) }
         }
     );
 
@@ -829,7 +829,7 @@ fn deserialize_field_visitor(
         quote_expr!(cx,
             match value {
                 $default_field_arms
-                _ => { Err(::serde::de::Error::unknown_field_error(value)) }
+                _ => { Err(::serde::de::Error::unknown_field(value)) }
             })
     } else {
         let field_arms: Vec<_> = formats.iter()
@@ -851,7 +851,7 @@ fn deserialize_field_visitor(
                     match value {
                         $arms
                         _ => {
-                            Err(::serde::de::Error::unknown_field_error(value))
+                            Err(::serde::de::Error::unknown_field(value))
                         }
                     }})
             })
@@ -862,7 +862,7 @@ fn deserialize_field_visitor(
                 $fmt_matches
                 _ => match value {
                     $default_field_arms
-                    _ => { Err(::serde::de::Error::unknown_field_error(value)) }
+                    _ => { Err(::serde::de::Error::unknown_field(value)) }
                 }
             }
         )
@@ -903,7 +903,7 @@ fn deserialize_field_visitor(
                         // TODO: would be better to generate a byte string literal match
                         match ::std::str::from_utf8(value) {
                             Ok(s) => self.visit_str(s),
-                            _ => Err(::serde::de::Error::syntax_error()),
+                            _ => Err(::serde::de::Error::syntax()),
                         }
                     }
                 }

--- a/serde_json/src/error.rs
+++ b/serde_json/src/error.rs
@@ -152,7 +152,7 @@ impl From<de::value::Error> for Error {
     fn from(error: de::value::Error) -> Error {
         match error {
             de::value::Error::SyntaxError => {
-                de::Error::syntax()
+                Error::SyntaxError(ErrorCode::ExpectedSomeValue, 0, 0)
             }
             de::value::Error::EndOfStreamError => {
                 de::Error::end_of_stream()
@@ -168,7 +168,7 @@ impl From<de::value::Error> for Error {
 }
 
 impl de::Error for Error {
-    fn syntax() -> Error {
+    fn syntax(_: &str) -> Error {
         Error::SyntaxError(ErrorCode::ExpectedSomeValue, 0, 0)
     }
 

--- a/serde_json/src/error.rs
+++ b/serde_json/src/error.rs
@@ -152,35 +152,35 @@ impl From<de::value::Error> for Error {
     fn from(error: de::value::Error) -> Error {
         match error {
             de::value::Error::SyntaxError => {
-                de::Error::syntax_error()
+                de::Error::syntax()
             }
             de::value::Error::EndOfStreamError => {
-                de::Error::end_of_stream_error()
+                de::Error::end_of_stream()
             }
             de::value::Error::UnknownFieldError(field) => {
                 Error::SyntaxError(ErrorCode::UnknownField(field), 0, 0)
             }
             de::value::Error::MissingFieldError(field) => {
-                de::Error::missing_field_error(field)
+                de::Error::missing_field(field)
             }
         }
     }
 }
 
 impl de::Error for Error {
-    fn syntax_error() -> Error {
+    fn syntax() -> Error {
         Error::SyntaxError(ErrorCode::ExpectedSomeValue, 0, 0)
     }
 
-    fn end_of_stream_error() -> Error {
+    fn end_of_stream() -> Error {
         Error::SyntaxError(ErrorCode::EOFWhileParsingValue, 0, 0)
     }
 
-    fn unknown_field_error(field: &str) -> Error {
+    fn unknown_field(field: &str) -> Error {
         Error::SyntaxError(ErrorCode::UnknownField(field.to_string()), 0, 0)
     }
 
-    fn missing_field_error(field: &'static str) -> Error {
+    fn missing_field(field: &'static str) -> Error {
         Error::MissingFieldError(field)
     }
 }

--- a/serde_json/src/value.rs
+++ b/serde_json/src/value.rs
@@ -700,7 +700,7 @@ impl de::Deserializer for Deserializer {
     {
         let value = match self.value.take() {
             Some(Value::Object(value)) => value,
-            Some(_) => { return Err(de::Error::syntax()); }
+            Some(_) => { return Err(de::Error::syntax("expected an enum")); }
             None => { return Err(de::Error::end_of_stream()); }
         };
 
@@ -708,12 +708,12 @@ impl de::Deserializer for Deserializer {
 
         let (variant, value) = match iter.next() {
             Some(v) => v,
-            None => return Err(de::Error::syntax()),
+            None => return Err(de::Error::syntax("expected a variant name")),
         };
 
         // enums are encoded in json as maps with a single key:value pair
         match iter.next() {
-            Some(_) => Err(de::Error::syntax()),
+            Some(_) => Err(de::Error::syntax("expected map")),
             None => visitor.visit(VariantDeserializer {
                 de: self,
                 val: Some(value),
@@ -768,7 +768,7 @@ impl<'a> de::VariantVisitor for VariantDeserializer<'a> {
                 visitor,
             )
         } else {
-            Err(de::Error::syntax())
+            Err(de::Error::syntax("expected a tuple"))
         }
     }
 
@@ -788,7 +788,7 @@ impl<'a> de::VariantVisitor for VariantDeserializer<'a> {
                 visitor,
             )
         } else {
-            Err(de::Error::syntax())
+            Err(de::Error::syntax("expected a struct"))
         }
     }
 }

--- a/serde_json/src/value.rs
+++ b/serde_json/src/value.rs
@@ -650,7 +650,7 @@ impl de::Deserializer for Deserializer {
     {
         let value = match self.value.take() {
             Some(value) => value,
-            None => { return Err(de::Error::end_of_stream_error()); }
+            None => { return Err(de::Error::end_of_stream()); }
         };
 
         match value {
@@ -687,7 +687,7 @@ impl de::Deserializer for Deserializer {
         match self.value {
             Some(Value::Null) => visitor.visit_none(),
             Some(_) => visitor.visit_some(self),
-            None => Err(de::Error::end_of_stream_error()),
+            None => Err(de::Error::end_of_stream()),
         }
     }
 
@@ -700,20 +700,20 @@ impl de::Deserializer for Deserializer {
     {
         let value = match self.value.take() {
             Some(Value::Object(value)) => value,
-            Some(_) => { return Err(de::Error::syntax_error()); }
-            None => { return Err(de::Error::end_of_stream_error()); }
+            Some(_) => { return Err(de::Error::syntax()); }
+            None => { return Err(de::Error::end_of_stream()); }
         };
 
         let mut iter = value.into_iter();
 
         let (variant, value) = match iter.next() {
             Some(v) => v,
-            None => return Err(de::Error::syntax_error()),
+            None => return Err(de::Error::syntax()),
         };
 
         // enums are encoded in json as maps with a single key:value pair
         match iter.next() {
-            Some(_) => Err(de::Error::syntax_error()),
+            Some(_) => Err(de::Error::syntax()),
             None => visitor.visit(VariantDeserializer {
                 de: self,
                 val: Some(value),
@@ -768,7 +768,7 @@ impl<'a> de::VariantVisitor for VariantDeserializer<'a> {
                 visitor,
             )
         } else {
-            Err(de::Error::syntax_error())
+            Err(de::Error::syntax())
         }
     }
 
@@ -788,7 +788,7 @@ impl<'a> de::VariantVisitor for VariantDeserializer<'a> {
                 visitor,
             )
         } else {
-            Err(de::Error::syntax_error())
+            Err(de::Error::syntax())
         }
     }
 }
@@ -834,7 +834,7 @@ impl<'a> de::SeqVisitor for SeqDeserializer<'a> {
         if self.len == 0 {
             Ok(())
         } else {
-            Err(de::Error::end_of_stream_error())
+            Err(de::Error::end_of_stream())
         }
     }
 
@@ -879,7 +879,7 @@ impl<'a> de::MapVisitor for MapDeserializer<'a> {
         if self.len == 0 {
             Ok(())
         } else {
-            Err(de::Error::end_of_stream_error())
+            Err(de::Error::end_of_stream())
         }
     }
 

--- a/serde_tests/benches/bench_enum.rs
+++ b/serde_tests/benches/bench_enum.rs
@@ -20,13 +20,13 @@ pub enum Error {
 }
 
 impl serde::de::Error for Error {
-    fn syntax_error() -> Error { Error::SyntaxError }
+    fn syntax() -> Error { Error::SyntaxError }
 
-    fn end_of_stream_error() -> Error { Error::EndOfStreamError }
+    fn end_of_stream() -> Error { Error::EndOfStreamError }
 
-    fn unknown_field_error(_: &str) -> Error { Error::SyntaxError }
+    fn unknown_field(_: &str) -> Error { Error::SyntaxError }
 
-    fn missing_field_error(_: &'static str) -> Error { Error::SyntaxError }
+    fn missing_field(_: &'static str) -> Error { Error::SyntaxError }
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/serde_tests/benches/bench_enum.rs
+++ b/serde_tests/benches/bench_enum.rs
@@ -20,7 +20,7 @@ pub enum Error {
 }
 
 impl serde::de::Error for Error {
-    fn syntax() -> Error { Error::SyntaxError }
+    fn syntax(_: &str) -> Error { Error::SyntaxError }
 
     fn end_of_stream() -> Error { Error::EndOfStreamError }
 

--- a/serde_tests/benches/bench_map.rs
+++ b/serde_tests/benches/bench_map.rs
@@ -17,7 +17,7 @@ pub enum Error {
 }
 
 impl serde::de::Error for Error {
-    fn syntax() -> Error { Error::SyntaxError }
+    fn syntax(_: &str) -> Error { Error::SyntaxError }
 
     fn end_of_stream() -> Error { Error::EndOfStream }
 

--- a/serde_tests/benches/bench_map.rs
+++ b/serde_tests/benches/bench_map.rs
@@ -17,13 +17,13 @@ pub enum Error {
 }
 
 impl serde::de::Error for Error {
-    fn syntax_error() -> Error { Error::SyntaxError }
+    fn syntax() -> Error { Error::SyntaxError }
 
-    fn end_of_stream_error() -> Error { Error::EndOfStream }
+    fn end_of_stream() -> Error { Error::EndOfStream }
 
-    fn unknown_field_error(_: &str) -> Error { Error::SyntaxError }
+    fn unknown_field(_: &str) -> Error { Error::SyntaxError }
 
-    fn missing_field_error(_: &'static str) -> Error {
+    fn missing_field(_: &'static str) -> Error {
         Error::MissingField
     }
 }
@@ -347,17 +347,17 @@ mod deserializer {
 
     impl de::Deserializer<Error> for IsizeDeserializer {
         #[inline]
-        fn end_of_stream_error(&mut self) -> Error {
+        fn end_of_stream(&mut self) -> Error {
             EndOfStream
         }
 
         #[inline]
-        fn syntax_error(&mut self, _token: de::Token, _expected: &[de::TokenKind]) -> Error {
+        fn syntax(&mut self, _token: de::Token, _expected: &[de::TokenKind]) -> Error {
             SyntaxError
         }
 
         #[inline]
-        fn unexpected_name_error(&mut self, _token: de::Token) -> Error {
+        fn unexpected_name(&mut self, _token: de::Token) -> Error {
             SyntaxError
         }
 

--- a/serde_tests/benches/bench_struct.rs
+++ b/serde_tests/benches/bench_struct.rs
@@ -33,13 +33,13 @@ pub enum Error {
 }
 
 impl serde::de::Error for Error {
-    fn syntax_error() -> Error { Error::SyntaxError }
+    fn syntax() -> Error { Error::SyntaxError }
 
-    fn end_of_stream_error() -> Error { Error::EndOfStream }
+    fn end_of_stream() -> Error { Error::EndOfStream }
 
-    fn unknown_field_error(_: &str) -> Error { Error::SyntaxError }
+    fn unknown_field(_: &str) -> Error { Error::SyntaxError }
 
-    fn missing_field_error(_: &'static str) -> Error {
+    fn missing_field(_: &'static str) -> Error {
         Error::MissingField
     }
 }

--- a/serde_tests/benches/bench_struct.rs
+++ b/serde_tests/benches/bench_struct.rs
@@ -33,7 +33,7 @@ pub enum Error {
 }
 
 impl serde::de::Error for Error {
-    fn syntax() -> Error { Error::SyntaxError }
+    fn syntax(_: &str) -> Error { Error::SyntaxError }
 
     fn end_of_stream() -> Error { Error::EndOfStream }
 

--- a/serde_tests/benches/bench_vec.rs
+++ b/serde_tests/benches/bench_vec.rs
@@ -15,7 +15,7 @@ pub enum Error {
 }
 
 impl serde::de::Error for Error {
-    fn syntax() -> Error { Error::SyntaxError }
+    fn syntax(_: &str) -> Error { Error::SyntaxError }
 
     fn end_of_stream() -> Error { Error::EndOfStreamError }
 

--- a/serde_tests/benches/bench_vec.rs
+++ b/serde_tests/benches/bench_vec.rs
@@ -15,13 +15,13 @@ pub enum Error {
 }
 
 impl serde::de::Error for Error {
-    fn syntax_error() -> Error { Error::SyntaxError }
+    fn syntax() -> Error { Error::SyntaxError }
 
-    fn end_of_stream_error() -> Error { Error::EndOfStreamError }
+    fn end_of_stream() -> Error { Error::EndOfStreamError }
 
-    fn unknown_field_error(_: &str) -> Error { Error::SyntaxError }
+    fn unknown_field(_: &str) -> Error { Error::SyntaxError }
 
-    fn missing_field_error(_: &'static str) -> Error { Error::SyntaxError }
+    fn missing_field(_: &'static str) -> Error { Error::SyntaxError }
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/serde_tests/tests/test_bytes.rs
+++ b/serde_tests/tests/test_bytes.rs
@@ -9,13 +9,13 @@ use serde_json;
 struct Error;
 
 impl serde::de::Error for Error {
-    fn syntax_error() -> Error { Error }
+    fn syntax() -> Error { Error }
 
-    fn end_of_stream_error() -> Error { Error }
+    fn end_of_stream() -> Error { Error }
 
-    fn unknown_field_error(_field: &str) -> Error { Error }
+    fn unknown_field(_field: &str) -> Error { Error }
 
-    fn missing_field_error(_field: &'static str) -> Error { Error }
+    fn missing_field(_field: &'static str) -> Error { Error }
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/serde_tests/tests/test_bytes.rs
+++ b/serde_tests/tests/test_bytes.rs
@@ -9,7 +9,7 @@ use serde_json;
 struct Error;
 
 impl serde::de::Error for Error {
-    fn syntax() -> Error { Error }
+    fn syntax(_: &str) -> Error { Error }
 
     fn end_of_stream() -> Error { Error }
 

--- a/serde_tests/tests/test_de.rs
+++ b/serde_tests/tests/test_de.rs
@@ -68,7 +68,7 @@ enum Error {
 }
 
 impl de::Error for Error {
-    fn syntax() -> Error { Error::SyntaxError }
+    fn syntax(_: &str) -> Error { Error::SyntaxError }
 
     fn end_of_stream() -> Error { Error::EndOfStreamError }
 

--- a/serde_tests/tests/test_de.rs
+++ b/serde_tests/tests/test_de.rs
@@ -68,15 +68,15 @@ enum Error {
 }
 
 impl de::Error for Error {
-    fn syntax_error() -> Error { Error::SyntaxError }
+    fn syntax() -> Error { Error::SyntaxError }
 
-    fn end_of_stream_error() -> Error { Error::EndOfStreamError }
+    fn end_of_stream() -> Error { Error::EndOfStreamError }
 
-    fn unknown_field_error(field: &str) -> Error {
+    fn unknown_field(field: &str) -> Error {
         Error::UnknownFieldError(field.to_string())
     }
 
-    fn missing_field_error(field: &'static str) -> Error {
+    fn missing_field(field: &'static str) -> Error {
         Error::MissingFieldError(field)
     }
 }


### PR DESCRIPTION
Closes #125