### PR TITLE
Improve error forwarding and `ValueDeserializer` usability – Take 2

### DIFF
--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -33,6 +33,7 @@ pub trait Error: Sized {
 
 /// `Type` represents all the primitive types that can be deserialized. This is used by
 /// `Error::kind_mismatch`.
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Type {
     /// Represents a `bool` type.
     Bool,

--- a/serde/src/de/value.rs
+++ b/serde/src/de/value.rs
@@ -22,7 +22,13 @@ use bytes;
 #[derive(Clone, Debug, PartialEq)]
 pub enum Error {
     /// The value had some syntatic error.
-    SyntaxError,
+    SyntaxError(String),
+
+    /// The value had an incorrect type.
+    TypeError(de::Type),
+
+    /// The value had an invalid length.
+    LengthError(usize),
 
     /// EOF while deserializing a value.
     EndOfStreamError,
@@ -35,7 +41,9 @@ pub enum Error {
 }
 
 impl de::Error for Error {
-    fn syntax(_: &str) -> Self { Error::SyntaxError }
+    fn syntax(msg: &str) -> Self { Error::SyntaxError(String::from(msg)) }
+    fn type_mismatch(type_: de::Type) -> Self { Error::TypeError(type_) }
+    fn length_mismatch(len: usize) -> Self { Error::LengthError(len) }
     fn end_of_stream() -> Self { Error::EndOfStreamError }
     fn unknown_field(field: &str) -> Self { Error::UnknownFieldError(String::from(field)) }
     fn missing_field(field: &'static str) -> Self { Error::MissingFieldError(field) }

--- a/serde/src/de/value.rs
+++ b/serde/src/de/value.rs
@@ -362,6 +362,38 @@ impl<T, E> ValueDeserializer<E> for HashSet<T>
 
 ///////////////////////////////////////////////////////////////////////////////
 
+/// A helper deserializer that deserializes a sequence using a `SeqVisitor`.
+pub struct SeqVisitorDeserializer<V_, E> {
+    visitor: V_,
+    marker: PhantomData<E>,
+}
+
+impl<V_, E> SeqVisitorDeserializer<V_, E>
+    where V_: de::SeqVisitor<Error = E>,
+          E: de::Error,
+{
+    /// Construct a new `SeqVisitorDeserializer<V_, E>`.
+    pub fn new(visitor: V_) -> Self {
+        SeqVisitorDeserializer{
+            visitor: visitor,
+            marker: PhantomData
+        }
+    }
+}
+
+impl<V_, E> de::Deserializer for SeqVisitorDeserializer<V_, E>
+    where V_: de::SeqVisitor<Error = E>,
+          E: de::Error,
+{
+    type Error = E;
+
+    fn visit<V: de::Visitor>(&mut self, mut visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_seq(&mut self.visitor)
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
 /// A helper deserializer that deserializes a map.
 pub struct MapDeserializer<I, K, V, E>
     where I: Iterator<Item=(K, V)>,
@@ -479,6 +511,38 @@ impl<K, V, E> ValueDeserializer<E> for HashMap<K, V>
     fn into_deserializer(self) -> Self::Deserializer {
         let len = self.len();
         MapDeserializer::new(self.into_iter(), len)
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+/// A helper deserializer that deserializes a map using a `MapVisitor`.
+pub struct MapVisitorDeserializer<V_, E> {
+    visitor: V_,
+    marker: PhantomData<E>,
+}
+
+impl<V_, E> MapVisitorDeserializer<V_, E>
+    where V_: de::MapVisitor<Error = E>,
+          E: de::Error,
+{
+    /// Construct a new `MapVisitorDeserializer<V_, E>`.
+    pub fn new(visitor: V_) -> Self {
+        MapVisitorDeserializer{
+            visitor: visitor,
+            marker: PhantomData
+        }
+    }
+}
+
+impl<V_, E> de::Deserializer for MapVisitorDeserializer<V_, E>
+    where V_: de::MapVisitor<Error = E>,
+          E: de::Error,
+{
+    type Error = E;
+
+    fn visit<V: de::Visitor>(&mut self, mut visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_map(&mut self.visitor)
     }
 }
 

--- a/serde/src/de/value.rs
+++ b/serde/src/de/value.rs
@@ -23,31 +23,31 @@ use bytes;
 #[derive(Clone, Debug, PartialEq)]
 pub enum Error {
     /// The value had some syntatic error.
-    SyntaxError(String),
+    Syntax(String),
 
     /// The value had an incorrect type.
-    TypeError(de::Type),
+    Type(de::Type),
 
     /// The value had an invalid length.
-    LengthError(usize),
+    Length(usize),
 
     /// EOF while deserializing a value.
-    EndOfStreamError,
+    EndOfStream,
 
     /// Unknown field in struct.
-    UnknownFieldError(String),
+    UnknownField(String),
 
     /// Struct is missing a field.
-    MissingFieldError(&'static str),
+    MissingField(&'static str),
 }
 
 impl de::Error for Error {
-    fn syntax(msg: &str) -> Self { Error::SyntaxError(String::from(msg)) }
-    fn type_mismatch(type_: de::Type) -> Self { Error::TypeError(type_) }
-    fn length_mismatch(len: usize) -> Self { Error::LengthError(len) }
-    fn end_of_stream() -> Self { Error::EndOfStreamError }
-    fn unknown_field(field: &str) -> Self { Error::UnknownFieldError(String::from(field)) }
-    fn missing_field(field: &'static str) -> Self { Error::MissingFieldError(field) }
+    fn syntax(msg: &str) -> Self { Error::Syntax(String::from(msg)) }
+    fn type_mismatch(type_: de::Type) -> Self { Error::Type(type_) }
+    fn length_mismatch(len: usize) -> Self { Error::Length(len) }
+    fn end_of_stream() -> Self { Error::EndOfStream }
+    fn unknown_field(field: &str) -> Self { Error::UnknownField(String::from(field)) }
+    fn missing_field(field: &'static str) -> Self { Error::MissingField(field) }
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
There are two changes in this PR:

When using a ValueDeserializer errors produced with the methods
type_mismatch, length_mismatch and syntax were not forwarded
correctly. These methods now store all information in the enum
de::value::Error.

In constrast to https://github.com/serde-rs/serde/pull/165 this PR makes it obsolete to add the `From<de::value::Error>` trait bound to the `de::Error` trait. Even the conversion of `de::value::Error` to the deserializer specific error is not needed with this PR, the ValueDeserializer is monomorphized to use the deserializer's error type.

An example for using a `ValueDeserializer` to forward deserializing to
another type's visitor:

```rust
fn visit_u8<E>(&mut self, value: u8) -> Result<Self::Value, E>
    where E: de::Error
{
    try!(Deserialize::deserialize(&mut value.into_deserializer()))
}
```

Please note that there is an regression in serde-rs/json which needs to
be fixed.
