### PR TITLE
Remove extraneous flag

### DIFF
--- a/serde_codegen/src/de.rs
+++ b/serde_codegen/src/de.rs
@@ -538,7 +538,6 @@ fn deserialize_item_enum(
                 let expr = builder.expr().str(variant.node.name);
                  attr::FieldAttrsBuilder::new(builder)
                     .name(expr)
-                    .default()
                     .build()
             })
             .collect()


### PR DESCRIPTION
Getting this out of the way in front of a bigger patch it would have gotten lost in. This change should do nothing. I think the intention here was to say, "Yes, take the default format if needed in renames", but this default is about data defaulting (and rename defaults are always taken anyway if needed).