### PR TITLE
Use SVG version of Travis CI build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Serde Rust Serialization Framework
 ==================================
 
-[![Build Status](https://api.travis-ci.org/serde-rs/serde.png?branch=master)](https://travis-ci.org/serde-rs/serde)
+[![Build Status](https://api.travis-ci.org/serde-rs/serde.svg?branch=master)](https://travis-ci.org/serde-rs/serde)
 [![Coverage Status](https://coveralls.io/repos/serde-rs/serde/badge.svg?branch=master&service=github)](https://coveralls.io/github/serde-rs/serde?branch=master)
 [![Latest Version](https://img.shields.io/crates/v/serde.svg)](https://crates.io/crates/serde)
 


### PR DESCRIPTION
This PR replaces the low res PNG Travis CI build status badge with it's high res SVG counterpart. 