### PR TITLE
Remove support for format-specific renames, replace with ser or de specific renames

### DIFF
--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -424,15 +424,6 @@ pub trait Deserializer {
     {
         self.deserialize(visitor)
     }
-
-    /// Specify a format string for the deserializer.
-    ///
-    /// The deserializer format is used to determine which format
-    /// specific field attributes should be used with the
-    /// deserializer.
-    fn format() -> &'static str {
-        ""
-    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -327,14 +327,6 @@ pub trait Serializer {
     {
         self.serialize_struct_elt(key, value)
     }
-
-    /// Specify a format string for the serializer.
-    ///
-    /// The serializer format is used to determine which format
-    /// specific field attributes should be used with the serializer.
-    fn format() -> &'static str {
-        ""
-    }
 }
 
 /// A trait that is used by a `Serialize` to iterate through a sequence.

--- a/serde_codegen/src/attr.rs
+++ b/serde_codegen/src/attr.rs
@@ -1,6 +1,3 @@
-use std::collections::HashMap;
-use std::collections::HashSet;
-
 use syntax::ast;
 use syntax::attr;
 use syntax::ext::base::ExtCtxt;
@@ -10,16 +7,6 @@ use syntax::ptr::P;
 use aster::AstBuilder;
 
 use error::Error;
-
-/// Represents field name information
-#[derive(Debug)]
-pub enum FieldNames {
-    Global(P<ast::Expr>),
-    Format {
-        formats: HashMap<P<ast::Expr>, P<ast::Expr>>,
-        default: P<ast::Expr>,
-    }
-}
 
 /// Represents container (e.g. struct) attribute information
 #[derive(Debug)]
@@ -65,18 +52,17 @@ impl ContainerAttrs {
 /// Represents field attribute information
 #[derive(Debug)]
 pub struct FieldAttrs {
+    ident: ast::Ident,
+    name: Option<ast::Lit>,
     skip_serializing_field: bool,
     skip_serializing_field_if_empty: bool,
     skip_serializing_field_if_none: bool,
-    names: FieldNames,
     use_default: bool,
 }
 
 impl FieldAttrs {
     /// Extract out the `#[serde(...)]` attributes from a struct field.
     pub fn from_field(cx: &ExtCtxt, field: &ast::StructField) -> Result<Self, Error> {
-        let builder = AstBuilder::new();
-
         let field_ident = match field.node.ident() {
             Some(ident) => ident,
             None => { cx.span_bug(field.span, "struct field has no name?") }
@@ -85,8 +71,7 @@ impl FieldAttrs {
         let mut skip_serializing_field = false;
         let mut skip_serializing_field_if_empty = false;
         let mut skip_serializing_field_if_none = false;
-        let mut field_name = builder.expr().str(field_ident);
-        let mut format_rename = HashMap::new();
+        let mut field_name = None;
         let mut use_default = false;
 
         for meta_items in field.node.attrs.iter().filter_map(get_serde_meta_items) {
@@ -94,21 +79,7 @@ impl FieldAttrs {
                 match meta_item.node {
                     // Parse `#[serde(rename="foo")]`
                     ast::MetaNameValue(ref name, ref lit) if name == &"rename" => {
-                        field_name = builder.expr().build_lit(P(lit.clone()));
-                    }
-
-                    // Parse `#[serde(rename(xml="foo", token="bar"))]`
-                    ast::MetaList(ref name, ref meta_items) if name == &"rename" => {
-                        for meta_item in meta_items {
-                            match meta_item.node {
-                                ast::MetaNameValue(ref name, ref lit) => {
-                                    let name = builder.expr().str(name);
-                                    let expr = builder.expr().build_lit(P(lit.clone()));
-                                    format_rename.insert(name, expr);
-                                }
-                                _ => { }
-                            }
-                        }
+                        field_name = Some(lit.clone());
                     }
 
                     // Parse `#[serde(default)]`
@@ -143,88 +114,32 @@ impl FieldAttrs {
             }
         }
 
-        let names = if format_rename.is_empty() {
-            FieldNames::Global(field_name)
-        } else {
-            FieldNames::Format {
-                formats: format_rename,
-                default: field_name,
-            }
-        };
-
         Ok(FieldAttrs {
+            ident: field_ident,
+            name: field_name,
             skip_serializing_field: skip_serializing_field,
             skip_serializing_field_if_empty: skip_serializing_field_if_empty,
             skip_serializing_field_if_none: skip_serializing_field_if_none,
-            names: names,
             use_default: use_default,
         })
     }
 
     pub fn from_variant(variant: &ast::Variant) -> Self {
-        let name = AstBuilder::new().expr().str(variant.node.name);
-
         FieldAttrs {
+            ident: variant.node.name,
+            name: None,
             skip_serializing_field: false,
             skip_serializing_field_if_empty: false,
             skip_serializing_field_if_none: false,
-            names: FieldNames::Global(name),
             use_default: false,
         }
     }
 
-    /// Return a set of formats that the field has attributes for.
-    pub fn formats(&self) -> HashSet<P<ast::Expr>> {
-        match self.names {
-            FieldNames::Format { ref formats, .. } => {
-                let mut set = HashSet::new();
-                for (fmt, _) in formats.iter() {
-                    set.insert(fmt.clone());
-                };
-                set
-            },
-            _ => HashSet::new()
-        }
-    }
-
-    /// Return an expression for the field key name for serialisation.
-    ///
-    /// The resulting expression assumes that `S` refers to a type
-    /// that implements `Serializer`.
-    pub fn serializer_key_expr(&self, cx: &ExtCtxt) -> P<ast::Expr> {
-        match self.names {
-            FieldNames::Global(ref name) => name.clone(),
-            FieldNames::Format { ref formats, ref default } => {
-                let arms = formats.iter()
-                    .map(|(fmt, lit)| {
-                        quote_arm!(cx, $fmt => { $lit })
-                    })
-                    .collect::<Vec<_>>();
-                quote_expr!(cx,
-                    match S::format() {
-                        $arms
-                        _ => { $default }
-                    }
-                )
-            },
-        }
-    }
-
     /// Return the default field name for the field.
-    pub fn default_key_expr(&self) -> &P<ast::Expr> {
-        match self.names {
-            FieldNames::Global(ref expr) => expr,
-            FieldNames::Format { ref default, .. } => default,
-        }
-    }
-
-    /// Return the field name for the field in the specified format.
-    pub fn key_expr(&self, format: &P<ast::Expr>) -> &P<ast::Expr> {
-        match self.names {
-            FieldNames::Global(ref expr) => expr,
-            FieldNames::Format { ref formats, ref default } => {
-                formats.get(format).unwrap_or(default)
-            }
+    pub fn name_expr(&self) -> P<ast::Expr> {
+        match self.name {
+            Some(ref name) => AstBuilder::new().expr().build_lit(P(name.clone())),
+            None => AstBuilder::new().expr().str(self.ident),
         }
     }
 

--- a/serde_codegen/src/attr.rs
+++ b/serde_codegen/src/attr.rs
@@ -21,6 +21,18 @@ pub enum FieldNames {
     }
 }
 
+/// Represents container (e.g. struct) attribute information
+#[derive(Debug)]
+pub struct ContainerAttrs {
+    deny_unknown_fields: bool,
+}
+
+impl ContainerAttrs {
+    pub fn deny_unknown_fields(&self) -> bool {
+        self.deny_unknown_fields
+    }
+}
+
 /// Represents field attribute information
 #[derive(Debug)]
 pub struct FieldAttrs {
@@ -260,18 +272,6 @@ impl<'a> FieldAttrsBuilder<'a> {
             names: names,
             use_default: self.use_default,
         }
-    }
-}
-
-/// Represents container (e.g. struct) attribute information
-#[derive(Debug)]
-pub struct ContainerAttrs {
-    deny_unknown_fields: bool,
-}
-
-impl ContainerAttrs {
-    pub fn deny_unknown_fields(&self) -> bool {
-        self.deny_unknown_fields
     }
 }
 

--- a/serde_codegen/src/de.rs
+++ b/serde_codegen/src/de.rs
@@ -554,7 +554,7 @@ fn deserialize_item_enum(
             enum_def.variants.iter()
                 .map(|variant| {
                     let attrs = try!(attr::VariantAttrs::from_variant(cx, variant));
-                    Ok(attrs.name_expr())
+                    Ok(attrs.deserialize_name_expr())
                 })
                 .collect()
         ),
@@ -924,7 +924,7 @@ fn deserialize_struct_visitor(
             fields.iter()
                 .map(|field| {
                     let attrs = try!(attr::FieldAttrs::from_field(cx, field));
-                    Ok(attrs.name_expr())
+                    Ok(attrs.deserialize_name_expr())
                 })
                 .collect()
         ),
@@ -1007,7 +1007,7 @@ fn deserialize_map(
             let missing_expr = if field_attr.use_default() {
                 quote_expr!(cx, ::std::default::Default::default())
             } else {
-                let name = field_attr.name_expr();
+                let name = field_attr.ident_expr();
                 quote_expr!(cx, try!(visitor.missing_field($name)))
             };
 

--- a/serde_codegen/src/de.rs
+++ b/serde_codegen/src/de.rs
@@ -553,12 +553,7 @@ fn deserialize_item_enum(
         cx,
         builder,
         enum_def.variants.iter()
-            .map(|variant| {
-                let expr = builder.expr().str(variant.node.name);
-                 attr::FieldAttrsBuilder::new(cx, builder)
-                    .name(expr)
-                    .build()
-            })
+            .map(|variant| attr::FieldAttrs::from_variant(variant))
             .collect(),
         container_attrs,
     );
@@ -967,7 +962,7 @@ fn deserialize_struct_visitor(
     let field_visitor = deserialize_field_visitor(
         cx,
         builder,
-        try!(attr::get_struct_field_attrs(cx, builder, fields)),
+        try!(attr::get_struct_field_attrs(cx, fields)),
         container_attrs
     );
 
@@ -1039,7 +1034,7 @@ fn deserialize_map(
         .chain(ignored_arm.into_iter())
         .collect();
 
-    let field_attrs = try!(attr::get_struct_field_attrs(cx, builder, fields));
+    let field_attrs = try!(attr::get_struct_field_attrs(cx, fields));
 
     let extract_values: Vec<P<ast::Stmt>> = field_names.iter()
         .zip(field_attrs.iter())

--- a/serde_codegen/src/de.rs
+++ b/serde_codegen/src/de.rs
@@ -14,8 +14,7 @@ use syntax::ext::base::{Annotatable, ExtCtxt};
 use syntax::ext::build::AstBuilder;
 use syntax::ptr::P;
 
-use attr::{self, ContainerAttrs};
-
+use attr;
 use error::Error;
 
 pub fn expand_derive_deserialize(
@@ -88,7 +87,7 @@ fn deserialize_body(
     impl_generics: &ast::Generics,
     ty: P<ast::Ty>,
 ) -> Result<P<ast::Expr>, Error> {
-    let container_attrs = try!(attr::get_container_attrs(cx, item));
+    let container_attrs = try!(attr::ContainerAttrs::from_item(cx, item));
 
     match item.node {
         ast::ItemStruct(ref variant_data, _) => {
@@ -129,7 +128,7 @@ fn deserialize_item_struct(
     ty: P<ast::Ty>,
     span: Span,
     variant_data: &ast::VariantData,
-    container_attrs: &ContainerAttrs,
+    container_attrs: &attr::ContainerAttrs,
 ) -> Result<P<ast::Expr>, Error> {
     match *variant_data {
         ast::VariantData::Unit(_) => {
@@ -478,7 +477,7 @@ fn deserialize_struct(
     impl_generics: &ast::Generics,
     ty: P<ast::Ty>,
     fields: &[ast::StructField],
-    container_attrs: &ContainerAttrs,
+    container_attrs: &attr::ContainerAttrs,
 ) -> Result<P<ast::Expr>, Error> {
     let where_clause = &impl_generics.where_clause;
 
@@ -544,7 +543,7 @@ fn deserialize_item_enum(
     impl_generics: &ast::Generics,
     ty: P<ast::Ty>,
     enum_def: &EnumDef,
-    container_attrs: &ContainerAttrs
+    container_attrs: &attr::ContainerAttrs
 ) -> Result<P<ast::Expr>, Error> {
     let where_clause = &impl_generics.where_clause;
 
@@ -642,7 +641,7 @@ fn deserialize_variant(
     generics: &ast::Generics,
     ty: P<ast::Ty>,
     variant: &ast::Variant,
-    container_attrs: &ContainerAttrs,
+    container_attrs: &attr::ContainerAttrs,
 ) -> Result<P<ast::Expr>, Error> {
     let variant_ident = variant.node.name;
 
@@ -735,7 +734,7 @@ fn deserialize_struct_variant(
     generics: &ast::Generics,
     ty: P<ast::Ty>,
     fields: &[ast::StructField],
-    container_attrs: &ContainerAttrs,
+    container_attrs: &attr::ContainerAttrs,
 ) -> Result<P<ast::Expr>, Error> {
     let where_clause = &generics.where_clause;
 
@@ -799,7 +798,7 @@ fn deserialize_field_visitor(
     cx: &ExtCtxt,
     builder: &aster::AstBuilder,
     field_attrs: Vec<attr::FieldAttrs>,
-    container_attrs: &ContainerAttrs,
+    container_attrs: &attr::ContainerAttrs,
 ) -> Vec<P<ast::Item>> {
     // Create the field names for the fields.
     let field_idents: Vec<ast::Ident> = (0 .. field_attrs.len())
@@ -963,7 +962,7 @@ fn deserialize_struct_visitor(
     builder: &aster::AstBuilder,
     struct_path: ast::Path,
     fields: &[ast::StructField],
-    container_attrs: &ContainerAttrs,
+    container_attrs: &attr::ContainerAttrs,
 ) -> Result<(Vec<P<ast::Item>>, P<ast::Stmt>, P<ast::Expr>), Error> {
     let field_visitor = deserialize_field_visitor(
         cx,
@@ -1006,7 +1005,7 @@ fn deserialize_map(
     builder: &aster::AstBuilder,
     struct_path: ast::Path,
     fields: &[ast::StructField],
-    container_attrs: &ContainerAttrs,
+    container_attrs: &attr::ContainerAttrs,
 ) -> Result<P<ast::Expr>, Error> {
     // Create the field names for the fields.
     let field_names: Vec<ast::Ident> = (0 .. fields.len())

--- a/serde_codegen/src/ser.rs
+++ b/serde_codegen/src/ser.rs
@@ -311,7 +311,7 @@ fn serialize_variant(
     let type_name = builder.expr().str(type_ident);
     let variant_ident = variant.node.name;
     let variant_attrs = try!(attr::VariantAttrs::from_variant(cx, variant));
-    let variant_name = variant_attrs.name_expr();
+    let variant_name = variant_attrs.serialize_name_expr();
 
     match variant.node.data {
         ast::VariantData::Unit(_) => {
@@ -613,7 +613,7 @@ fn serialize_struct_visitor<I>(
         .filter(|&(ref field, _)| !field.skip_serializing_field())
         .enumerate()
         .map(|(i, (ref field, value_expr))| {
-            let key_expr = field.name_expr();
+            let key_expr = field.serialize_name_expr();
 
             let stmt = if field.skip_serializing_field_if_empty() {
                 quote_stmt!(cx, if ($value_expr).is_empty() { continue; })

--- a/serde_codegen/src/ser.rs
+++ b/serde_codegen/src/ser.rs
@@ -612,7 +612,7 @@ fn serialize_struct_visitor<I>(
         .filter(|&(ref field, _)| !field.skip_serializing_field())
         .enumerate()
         .map(|(i, (ref field, value_expr))| {
-            let key_expr = field.serializer_key_expr(cx);
+            let key_expr = field.name_expr();
 
             let stmt = if field.skip_serializing_field_if_empty() {
                 quote_stmt!(cx, if ($value_expr).is_empty() { continue; })

--- a/serde_codegen/src/ser.rs
+++ b/serde_codegen/src/ser.rs
@@ -86,7 +86,7 @@ fn serialize_body(
 ) -> Result<P<ast::Expr>, Error> {
     // Note: While we don't have any container attributes, we still want to try to
     // parse them so we can report a proper error if we get passed an unknown attribute.
-    let _ = try!(attr::get_container_attrs(cx, item));
+    let _container_attrs = try!(attr::ContainerAttrs::from_item(cx, item));
 
     match item.node {
         ast::ItemStruct(ref variant_data, _) => {

--- a/serde_codegen/src/ser.rs
+++ b/serde_codegen/src/ser.rs
@@ -605,7 +605,7 @@ fn serialize_struct_visitor<I>(
 {
     let value_exprs = value_exprs.collect::<Vec<_>>();
 
-    let field_attrs = try!(attr::get_struct_field_attrs(cx, builder, fields));
+    let field_attrs = try!(attr::get_struct_field_attrs(cx, fields));
 
     let arms: Vec<ast::Arm> = field_attrs.iter()
         .zip(value_exprs.iter())

--- a/serde_codegen/src/ser.rs
+++ b/serde_codegen/src/ser.rs
@@ -310,7 +310,8 @@ fn serialize_variant(
 ) -> Result<ast::Arm, Error> {
     let type_name = builder.expr().str(type_ident);
     let variant_ident = variant.node.name;
-    let variant_name = builder.expr().str(variant_ident);
+    let variant_attrs = try!(attr::VariantAttrs::from_variant(cx, variant));
+    let variant_name = variant_attrs.name_expr();
 
     match variant.node.data {
         ast::VariantData::Unit(_) => {

--- a/serde_codegen/src/ser.rs
+++ b/serde_codegen/src/ser.rs
@@ -84,20 +84,18 @@ fn serialize_body(
     impl_generics: &ast::Generics,
     ty: P<ast::Ty>,
 ) -> Result<P<ast::Expr>, Error> {
-    // Note: While we don't have any container attributes, we still want to try to
-    // parse them so we can report a proper error if we get passed an unknown attribute.
-    let _container_attrs = try!(attr::ContainerAttrs::from_item(cx, item));
+    let container_attrs = try!(attr::ContainerAttrs::from_item(cx, item));
 
     match item.node {
         ast::ItemStruct(ref variant_data, _) => {
             serialize_item_struct(
                 cx,
                 builder,
-                item,
                 impl_generics,
                 ty,
                 item.span,
                 variant_data,
+                &container_attrs,
             )
         }
         ast::ItemEnum(ref enum_def, _) => {
@@ -108,6 +106,7 @@ fn serialize_body(
                 impl_generics,
                 ty,
                 enum_def,
+                &container_attrs,
             )
         }
         _ => {
@@ -120,25 +119,23 @@ fn serialize_body(
 fn serialize_item_struct(
     cx: &ExtCtxt,
     builder: &aster::AstBuilder,
-    item: &Item,
     impl_generics: &ast::Generics,
     ty: P<ast::Ty>,
     span: Span,
     variant_data: &ast::VariantData,
+    container_attrs: &attr::ContainerAttrs,
 ) -> Result<P<ast::Expr>, Error> {
     match *variant_data {
         ast::VariantData::Unit(_) => {
             serialize_unit_struct(
                 cx,
-                &builder,
-                item.ident,
+                container_attrs,
             )
         }
         ast::VariantData::Tuple(ref fields, _) if fields.len() == 1 => {
             serialize_newtype_struct(
                 cx,
-                &builder,
-                item.ident,
+                container_attrs,
             )
         }
         ast::VariantData::Tuple(ref fields, _) => {
@@ -149,10 +146,10 @@ fn serialize_item_struct(
             serialize_tuple_struct(
                 cx,
                 &builder,
-                item.ident,
                 impl_generics,
                 ty,
                 fields.len(),
+                container_attrs,
             )
         }
         ast::VariantData::Struct(ref fields, _) => {
@@ -163,10 +160,10 @@ fn serialize_item_struct(
             serialize_struct(
                 cx,
                 &builder,
-                item.ident,
                 impl_generics,
                 ty,
                 fields,
+                container_attrs,
             )
         }
     }
@@ -174,10 +171,9 @@ fn serialize_item_struct(
 
 fn serialize_unit_struct(
     cx: &ExtCtxt,
-    builder: &aster::AstBuilder,
-    type_ident: Ident
+    container_attrs: &attr::ContainerAttrs,
 ) -> Result<P<ast::Expr>, Error> {
-    let type_name = builder.expr().str(type_ident);
+    let type_name = container_attrs.serialize_name_expr();
 
     Ok(quote_expr!(cx,
         serializer.serialize_unit_struct($type_name)
@@ -186,10 +182,9 @@ fn serialize_unit_struct(
 
 fn serialize_newtype_struct(
     cx: &ExtCtxt,
-    builder: &aster::AstBuilder,
-    type_ident: Ident
+    container_attrs: &attr::ContainerAttrs,
 ) -> Result<P<ast::Expr>, Error> {
-    let type_name = builder.expr().str(type_ident);
+    let type_name = container_attrs.serialize_name_expr();
 
     Ok(quote_expr!(cx,
         serializer.serialize_newtype_struct($type_name, &self.0)
@@ -199,10 +194,10 @@ fn serialize_newtype_struct(
 fn serialize_tuple_struct(
     cx: &ExtCtxt,
     builder: &aster::AstBuilder,
-    type_ident: Ident,
     impl_generics: &ast::Generics,
     ty: P<ast::Ty>,
     fields: usize,
+    container_attrs: &attr::ContainerAttrs,
 ) -> Result<P<ast::Expr>, Error> {
     let (visitor_struct, visitor_impl) = serialize_tuple_struct_visitor(
         cx,
@@ -216,7 +211,7 @@ fn serialize_tuple_struct(
         impl_generics,
     );
 
-    let type_name = builder.expr().str(type_ident);
+    let type_name = container_attrs.serialize_name_expr();
 
     Ok(quote_expr!(cx, {
         $visitor_struct
@@ -232,10 +227,10 @@ fn serialize_tuple_struct(
 fn serialize_struct(
     cx: &ExtCtxt,
     builder: &aster::AstBuilder,
-    type_ident: Ident,
     impl_generics: &ast::Generics,
     ty: P<ast::Ty>,
     fields: &[ast::StructField],
+    container_attrs: &attr::ContainerAttrs,
 ) -> Result<P<ast::Expr>, Error> {
     let value_exprs = fields.iter().map(|field| {
         let name = field.node.ident().expect("struct has unnamed field");
@@ -255,7 +250,7 @@ fn serialize_struct(
         value_exprs,
     ));
 
-    let type_name = builder.expr().str(type_ident);
+    let type_name = container_attrs.serialize_name_expr();
 
     Ok(quote_expr!(cx, {
         $visitor_struct
@@ -275,6 +270,7 @@ fn serialize_item_enum(
     impl_generics: &ast::Generics,
     ty: P<ast::Ty>,
     enum_def: &ast::EnumDef,
+    container_attrs: &attr::ContainerAttrs,
 ) -> Result<P<ast::Expr>, Error> {
     let mut arms = vec![];
 
@@ -287,6 +283,7 @@ fn serialize_item_enum(
             ty.clone(),
             variant,
             variant_index,
+            container_attrs,
         ));
 
         arms.push(arm);
@@ -307,8 +304,10 @@ fn serialize_variant(
     ty: P<ast::Ty>,
     variant: &ast::Variant,
     variant_index: usize,
+    container_attrs: &attr::ContainerAttrs,
 ) -> Result<ast::Arm, Error> {
-    let type_name = builder.expr().str(type_ident);
+    let type_name = container_attrs.serialize_name_expr();
+
     let variant_ident = variant.node.name;
     let variant_attrs = try!(attr::VariantAttrs::from_variant(cx, variant));
     let variant_name = variant_attrs.serialize_name_expr();

--- a/serde_tests/tests/test_annotations.rs
+++ b/serde_tests/tests/test_annotations.rs
@@ -29,22 +29,6 @@ struct Rename {
     a2: i32,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-struct FormatRename {
-    a1: i32,
-    #[serde(rename(xml= "a4", token="a5"))]
-    a2: i32,
-}
-
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
-enum SerEnum<A> {
-    Map {
-        a: i8,
-        #[serde(rename(xml= "c", token="d"))]
-        b: A,
-    },
-}
-
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
 struct SkipSerializingFields<A: default::Default> {
     a: i8,
@@ -166,49 +150,6 @@ fn test_rename() {
             Token::MapSep,
             Token::Str("a3"),
             Token::I32(2),
-
-            Token::MapEnd,
-        ]
-    );
-}
-
-#[test]
-fn test_format_rename() {
-    assert_tokens(
-        &FormatRename { a1: 1, a2: 2 },
-        vec![
-            Token::StructStart("FormatRename", Some(2)),
-
-            Token::MapSep,
-            Token::Str("a1"),
-            Token::I32(1),
-
-            Token::MapSep,
-            Token::Str("a5"),
-            Token::I32(2),
-
-            Token::MapEnd,
-        ]
-    );
-}
-
-#[test]
-fn test_enum_format_rename() {
-    assert_tokens(
-        &SerEnum::Map {
-            a: 0,
-            b: String::new(),
-        },
-        vec![
-            Token::EnumMapStart("SerEnum", "Map", Some(2)),
-
-            Token::MapSep,
-            Token::Str("a"),
-            Token::I8(0),
-
-            Token::MapSep,
-            Token::Str("d"),
-            Token::Str(""),
 
             Token::MapEnd,
         ]

--- a/serde_tests/tests/test_annotations.rs
+++ b/serde_tests/tests/test_annotations.rs
@@ -29,6 +29,12 @@ struct Rename {
     a2: i32,
 }
 
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+enum RenameEnumVariant {
+    #[serde(rename="bruce_wayne")]
+    Batman,
+}
+
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
 struct SkipSerializingFields<A: default::Default> {
     a: i8,
@@ -152,6 +158,16 @@ fn test_rename() {
             Token::I32(2),
 
             Token::MapEnd,
+        ]
+    );
+}
+
+#[test]
+fn test_rename_enum_variant() {
+    assert_tokens(
+        &RenameEnumVariant::Batman,
+        vec![
+            Token::EnumUnit("RenameEnumVariant", "bruce_wayne"),
         ]
     );
 }

--- a/serde_tests/tests/test_annotations.rs
+++ b/serde_tests/tests/test_annotations.rs
@@ -36,7 +36,7 @@ enum RenameVariantVariant {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
-struct RenameStructSerializeDeserialize {
+struct RenameStructFieldSerializeDeserialize {
     a1: i32,
     #[serde(rename(serialize="a4", deserialize="a5"))]
     a2: i32,
@@ -171,7 +171,7 @@ fn test_ignore_unknown() {
 }
 
 #[test]
-fn test_rename() {
+fn test_rename_struct_field() {
     assert_tokens(
         &Rename { a1: 1, a2: 2 },
         vec![
@@ -201,11 +201,11 @@ fn test_rename_enum_variant() {
 }
 
 #[test]
-fn test_rename_struct_serialize_deserialize() {
+fn test_rename_struct_field_serialize_deserialize() {
     assert_ser_tokens(
-        &RenameStructSerializeDeserialize { a1: 1, a2: 2 },
+        &RenameStructFieldSerializeDeserialize { a1: 1, a2: 2 },
         &[
-            Token::StructStart("RenameStructSerializeDeserialize", Some(2)),
+            Token::StructStart("RenameStructFieldSerializeDeserialize", Some(2)),
 
             Token::MapSep,
             Token::Str("a1"),
@@ -220,9 +220,9 @@ fn test_rename_struct_serialize_deserialize() {
     );
 
     assert_de_tokens(
-        &RenameStructSerializeDeserialize { a1: 1, a2: 2 },
+        &RenameStructFieldSerializeDeserialize { a1: 1, a2: 2 },
         vec![
-            Token::StructStart("RenameStructSerializeDeserialize", Some(2)),
+            Token::StructStart("RenameStructFieldSerializeDeserialize", Some(2)),
 
             Token::MapSep,
             Token::Str("a1"),

--- a/serde_tests/tests/test_annotations.rs
+++ b/serde_tests/tests/test_annotations.rs
@@ -30,9 +30,37 @@ struct Rename {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
-enum RenameEnumVariant {
+enum RenameVariantVariant {
     #[serde(rename="bruce_wayne")]
     Batman,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct RenameStructSerializeDeserialize {
+    a1: i32,
+    #[serde(rename(serialize="a4", deserialize="a5"))]
+    a2: i32,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+enum RenameEnum {
+    #[serde(rename="bruce_wayne")]
+    Batman,
+}
+
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
+enum RenameVariantSerializeDeserialize<A> {
+    Map {
+        a: i8,
+        #[serde(rename(serialize="c", deserialize="d"))]
+        b: A,
+    },
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+enum RenameEnumVariantSerializeDeserialize {
+    #[serde(rename(serialize="dick_grayson", deserialize="jason_todd"))]
+    Robin,
 }
 
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
@@ -165,9 +193,106 @@ fn test_rename() {
 #[test]
 fn test_rename_enum_variant() {
     assert_tokens(
-        &RenameEnumVariant::Batman,
+        &RenameVariantVariant::Batman,
         vec![
-            Token::EnumUnit("RenameEnumVariant", "bruce_wayne"),
+            Token::EnumUnit("RenameVariantVariant", "bruce_wayne"),
+        ]
+    );
+}
+
+#[test]
+fn test_rename_struct_serialize_deserialize() {
+    assert_ser_tokens(
+        &RenameStructSerializeDeserialize { a1: 1, a2: 2 },
+        &[
+            Token::StructStart("RenameStructSerializeDeserialize", Some(2)),
+
+            Token::MapSep,
+            Token::Str("a1"),
+            Token::I32(1),
+
+            Token::MapSep,
+            Token::Str("a4"),
+            Token::I32(2),
+
+            Token::MapEnd,
+        ]
+    );
+
+    assert_de_tokens(
+        &RenameStructSerializeDeserialize { a1: 1, a2: 2 },
+        vec![
+            Token::StructStart("RenameStructSerializeDeserialize", Some(2)),
+
+            Token::MapSep,
+            Token::Str("a1"),
+            Token::I32(1),
+
+            Token::MapSep,
+            Token::Str("a5"),
+            Token::I32(2),
+
+            Token::MapEnd,
+        ]
+    );
+}
+
+#[test]
+fn test_rename_variant_serialize_deserialize() {
+    assert_ser_tokens(
+        &RenameEnumVariantSerializeDeserialize::Robin,
+        &[
+            Token::EnumUnit("RenameEnumVariantSerializeDeserialize", "dick_grayson"),
+        ]
+    );
+
+    assert_de_tokens(
+        &RenameEnumVariantSerializeDeserialize::Robin,
+        vec![
+            Token::EnumUnit("RenameEnumVariantSerializeDeserialize", "jason_todd"),
+        ]
+    );
+}
+
+#[test]
+fn test_enum_serialize_deserialize() {
+    assert_ser_tokens(
+        &RenameVariantSerializeDeserialize::Map {
+            a: 0,
+            b: String::new(),
+        },
+        &[
+            Token::EnumMapStart("RenameVariantSerializeDeserialize", "Map", Some(2)),
+
+            Token::MapSep,
+            Token::Str("a"),
+            Token::I8(0),
+
+            Token::MapSep,
+            Token::Str("c"),
+            Token::Str(""),
+
+            Token::MapEnd,
+        ]
+    );
+
+    assert_de_tokens(
+        &RenameVariantSerializeDeserialize::Map {
+            a: 0,
+            b: String::new(),
+        },
+        vec![
+            Token::EnumMapStart("RenameVariantSerializeDeserialize", "Map", Some(2)),
+
+            Token::MapSep,
+            Token::Str("a"),
+            Token::I8(0),
+
+            Token::MapSep,
+            Token::Str("d"),
+            Token::Str(""),
+
+            Token::MapEnd,
         ]
     );
 }

--- a/serde_tests/tests/token.rs
+++ b/serde_tests/tests/token.rs
@@ -301,10 +301,6 @@ impl<'a, I> ser::Serializer for Serializer<I>
         try!(key.serialize(self));
         value.serialize(self)
     }
-
-    fn format() -> &'static str {
-        "token"
-    }
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -582,10 +578,6 @@ impl<I> de::Deserializer for Deserializer<I>
             Some(_) => self.deserialize(visitor),
             None => Err(Error::EndOfStreamError),
         }
-    }
-
-    fn format() -> &'static str {
-        "token"
     }
 }
 


### PR DESCRIPTION
This effectively reverts #69, and restores the functionality added in #62. This feature that allows format-specific renames has never been used, and it's complicating the implementation of #207.

According to #61, if one uses serde to serialize requests that pass url-encoded parameters to a server, it might get responses back with a different capitalization scheme. This patch restores the behavior implemented in #62.

This closes #211.
