### PR TITLE
Fix code block end marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Or with nightly:
 ```rust
 % cargo build --features nightly --no-default-features
 ...
+```
 
 Serialization without Macros
 ============================


### PR DESCRIPTION
Looks like someone accidentally removed the \`\`\` from the end of a code block, causing the `Serialization without Macros` section to be formatted like code