### PR TITLE
add link to the README from the docs

### DIFF
--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -5,6 +5,9 @@
 //! handshake protocol between serializers and serializees can be completely optimized away,
 //! leaving serde to perform roughly the same speed as a hand written serializer for a specific
 //! type.
+//! 
+//! For a detailed tutorial on the different ways to use serde please check out the
+//! [github repository](https://github.com/serde-rs/serde)
 
 #![doc(html_root_url="https://serde-rs.github.io/serde/serde")]
 #![cfg_attr(feature = "nightly", feature(collections, core, enumset, nonzero, step_trait, zero_one))]


### PR DESCRIPTION
The lack of detailed explanations on the starting page in the docs was noted at https://users.rust-lang.org/t/lets-talk-about-ecosystem-documentation/2791/25