### PR TITLE
Add skip serializing fields if empty or none

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Documentation is available at:
 * [serde\_json](https://serde-rs.github.io/serde/serde_json/serde_json/index.html)
 * [serde\_codegen](https://serde-rs.github.io/serde/serde_codegen/serde_codegen/index.html)
 
-Using Serde
-===========
+Using Serde with Nightly Rust and serde\_macros
+===============================================
 
 Here is a simple example that demonstrates how to use Serde by serializing and
 deserializing to JSON. Serde comes with some powerful code generation libraries
@@ -75,6 +75,9 @@ When run, it produces:
 {"x":1,"y":2}
 Point { x: 1, y: 2 }
 ```
+
+Using Serde with Stable Rust, syntex, and serde\_codegen
+========================================================
 
 Stable Rust is a little more complicated because it does not yet support
 compiler plugins. Instead we need to use the code generation library
@@ -215,6 +218,19 @@ include!(concat!(env!("OUT_DIR"), "/main.rs"));
 
 The `src/main.rs.in` is the same as before.
 
+Then to run with stable:
+
+```
+% cargo build
+...
+```
+
+Or with nightly:
+
+```rust
+% cargo build --features nightly --no-default-features
+...
+
 Serialization without Macros
 ============================
 
@@ -311,6 +327,8 @@ as a named map. Its visitor uses a simple state machine to iterate through all
 the fields:
 
 ```rust
+extern crate serde;
+
 struct Point {
     x: i32,
     y: i32,
@@ -479,6 +497,13 @@ deserializes an enum variant from a string. So for our `Point` example from
 before, we need to generate:
 
 ```rust
+extern crate serde;
+
+struct Point {
+    x: i32,
+    y: i32,
+}
+
 enum PointField {
     X,
     Y,
@@ -507,11 +532,7 @@ impl serde::Deserialize for PointField {
         deserializer.visit(PointFieldVisitor)
     }
 }
-```
 
-This is then used in our actual deserializer:
-
-```rust
 impl serde::Deserialize for Point {
     fn deserialize<D>(deserializer: &mut D) -> Result<Point, D::Error>
         where D: serde::de::Deserializer

--- a/README.md
+++ b/README.md
@@ -578,6 +578,21 @@ impl serde::de::Visitor for PointVisitor {
 }
 ```
 
+Annotations
+===========
+
+`serde_codegen` and `serde_macros` support annotations that help to customize
+how types are serialized. Here are the supported annotations:
+
+| Annotation                                   | Function                                                       |
+| ----------                                   | --------                                                       |
+| `#[serde(rename(json="name1", xml="name2"))` | Serialize this field with the given name for the given formats |
+| `#[serde(default)`                           | If the value is not specified, use the `Default::default()`    |
+| `#[serde(rename="name")`                     | Serialize this field with the given name                       |
+| `#[serde(skip_serializing)`                  | Do not serialize this value                                    |
+| `#[serde(skip_serializing_if_empty)`         | Do not serialize this value if `$value.is_empty()` is `true`   |
+| `#[serde(skip_serializing_if_none)`          | Do not serialize this value if `$value.is_none()` is `true`    |
+
 Serialization Formats Using Serde
 =================================
 

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -337,7 +337,7 @@ pub trait SeqVisitor {
     }
 }
 
-/// A trait that is used by a `Serializer` to iterate through a map.
+/// A trait that is used by a `Serialize` to iterate through a map.
 pub trait MapVisitor {
     /// Serializes a map item in the serializer.
     ///

--- a/serde_codegen/src/de.rs
+++ b/serde_codegen/src/de.rs
@@ -543,11 +543,13 @@ fn deserialize_item_enum(
         cx,
         builder,
         enum_def.variants.iter()
-            .map(|variant|
-                 attr::FieldAttrs::new(
-                     false,
-                     true,
-                     builder.expr().str(variant.node.name)))
+            .map(|variant| {
+                let expr = builder.expr().str(variant.node.name);
+                 attr::FieldAttrsBuilder::new(builder)
+                    .name(expr)
+                    .default()
+                    .build()
+            })
             .collect()
     );
 

--- a/serde_codegen/src/field.rs
+++ b/serde_codegen/src/field.rs
@@ -1,147 +1,17 @@
-use std::collections::HashMap;
+use syntax::ast;
+use syntax::ext::base::ExtCtxt;
 
 use aster;
-
-use syntax::ast;
-use syntax::attr;
-use syntax::ext::base::ExtCtxt;
-use syntax::ptr::P;
-
-use attr::FieldAttrs;
-
-enum Rename<'a> {
-    None,
-    Global(&'a ast::Lit),
-    Format(HashMap<P<ast::Expr>, &'a ast::Lit>)
-}
-
-fn rename<'a>(
-    builder: &aster::AstBuilder,
-    mi: &'a ast::MetaItem,
-    ) -> Option<Rename<'a>>
-{
-    match mi.node {
-        ast::MetaNameValue(ref n, ref lit) => {
-            if n == &"rename" {
-                Some(Rename::Global(lit))
-            } else {
-                None
-            }
-        },
-        ast::MetaList(ref n, ref items) => {
-            if n == &"rename" {
-                let mut m = HashMap::new();
-                m.extend(
-                    items.iter()
-                        .filter_map(
-                            |item|
-                            match item.node {
-                                ast::MetaNameValue(ref n, ref lit) =>
-                                    Some((builder.expr().str(n),
-                                          lit)),
-                                _ => None
-                            }));
-                Some(Rename::Format(m))
-            } else {
-                None
-            }
-        },
-        _ => None
-    }
-}
-
-fn default_value(mi: &ast::MetaItem) -> bool {
-    if let ast::MetaItem_::MetaWord(ref n) = mi.node {
-        n == &"default"
-    } else {
-        false
-    }
-}
-
-fn skip_serializing_field(mi: &ast::MetaItem) -> bool {
-    if let ast::MetaItem_::MetaWord(ref n) = mi.node {
-        n == &"skip_serializing"
-    } else {
-        false
-    }
-}
-
-fn field_attrs<'a>(
-    builder: &aster::AstBuilder,
-    field: &'a ast::StructField,
-) -> (Rename<'a>, bool, bool) {
-    field.node.attrs.iter()
-        .find(|sa| {
-            if let ast::MetaList(ref n, _) = sa.node.value.node {
-                n == &"serde"
-            } else {
-                false
-            }
-        })
-        .and_then(|sa| {
-            if let ast::MetaList(_, ref vals) = sa.node.value.node {
-                attr::mark_used(&sa);
-                Some((
-                    vals.iter()
-                        .fold(None, |v, mi| v.or(rename(builder, mi)))
-                        .unwrap_or(Rename::None),
-                    vals.iter().any(|mi| default_value(mi)),
-                    vals.iter().any(|mi| skip_serializing_field(mi)),
-                ))
-            } else {
-                Some((Rename::None, false, false))
-            }
-        })
-        .unwrap_or((Rename::None, false, false))
-}
+use attr::{FieldAttrs, FieldAttrsBuilder};
 
 pub fn struct_field_attrs(
-    cx: &ExtCtxt,
+    _cx: &ExtCtxt,
     builder: &aster::AstBuilder,
     struct_def: &ast::StructDef,
 ) -> Vec<FieldAttrs> {
     struct_def.fields.iter()
         .map(|field| {
-            match field_attrs(builder, field) {
-                (Rename::Global(rename), default_value, skip_serializing_field) =>
-                    FieldAttrs::new(
-                        skip_serializing_field,
-                        default_value,
-                        builder.expr().build_lit(P(rename.clone()))),
-                (Rename::Format(renames), default_value, skip_serializing_field) => {
-                    let mut res = HashMap::new();
-                    res.extend(
-                        renames.into_iter()
-                            .map(|(k,v)|
-                                 (k, builder.expr().build_lit(P(v.clone())))));
-                    FieldAttrs::new_with_formats(
-                        skip_serializing_field,
-                        default_value,
-                        default_field_name(cx, builder, field.node.kind),
-                        res)
-                },
-                (Rename::None, default_value, skip_serializing_field) => {
-                    FieldAttrs::new(
-                        skip_serializing_field,
-                        default_value,
-                        default_field_name(cx, builder, field.node.kind))
-                }
-            }
+            FieldAttrsBuilder::new(builder).field(field).build()
         })
         .collect()
-}
-
-fn default_field_name(
-    cx: &ExtCtxt,
-    builder: &aster::AstBuilder,
-    kind: ast::StructFieldKind,
-) -> P<ast::Expr> {
-    match kind {
-        ast::NamedField(name, _) => {
-            builder.expr().str(name)
-        }
-        ast::UnnamedField(_) => {
-            cx.bug("struct has named and unnamed fields")
-        }
-    }
 }

--- a/serde_tests/tests/test_annotations.rs
+++ b/serde_tests/tests/test_annotations.rs
@@ -39,6 +39,20 @@ struct SkipSerializingFields<A: default::Default> {
     b: A,
 }
 
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
+struct SkipSerializingIfEmptyFields<A: default::Default> {
+    a: i8,
+    #[serde(skip_serializing_if_empty, default)]
+    b: Vec<A>,
+}
+
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
+struct SkipSerializingIfNoneFields<A: default::Default> {
+    a: i8,
+    #[serde(skip_serializing_if_none, default)]
+    b: Option<A>,
+}
+
 #[test]
 fn test_default() {
     assert_de_tokens(
@@ -164,6 +178,164 @@ fn test_skip_serializing_fields() {
             Token::MapSep,
             Token::Str("a"),
             Token::I8(1),
+
+            Token::MapEnd,
+        ]
+    );
+}
+
+#[test]
+fn test_skip_serializing_fields_if_empty() {
+    assert_ser_tokens(
+        &SkipSerializingIfEmptyFields::<i32> {
+            a: 1,
+            b: vec![],
+        },
+        &[
+            Token::StructStart("SkipSerializingIfEmptyFields", Some(1)),
+
+            Token::MapSep,
+            Token::Str("a"),
+            Token::I8(1),
+
+            Token::MapEnd,
+        ]
+    );
+
+    assert_de_tokens(
+        &SkipSerializingIfEmptyFields::<i32> {
+            a: 1,
+            b: vec![],
+        },
+        vec![
+            Token::StructStart("SkipSerializingIfEmptyFields", Some(1)),
+
+            Token::MapSep,
+            Token::Str("a"),
+            Token::I8(1),
+
+            Token::MapEnd,
+        ]
+    );
+
+    assert_ser_tokens(
+        &SkipSerializingIfEmptyFields {
+            a: 1,
+            b: vec![2],
+        },
+        &[
+            Token::StructStart("SkipSerializingIfEmptyFields", Some(2)),
+
+            Token::MapSep,
+            Token::Str("a"),
+            Token::I8(1),
+
+            Token::MapSep,
+            Token::Str("b"),
+            Token::SeqStart(Some(1)),
+            Token::SeqSep,
+            Token::I32(2),
+            Token::SeqEnd,
+
+            Token::MapEnd,
+        ]
+    );
+
+    assert_de_tokens(
+        &SkipSerializingIfEmptyFields {
+            a: 1,
+            b: vec![2],
+        },
+        vec![
+            Token::StructStart("SkipSerializingIfEmptyFields", Some(2)),
+
+            Token::MapSep,
+            Token::Str("a"),
+            Token::I8(1),
+
+            Token::MapSep,
+            Token::Str("b"),
+            Token::SeqStart(Some(1)),
+            Token::SeqSep,
+            Token::I32(2),
+            Token::SeqEnd,
+
+            Token::MapEnd,
+        ]
+    );
+}
+
+#[test]
+fn test_skip_serializing_fields_if_none() {
+    assert_ser_tokens(
+        &SkipSerializingIfNoneFields::<i32> {
+            a: 1,
+            b: None,
+        },
+        &[
+            Token::StructStart("SkipSerializingIfNoneFields", Some(1)),
+
+            Token::MapSep,
+            Token::Str("a"),
+            Token::I8(1),
+
+            Token::MapEnd,
+        ]
+    );
+
+    assert_de_tokens(
+        &SkipSerializingIfNoneFields::<i32> {
+            a: 1,
+            b: None,
+        },
+        vec![
+            Token::StructStart("SkipSerializingIfNoneFields", Some(1)),
+
+            Token::MapSep,
+            Token::Str("a"),
+            Token::I8(1),
+
+            Token::MapEnd,
+        ]
+    );
+
+    assert_ser_tokens(
+        &SkipSerializingIfNoneFields {
+            a: 1,
+            b: Some(2),
+        },
+        &[
+            Token::StructStart("SkipSerializingIfNoneFields", Some(2)),
+
+            Token::MapSep,
+            Token::Str("a"),
+            Token::I8(1),
+
+            Token::MapSep,
+            Token::Str("b"),
+            Token::Option(true),
+            Token::I32(2),
+
+            Token::MapEnd,
+        ]
+    );
+
+    assert_de_tokens(
+        &SkipSerializingIfNoneFields {
+            a: 1,
+            b: Some(2),
+        },
+        vec![
+            Token::StructStart("SkipSerializingIfNoneFields", Some(2)),
+
+            Token::MapSep,
+            Token::Str("a"),
+            Token::I8(1),
+
+            Token::MapSep,
+            Token::Str("b"),
+            Token::Option(true),
+            Token::I32(2),
 
             Token::MapEnd,
         ]


### PR DESCRIPTION
This adds two new macro annotations that will skip serializing a field if `$value.is_empty()` or `$value.is_none()` is `true`.