### PR TITLE
json deser from Value adjusted to be equal to deser from strings

### DIFF
--- a/serde_json/src/value.rs
+++ b/serde_json/src/value.rs
@@ -723,6 +723,15 @@ impl de::Deserializer for Deserializer {
     }
 
     #[inline]
+    fn visit_newtype_struct<V>(&mut self,
+                               _name: &'static str,
+                               mut visitor: V) -> Result<V::Value, Self::Error>
+        where V: de::Visitor,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    #[inline]
     fn format() -> &'static str {
         "json"
     }


### PR DESCRIPTION
the default impl from the trait deserializes from a single element tuple. This caused a confusing bug in my code where deserialization failed when deserializing from `Value`, but worked if i turned the `Value` into a string in-between.