### PR TITLE
Field serialization proxy via newtypes

### DIFF
--- a/serde_codegen/Cargo.toml
+++ b/serde_codegen/Cargo.toml
@@ -16,11 +16,11 @@ with-syntex = ["quasi/with-syntex", "quasi_codegen", "quasi_codegen/with-syntex"
 
 [build-dependencies]
 quasi_codegen = { version = "^0.3.9", optional = true }
-syntex = { version = "^0.22.0", optional = true }
+syntex = { version = "^0.24.0", optional = true }
 
 [dependencies]
 aster = { version = "^0.9.0", default-features = false }
 quasi = { version = "^0.3.9", default-features = false }
 quasi_macros = { version = "^0.3.9", optional = true }
-syntex = { version = "^0.22.0", optional = true }
-syntex_syntax = { version = "^0.23.0", optional = true }
+syntex = { version = "^0.24.0", optional = true }
+syntex_syntax = { version = "^0.24.0", optional = true }

--- a/serde_codegen/src/de.rs
+++ b/serde_codegen/src/de.rs
@@ -978,13 +978,13 @@ fn deserialize_map(
         .map(|(field_name, field_attr)| {
             let visit_value = if let Some(deserializer) = field_attr.deserializer() {
                 let deserializer = cx.parse_expr(deserializer.into());
-                quote_expr!(cx, Some(try!(visitor.visit_value::<$deserializer>()).into()))
+                quote_expr!(cx, ::std::convert::Into::into(try!(visitor.visit_value::<$deserializer>())))
             } else {
-                quote_expr!(cx, Some(try!(visitor.visit_value())))
+                quote_expr!(cx, try!(visitor.visit_value()))
             };
             quote_arm!(cx,
                 __Field::$field_name => {
-                    $field_name = $visit_value;
+                    $field_name = Some($visit_value);
                 }
             )
         })

--- a/serde_tests/Cargo.toml
+++ b/serde_tests/Cargo.toml
@@ -11,15 +11,15 @@ keywords = ["serialization"]
 build = "build.rs"
 
 [build-dependencies]
-syntex = { version = "^0.22.0" }
-syntex_syntax = { version = "^0.23.0" }
+syntex = { version = "^0.24.0" }
+syntex_syntax = { version = "^0.24.0" }
 serde_codegen = { version = "*", path = "../serde_codegen", features = ["with-syntex"] }
 
 [dev-dependencies]
 num = "^0.1.27"
 rustc-serialize = "^0.3.16"
 serde = { version = "*", path = "../serde", features = ["num-impls"] }
-syntex = "^0.22.0"
+syntex = "^0.24.0"
 
 [[test]]
 name = "test"


### PR DESCRIPTION
This change adds two new attributes: `serializer` and `deserializer`. They can be used to specify a newtype that performs {de,}serialization functionality without actually making it part of your struct type definition.

Mainly looking for design and implementation feedback. I did this pretty quickly and haven't tested it much with real-life workloads yet. I may have missed some cases (enum variants? tuples?).

## serializer

An expression that resolves to a function or newtype that, when called, produces a value to be serialized. The prototype is roughly `for<T: serde::Serialize> FnOnce(&ValueType) -> T`.

```rust
struct Serializer<'a>(&'a u8);

impl<'a> serde::Serialize for Serializer<'a> { ... }

#[derive(Serialize)]
struct S {
    #[serde(serializer = "Serializer")]
    v: u8,
}
```

## deserializer

A name or path to a type that satisfies `T: serde::Deserialize + Into<ValueType>`

```rust
struct Deserializer(u8);

impl serde::Deserialize for Deserializer { ... }
impl Into<u8> for Deserializer { ... }

#[derive(Deserialize)]
struct S {
    #[serde(deserializer = "Deserializer")]
    v: u8,
}
```