### PR TITLE
feat(de): Support struct key hinting

### DIFF
--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -403,6 +403,16 @@ pub trait Deserializer {
         self.visit_seq(visitor)
     }
 
+    /// This method hints that the `Deserialize` type is expecting some sort of struct key mapping.
+    /// This allows deserializers to choose between &str, usize, or &[u8] to properly deserialize a
+    /// struct key.
+    #[inline]
+    fn visit_struct_key<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor,
+    {
+        self.visit(visitor)
+    }
+
     /// Specify a format string for the deserializer.
     ///
     /// The deserializer format is used to determine which format

--- a/serde_codegen/src/de.rs
+++ b/serde_codegen/src/de.rs
@@ -917,7 +917,7 @@ fn deserialize_field_visitor(
                     }
                 }
 
-                deserializer.visit(__FieldVisitor::<D>{ phantom: PhantomData })
+                deserializer.visit_struct_key(__FieldVisitor::<D>{ phantom: PhantomData })
             }
         }
     ).unwrap();


### PR DESCRIPTION
Formats that do not provide type hints in the serialized format (bincode, redis) rely on hinting in the deserializer. Struct key hinting was not previously supported. This was not an issue in the past because
bincode serializes structs as a keyless sequence of values. However, redis data is stored (key, value, key, value, ...), and the keys must be deserialized to properly create a struct.

The default implementation of `visit_struct_key` is simply `visit` since that was the previous method called in codegen.

I think this should be backwards compatible with 0.6.x, but you guys would know best. I am happy to resubmit against 0.7 if needed.