### PR TITLE
fix(clippy): make clippy optional

### DIFF
--- a/serde_macros/Cargo.toml
+++ b/serde_macros/Cargo.toml
@@ -13,7 +13,7 @@ name = "serde_macros"
 plugin = true
 
 [dependencies]
-clippy = "^0.0.37"
+clippy = { version = "^0.0.37", optional = true }
 serde_codegen = { version = "^0.6.10", path = "../serde_codegen", default-features = false, features = ["nightly"] }
 
 [dev-dependencies]

--- a/serde_macros/benches/bench.rs
+++ b/serde_macros/benches/bench.rs
@@ -1,5 +1,5 @@
 #![feature(custom_attribute, custom_derive, plugin, test)]
-#![plugin(clippy)]
+#![cfg_attr(feature = "clippy", plugin(clippy))]
 #![plugin(serde_macros)]
 
 extern crate num;

--- a/serde_macros/src/lib.rs
+++ b/serde_macros/src/lib.rs
@@ -1,5 +1,6 @@
-#![feature(plugin, plugin_registrar, rustc_private)]
-#![plugin(clippy)]
+#![feature(plugin_registrar, rustc_private)]
+#![cfg_attr(feature = "clippy", feature(plugin))]
+#![cfg_attr(feature = "clippy", plugin(clippy))]
 
 extern crate serde_codegen;
 extern crate rustc_plugin;


### PR DESCRIPTION
I noticed when building `serde_macros` that it was pulling in `clippy` as required. It seems like this should be an optional dependency here too, like in the other serde crates.

Also, I noticed setting the version such as `clippy = "^0.0.37"` will require updates as clippy/nightly break. If desired, I can submit another PR to change the clippy dependency to `clippy = "^0.0"` to allow all future `0.0.*` clippy versions (I can do this across all the serde crates). This way you won't have to change the `Cargo.toml` when another clippy version is released.

Let me know. Thanks!