### PR TITLE
plugin(clippy) now relies on feature = "clippy"

### DIFF
--- a/serde_codegen/src/lib.rs
+++ b/serde_codegen/src/lib.rs
@@ -1,5 +1,5 @@
-#![cfg_attr(feature = "nightly", plugin(clippy))]
-#![cfg_attr(feature = "nightly", allow(used_underscore_binding))]
+#![cfg_attr(feature = "clippy", plugin(clippy))]
+#![cfg_attr(feature = "clippy", allow(used_underscore_binding))]
 #![cfg_attr(not(feature = "with-syntex"), feature(rustc_private, plugin))]
 #![cfg_attr(not(feature = "with-syntex"), plugin(quasi_macros))]
 


### PR DESCRIPTION
Was previously nightly. This resulted in compilation error when the clippy feature was not enabled because the clippy crate could not be found.