### PR TITLE
Improve error forwarding and `ValueDeserializer` usability

### DIFF
--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -7,7 +7,7 @@ pub mod value;
 
 /// `Error` is a trait that allows a `Deserialize` to generically create a
 /// `Deserializer` error.
-pub trait Error: Sized {
+pub trait Error: From<value::Error> + Sized {
     /// Raised when there is general error when deserializing a type.
     fn syntax(msg: &str) -> Self;
 

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -33,6 +33,7 @@ pub trait Error: Sized {
 
 /// `Type` represents all the primitive types that can be deserialized. This is used by
 /// `Error::kind_mismatch`.
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Type {
     /// Represents a `bool` type.
     Bool,

--- a/serde/src/de/value.rs
+++ b/serde/src/de/value.rs
@@ -22,7 +22,13 @@ use bytes;
 #[derive(Clone, Debug, PartialEq)]
 pub enum Error {
     /// The value had some syntatic error.
-    SyntaxError,
+    SyntaxError(String),
+
+    /// The value had an incorrect type.
+    TypeError(de::Type),
+
+    /// The value had an invalid length.
+    LengthError(usize),
 
     /// EOF while deserializing a value.
     EndOfStreamError,
@@ -35,7 +41,9 @@ pub enum Error {
 }
 
 impl de::Error for Error {
-    fn syntax(_: &str) -> Self { Error::SyntaxError }
+    fn syntax(msg: &str) -> Self { Error::SyntaxError(String::from(msg)) }
+    fn type_mismatch(type_: de::Type) -> Self { Error::TypeError(type_) }
+    fn length_mismatch(len: usize) -> Self { Error::LengthError(len) }
     fn end_of_stream() -> Self { Error::EndOfStreamError }
     fn unknown_field(field: &str) -> Self { Error::UnknownFieldError(String::from(field)) }
     fn missing_field(field: &'static str) -> Self { Error::MissingFieldError(field) }

--- a/serde/src/de/value.rs
+++ b/serde/src/de/value.rs
@@ -22,31 +22,31 @@ use bytes;
 #[derive(Clone, Debug, PartialEq)]
 pub enum Error {
     /// The value had some syntatic error.
-    SyntaxError(String),
+    Syntax(String),
 
     /// The value had an incorrect type.
-    TypeError(de::Type),
+    Type(de::Type),
 
     /// The value had an invalid length.
-    LengthError(usize),
+    Length(usize),
 
     /// EOF while deserializing a value.
-    EndOfStreamError,
+    EndOfStream,
 
     /// Unknown field in struct.
-    UnknownFieldError(String),
+    UnknownField(String),
 
     /// Struct is missing a field.
-    MissingFieldError(&'static str),
+    MissingField(&'static str),
 }
 
 impl de::Error for Error {
-    fn syntax(msg: &str) -> Self { Error::SyntaxError(String::from(msg)) }
-    fn type_mismatch(type_: de::Type) -> Self { Error::TypeError(type_) }
-    fn length_mismatch(len: usize) -> Self { Error::LengthError(len) }
-    fn end_of_stream() -> Self { Error::EndOfStreamError }
-    fn unknown_field(field: &str) -> Self { Error::UnknownFieldError(String::from(field)) }
-    fn missing_field(field: &'static str) -> Self { Error::MissingFieldError(field) }
+    fn syntax(msg: &str) -> Self { Error::Syntax(String::from(msg)) }
+    fn type_mismatch(type_: de::Type) -> Self { Error::Type(type_) }
+    fn length_mismatch(len: usize) -> Self { Error::Length(len) }
+    fn end_of_stream() -> Self { Error::EndOfStream }
+    fn unknown_field(field: &str) -> Self { Error::UnknownField(String::from(field)) }
+    fn missing_field(field: &'static str) -> Self { Error::MissingField(field) }
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
There are two changes in this PR, I'm citing the commit messages here:

> When using a `ValueDeserializer` errors produced with the methods
> `type_mismatch`, `length_mismatch` and `syntax` were not forwarded
> correctly. These methods now store all information in the enum
> `de::value::Error`.

and

> Motivation for this change is to enable easy forwarding of visitor calls
> to other types implementing `Deserialize`:
>
> ```rust
> fn visit_u8<E>(&mut self, value: u8) -> Result<Self::Value, E>
>     where E: de::Error
> {
>     try!(Deserialize::deserialize(&mut value.into_deserializer())
>          .map_err(From::from))
> }
> ```
>
> Because `E` is generic one can't implement `From<de::value::Error>` for
> the non-local type `E`.

I don't know if adding a trait constraint is the right thing to do, but `de::value::Error` is a important part of the API of serde which may justify the additional constraint. The Json library already implemented it.