### PR TITLE
Add a Sized requirement to the Deserialize trait.

### DIFF
--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -68,7 +68,7 @@ pub enum Type {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-pub trait Deserialize {
+pub trait Deserialize: Sized {
     /// Deserialize this value given this `Deserializer`.
     fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
         where D: Deserializer;


### PR DESCRIPTION
Resolves warnings introduced in RFC 1214.