### PR TITLE
Bump clippy dependency to compile on 1.8.

### DIFF
--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde"
-version = "0.6.10"
+version = "0.6.11"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "A generic serialization/deserialization framework"
@@ -17,5 +17,5 @@ num-impls = ["num-bigint", "num-complex", "num-rational"]
 num-rational = ["num/rational"]
 
 [dependencies]
-clippy = { version = "^0.0.36", optional = true }
+clippy = { version = "^0.0.37", optional = true }
 num = { version = "^0.1.27", default-features = false }

--- a/serde_codegen/Cargo.toml
+++ b/serde_codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_codegen"
-version = "0.6.10"
+version = "0.6.11"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Macros to auto-generate implementations for the serde framework"
@@ -20,7 +20,7 @@ syntex = { version = "^0.26.0", optional = true }
 
 [dependencies]
 aster = { version = "^0.10.0", default-features = false }
-clippy = { version = "^0.0.36", optional = true }
+clippy = { version = "^0.0.37", optional = true }
 quasi = { version = "^0.4.0", default-features = false }
 quasi_macros = { version = "^0.4.0", optional = true }
 syntex = { version = "^0.26.0", optional = true }

--- a/serde_macros/Cargo.toml
+++ b/serde_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_macros"
-version = "0.6.10"
+version = "0.6.11"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Macros to auto-generate implementations for the serde framework"
@@ -13,7 +13,7 @@ name = "serde_macros"
 plugin = true
 
 [dependencies]
-clippy = "^0.0.36"
+clippy = "^0.0.37"
 serde_codegen = { version = "^0.6.10", path = "../serde_codegen", default-features = false, features = ["nightly"] }
 
 [dev-dependencies]

--- a/serde_tests/Cargo.toml
+++ b/serde_tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_tests"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "A generic serialization/deserialization framework"
@@ -25,7 +25,7 @@ serde = { version = "*", path = "../serde", features = ["num-impls"] }
 syntex = "^0.26.0"
 
 [dependencies]
-clippy = { version = "^0.0.36", optional = true }
+clippy = { version = "^0.0.37", optional = true }
 
 [[test]]
 name = "test"


### PR DESCRIPTION
The build fails on rustc 1.8 as clippy 0.0.36 no longer compiles. This bumps up the version of clippy to make it compile on nightly again.