### PR TITLE
Reject serializing maps to JSON with non-string keys

### DIFF
--- a/serde_json/src/ser.rs
+++ b/serde_json/src/ser.rs
@@ -1,8 +1,8 @@
 use std::io;
 use std::num::FpCategory;
-use std::string::FromUtf8Error;
 
 use serde::ser;
+use super::error::{Error, ErrorCode, Result};
 
 /// A structure for implementing serialization to JSON.
 pub struct Serializer<W, F=CompactFormatter> {
@@ -60,109 +60,109 @@ impl<W, F> ser::Serializer for Serializer<W, F>
     where W: io::Write,
           F: Formatter,
 {
-    type Error = io::Error;
+    type Error = Error;
 
     #[inline]
-    fn visit_bool(&mut self, value: bool) -> io::Result<()> {
+    fn visit_bool(&mut self, value: bool) -> Result<()> {
         if value {
-            self.writer.write_all(b"true")
+            self.writer.write_all(b"true").map_err(From::from)
         } else {
-            self.writer.write_all(b"false")
+            self.writer.write_all(b"false").map_err(From::from)
         }
     }
 
     #[inline]
-    fn visit_isize(&mut self, value: isize) -> io::Result<()> {
-        write!(&mut self.writer, "{}", value)
+    fn visit_isize(&mut self, value: isize) -> Result<()> {
+        write!(&mut self.writer, "{}", value).map_err(From::from)
     }
 
     #[inline]
-    fn visit_i8(&mut self, value: i8) -> io::Result<()> {
-        write!(&mut self.writer, "{}", value)
+    fn visit_i8(&mut self, value: i8) -> Result<()> {
+        write!(&mut self.writer, "{}", value).map_err(From::from)
     }
 
     #[inline]
-    fn visit_i16(&mut self, value: i16) -> io::Result<()> {
-        write!(&mut self.writer, "{}", value)
+    fn visit_i16(&mut self, value: i16) -> Result<()> {
+        write!(&mut self.writer, "{}", value).map_err(From::from)
     }
 
     #[inline]
-    fn visit_i32(&mut self, value: i32) -> io::Result<()> {
-        write!(&mut self.writer, "{}", value)
+    fn visit_i32(&mut self, value: i32) -> Result<()> {
+        write!(&mut self.writer, "{}", value).map_err(From::from)
     }
 
     #[inline]
-    fn visit_i64(&mut self, value: i64) -> io::Result<()> {
-        write!(&mut self.writer, "{}", value)
+    fn visit_i64(&mut self, value: i64) -> Result<()> {
+        write!(&mut self.writer, "{}", value).map_err(From::from)
     }
 
     #[inline]
-    fn visit_usize(&mut self, value: usize) -> io::Result<()> {
-        write!(&mut self.writer, "{}", value)
+    fn visit_usize(&mut self, value: usize) -> Result<()> {
+        write!(&mut self.writer, "{}", value).map_err(From::from)
     }
 
     #[inline]
-    fn visit_u8(&mut self, value: u8) -> io::Result<()> {
-        write!(&mut self.writer, "{}", value)
+    fn visit_u8(&mut self, value: u8) -> Result<()> {
+        write!(&mut self.writer, "{}", value).map_err(From::from)
     }
 
     #[inline]
-    fn visit_u16(&mut self, value: u16) -> io::Result<()> {
-        write!(&mut self.writer, "{}", value)
+    fn visit_u16(&mut self, value: u16) -> Result<()> {
+        write!(&mut self.writer, "{}", value).map_err(From::from)
     }
 
     #[inline]
-    fn visit_u32(&mut self, value: u32) -> io::Result<()> {
-        write!(&mut self.writer, "{}", value)
+    fn visit_u32(&mut self, value: u32) -> Result<()> {
+        write!(&mut self.writer, "{}", value).map_err(From::from)
     }
 
     #[inline]
-    fn visit_u64(&mut self, value: u64) -> io::Result<()> {
-        write!(&mut self.writer, "{}", value)
+    fn visit_u64(&mut self, value: u64) -> Result<()> {
+        write!(&mut self.writer, "{}", value).map_err(From::from)
     }
 
     #[inline]
-    fn visit_f32(&mut self, value: f32) -> io::Result<()> {
-        fmt_f32_or_null(&mut self.writer, value)
+    fn visit_f32(&mut self, value: f32) -> Result<()> {
+        fmt_f32_or_null(&mut self.writer, value).map_err(From::from)
     }
 
     #[inline]
-    fn visit_f64(&mut self, value: f64) -> io::Result<()> {
-        fmt_f64_or_null(&mut self.writer, value)
+    fn visit_f64(&mut self, value: f64) -> Result<()> {
+        fmt_f64_or_null(&mut self.writer, value).map_err(From::from)
     }
 
     #[inline]
-    fn visit_char(&mut self, value: char) -> io::Result<()> {
-        escape_char(&mut self.writer, value)
+    fn visit_char(&mut self, value: char) -> Result<()> {
+        escape_char(&mut self.writer, value).map_err(From::from)
     }
 
     #[inline]
-    fn visit_str(&mut self, value: &str) -> io::Result<()> {
-        escape_str(&mut self.writer, value)
+    fn visit_str(&mut self, value: &str) -> Result<()> {
+        escape_str(&mut self.writer, value).map_err(From::from)
     }
 
     #[inline]
-    fn visit_none(&mut self) -> io::Result<()> {
+    fn visit_none(&mut self) -> Result<()> {
         self.visit_unit()
     }
 
     #[inline]
-    fn visit_some<V>(&mut self, value: V) -> io::Result<()>
+    fn visit_some<V>(&mut self, value: V) -> Result<()>
         where V: ser::Serialize
     {
         value.serialize(self)
     }
 
     #[inline]
-    fn visit_unit(&mut self) -> io::Result<()> {
-        self.writer.write_all(b"null")
+    fn visit_unit(&mut self) -> Result<()> {
+        self.writer.write_all(b"null").map_err(From::from)
     }
 
     /// Override `visit_newtype_struct` to serialize newtypes without an object wrapper.
     #[inline]
     fn visit_newtype_struct<T>(&mut self,
                                _name: &'static str,
-                               value: T) -> Result<(), Self::Error>
+                               value: T) -> Result<()>
         where T: ser::Serialize,
     {
         value.serialize(self)
@@ -172,7 +172,7 @@ impl<W, F> ser::Serializer for Serializer<W, F>
     fn visit_unit_variant(&mut self,
                           _name: &str,
                           _variant_index: usize,
-                          variant: &str) -> io::Result<()> {
+                          variant: &str) -> Result<()> {
         try!(self.formatter.open(&mut self.writer, b'{'));
         try!(self.formatter.comma(&mut self.writer, true));
         try!(self.visit_str(variant));
@@ -186,7 +186,7 @@ impl<W, F> ser::Serializer for Serializer<W, F>
                                 _name: &str,
                                 _variant_index: usize,
                                 variant: &str,
-                                value: T) -> io::Result<()>
+                                value: T) -> Result<()>
         where T: ser::Serialize,
     {
         try!(self.formatter.open(&mut self.writer, b'{'));
@@ -198,12 +198,12 @@ impl<W, F> ser::Serializer for Serializer<W, F>
     }
 
     #[inline]
-    fn visit_seq<V>(&mut self, mut visitor: V) -> io::Result<()>
+    fn visit_seq<V>(&mut self, mut visitor: V) -> Result<()>
         where V: ser::SeqVisitor,
     {
         match visitor.len() {
             Some(len) if len == 0 => {
-                self.writer.write_all(b"[]")
+                self.writer.write_all(b"[]").map_err(From::from)
             }
             _ => {
                 try!(self.formatter.open(&mut self.writer, b'['));
@@ -212,7 +212,7 @@ impl<W, F> ser::Serializer for Serializer<W, F>
 
                 while let Some(()) = try!(visitor.visit(self)) { }
 
-                self.formatter.close(&mut self.writer, b']')
+                self.formatter.close(&mut self.writer, b']').map_err(From::from)
             }
         }
 
@@ -223,7 +223,7 @@ impl<W, F> ser::Serializer for Serializer<W, F>
                               _name: &str,
                               _variant_index: usize,
                               variant: &str,
-                              visitor: V) -> io::Result<()>
+                              visitor: V) -> Result<()>
         where V: ser::SeqVisitor,
     {
         try!(self.formatter.open(&mut self.writer, b'{'));
@@ -235,7 +235,7 @@ impl<W, F> ser::Serializer for Serializer<W, F>
     }
 
     #[inline]
-    fn visit_seq_elt<T>(&mut self, value: T) -> io::Result<()>
+    fn visit_seq_elt<T>(&mut self, value: T) -> Result<()>
         where T: ser::Serialize,
     {
         try!(self.formatter.comma(&mut self.writer, self.first));
@@ -247,12 +247,12 @@ impl<W, F> ser::Serializer for Serializer<W, F>
     }
 
     #[inline]
-    fn visit_map<V>(&mut self, mut visitor: V) -> io::Result<()>
+    fn visit_map<V>(&mut self, mut visitor: V) -> Result<()>
         where V: ser::MapVisitor,
     {
         match visitor.len() {
             Some(len) if len == 0 => {
-                self.writer.write_all(b"{}")
+                self.writer.write_all(b"{}").map_err(From::from)
             }
             _ => {
                 try!(self.formatter.open(&mut self.writer, b'{'));
@@ -271,7 +271,7 @@ impl<W, F> ser::Serializer for Serializer<W, F>
                                _name: &str,
                                _variant_index: usize,
                                variant: &str,
-                               visitor: V) -> io::Result<()>
+                               visitor: V) -> Result<()>
         where V: ser::MapVisitor,
     {
         try!(self.formatter.open(&mut self.writer, b'{'));
@@ -284,13 +284,13 @@ impl<W, F> ser::Serializer for Serializer<W, F>
     }
 
     #[inline]
-    fn visit_map_elt<K, V>(&mut self, key: K, value: V) -> io::Result<()>
+    fn visit_map_elt<K, V>(&mut self, key: K, value: V) -> Result<()>
         where K: ser::Serialize,
               V: ser::Serialize,
     {
         try!(self.formatter.comma(&mut self.writer, self.first));
 
-        try!(key.serialize(self));
+        try!(key.serialize(&mut MapKeySerializer { ser: self }));
         try!(self.formatter.colon(&mut self.writer));
         try!(value.serialize(self));
 
@@ -305,49 +305,120 @@ impl<W, F> ser::Serializer for Serializer<W, F>
     }
 }
 
+struct MapKeySerializer<'a, W: 'a, F: 'a> {
+    ser: &'a mut Serializer<W, F>,
+}
+
+impl<'a, W, F> ser::Serializer for MapKeySerializer<'a, W, F>
+    where W: io::Write,
+          F: Formatter,
+{
+    type Error = Error;
+
+    #[inline]
+    fn visit_str(&mut self, value: &str) -> Result<()> {
+        self.ser.visit_str(value)
+    }
+
+    fn visit_bool(&mut self, _value: bool) -> Result<()> {
+        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+    }
+
+    fn visit_i64(&mut self, _value: i64) -> Result<()> {
+        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+    }
+
+    fn visit_u64(&mut self, _value: u64) -> Result<()> {
+        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+    }
+
+    fn visit_f64(&mut self, _value: f64) -> Result<()> {
+        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+    }
+
+    fn visit_unit(&mut self) -> Result<()> {
+        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+    }
+
+    fn visit_none(&mut self) -> Result<()> {
+        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+    }
+
+    fn visit_some<V>(&mut self, _value: V) -> Result<()>
+        where V: ser::Serialize
+    {
+        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+    }
+
+    fn visit_seq<V>(&mut self, _visitor: V) -> Result<()>
+        where V: ser::SeqVisitor,
+    {
+        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+    }
+
+    fn visit_seq_elt<T>(&mut self, _value: T) -> Result<()>
+        where T: ser::Serialize,
+    {
+        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+    }
+
+    fn visit_map<V>(&mut self, _visitor: V) -> Result<()>
+        where V: ser::MapVisitor,
+    {
+        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+    }
+
+    fn visit_map_elt<K, V>(&mut self, _key: K, _value: V) -> Result<()>
+        where K: ser::Serialize,
+              V: ser::Serialize,
+    {
+        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+    }
+}
+
 pub trait Formatter {
-    fn open<W>(&mut self, writer: &mut W, ch: u8) -> io::Result<()>
+    fn open<W>(&mut self, writer: &mut W, ch: u8) -> Result<()>
         where W: io::Write;
 
-    fn comma<W>(&mut self, writer: &mut W, first: bool) -> io::Result<()>
+    fn comma<W>(&mut self, writer: &mut W, first: bool) -> Result<()>
         where W: io::Write;
 
-    fn colon<W>(&mut self, writer: &mut W) -> io::Result<()>
+    fn colon<W>(&mut self, writer: &mut W) -> Result<()>
         where W: io::Write;
 
-    fn close<W>(&mut self, writer: &mut W, ch: u8) -> io::Result<()>
+    fn close<W>(&mut self, writer: &mut W, ch: u8) -> Result<()>
         where W: io::Write;
 }
 
 pub struct CompactFormatter;
 
 impl Formatter for CompactFormatter {
-    fn open<W>(&mut self, writer: &mut W, ch: u8) -> io::Result<()>
+    fn open<W>(&mut self, writer: &mut W, ch: u8) -> Result<()>
         where W: io::Write,
     {
-        writer.write_all(&[ch])
+        writer.write_all(&[ch]).map_err(From::from)
     }
 
-    fn comma<W>(&mut self, writer: &mut W, first: bool) -> io::Result<()>
+    fn comma<W>(&mut self, writer: &mut W, first: bool) -> Result<()>
         where W: io::Write,
     {
         if first {
             Ok(())
         } else {
-            writer.write_all(b",")
+            writer.write_all(b",").map_err(From::from)
         }
     }
 
-    fn colon<W>(&mut self, writer: &mut W) -> io::Result<()>
+    fn colon<W>(&mut self, writer: &mut W) -> Result<()>
         where W: io::Write,
     {
-        writer.write_all(b":")
+        writer.write_all(b":").map_err(From::from)
     }
 
-    fn close<W>(&mut self, writer: &mut W, ch: u8) -> io::Result<()>
+    fn close<W>(&mut self, writer: &mut W, ch: u8) -> Result<()>
         where W: io::Write,
     {
-        writer.write_all(&[ch])
+        writer.write_all(&[ch]).map_err(From::from)
     }
 }
 
@@ -370,14 +441,14 @@ impl<'a> PrettyFormatter<'a> {
 }
 
 impl<'a> Formatter for PrettyFormatter<'a> {
-    fn open<W>(&mut self, writer: &mut W, ch: u8) -> io::Result<()>
+    fn open<W>(&mut self, writer: &mut W, ch: u8) -> Result<()>
         where W: io::Write,
     {
         self.current_indent += 1;
-        writer.write_all(&[ch])
+        writer.write_all(&[ch]).map_err(From::from)
     }
 
-    fn comma<W>(&mut self, writer: &mut W, first: bool) -> io::Result<()>
+    fn comma<W>(&mut self, writer: &mut W, first: bool) -> Result<()>
         where W: io::Write,
     {
         if first {
@@ -389,25 +460,25 @@ impl<'a> Formatter for PrettyFormatter<'a> {
         indent(writer, self.current_indent, self.indent)
     }
 
-    fn colon<W>(&mut self, writer: &mut W) -> io::Result<()>
+    fn colon<W>(&mut self, writer: &mut W) -> Result<()>
         where W: io::Write,
     {
-        writer.write_all(b": ")
+        writer.write_all(b": ").map_err(From::from)
     }
 
-    fn close<W>(&mut self, writer: &mut W, ch: u8) -> io::Result<()>
+    fn close<W>(&mut self, writer: &mut W, ch: u8) -> Result<()>
         where W: io::Write,
     {
         self.current_indent -= 1;
         try!(writer.write(b"\n"));
         try!(indent(writer, self.current_indent, self.indent));
 
-        writer.write_all(&[ch])
+        writer.write_all(&[ch]).map_err(From::from)
     }
 }
 
 #[inline]
-pub fn escape_bytes<W>(wr: &mut W, bytes: &[u8]) -> io::Result<()>
+pub fn escape_bytes<W>(wr: &mut W, bytes: &[u8]) -> Result<()>
     where W: io::Write
 {
     try!(wr.write_all(b"\""));
@@ -444,14 +515,14 @@ pub fn escape_bytes<W>(wr: &mut W, bytes: &[u8]) -> io::Result<()>
 }
 
 #[inline]
-pub fn escape_str<W>(wr: &mut W, value: &str) -> io::Result<()>
+pub fn escape_str<W>(wr: &mut W, value: &str) -> Result<()>
     where W: io::Write
 {
     escape_bytes(wr, value.as_bytes())
 }
 
 #[inline]
-fn escape_char<W>(wr: &mut W, value: char) -> io::Result<()>
+fn escape_char<W>(wr: &mut W, value: char) -> Result<()>
     where W: io::Write
 {
     // FIXME: this allocation is required in order to be compatible with stable
@@ -459,31 +530,39 @@ fn escape_char<W>(wr: &mut W, value: char) -> io::Result<()>
     escape_bytes(wr, value.to_string().as_bytes())
 }
 
-fn fmt_f32_or_null<W>(wr: &mut W, value: f32) -> io::Result<()>
+fn fmt_f32_or_null<W>(wr: &mut W, value: f32) -> Result<()>
     where W: io::Write
 {
     match value.classify() {
-        FpCategory::Nan | FpCategory::Infinite => wr.write_all(b"null"),
+        FpCategory::Nan | FpCategory::Infinite => {
+            try!(wr.write_all(b"null"))
+        }
         _ => {
-            write!(wr, "{:?}", value)
+            try!(write!(wr, "{:?}", value))
         }
     }
+
+    Ok(())
 }
 
-fn fmt_f64_or_null<W>(wr: &mut W, value: f64) -> io::Result<()>
+fn fmt_f64_or_null<W>(wr: &mut W, value: f64) -> Result<()>
     where W: io::Write
 {
     match value.classify() {
-        FpCategory::Nan | FpCategory::Infinite => wr.write_all(b"null"),
+        FpCategory::Nan | FpCategory::Infinite => {
+            try!(wr.write_all(b"null"))
+        }
         _ => {
-            write!(wr, "{:?}", value)
+            try!(write!(wr, "{:?}", value))
         }
     }
+
+    Ok(())
 }
 
 /// Encode the specified struct into a json `[u8]` writer.
 #[inline]
-pub fn to_writer<W, T>(writer: &mut W, value: &T) -> io::Result<()>
+pub fn to_writer<W, T>(writer: &mut W, value: &T) -> Result<()>
     where W: io::Write,
           T: ser::Serialize,
 {
@@ -494,7 +573,7 @@ pub fn to_writer<W, T>(writer: &mut W, value: &T) -> io::Result<()>
 
 /// Encode the specified struct into a json `[u8]` writer.
 #[inline]
-pub fn to_writer_pretty<W, T>(writer: &mut W, value: &T) -> io::Result<()>
+pub fn to_writer_pretty<W, T>(writer: &mut W, value: &T) -> Result<()>
     where W: io::Write,
           T: ser::Serialize,
 {
@@ -505,47 +584,49 @@ pub fn to_writer_pretty<W, T>(writer: &mut W, value: &T) -> io::Result<()>
 
 /// Encode the specified struct into a json `[u8]` buffer.
 #[inline]
-pub fn to_vec<T>(value: &T) -> Vec<u8>
+pub fn to_vec<T>(value: &T) -> Result<Vec<u8>>
     where T: ser::Serialize,
 {
     // We are writing to a Vec, which doesn't fail. So we can ignore
     // the error.
     let mut writer = Vec::with_capacity(128);
-    to_writer(&mut writer, value).unwrap();
-    writer
+    try!(to_writer(&mut writer, value));
+    Ok(writer)
 }
 
 /// Encode the specified struct into a json `[u8]` buffer.
 #[inline]
-pub fn to_vec_pretty<T>(value: &T) -> Vec<u8>
+pub fn to_vec_pretty<T>(value: &T) -> Result<Vec<u8>>
     where T: ser::Serialize,
 {
     // We are writing to a Vec, which doesn't fail. So we can ignore
     // the error.
     let mut writer = Vec::with_capacity(128);
-    to_writer_pretty(&mut writer, value).unwrap();
-    writer
+    try!(to_writer_pretty(&mut writer, value));
+    Ok(writer)
 }
 
 /// Encode the specified struct into a json `String` buffer.
 #[inline]
-pub fn to_string<T>(value: &T) -> Result<String, FromUtf8Error>
+pub fn to_string<T>(value: &T) -> Result<String>
     where T: ser::Serialize
 {
-    let vec = to_vec(value);
-    String::from_utf8(vec)
+    let vec = try!(to_vec(value));
+    let string = try!(String::from_utf8(vec));
+    Ok(string)
 }
 
 /// Encode the specified struct into a json `String` buffer.
 #[inline]
-pub fn to_string_pretty<T>(value: &T) -> Result<String, FromUtf8Error>
+pub fn to_string_pretty<T>(value: &T) -> Result<String>
     where T: ser::Serialize
 {
-    let vec = to_vec_pretty(value);
-    String::from_utf8(vec)
+    let vec = try!(to_vec_pretty(value));
+    let string = try!(String::from_utf8(vec));
+    Ok(string)
 }
 
-fn indent<W>(wr: &mut W, n: usize, s: &[u8]) -> io::Result<()>
+fn indent<W>(wr: &mut W, n: usize, s: &[u8]) -> Result<()>
     where W: io::Write,
 {
     for _ in 0 .. n {

--- a/serde_tests/benches/bench_log.rs
+++ b/serde_tests/benches/bench_log.rs
@@ -1,6 +1,6 @@
 use std::io::{self, Read, Write};
 use num::FromPrimitive;
-use test::Bencher;
+use test::{Bencher, black_box};
 
 use rustc_serialize;
 
@@ -1093,7 +1093,7 @@ fn test_encoder() {
 
     {
         let mut encoder = rustc_serialize::json::Encoder::new(&mut wr);
-        log.encode(&mut encoder).unwrap();
+        log.encode(&mut encoder).unwrap()
     }
 
     assert_eq!(&wr, &JSON_STR);
@@ -1116,7 +1116,7 @@ fn bench_encoder(b: &mut Bencher) {
         wr.clear();
 
         let mut encoder = rustc_serialize::json::Encoder::new(&mut wr);
-        log.encode(&mut encoder).unwrap();
+        log.encode(&mut encoder).unwrap()
     });
 }
 
@@ -1134,7 +1134,7 @@ fn bench_serializer(b: &mut Bencher) {
     b.bytes = json.len() as u64;
 
     b.iter(|| {
-        serde_json::to_vec(&log).unwrap();
+        serde_json::to_vec(&log).unwrap()
     });
 }
 
@@ -1162,7 +1162,8 @@ fn bench_serializer_vec(b: &mut Bencher) {
 
         let mut serializer = serde_json::Serializer::new(wr.by_ref());
         log.serialize(&mut serializer).unwrap();
-        let _json = serializer.into_inner();
+        let json = serializer.into_inner();
+        black_box(json);
     });
 }
 
@@ -1180,7 +1181,8 @@ fn bench_serializer_slice(b: &mut Bencher) {
 
         let mut serializer = serde_json::Serializer::new(wr.by_ref());
         log.serialize(&mut serializer).unwrap();
-        let _json = serializer.into_inner();
+        let json = serializer.into_inner();
+        black_box(json);
     });
 }
 
@@ -1193,7 +1195,8 @@ fn test_serializer_my_mem_writer0() {
     {
         let mut serializer = serde_json::Serializer::new(wr.by_ref());
         log.serialize(&mut serializer).unwrap();
-        let _json = serializer.into_inner();
+        let json = serializer.into_inner();
+        black_box(json);
     }
 
     assert_eq!(&wr.buf, &JSON_STR.as_bytes());
@@ -1212,7 +1215,8 @@ fn bench_serializer_my_mem_writer0(b: &mut Bencher) {
 
         let mut serializer = serde_json::Serializer::new(wr.by_ref());
         log.serialize(&mut serializer).unwrap();
-        let _json = serializer.into_inner();
+        let json = serializer.into_inner();
+        black_box(json);
     });
 }
 
@@ -1225,7 +1229,8 @@ fn test_serializer_my_mem_writer1() {
     {
         let mut serializer = serde_json::Serializer::new(wr.by_ref());
         log.serialize(&mut serializer).unwrap();
-        let _json = serializer.into_inner();
+        let json = serializer.into_inner();
+        black_box(json);
     }
 
     assert_eq!(&wr.buf, &JSON_STR.as_bytes());
@@ -1244,7 +1249,8 @@ fn bench_serializer_my_mem_writer1(b: &mut Bencher) {
 
         let mut serializer = serde_json::Serializer::new(wr.by_ref());
         log.serialize(&mut serializer).unwrap();
-        let _json = serializer.into_inner();
+        let json = serializer.into_inner();
+        black_box(json);
     });
 }
 
@@ -1254,7 +1260,7 @@ fn bench_copy(b: &mut Bencher) {
     b.bytes = json.len() as u64;
 
     b.iter(|| {
-        let _json = JSON_STR.as_bytes().to_vec();
+        JSON_STR.as_bytes().to_vec()
     });
 }
 
@@ -1441,7 +1447,7 @@ fn bench_manual_serialize_vec_no_escape(b: &mut Bencher) {
 
     b.iter(|| {
         wr.clear();
-        manual_serialize_no_escape(&mut wr, &log);
+        manual_serialize_no_escape(&mut wr, &log)
     });
 }
 
@@ -1467,7 +1473,7 @@ fn bench_manual_serialize_vec_escape(b: &mut Bencher) {
     b.iter(|| {
         wr.clear();
 
-        manual_serialize_escape(&mut wr, &log);
+        manual_serialize_escape(&mut wr, &log)
     });
 }
 
@@ -1493,7 +1499,7 @@ fn bench_manual_serialize_my_mem_writer0_no_escape(b: &mut Bencher) {
     b.iter(|| {
         wr.buf.clear();
 
-        manual_serialize_no_escape(&mut wr, &log);
+        manual_serialize_no_escape(&mut wr, &log)
     });
 }
 
@@ -1519,7 +1525,7 @@ fn bench_manual_serialize_my_mem_writer0_escape(b: &mut Bencher) {
     b.iter(|| {
         wr.buf.clear();
 
-        manual_serialize_escape(&mut wr, &log);
+        manual_serialize_escape(&mut wr, &log)
     });
 }
 
@@ -1545,7 +1551,7 @@ fn bench_manual_serialize_my_mem_writer1_no_escape(b: &mut Bencher) {
     b.iter(|| {
         wr.buf.clear();
 
-        manual_serialize_no_escape(&mut wr, &log);
+        manual_serialize_no_escape(&mut wr, &log)
     });
 }
 
@@ -1571,7 +1577,7 @@ fn bench_manual_serialize_my_mem_writer1_escape(b: &mut Bencher) {
     b.iter(|| {
         wr.buf.clear();
 
-        manual_serialize_escape(&mut wr, &log);
+        manual_serialize_escape(&mut wr, &log)
     });
 }
 
@@ -1584,7 +1590,8 @@ fn bench_decoder(b: &mut Bencher) {
     b.iter(|| {
         let json = Json::from_str(JSON_STR).unwrap();
         let mut decoder = rustc_serialize::json::Decoder::new(json);
-        let _log: Log = rustc_serialize::Decodable::decode(&mut decoder).unwrap();
+        let log: Log = rustc_serialize::Decodable::decode(&mut decoder).unwrap();
+        log
     });
 }
 
@@ -1593,6 +1600,7 @@ fn bench_deserializer(b: &mut Bencher) {
     b.bytes = JSON_STR.len() as u64;
 
     b.iter(|| {
-        let _log: Log = serde_json::from_str(JSON_STR).unwrap();
+        let log: Log = serde_json::from_str(JSON_STR).unwrap();
+        log
     });
 }

--- a/serde_tests/benches/bench_log.rs
+++ b/serde_tests/benches/bench_log.rs
@@ -1123,18 +1123,18 @@ fn bench_encoder(b: &mut Bencher) {
 #[test]
 fn test_serializer() {
     let log = Log::new();
-    let json = serde_json::to_vec(&log);
+    let json = serde_json::to_vec(&log).unwrap();
     assert_eq!(json, JSON_STR.as_bytes());
 }
 
 #[bench]
 fn bench_serializer(b: &mut Bencher) {
     let log = Log::new();
-    let json = serde_json::to_vec(&log);
+    let json = serde_json::to_vec(&log).unwrap();
     b.bytes = json.len() as u64;
 
     b.iter(|| {
-        let _ = serde_json::to_vec(&log);
+        serde_json::to_vec(&log).unwrap();
     });
 }
 
@@ -1152,7 +1152,7 @@ fn test_serializer_vec() {
 #[bench]
 fn bench_serializer_vec(b: &mut Bencher) {
     let log = Log::new();
-    let json = serde_json::to_vec(&log);
+    let json = serde_json::to_vec(&log).unwrap();
     b.bytes = json.len() as u64;
 
     let mut wr = Vec::with_capacity(1024);
@@ -1169,7 +1169,7 @@ fn bench_serializer_vec(b: &mut Bencher) {
 #[bench]
 fn bench_serializer_slice(b: &mut Bencher) {
     let log = Log::new();
-    let json = serde_json::to_vec(&log);
+    let json = serde_json::to_vec(&log).unwrap();
     b.bytes = json.len() as u64;
 
     let mut buf = [0; 1024];
@@ -1202,7 +1202,7 @@ fn test_serializer_my_mem_writer0() {
 #[bench]
 fn bench_serializer_my_mem_writer0(b: &mut Bencher) {
     let log = Log::new();
-    let json = serde_json::to_vec(&log);
+    let json = serde_json::to_vec(&log).unwrap();
     b.bytes = json.len() as u64;
 
     let mut wr = MyMemWriter0::with_capacity(1024);
@@ -1234,7 +1234,7 @@ fn test_serializer_my_mem_writer1() {
 #[bench]
 fn bench_serializer_my_mem_writer1(b: &mut Bencher) {
     let log = Log::new();
-    let json = serde_json::to_vec(&log);
+    let json = serde_json::to_vec(&log).unwrap();
     b.bytes = json.len() as u64;
 
     let mut wr = MyMemWriter1::with_capacity(1024);

--- a/serde_tests/tests/test_json.rs
+++ b/serde_tests/tests/test_json.rs
@@ -1348,3 +1348,16 @@ fn test_deserialize_from_stream() {
 
     assert_eq!(request, response);
 }
+
+#[test]
+fn test_serialize_rejects_non_key_maps() {
+    let map = treemap!(
+        1 => 2,
+        3 => 4
+    );
+
+    match serde_json::to_vec(&map).unwrap_err() {
+        serde_json::Error::SyntaxError(serde_json::ErrorCode::KeyMustBeAString, 0, 0) => {}
+        _ => panic!("integers used as keys"),
+    }
+}


### PR DESCRIPTION
Closes #122. This is a breaking change since it modifies the return type of serde_json::to_vec{,pretty}, so it'll require a major version bump of serde_json.

This also black boxes the json log benchmarks, which unfortunately cuts `bench_log::bench_deserializer` from about 120MB/s to 85MB/s :/