### PR TITLE
Opt-out of `num`s `default-features`

### DIFF
--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -9,8 +9,9 @@ documentation = "https://serde-rs.github.io/serde/serde/serde/index.html"
 readme = "../README.md"
 keywords = ["serde", "serialization"]
 
-[dependencies]
-num = "^0.1.27"
+[dependencies.num]
+version = "^0.1.27"
+default-features = false
 
 [features]
 nightly = []


### PR DESCRIPTION
`num` pulls in deps for features that `serde` doesn't need, so opt-out of them.