### PR TITLE
feat(de): Support hinting for IgnoredAny

### DIFF
--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -1004,7 +1004,8 @@ impl Deserialize for IgnoredAny {
             }
         }
 
-        deserializer.deserialize(IgnoredAnyVisitor)
+        // TODO maybe not necessary with impl specialization
+        deserializer.deserialize_ignored_any(IgnoredAnyVisitor)
     }
 }
 

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -416,6 +416,15 @@ pub trait Deserializer {
         self.deserialize(visitor)
     }
 
+    /// This method hints that the `Deserialize` type needs to deserialize a value whose type
+    /// doesn't matter because it is ignored.
+    #[inline]
+    fn deserialize_ignored_any<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor
+    {
+        self.deserialize(visitor)
+    }
+
     /// Specify a format string for the deserializer.
     ///
     /// The deserializer format is used to determine which format


### PR DESCRIPTION
IgnoredAny was calling `deserializer.deserialize` directly which is guaranteed to Error for certain formats like redis and bincode. This adds a `deserialize_ignored_any` method to hint to such implementations.

This is not relevant for 0.6 line since ignoring is only supported on 0.7.