### PR TITLE
Use deserializer.deserialize_string for PathBuf

### DIFF
--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -755,7 +755,7 @@ impl Deserialize for path::PathBuf {
     fn deserialize<D>(deserializer: &mut D) -> Result<path::PathBuf, D::Error>
         where D: Deserializer,
     {
-        deserializer.deserialize(PathBufVisitor)
+        deserializer.deserialize_string(PathBufVisitor)
     }
 }
 


### PR DESCRIPTION
It looks like PathBuf always serializes as a string, so why not skip the indirection?

The motivation for this is [this bug](https://github.com/TyOverby/bincode/issues/53) in bincode.