### PR TITLE
Support rename for enum variants.

### DIFF
--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -1001,6 +1001,245 @@ impl Deserialize for IgnoredAny {
     }
 }
 
+///////////////////////////////////////////////////////////////////////////////
+
+/// See: RenamedDeserializer::rename_deserializer
+pub struct RenamedDeserializer<MAIN, NAME> {
+    main: MAIN,
+    new_name: PhantomData<NAME>,
+}
+
+impl <MAIN, NAME> RenamedDeserializer<MAIN, NAME> {
+    /// Returns a new Deserializer wrapping main_deserializer, which forwards all methods
+    /// to main_deserializer, except for format(), which it forwards to the NAME type.
+    ///
+    /// This is useful for Deserializer authors who use helper deserializers, but want
+    /// those helper serializers to share the same name as the parent deserializers
+    /// for the purposes of, for example, field renaming.
+    pub fn rename_deserializer(main_deserializer: MAIN) -> RenamedDeserializer<MAIN, NAME> {
+        RenamedDeserializer{ main: main_deserializer, new_name: PhantomData }
+    }
+}
+
+#[allow(missing_docs)]
+impl <MAIN: Deserializer, NAME: Deserializer> Deserializer for RenamedDeserializer<MAIN, NAME>
+{
+    type Error = MAIN::Error;
+
+    #[inline]
+    fn deserialize<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor
+    {
+        self.main.deserialize(visitor)
+    }
+
+    #[inline]
+    fn deserialize_bool<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor,
+    {
+        self.main.deserialize_bool(visitor)
+    }
+
+    #[inline]
+    fn deserialize_usize<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor,
+    {
+        self.main.deserialize_usize(visitor)
+    }
+
+    #[inline]
+    fn deserialize_u8<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor,
+    {
+        self.main.deserialize_u8(visitor)
+    }
+
+    #[inline]
+    fn deserialize_u16<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor,
+    {
+        self.main.deserialize_u16(visitor)
+    }
+
+    #[inline]
+    fn deserialize_u32<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor,
+    {
+        self.main.deserialize_u32(visitor)
+    }
+
+    #[inline]
+    fn deserialize_u64<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor,
+    {
+        self.main.deserialize_u64(visitor)
+    }
+
+    #[inline]
+    fn deserialize_isize<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor,
+    {
+        self.main.deserialize_isize(visitor)
+    }
+
+    #[inline]
+    fn deserialize_i8<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor,
+    {
+        self.main.deserialize_i8(visitor)
+    }
+
+    #[inline]
+    fn deserialize_i16<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor,
+    {
+        self.main.deserialize_i16(visitor)
+    }
+
+    #[inline]
+    fn deserialize_i32<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor,
+    {
+        self.main.deserialize_i32(visitor)
+    }
+
+    #[inline]
+    fn deserialize_i64<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor,
+    {
+        self.main.deserialize_i64(visitor)
+    }
+
+    #[inline]
+    fn deserialize_f32<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor,
+    {
+        self.main.deserialize_f32(visitor)
+    }
+
+    #[inline]
+    fn deserialize_f64<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor,
+    {
+        self.main.deserialize_f64(visitor)
+    }
+
+    #[inline]
+    fn deserialize_char<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor,
+    {
+        self.main.deserialize_char(visitor)
+    }
+
+    #[inline]
+    fn deserialize_str<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor,
+    {
+        self.main.deserialize_str(visitor)
+    }
+
+    #[inline]
+    fn deserialize_string<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor,
+    {
+        self.main.deserialize_string(visitor)
+    }
+
+    #[inline]
+    fn deserialize_unit<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor,
+    {
+        self.main.deserialize_unit(visitor)
+    }
+
+    #[inline]
+    fn deserialize_option<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor,
+    {
+        self.main.deserialize_option(visitor)
+    }
+
+    #[inline]
+    fn deserialize_seq<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor,
+    {
+        self.main.deserialize_seq(visitor)
+    }
+
+    #[inline]
+    fn deserialize_map<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor,
+    {
+        self.main.deserialize_map(visitor)
+    }
+
+    #[inline]
+    fn deserialize_unit_struct<V>(&mut self,
+                            name: &'static str,
+                            visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor,
+    {
+        self.main.deserialize_unit_struct(name, visitor)
+    }
+
+    #[inline]
+    fn deserialize_newtype_struct<V>(&mut self,
+                               name: &'static str,
+                               visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor,
+    {
+        self.main.deserialize_newtype_struct(name, visitor)
+    }
+
+    #[inline]
+    fn deserialize_tuple_struct<V>(&mut self,
+                             name: &'static str,
+                             len: usize,
+                             visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor,
+    {
+        self.main.deserialize_tuple_struct(name, len, visitor)
+    }
+
+    #[inline]
+    fn deserialize_struct<V>(&mut self,
+                       name: &'static str,
+                       fields: &'static [&'static str],
+                       visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor,
+    {
+        self.main.deserialize_struct(name, fields, visitor)
+    }
+
+    #[inline]
+    fn deserialize_tuple<V>(&mut self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor,
+    {
+        self.main.deserialize_seq(visitor)
+    }
+
+    #[inline]
+    fn deserialize_enum<V>(&mut self,
+                     enum_name: &'static str,
+                     variants: &'static [&'static str],
+                     visitor: V) -> Result<V::Value, Self::Error>
+        where V: EnumVisitor,
+    {
+        self.main.deserialize_enum(enum_name, variants, visitor)
+    }
+
+    #[inline]
+    fn deserialize_bytes<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor,
+    {
+        self.main.deserialize_bytes(visitor)
+    }
+
+    fn format() -> &'static str {
+        NAME::format()
+    }
+
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/serde_codegen/src/attr.rs
+++ b/serde_codegen/src/attr.rs
@@ -19,7 +19,7 @@ pub enum FieldNames {
     }
 }
 
-/// Represents field attribute information
+/// Represents field or variant attribute information
 #[derive(Debug)]
 pub struct FieldAttrs {
     skip_serializing_field: bool,
@@ -147,6 +147,11 @@ impl<'a> FieldAttrsBuilder<'a> {
         }
 
         Ok(self)
+    }
+
+    pub fn variant(mut self, variant: &ast::Variant) -> Result<FieldAttrsBuilder<'a>, ()> {
+        self.name = Some(self.builder.expr().str(variant.node.name));
+        self.attrs(&variant.node.attrs)
     }
 
     pub fn attr(mut self, attr: &ast::Attribute) -> Result<FieldAttrsBuilder<'a>, ()> {

--- a/serde_codegen/src/de.rs
+++ b/serde_codegen/src/de.rs
@@ -549,17 +549,16 @@ fn deserialize_item_enum(
 
     let type_name = builder.expr().str(type_ident);
 
+    let variant_attrs = try!(field::variant_attrs(
+        cx,
+        builder,
+        &*(enum_def.variants)
+    ));
+
     let variant_visitor = deserialize_field_visitor(
         cx,
         builder,
-        enum_def.variants.iter()
-            .map(|variant| {
-                let expr = builder.expr().str(variant.node.name);
-                 attr::FieldAttrsBuilder::new(cx, builder)
-                    .name(expr)
-                    .build()
-            })
-            .collect(),
+        variant_attrs,
         container_attrs,
     );
 

--- a/serde_codegen/src/field.rs
+++ b/serde_codegen/src/field.rs
@@ -1,5 +1,6 @@
 use syntax::ast;
 use syntax::ext::base::ExtCtxt;
+use syntax::ptr;
 
 use aster;
 use attr;
@@ -13,6 +14,22 @@ pub fn struct_field_attrs(
     for field in fields {
         let builder = attr::FieldAttrsBuilder::new(cx, builder);
         let builder = try!(builder.field(field));
+        let attr = builder.build();
+        attrs.push(attr);
+    }
+
+    Ok(attrs)
+}
+
+pub fn variant_attrs(
+    cx: &ExtCtxt,
+    builder: &aster::AstBuilder,
+    variants: &[ptr::P<ast::Variant>],
+) -> Result<Vec<attr::FieldAttrs>, ()> {
+    let mut attrs = vec![];
+    for variant in variants {
+        let builder = attr::FieldAttrsBuilder::new(cx, builder);
+        let builder = try!(builder.variant(variant));
         let attr = builder.build();
         attrs.push(attr);
     }

--- a/serde_tests/tests/test_annotations.rs
+++ b/serde_tests/tests/test_annotations.rs
@@ -30,6 +30,12 @@ struct Rename {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+enum RenameEnum {
+    #[serde(rename="bruce_wayne")]
+    Batman,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 struct FormatRename {
     a1: i32,
     #[serde(rename(xml= "a4", token="a5"))]
@@ -43,6 +49,12 @@ enum SerEnum<A> {
         #[serde(rename(xml= "c", token="d"))]
         b: A,
     },
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+enum FormatRenameEnum {
+    #[serde(rename(xml="dick_grayson", token="jason_todd"))]
+    Robin,
 }
 
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
@@ -170,6 +182,13 @@ fn test_rename() {
             Token::MapEnd,
         ]
     );
+
+    assert_tokens(
+        &RenameEnum::Batman,
+        vec![
+            Token::EnumUnit("RenameEnum", "bruce_wayne"),
+        ]
+    );
 }
 
 #[test]
@@ -188,6 +207,13 @@ fn test_format_rename() {
             Token::I32(2),
 
             Token::MapEnd,
+        ]
+    );
+
+    assert_tokens(
+        &FormatRenameEnum::Robin,
+        vec![
+            Token::EnumUnit("FormatRenameEnum", "jason_todd"),
         ]
     );
 }


### PR DESCRIPTION
Closes #182, #195
Obviates PR https://github.com/serde-rs/serde/pull/205

Unfortunately there are some minor snags/quibbles:

The old behavior was to silently ignore the attribute on variants, so this could theoretically be a breaking change for someone who tried it out, but it didn't work, but they left it in production code. I don't have a strong opinion about what to do here. This change is the easiest route: keep the name. If you want to do something different (pick a different name; or release validation to forbid the old behavior for a few months and hold this in reserve) I'd be happy to bolt that on. I'm working on attr validation anyway, which is why the attr.rs change is anemic here.

I ran into a glitch with format names. Deserializer format name is determined very locally, which meant any Deserializer that uses a ValueDeserializer as a helper wouldn't get format-specific renames applied as intended. My first inclination was to pass the parent Deserializer type down from the top level of the codenned nest all the way into leaf nestings, so that the root Deserializer always governed the format name. My rust-fu wasn't up to the task. Instead, this lets Deserializer authors control nested format names. More flexible, but more easy to forget. I can take another crack at my original plan if that's what you'd prefer.