### PR TITLE
Add codegen expr magic for default, skip serializing, and alternative serializers

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,22 +670,36 @@ Annotations
 `serde_codegen` and `serde_macros` support annotations that help to customize
 how types are serialized. Here are the supported annotations:
 
+Container Annotations:
+
+| Annotation                             | Function                                                                                                                                           |
+| ----------                             | --------                                                                                                                                           |
+| `#[serde(rename="name")`               | Serialize and deserialize this container with the given name                                                                                       |
+| `#[serde(rename(serialize="name1"))`   | Serialize this container with the given name                                                                                                       |
+| `#[serde(rename(deserialize="name1"))` | Deserialize this container with the given name                                                                                                     |
+| `#[serde(deny_unknown_fields)`         | Always error during serialization when encountering unknown fields. When absent, unknown fields are ignored for self-describing formats like JSON. |
+
+Variant Annotations:
+
+| Annotation                             | Function                                                   |
+| ----------                             | --------                                                   |
+| `#[serde(rename="name")`               | Serialize and deserialize this variant with the given name |
+| `#[serde(rename(serialize="name1"))`   | Serialize this variant with the given name                 |
+| `#[serde(rename(deserialize="name1"))` | Deserialize this variant with the given name               |
+
 Field Annotations:
 
-| Annotation                                   | Function                                                       |
-| ----------                                   | --------                                                       |
-| `#[serde(rename(json="name1", xml="name2"))` | Serialize this field with the given name for the given formats |
-| `#[serde(default)`                           | If the value is not specified, use the `Default::default()`    |
-| `#[serde(rename="name")`                     | Serialize this field with the given name                       |
-| `#[serde(skip_serializing)`                  | Do not serialize this value                                    |
-| `#[serde(skip_serializing_if_empty)`         | Do not serialize this value if `$value.is_empty()` is `true`   |
-| `#[serde(skip_serializing_if_none)`          | Do not serialize this value if `$value.is_none()` is `true`    |
-
-Structure Annotations:
-
-| Annotation                  | Function                                                                                                                                           |
-| ----------                  | --------                                                                                                                                           |
-| `#[serde(deny_unknown_fields)` | Always error during serialization when encountering unknown fields. When absent, unknown fields are ignored for self-describing formats like JSON. |
+| Annotation                             | Function                                                           |
+| ----------                             | --------                                                           |
+| `#[serde(rename="name")`               | Serialize and deserialize this field with the given name           |
+| `#[serde(rename(serialize="name1"))`   | Serialize this field with the given name                           |
+| `#[serde(rename(deserialize="name1"))` | Deserialize this field with the given name                         |
+| `#[serde(default)`                     | If the value is not specified, use the `Default::default()`        |
+| `#[serde(default="$expr")`             | If the value is not specified, use the `$expr` expression          |
+| `#[serde(skip_serializing)`            | Do not serialize this value                                        |
+| `#[serde(skip_serializing_if="$expr")` | Do not serialize this value if the `$expr` expression returns true |
+| `#[serde(serialize_with="$expr")`      | Use the `$expr` expression to serialize this field                 |
+| `#[serde(deserialize_with="$expr")`    | Use the `$expr` expression to deserialize this field               |
 
 
 Serialization Formats Using Serde

--- a/README.md
+++ b/README.md
@@ -689,18 +689,17 @@ Variant Annotations:
 
 Field Annotations:
 
-| Annotation                             | Function                                                           |
-| ----------                             | --------                                                           |
-| `#[serde(rename="name")`               | Serialize and deserialize this field with the given name           |
-| `#[serde(rename(serialize="name1"))`   | Serialize this field with the given name                           |
-| `#[serde(rename(deserialize="name1"))` | Deserialize this field with the given name                         |
-| `#[serde(default)`                     | If the value is not specified, use the `Default::default()`        |
-| `#[serde(default="$expr")`             | If the value is not specified, use the `$expr` expression          |
-| `#[serde(skip_serializing)`            | Do not serialize this value                                        |
-| `#[serde(skip_serializing_if="$expr")` | Do not serialize this value if the `$expr` expression returns true |
-| `#[serde(serialize_with="$expr")`      | Use the `$expr` expression to serialize this field                 |
-| `#[serde(deserialize_with="$expr")`    | Use the `$expr` expression to deserialize this field               |
-
+| Annotation                             | Function                                                                                                   |
+| ----------                             | --------                                                                                                   |
+| `#[serde(rename="name")`               | Serialize and deserialize this field with the given name                                                   |
+| `#[serde(rename(serialize="name1"))`   | Serialize this field with the given name                                                                   |
+| `#[serde(rename(deserialize="name1"))` | Deserialize this field with the given name                                                                 |
+| `#[serde(default)`                     | If the value is not specified, use the `Default::default()`                                                |
+| `#[serde(default="$path")`             | Call the path to a function `fn() -> T` to build the value                                                 |
+| `#[serde(skip_serializing)`            | Do not serialize this value                                                                                |
+| `#[serde(skip_serializing_if="$path")` | Do not serialize this value if this function `fn(&T) -> bool` returns `false`                              |
+| `#[serde(serialize_with="$path")`      | Call a function `fn<T, S>(&T, &mut S) -> Result<(), S::Error> where S: Serializer` to serialize this value |
+| `#[serde(deserialize_with="$path")`    | Call a function `fn<T, D>(&mut D) -> Result<T, D::Error> where D: Deserializer` to deserialize this value  |
 
 Serialization Formats Using Serde
 =================================

--- a/serde_codegen/src/attr.rs
+++ b/serde_codegen/src/attr.rs
@@ -167,8 +167,6 @@ pub struct FieldAttrs {
     deserialize_name: Option<ast::Lit>,
     skip_serializing_field: bool,
     skip_serializing_field_if: Option<P<ast::Expr>>,
-    skip_serializing_field_if_empty: bool,
-    skip_serializing_field_if_none: bool,
     default_expr_if_missing: Option<P<ast::Expr>>,
     serialize_with: Option<P<ast::Expr>>,
     deserialize_with: Option<P<ast::Expr>>,
@@ -193,8 +191,6 @@ impl FieldAttrs {
             deserialize_name: None,
             skip_serializing_field: false,
             skip_serializing_field_if: None,
-            skip_serializing_field_if_empty: false,
-            skip_serializing_field_if_none: false,
             default_expr_if_missing: None,
             serialize_with: None,
             deserialize_with: None,
@@ -249,16 +245,6 @@ impl FieldAttrs {
                         );
 
                         field_attrs.skip_serializing_field_if = Some(expr);
-                    }
-
-                    // Parse `#[serde(skip_serializing_if_none)]`
-                    ast::MetaItemKind::Word(ref name) if name == &"skip_serializing_if_none" => {
-                        field_attrs.skip_serializing_field_if_none = true;
-                    }
-
-                    // Parse `#[serde(skip_serializing_if_empty)]`
-                    ast::MetaItemKind::Word(ref name) if name == &"skip_serializing_if_empty" => {
-                        field_attrs.skip_serializing_field_if_empty = true;
                     }
 
                     // Parse `#[serde(serialize_with="...")]`
@@ -343,14 +329,6 @@ impl FieldAttrs {
 
     pub fn skip_serializing_field_if(&self) -> Option<&P<ast::Expr>> {
         self.skip_serializing_field_if.as_ref()
-    }
-
-    pub fn skip_serializing_field_if_empty(&self) -> bool {
-        self.skip_serializing_field_if_empty
-    }
-
-    pub fn skip_serializing_field_if_none(&self) -> bool {
-        self.skip_serializing_field_if_none
     }
 
     pub fn serialize_with(&self) -> Option<&P<ast::Expr>> {

--- a/serde_codegen/src/de.rs
+++ b/serde_codegen/src/de.rs
@@ -506,7 +506,8 @@ fn deserialize_struct(
         &ty,
         impl_generics,
         fields,
-        container_attrs
+        container_attrs,
+        false,
     ));
 
     let type_name = container_attrs.deserialize_name_expr();
@@ -762,6 +763,7 @@ fn deserialize_struct_variant(
         generics,
         fields,
         container_attrs,
+        true,
     ));
 
     let (visitor_item, visitor_ty, visitor_expr, visitor_generics) = try!(deserialize_visitor(
@@ -926,6 +928,7 @@ fn deserialize_struct_visitor(
     generics: &ast::Generics,
     fields: &[ast::StructField],
     container_attrs: &attr::ContainerAttrs,
+    is_enum: bool,
 ) -> Result<(Vec<P<ast::Item>>, ast::Stmt, P<ast::Expr>), Error> {
     let field_exprs = fields.iter()
         .map(|field| {
@@ -933,7 +936,8 @@ fn deserialize_struct_visitor(
                 attr::FieldAttrs::from_field(cx,
                                              container_ty,
                                              generics,
-                                             field)
+                                             field,
+                                             is_enum)
             );
             Ok(field_attrs.deserialize_name_expr())
         })
@@ -954,6 +958,7 @@ fn deserialize_struct_visitor(
         generics,
         fields,
         container_attrs,
+        is_enum,
     ));
 
     let fields_expr = builder.expr().ref_().slice()
@@ -985,6 +990,7 @@ fn deserialize_map(
     generics: &ast::Generics,
     fields: &[ast::StructField],
     container_attrs: &attr::ContainerAttrs,
+    is_enum: bool,
 ) -> Result<P<ast::Expr>, Error> {
     // Create the field names for the fields.
     let field_names: Vec<ast::Ident> = (0 .. fields.len())
@@ -993,7 +999,7 @@ fn deserialize_map(
 
     let field_attrs: Vec<_> = try!(
         fields.iter()
-            .map(|field| attr::FieldAttrs::from_field(cx, container_ty, generics, field))
+            .map(|field| attr::FieldAttrs::from_field(cx, container_ty, generics, field, is_enum))
             .collect()
     );
 

--- a/serde_codegen/src/ser.rs
+++ b/serde_codegen/src/ser.rs
@@ -605,7 +605,7 @@ fn serialize_struct_visitor<I>(
 {
     let value_exprs = value_exprs.collect::<Vec<_>>();
 
-    let field_attrs = try!(attr::get_struct_field_attrs(cx, fields));
+    let field_attrs = try!(attr::get_struct_field_attrs(cx, generics, fields));
 
     let arms: Vec<ast::Arm> = field_attrs.iter()
         .zip(value_exprs.iter())

--- a/serde_codegen/src/ser.rs
+++ b/serde_codegen/src/ser.rs
@@ -672,8 +672,13 @@ fn serialize_struct_visitor(
                 }
             };
 
+            let field_expr = match field_attr.serialize_with() {
+                Some(expr) => expr.clone(),
+                None => quote_expr!(cx, &self.value.$name),
+            };
+
             let expr = quote_expr!(cx,
-                serializer.$serializer_method($key_expr, &self.value.$name)
+                serializer.$serializer_method($key_expr, $field_expr)
             );
 
             quote_arm!(cx,

--- a/serde_codegen/src/ser.rs
+++ b/serde_codegen/src/ser.rs
@@ -256,6 +256,7 @@ fn serialize_struct(
         builder.id("serialize_struct_elt"),
         fields,
         impl_generics,
+        false,
     ));
 
     let type_name = container_attrs.serialize_name_expr();
@@ -547,6 +548,7 @@ fn serialize_struct_variant(
         builder.id("serialize_struct_variant_elt"),
         fields,
         &variant_generics,
+        true,
     ));
 
     let container_name = container_attrs.serialize_name_expr();
@@ -644,9 +646,10 @@ fn serialize_struct_visitor(
     serializer_method: ast::Ident,
     fields: &[ast::StructField],
     generics: &ast::Generics,
+    is_enum: bool,
 ) -> Result<(P<ast::Item>, P<ast::Item>), Error> {
     let field_attrs = try!(
-        attr::get_struct_field_attrs(cx, &structure_ty, generics, fields)
+        attr::get_struct_field_attrs(cx, &structure_ty, generics, fields, is_enum)
     );
 
     let arms: Vec<ast::Arm> = fields.iter().zip(field_attrs.iter())

--- a/serde_tests/tests/test_annotations.rs
+++ b/serde_tests/tests/test_annotations.rs
@@ -9,10 +9,14 @@ use token::{
 
 trait Trait {
     fn my_default() -> Self;
+
+    fn should_skip(&self) -> bool;
 }
 
 impl Trait for i32 {
     fn my_default() -> Self { 123 }
+
+    fn should_skip(&self) -> bool { *self == 123 }
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -31,19 +35,19 @@ fn test_default_struct() {
         vec![
             Token::StructStart("DefaultStruct", Some(3)),
 
-            Token::MapSep,
+            Token::StructSep,
             Token::Str("a1"),
             Token::I32(1),
 
-            Token::MapSep,
+            Token::StructSep,
             Token::Str("a2"),
             Token::I32(2),
 
-            Token::MapSep,
+            Token::StructSep,
             Token::Str("a3"),
             Token::I32(3),
 
-            Token::MapEnd,
+            Token::StructEnd,
         ]
     );
 
@@ -52,11 +56,11 @@ fn test_default_struct() {
         vec![
             Token::StructStart("DefaultStruct", Some(1)),
 
-            Token::MapSep,
+            Token::StructSep,
             Token::Str("a1"),
             Token::I32(1),
 
-            Token::MapEnd,
+            Token::StructEnd,
         ]
     );
 }
@@ -79,19 +83,19 @@ fn test_default_enum() {
         vec![
             Token::EnumMapStart("DefaultEnum", "Struct", Some(3)),
 
-            Token::MapSep,
+            Token::EnumMapSep,
             Token::Str("a1"),
             Token::I32(1),
 
-            Token::MapSep,
+            Token::EnumMapSep,
             Token::Str("a2"),
             Token::I32(2),
 
-            Token::MapSep,
+            Token::EnumMapSep,
             Token::Str("a3"),
             Token::I32(3),
 
-            Token::MapEnd,
+            Token::EnumMapEnd,
         ]
     );
 
@@ -100,11 +104,11 @@ fn test_default_enum() {
         vec![
             Token::EnumMapStart("DefaultEnum", "Struct", Some(3)),
 
-            Token::MapSep,
+            Token::EnumMapSep,
             Token::Str("a1"),
             Token::I32(1),
 
-            Token::MapEnd,
+            Token::EnumMapEnd,
         ]
     );
 }
@@ -123,34 +127,34 @@ fn test_ignore_unknown() {
         vec![
             Token::StructStart("DefaultStruct", Some(5)),
 
-            Token::MapSep,
+            Token::StructSep,
             Token::Str("whoops1"),
             Token::I32(2),
 
-            Token::MapSep,
+            Token::StructSep,
             Token::Str("a1"),
             Token::I32(1),
 
-            Token::MapSep,
+            Token::StructSep,
             Token::Str("whoops2"),
             Token::SeqStart(Some(1)),
             Token::SeqSep,
             Token::I32(2),
             Token::SeqEnd,
 
-            Token::MapSep,
+            Token::StructSep,
             Token::Str("a2"),
             Token::I32(2),
 
-            Token::MapSep,
+            Token::StructSep,
             Token::Str("whoops3"),
             Token::I32(2),
 
-            Token::MapSep,
+            Token::StructSep,
             Token::Str("a3"),
             Token::I32(3),
 
-            Token::MapEnd,
+            Token::StructEnd,
         ]
     );
 
@@ -158,15 +162,15 @@ fn test_ignore_unknown() {
         vec![
             Token::StructStart("DenyUnknown", Some(2)),
 
-            Token::MapSep,
+            Token::StructSep,
             Token::Str("a1"),
             Token::I32(1),
 
-            Token::MapSep,
+            Token::StructSep,
             Token::Str("whoops"),
             Token::I32(2),
 
-            Token::MapEnd,
+            Token::StructEnd,
         ],
         Error::UnknownFieldError("whoops".to_owned())
     );
@@ -195,15 +199,15 @@ fn test_rename_struct() {
         vec![
             Token::StructStart("Superhero", Some(2)),
 
-            Token::MapSep,
+            Token::StructSep,
             Token::Str("a1"),
             Token::I32(1),
 
-            Token::MapSep,
+            Token::StructSep,
             Token::Str("a3"),
             Token::I32(2),
 
-            Token::MapEnd,
+            Token::StructEnd,
         ]
     );
 
@@ -212,15 +216,15 @@ fn test_rename_struct() {
         &[
             Token::StructStart("SuperheroSer", Some(2)),
 
-            Token::MapSep,
+            Token::StructSep,
             Token::Str("a1"),
             Token::I32(1),
 
-            Token::MapSep,
+            Token::StructSep,
             Token::Str("a4"),
             Token::I32(2),
 
-            Token::MapEnd,
+            Token::StructEnd,
         ]
     );
 
@@ -229,15 +233,15 @@ fn test_rename_struct() {
         vec![
             Token::StructStart("SuperheroDe", Some(2)),
 
-            Token::MapSep,
+            Token::StructSep,
             Token::Str("a1"),
             Token::I32(1),
 
-            Token::MapSep,
+            Token::StructSep,
             Token::Str("a5"),
             Token::I32(2),
 
-            Token::MapEnd,
+            Token::StructEnd,
         ]
     );
 }
@@ -281,7 +285,7 @@ fn test_rename_enum() {
     assert_tokens(
         &RenameEnum::Superman(0),
         vec![
-            Token::EnumNewtype("Superhero", "clark_kent"),
+            Token::EnumNewType("Superhero", "clark_kent"),
             Token::I8(0),
         ]
     );
@@ -291,13 +295,13 @@ fn test_rename_enum() {
         vec![
             Token::EnumSeqStart("Superhero", "diana_prince", Some(2)),
 
-            Token::SeqSep,
+            Token::EnumSeqSep,
             Token::I8(0),
 
-            Token::SeqSep,
+            Token::EnumSeqSep,
             Token::I8(1),
 
-            Token::SeqEnd,
+            Token::EnumSeqEnd,
         ]
     );
 
@@ -306,11 +310,11 @@ fn test_rename_enum() {
         vec![
             Token::EnumMapStart("Superhero", "barry_allan", Some(1)),
 
-            Token::MapSep,
+            Token::EnumMapSep,
             Token::Str("b"),
             Token::I32(1),
 
-            Token::MapEnd,
+            Token::EnumMapEnd,
         ]
     );
 
@@ -322,15 +326,15 @@ fn test_rename_enum() {
         &[
             Token::EnumMapStart("SuperheroSer", "dick_grayson", Some(2)),
 
-            Token::MapSep,
+            Token::EnumMapSep,
             Token::Str("a"),
             Token::I8(0),
 
-            Token::MapSep,
+            Token::EnumMapSep,
             Token::Str("c"),
             Token::Str(""),
 
-            Token::MapEnd,
+            Token::EnumMapEnd,
         ]
     );
 
@@ -342,24 +346,26 @@ fn test_rename_enum() {
         vec![
             Token::EnumMapStart("SuperheroDe", "jason_todd", Some(2)),
 
-            Token::MapSep,
+            Token::EnumMapSep,
             Token::Str("a"),
             Token::I8(0),
 
-            Token::MapSep,
+            Token::EnumMapSep,
             Token::Str("d"),
             Token::Str(""),
 
-            Token::MapEnd,
+            Token::EnumMapEnd,
         ]
     );
 }
 
 #[derive(Debug, PartialEq, Serialize)]
-struct SkipSerializingStruct<'a, B, D, E> {
+struct SkipSerializingStruct<'a, B, C, D, E> where C: Trait {
     a: &'a i8,
     #[serde(skip_serializing)]
     b: B,
+    #[serde(skip_serializing_if="self.c.should_skip()")]
+    c: C,
     #[serde(skip_serializing_if_none)]
     d: Option<D>,
     #[serde(skip_serializing_if_empty)]
@@ -373,29 +379,34 @@ fn test_skip_serializing_struct() {
         &SkipSerializingStruct {
             a: &a,
             b: 2,
+            c: 3,
             d: Some(4),
             e: vec![5],
         },
         &[
-            Token::StructStart("SkipSerializingStruct", Some(3)),
+            Token::StructStart("SkipSerializingStruct", Some(4)),
 
-            Token::MapSep,
+            Token::StructSep,
             Token::Str("a"),
             Token::I8(1),
 
-            Token::MapSep,
+            Token::StructSep,
+            Token::Str("c"),
+            Token::I32(3),
+
+            Token::StructSep,
             Token::Str("d"),
             Token::Option(true),
             Token::I32(4),
 
-            Token::MapSep,
+            Token::StructSep,
             Token::Str("e"),
             Token::SeqStart(Some(1)),
             Token::SeqSep,
             Token::I32(5),
             Token::SeqEnd,
 
-            Token::MapEnd,
+            Token::StructEnd,
         ]
     );
 
@@ -403,27 +414,30 @@ fn test_skip_serializing_struct() {
         &SkipSerializingStruct {
             a: &a,
             b: 2,
+            c: 123,
             d: None::<u8>,
             e: Vec::<u8>::new(),
         },
         &[
             Token::StructStart("SkipSerializingStruct", Some(1)),
 
-            Token::MapSep,
+            Token::StructSep,
             Token::Str("a"),
             Token::I8(1),
 
-            Token::MapEnd,
+            Token::StructEnd,
         ]
     );
 }
 
 #[derive(Debug, PartialEq, Serialize)]
-enum SkipSerializingEnum<'a, B, D, E> {
+enum SkipSerializingEnum<'a, B, C, D, E> where C: Trait {
     Struct {
         a: &'a i8,
         #[serde(skip_serializing)]
         _b: B,
+        #[serde(skip_serializing_if="self.c.should_skip()")]
+        c: C,
         #[serde(skip_serializing_if_none)]
         d: Option<D>,
         #[serde(skip_serializing_if_empty)]
@@ -438,29 +452,34 @@ fn test_skip_serializing_enum() {
         &SkipSerializingEnum::Struct {
             a: &a,
             _b: 2,
+            c: 3,
             d: Some(4),
             e: vec![5],
         },
         &[
-            Token::EnumMapStart("SkipSerializingEnum", "Struct", Some(3)),
+            Token::EnumMapStart("SkipSerializingEnum", "Struct", Some(4)),
 
-            Token::MapSep,
+            Token::EnumMapSep,
             Token::Str("a"),
             Token::I8(1),
 
-            Token::MapSep,
+            Token::EnumMapSep,
+            Token::Str("c"),
+            Token::I32(3),
+
+            Token::EnumMapSep,
             Token::Str("d"),
             Token::Option(true),
             Token::I32(4),
 
-            Token::MapSep,
+            Token::EnumMapSep,
             Token::Str("e"),
             Token::SeqStart(Some(1)),
             Token::SeqSep,
             Token::I32(5),
             Token::SeqEnd,
 
-            Token::MapEnd,
+            Token::EnumMapEnd,
         ]
     );
 
@@ -468,17 +487,18 @@ fn test_skip_serializing_enum() {
         &SkipSerializingEnum::Struct {
             a: &a,
             _b: 2,
+            c: 123,
             d: None::<u8>,
             e: Vec::<u8>::new(),
         },
         &[
             Token::EnumMapStart("SkipSerializingEnum", "Struct", Some(1)),
 
-            Token::MapSep,
+            Token::EnumMapSep,
             Token::Str("a"),
             Token::I8(1),
 
-            Token::MapEnd,
+            Token::EnumMapEnd,
         ]
     );
 }

--- a/serde_tests/tests/test_annotations.rs
+++ b/serde_tests/tests/test_annotations.rs
@@ -1,5 +1,3 @@
-use std::default;
-
 use token::{
     Error,
     Token,
@@ -14,76 +12,6 @@ struct Default {
     a1: i32,
     #[serde(default)]
     a2: i32,
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct DisallowUnknown {
-    a1: i32,
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-#[serde(rename="Superhero")]
-struct RenameStruct {
-    a1: i32,
-    #[serde(rename="a3")]
-    a2: i32,
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-#[serde(rename(serialize="SuperheroSer", deserialize="SuperheroDe"))]
-struct RenameStructSerializeDeserialize {
-    a1: i32,
-    #[serde(rename(serialize="a4", deserialize="a5"))]
-    a2: i32,
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-#[serde(rename="Superhero")]
-enum RenameEnum {
-    #[serde(rename="bruce_wayne")]
-    Batman,
-    #[serde(rename="clark_kent")]
-    Superman(i8),
-    #[serde(rename="diana_prince")]
-    WonderWoman(i8, i8),
-    #[serde(rename="barry_allan")]
-    Flash {
-        #[serde(rename="b")]
-        a: i32,
-    },
-}
-
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
-#[serde(rename(serialize="SuperheroSer", deserialize="SuperheroDe"))]
-enum RenameEnumSerializeDeserialize<A> {
-    #[serde(rename(serialize="dick_grayson", deserialize="jason_todd"))]
-    Robin {
-        a: i8,
-        #[serde(rename(serialize="c", deserialize="d"))]
-        b: A,
-    },
-}
-
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
-struct SkipSerializingFields<A: default::Default> {
-    a: i8,
-    #[serde(skip_serializing, default)]
-    b: A,
-}
-
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
-struct SkipSerializingIfEmptyFields<A: default::Default> {
-    a: i8,
-    #[serde(skip_serializing_if_empty, default)]
-    b: Vec<A>,
-}
-
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
-struct SkipSerializingIfNoneFields<A: default::Default> {
-    a: i8,
-    #[serde(skip_serializing_if_none, default)]
-    b: Option<A>,
 }
 
 #[test]
@@ -117,6 +45,12 @@ fn test_default() {
             Token::MapEnd,
         ]
     );
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DenyUnknown {
+    a1: i32,
 }
 
 #[test]
@@ -154,9 +88,9 @@ fn test_ignore_unknown() {
         ]
     );
 
-    assert_de_tokens_error::<DisallowUnknown>(
+    assert_de_tokens_error::<DenyUnknown>(
         vec![
-            Token::StructStart("DisallowUnknown", Some(2)),
+            Token::StructStart("DenyUnknown", Some(2)),
 
             Token::MapSep,
             Token::Str("a1"),
@@ -170,6 +104,22 @@ fn test_ignore_unknown() {
         ],
         Error::UnknownFieldError("whoops".to_owned())
     );
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename="Superhero")]
+struct RenameStruct {
+    a1: i32,
+    #[serde(rename="a3")]
+    a2: i32,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename(serialize="SuperheroSer", deserialize="SuperheroDe"))]
+struct RenameStructSerializeDeserialize {
+    a1: i32,
+    #[serde(rename(serialize="a4", deserialize="a5"))]
+    a2: i32,
 }
 
 #[test]
@@ -190,10 +140,7 @@ fn test_rename_struct() {
             Token::MapEnd,
         ]
     );
-}
 
-#[test]
-fn test_rename_struct_serialize_deserialize() {
     assert_ser_tokens(
         &RenameStructSerializeDeserialize { a1: 1, a2: 2 },
         &[
@@ -227,6 +174,33 @@ fn test_rename_struct_serialize_deserialize() {
             Token::MapEnd,
         ]
     );
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename="Superhero")]
+enum RenameEnum {
+    #[serde(rename="bruce_wayne")]
+    Batman,
+    #[serde(rename="clark_kent")]
+    Superman(i8),
+    #[serde(rename="diana_prince")]
+    WonderWoman(i8, i8),
+    #[serde(rename="barry_allan")]
+    Flash {
+        #[serde(rename="b")]
+        a: i32,
+    },
+}
+
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[serde(rename(serialize="SuperheroSer", deserialize="SuperheroDe"))]
+enum RenameEnumSerializeDeserialize<A> {
+    #[serde(rename(serialize="dick_grayson", deserialize="jason_todd"))]
+    Robin {
+        a: i8,
+        #[serde(rename(serialize="c", deserialize="d"))]
+        b: A,
+    },
 }
 
 #[test]
@@ -273,10 +247,7 @@ fn test_rename_enum() {
             Token::MapEnd,
         ]
     );
-}
 
-#[test]
-fn test_enum_serialize_deserialize() {
     assert_ser_tokens(
         &RenameEnumSerializeDeserialize::Robin {
             a: 0,
@@ -318,31 +289,59 @@ fn test_enum_serialize_deserialize() {
     );
 }
 
+#[derive(Debug, PartialEq, Serialize)]
+struct SkipSerializingStruct<'a, B, D, E> {
+    a: &'a i8,
+    #[serde(skip_serializing)]
+    b: B,
+    #[serde(skip_serializing_if_none)]
+    d: Option<D>,
+    #[serde(skip_serializing_if_empty)]
+    e: Vec<E>,
+}
+
 #[test]
-fn test_skip_serializing_fields() {
+fn test_skip_serializing_struct() {
+    let a = 1;
     assert_ser_tokens(
-        &SkipSerializingFields {
-            a: 1,
+        &SkipSerializingStruct {
+            a: &a,
             b: 2,
+            d: Some(4),
+            e: vec![5],
         },
         &[
-            Token::StructStart("SkipSerializingFields", Some(1)),
+            Token::StructStart("SkipSerializingStruct", Some(3)),
 
             Token::MapSep,
             Token::Str("a"),
             Token::I8(1),
 
+            Token::MapSep,
+            Token::Str("d"),
+            Token::Option(true),
+            Token::I32(4),
+
+            Token::MapSep,
+            Token::Str("e"),
+            Token::SeqStart(Some(1)),
+            Token::SeqSep,
+            Token::I32(5),
+            Token::SeqEnd,
+
             Token::MapEnd,
         ]
     );
 
-    assert_de_tokens(
-        &SkipSerializingFields {
-            a: 1,
-            b: 0,
+    assert_ser_tokens(
+        &SkipSerializingStruct {
+            a: &a,
+            b: 2,
+            d: None::<u8>,
+            e: Vec::<u8>::new(),
         },
-        vec![
-            Token::StructStart("SkipSerializingFields", Some(1)),
+        &[
+            Token::StructStart("SkipSerializingStruct", Some(1)),
 
             Token::MapSep,
             Token::Str("a"),
@@ -353,158 +352,65 @@ fn test_skip_serializing_fields() {
     );
 }
 
-#[test]
-fn test_skip_serializing_fields_if_empty() {
-    assert_ser_tokens(
-        &SkipSerializingIfEmptyFields::<i32> {
-            a: 1,
-            b: vec![],
-        },
-        &[
-            Token::StructStart("SkipSerializingIfEmptyFields", Some(1)),
-
-            Token::MapSep,
-            Token::Str("a"),
-            Token::I8(1),
-
-            Token::MapEnd,
-        ]
-    );
-
-    assert_de_tokens(
-        &SkipSerializingIfEmptyFields::<i32> {
-            a: 1,
-            b: vec![],
-        },
-        vec![
-            Token::StructStart("SkipSerializingIfEmptyFields", Some(1)),
-
-            Token::MapSep,
-            Token::Str("a"),
-            Token::I8(1),
-
-            Token::MapEnd,
-        ]
-    );
-
-    assert_ser_tokens(
-        &SkipSerializingIfEmptyFields {
-            a: 1,
-            b: vec![2],
-        },
-        &[
-            Token::StructStart("SkipSerializingIfEmptyFields", Some(2)),
-
-            Token::MapSep,
-            Token::Str("a"),
-            Token::I8(1),
-
-            Token::MapSep,
-            Token::Str("b"),
-            Token::SeqStart(Some(1)),
-            Token::SeqSep,
-            Token::I32(2),
-            Token::SeqEnd,
-
-            Token::MapEnd,
-        ]
-    );
-
-    assert_de_tokens(
-        &SkipSerializingIfEmptyFields {
-            a: 1,
-            b: vec![2],
-        },
-        vec![
-            Token::StructStart("SkipSerializingIfEmptyFields", Some(2)),
-
-            Token::MapSep,
-            Token::Str("a"),
-            Token::I8(1),
-
-            Token::MapSep,
-            Token::Str("b"),
-            Token::SeqStart(Some(1)),
-            Token::SeqSep,
-            Token::I32(2),
-            Token::SeqEnd,
-
-            Token::MapEnd,
-        ]
-    );
+#[derive(Debug, PartialEq, Serialize)]
+enum SkipSerializingEnum<'a, B, D, E> {
+    Struct {
+        a: &'a i8,
+        #[serde(skip_serializing)]
+        _b: B,
+        #[serde(skip_serializing_if_none)]
+        d: Option<D>,
+        #[serde(skip_serializing_if_empty)]
+        e: Vec<E>,
+    }
 }
 
 #[test]
-fn test_skip_serializing_fields_if_none() {
+fn test_skip_serializing_enum() {
+    let a = 1;
     assert_ser_tokens(
-        &SkipSerializingIfNoneFields::<i32> {
-            a: 1,
-            b: None,
+        &SkipSerializingEnum::Struct {
+            a: &a,
+            _b: 2,
+            d: Some(4),
+            e: vec![5],
         },
         &[
-            Token::StructStart("SkipSerializingIfNoneFields", Some(1)),
+            Token::EnumMapStart("SkipSerializingEnum", "Struct", Some(3)),
 
             Token::MapSep,
             Token::Str("a"),
             Token::I8(1),
 
-            Token::MapEnd,
-        ]
-    );
-
-    assert_de_tokens(
-        &SkipSerializingIfNoneFields::<i32> {
-            a: 1,
-            b: None,
-        },
-        vec![
-            Token::StructStart("SkipSerializingIfNoneFields", Some(1)),
+            Token::MapSep,
+            Token::Str("d"),
+            Token::Option(true),
+            Token::I32(4),
 
             Token::MapSep,
-            Token::Str("a"),
-            Token::I8(1),
+            Token::Str("e"),
+            Token::SeqStart(Some(1)),
+            Token::SeqSep,
+            Token::I32(5),
+            Token::SeqEnd,
 
             Token::MapEnd,
         ]
     );
 
     assert_ser_tokens(
-        &SkipSerializingIfNoneFields {
-            a: 1,
-            b: Some(2),
+        &SkipSerializingEnum::Struct {
+            a: &a,
+            _b: 2,
+            d: None::<u8>,
+            e: Vec::<u8>::new(),
         },
         &[
-            Token::StructStart("SkipSerializingIfNoneFields", Some(2)),
+            Token::EnumMapStart("SkipSerializingEnum", "Struct", Some(1)),
 
             Token::MapSep,
             Token::Str("a"),
             Token::I8(1),
-
-            Token::MapSep,
-            Token::Str("b"),
-            Token::Option(true),
-            Token::I32(2),
-
-            Token::MapEnd,
-        ]
-    );
-
-    assert_de_tokens(
-        &SkipSerializingIfNoneFields {
-            a: 1,
-            b: Some(2),
-        },
-        vec![
-            Token::StructStart("SkipSerializingIfNoneFields", Some(2)),
-
-            Token::MapSep,
-            Token::Str("a"),
-            Token::I8(1),
-
-            Token::MapSep,
-            Token::Str("b"),
-            Token::Option(true),
-            Token::I32(2),
 
             Token::MapEnd,
         ]

--- a/serde_tests/tests/test_annotations.rs
+++ b/serde_tests/tests/test_annotations.rs
@@ -389,16 +389,12 @@ fn test_rename_enum() {
 }
 
 #[derive(Debug, PartialEq, Serialize)]
-struct SkipSerializingStruct<'a, B, C, D, E> where C: Trait {
+struct SkipSerializingStruct<'a, B, C> where C: Trait {
     a: &'a i8,
     #[serde(skip_serializing)]
     b: B,
     #[serde(skip_serializing_if="self.c.should_skip()")]
     c: C,
-    #[serde(skip_serializing_if_none)]
-    d: Option<D>,
-    #[serde(skip_serializing_if_empty)]
-    e: Vec<E>,
 }
 
 #[test]
@@ -409,11 +405,9 @@ fn test_skip_serializing_struct() {
             a: &a,
             b: 2,
             c: 3,
-            d: Some(4),
-            e: vec![5],
         },
         &[
-            Token::StructStart("SkipSerializingStruct", Some(4)),
+            Token::StructStart("SkipSerializingStruct", Some(2)),
 
             Token::StructSep,
             Token::Str("a"),
@@ -422,18 +416,6 @@ fn test_skip_serializing_struct() {
             Token::StructSep,
             Token::Str("c"),
             Token::I32(3),
-
-            Token::StructSep,
-            Token::Str("d"),
-            Token::Option(true),
-            Token::I32(4),
-
-            Token::StructSep,
-            Token::Str("e"),
-            Token::SeqStart(Some(1)),
-            Token::SeqSep,
-            Token::I32(5),
-            Token::SeqEnd,
 
             Token::StructEnd,
         ]
@@ -444,8 +426,6 @@ fn test_skip_serializing_struct() {
             a: &a,
             b: 2,
             c: 123,
-            d: None::<u8>,
-            e: Vec::<u8>::new(),
         },
         &[
             Token::StructStart("SkipSerializingStruct", Some(1)),
@@ -460,17 +440,13 @@ fn test_skip_serializing_struct() {
 }
 
 #[derive(Debug, PartialEq, Serialize)]
-enum SkipSerializingEnum<'a, B, C, D, E> where C: Trait {
+enum SkipSerializingEnum<'a, B, C> where C: Trait {
     Struct {
         a: &'a i8,
         #[serde(skip_serializing)]
         _b: B,
         #[serde(skip_serializing_if="self.c.should_skip()")]
         c: C,
-        #[serde(skip_serializing_if_none)]
-        d: Option<D>,
-        #[serde(skip_serializing_if_empty)]
-        e: Vec<E>,
     }
 }
 
@@ -482,11 +458,9 @@ fn test_skip_serializing_enum() {
             a: &a,
             _b: 2,
             c: 3,
-            d: Some(4),
-            e: vec![5],
         },
         &[
-            Token::EnumMapStart("SkipSerializingEnum", "Struct", Some(4)),
+            Token::EnumMapStart("SkipSerializingEnum", "Struct", Some(2)),
 
             Token::EnumMapSep,
             Token::Str("a"),
@@ -495,18 +469,6 @@ fn test_skip_serializing_enum() {
             Token::EnumMapSep,
             Token::Str("c"),
             Token::I32(3),
-
-            Token::EnumMapSep,
-            Token::Str("d"),
-            Token::Option(true),
-            Token::I32(4),
-
-            Token::EnumMapSep,
-            Token::Str("e"),
-            Token::SeqStart(Some(1)),
-            Token::SeqSep,
-            Token::I32(5),
-            Token::SeqEnd,
 
             Token::EnumMapEnd,
         ]
@@ -517,8 +479,6 @@ fn test_skip_serializing_enum() {
             a: &a,
             _b: 2,
             c: 123,
-            d: None::<u8>,
-            e: Vec::<u8>::new(),
         },
         &[
             Token::EnumMapStart("SkipSerializingEnum", "Struct", Some(1)),

--- a/serde_tests/tests/test_annotations.rs
+++ b/serde_tests/tests/test_annotations.rs
@@ -53,7 +53,7 @@ struct DefaultStruct<A, B: Default, C> where C: Trait {
     a1: A,
     #[serde(default)]
     a2: B,
-    #[serde(default="Trait::my_default()")]
+    #[serde(default="Trait::my_default")]
     a3: C,
 }
 
@@ -100,7 +100,7 @@ enum DefaultEnum<A, B: Default, C> where C: Trait {
         a1: A,
         #[serde(default)]
         a2: B,
-        #[serde(default="Trait::my_default()")]
+        #[serde(default="Trait::my_default")]
         a3: C,
     }
 }
@@ -393,7 +393,7 @@ struct SkipSerializingStruct<'a, B, C> where C: Trait {
     a: &'a i8,
     #[serde(skip_serializing)]
     b: B,
-    #[serde(skip_serializing_if="self.c.should_skip()")]
+    #[serde(skip_serializing_if="Trait::should_skip")]
     c: C,
 }
 
@@ -445,7 +445,7 @@ enum SkipSerializingEnum<'a, B, C> where C: Trait {
         a: &'a i8,
         #[serde(skip_serializing)]
         _b: B,
-        #[serde(skip_serializing_if="self.c.should_skip()")]
+        #[serde(skip_serializing_if="Trait::should_skip")]
         c: C,
     }
 }
@@ -495,7 +495,7 @@ fn test_skip_serializing_enum() {
 #[derive(Debug, PartialEq, Serialize)]
 struct SerializeWithStruct<'a, B> where B: Trait {
     a: &'a i8,
-    #[serde(serialize_with="self.b.serialize_with(serializer)")]
+    #[serde(serialize_with="Trait::serialize_with")]
     b: B,
 }
 
@@ -547,7 +547,7 @@ fn test_serialize_with_struct() {
 enum SerializeWithEnum<'a, B> where B: Trait {
     Struct {
         a: &'a i8,
-        #[serde(serialize_with="self.b.serialize_with(serializer)")]
+        #[serde(serialize_with="Trait::serialize_with")]
         b: B,
     }
 }
@@ -599,7 +599,7 @@ fn test_serialize_with_enum() {
 #[derive(Debug, PartialEq, Deserialize)]
 struct DeserializeWithStruct<B> where B: Trait {
     a: i8,
-    #[serde(deserialize_with="Trait::deserialize_with(deserializer)")]
+    #[serde(deserialize_with="Trait::deserialize_with")]
     b: B,
 }
 
@@ -650,7 +650,7 @@ fn test_deserialize_with_struct() {
 enum DeserializeWithEnum<B> where B: Trait {
     Struct {
         a: i8,
-        #[serde(deserialize_with="Trait::deserialize_with(deserializer)")]
+        #[serde(deserialize_with="Trait::deserialize_with")]
         b: B,
     }
 }

--- a/serde_tests/tests/test_de.rs
+++ b/serde_tests/tests/test_de.rs
@@ -184,27 +184,27 @@ declare_tests! {
         ],
         TupleStruct(1, 2, 3) => vec![
             Token::TupleStructStart("TupleStruct", Some(3)),
-                Token::SeqSep,
+                Token::TupleSeqSep,
                 Token::I32(1),
 
-                Token::SeqSep,
+                Token::TupleSeqSep,
                 Token::I32(2),
 
-                Token::SeqSep,
+                Token::TupleSeqSep,
                 Token::I32(3),
-            Token::SeqEnd,
+            Token::TupleSeqEnd,
         ],
         TupleStruct(1, 2, 3) => vec![
             Token::TupleStructStart("TupleStruct", None),
-                Token::SeqSep,
+                Token::TupleSeqSep,
                 Token::I32(1),
 
-                Token::SeqSep,
+                Token::TupleSeqSep,
                 Token::I32(2),
 
-                Token::SeqSep,
+                Token::TupleSeqSep,
                 Token::I32(3),
-            Token::SeqEnd,
+            Token::TupleSeqEnd,
         ],
     }
     test_btreeset {
@@ -495,18 +495,18 @@ declare_tests! {
         ],
         Struct { a: 1, b: 2, c: 3 } => vec![
             Token::StructStart("Struct", Some(3)),
-                Token::MapSep,
+                Token::StructSep,
                 Token::Str("a"),
                 Token::I32(1),
 
-                Token::MapSep,
+                Token::StructSep,
                 Token::Str("b"),
                 Token::I32(2),
 
-                Token::MapSep,
+                Token::StructSep,
                 Token::Str("c"),
                 Token::I32(3),
-            Token::MapEnd,
+            Token::StructEnd,
         ],
     }
     test_enum_unit {
@@ -516,39 +516,39 @@ declare_tests! {
     }
     test_enum_simple {
         Enum::Simple(1) => vec![
-            Token::EnumNewtype("Enum", "Simple"),
+            Token::EnumNewType("Enum", "Simple"),
             Token::I32(1),
         ],
     }
     test_enum_seq {
         Enum::Seq(1, 2, 3) => vec![
             Token::EnumSeqStart("Enum", "Seq", Some(3)),
-                Token::SeqSep,
+                Token::EnumSeqSep,
                 Token::I32(1),
 
-                Token::SeqSep,
+                Token::EnumSeqSep,
                 Token::I32(2),
 
-                Token::SeqSep,
+                Token::EnumSeqSep,
                 Token::I32(3),
-            Token::SeqEnd,
+            Token::EnumSeqEnd,
         ],
     }
     test_enum_map {
         Enum::Map { a: 1, b: 2, c: 3 } => vec![
             Token::EnumMapStart("Enum", "Map", Some(3)),
-                Token::MapSep,
+                Token::EnumMapSep,
                 Token::Str("a"),
                 Token::I32(1),
 
-                Token::MapSep,
+                Token::EnumMapSep,
                 Token::Str("b"),
                 Token::I32(2),
 
-                Token::MapSep,
+                Token::EnumMapSep,
                 Token::Str("c"),
                 Token::I32(3),
-            Token::MapEnd,
+            Token::EnumMapEnd,
         ],
     }
     test_enum_unit_usize {

--- a/serde_tests/tests/test_macros.rs
+++ b/serde_tests/tests/test_macros.rs
@@ -123,7 +123,7 @@ pub struct GenericStruct<T> {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub struct GenericNewtypeStruct<T>(T);
+pub struct GenericNewTypeStruct<T>(T);
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct GenericTupleStruct<T, U>(T, U);
@@ -131,7 +131,7 @@ pub struct GenericTupleStruct<T, U>(T, U);
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum GenericEnum<T, U> {
     Unit,
-    Newtype(T),
+    NewType(T),
     Seq(T, U),
     Map { x: T, y: U },
 }
@@ -153,16 +153,16 @@ fn test_ser_named_tuple() {
         &SerNamedTuple(&a, &mut b, c),
         &[
             Token::TupleStructStart("SerNamedTuple", Some(3)),
-            Token::SeqSep,
+            Token::TupleSeqSep,
             Token::I32(5),
 
-            Token::SeqSep,
+            Token::TupleSeqSep,
             Token::I32(6),
 
-            Token::SeqSep,
+            Token::TupleSeqSep,
             Token::I32(7),
 
-            Token::SeqEnd,
+            Token::TupleSeqEnd,
         ],
     );
 }
@@ -172,7 +172,7 @@ fn test_de_named_tuple() {
     assert_de_tokens(
         &DeNamedTuple(5, 6, 7),
         vec![
-            Token::TupleStructStart("DeNamedTuple", Some(3)),
+            Token::SeqStart(Some(3)),
             Token::SeqSep,
             Token::I32(5),
 
@@ -183,6 +183,23 @@ fn test_de_named_tuple() {
             Token::I32(7),
 
             Token::SeqEnd,
+        ]
+    );
+
+    assert_de_tokens(
+        &DeNamedTuple(5, 6, 7),
+        vec![
+            Token::TupleStructStart("DeNamedTuple", Some(3)),
+            Token::TupleSeqSep,
+            Token::I32(5),
+
+            Token::TupleSeqSep,
+            Token::I32(6),
+
+            Token::TupleSeqSep,
+            Token::I32(7),
+
+            Token::TupleSeqEnd,
         ]
     );
 }
@@ -202,19 +219,19 @@ fn test_ser_named_map() {
         &[
             Token::StructStart("SerNamedMap", Some(3)),
 
-            Token::MapSep,
+            Token::StructSep,
             Token::Str("a"),
             Token::I32(5),
 
-            Token::MapSep,
+            Token::StructSep,
             Token::Str("b"),
             Token::I32(6),
 
-            Token::MapSep,
+            Token::StructSep,
             Token::Str("c"),
             Token::I32(7),
 
-            Token::MapEnd,
+            Token::StructEnd,
         ]
     );
 }
@@ -230,19 +247,19 @@ fn test_de_named_map() {
         vec![
             Token::StructStart("DeNamedMap", Some(3)),
 
-            Token::MapSep,
+            Token::StructSep,
             Token::Str("a"),
             Token::I32(5),
 
-            Token::MapSep,
+            Token::StructSep,
             Token::Str("b"),
             Token::I32(6),
 
-            Token::MapSep,
+            Token::StructSep,
             Token::Str("c"),
             Token::I32(7),
 
-            Token::MapEnd,
+            Token::StructEnd,
         ]
     );
 }
@@ -278,19 +295,19 @@ fn test_ser_enum_seq() {
         &[
             Token::EnumSeqStart("SerEnum", "Seq", Some(4)),
 
-            Token::SeqSep,
+            Token::EnumSeqSep,
             Token::I8(1),
 
-            Token::SeqSep,
+            Token::EnumSeqSep,
             Token::I32(2),
 
-            Token::SeqSep,
+            Token::EnumSeqSep,
             Token::I32(3),
 
-            Token::SeqSep,
+            Token::EnumSeqSep,
             Token::I32(5),
 
-            Token::SeqEnd,
+            Token::EnumSeqEnd,
         ],
     );
 }
@@ -316,23 +333,23 @@ fn test_ser_enum_map() {
         &[
             Token::EnumMapStart("SerEnum", "Map", Some(4)),
 
-            Token::MapSep,
+            Token::EnumMapSep,
             Token::Str("a"),
             Token::I8(1),
 
-            Token::MapSep,
+            Token::EnumMapSep,
             Token::Str("b"),
             Token::I32(2),
 
-            Token::MapSep,
+            Token::EnumMapSep,
             Token::Str("c"),
             Token::I32(3),
 
-            Token::MapSep,
+            Token::EnumMapSep,
             Token::Str("e"),
             Token::I32(5),
 
-            Token::MapEnd,
+            Token::EnumMapEnd,
         ],
     );
 }
@@ -368,19 +385,19 @@ fn test_de_enum_seq() {
         vec![
             Token::EnumSeqStart("DeEnum", "Seq", Some(4)),
 
-            Token::SeqSep,
+            Token::EnumSeqSep,
             Token::I8(1),
 
-            Token::SeqSep,
+            Token::EnumSeqSep,
             Token::I32(2),
 
-            Token::SeqSep,
+            Token::EnumSeqSep,
             Token::I32(3),
 
-            Token::SeqSep,
+            Token::EnumSeqSep,
             Token::I32(5),
 
-            Token::SeqEnd,
+            Token::EnumSeqEnd,
         ],
     );
 }
@@ -406,23 +423,23 @@ fn test_de_enum_map() {
         vec![
             Token::EnumMapStart("DeEnum", "Map", Some(4)),
 
-            Token::MapSep,
+            Token::EnumMapSep,
             Token::Str("a"),
             Token::I8(1),
 
-            Token::MapSep,
+            Token::EnumMapSep,
             Token::Str("b"),
             Token::I32(2),
 
-            Token::MapSep,
+            Token::EnumMapSep,
             Token::Str("c"),
             Token::I32(3),
 
-            Token::MapSep,
+            Token::EnumMapSep,
             Token::Str("e"),
             Token::I32(5),
 
-            Token::MapEnd,
+            Token::EnumMapEnd,
         ],
     );
 }
@@ -434,7 +451,7 @@ fn test_lifetimes() {
     assert_ser_tokens(
         &Lifetimes::LifetimeSeq(&value),
         &[
-            Token::EnumNewtype("Lifetimes", "LifetimeSeq"),
+            Token::EnumNewType("Lifetimes", "LifetimeSeq"),
             Token::I32(5),
         ]
     );
@@ -442,7 +459,7 @@ fn test_lifetimes() {
     assert_ser_tokens(
         &Lifetimes::NoLifetimeSeq(5),
         &[
-            Token::EnumNewtype("Lifetimes", "NoLifetimeSeq"),
+            Token::EnumNewType("Lifetimes", "NoLifetimeSeq"),
             Token::I32(5),
         ]
     );
@@ -452,11 +469,11 @@ fn test_lifetimes() {
         &[
             Token::EnumMapStart("Lifetimes", "LifetimeMap", Some(1)),
 
-            Token::MapSep,
+            Token::EnumMapSep,
             Token::Str("a"),
             Token::I32(5),
 
-            Token::MapEnd,
+            Token::EnumMapEnd,
         ]
     );
 
@@ -465,11 +482,11 @@ fn test_lifetimes() {
         &[
             Token::EnumMapStart("Lifetimes", "NoLifetimeMap", Some(1)),
 
-            Token::MapSep,
+            Token::EnumMapSep,
             Token::Str("a"),
             Token::I32(5),
 
-            Token::MapEnd,
+            Token::EnumMapEnd,
         ]
     );
 }
@@ -481,11 +498,11 @@ fn test_generic_struct() {
         vec![
             Token::StructStart("GenericStruct", Some(1)),
 
-            Token::MapSep,
+            Token::StructSep,
             Token::Str("x"),
             Token::U32(5),
 
-            Token::MapEnd,
+            Token::StructEnd,
         ]
     );
 }
@@ -493,9 +510,9 @@ fn test_generic_struct() {
 #[test]
 fn test_generic_newtype_struct() {
     assert_tokens(
-        &GenericNewtypeStruct(5u32),
+        &GenericNewTypeStruct(5u32),
         vec![
-            Token::StructNewtype("GenericNewtypeStruct"),
+            Token::StructNewType("GenericNewTypeStruct"),
             Token::U32(5),
         ]
     );
@@ -508,13 +525,13 @@ fn test_generic_tuple_struct() {
         vec![
             Token::TupleStructStart("GenericTupleStruct", Some(2)),
 
-            Token::SeqSep,
+            Token::TupleSeqSep,
             Token::U32(5),
 
-            Token::SeqSep,
+            Token::TupleSeqSep,
             Token::U32(6),
 
-            Token::SeqEnd,
+            Token::TupleSeqEnd,
         ]
     );
 }
@@ -532,9 +549,9 @@ fn test_generic_enum_unit() {
 #[test]
 fn test_generic_enum_newtype() {
     assert_tokens(
-        &GenericEnum::Newtype::<u32, u32>(5),
+        &GenericEnum::NewType::<u32, u32>(5),
         vec![
-            Token::EnumNewtype("GenericEnum", "Newtype"),
+            Token::EnumNewType("GenericEnum", "NewType"),
             Token::U32(5),
         ]
     );
@@ -547,13 +564,13 @@ fn test_generic_enum_seq() {
         vec![
             Token::EnumSeqStart("GenericEnum", "Seq", Some(2)),
 
-            Token::SeqSep,
+            Token::EnumSeqSep,
             Token::U32(5),
 
-            Token::SeqSep,
+            Token::EnumSeqSep,
             Token::U32(6),
 
-            Token::SeqEnd,
+            Token::EnumSeqEnd,
         ]
     );
 }
@@ -565,15 +582,15 @@ fn test_generic_enum_map() {
         vec![
             Token::EnumMapStart("GenericEnum", "Map", Some(2)),
 
-            Token::MapSep,
+            Token::EnumMapSep,
             Token::Str("x"),
             Token::U32(5),
 
-            Token::MapSep,
+            Token::EnumMapSep,
             Token::Str("y"),
             Token::U32(6),
 
-            Token::MapEnd,
+            Token::EnumMapEnd,
         ]
     );
 }

--- a/serde_tests/tests/test_ser.rs
+++ b/serde_tests/tests/test_ser.rs
@@ -76,11 +76,11 @@ declare_ser_tests! {
     }
     test_result {
         Ok::<i32, i32>(0) => &[
-            Token::EnumNewtype("Result", "Ok"),
+            Token::EnumNewType("Result", "Ok"),
             Token::I32(0),
         ],
         Err::<i32, i32>(1) => &[
-            Token::EnumNewtype("Result", "Err"),
+            Token::EnumNewType("Result", "Err"),
             Token::I32(1),
         ],
     }
@@ -214,56 +214,56 @@ declare_ser_tests! {
     test_tuple_struct {
         TupleStruct(1, 2, 3) => &[
             Token::TupleStructStart("TupleStruct", Some(3)),
-                Token::SeqSep,
+                Token::TupleSeqSep,
                 Token::I32(1),
 
-                Token::SeqSep,
+                Token::TupleSeqSep,
                 Token::I32(2),
 
-                Token::SeqSep,
+                Token::TupleSeqSep,
                 Token::I32(3),
-            Token::SeqEnd,
+            Token::TupleSeqEnd,
         ],
     }
     test_struct {
         Struct { a: 1, b: 2, c: 3 } => &[
             Token::StructStart("Struct", Some(3)),
-                Token::MapSep,
+                Token::StructSep,
                 Token::Str("a"),
                 Token::I32(1),
 
-                Token::MapSep,
+                Token::StructSep,
                 Token::Str("b"),
                 Token::I32(2),
 
-                Token::MapSep,
+                Token::StructSep,
                 Token::Str("c"),
                 Token::I32(3),
-            Token::MapEnd,
+            Token::StructEnd,
         ],
     }
     test_enum {
         Enum::Unit => &[Token::EnumUnit("Enum", "Unit")],
-        Enum::One(42) => &[Token::EnumNewtype("Enum", "One"), Token::I32(42)],
+        Enum::One(42) => &[Token::EnumNewType("Enum", "One"), Token::I32(42)],
         Enum::Seq(1, 2) => &[
             Token::EnumSeqStart("Enum", "Seq", Some(2)),
-                Token::SeqSep,
+                Token::EnumSeqSep,
                 Token::I32(1),
 
-                Token::SeqSep,
+                Token::EnumSeqSep,
                 Token::I32(2),
-            Token::SeqEnd,
+            Token::EnumSeqEnd,
         ],
         Enum::Map { a: 1, b: 2 } => &[
             Token::EnumMapStart("Enum", "Map", Some(2)),
-                Token::MapSep,
+                Token::EnumMapSep,
                 Token::Str("a"),
                 Token::I32(1),
 
-                Token::MapSep,
+                Token::EnumMapSep,
                 Token::Str("b"),
                 Token::I32(2),
-            Token::MapEnd,
+            Token::EnumMapEnd,
         ],
     }
     test_num_bigint {


### PR DESCRIPTION


This is an alternative implementation of #214, #198, #208 and implements #90 and #216. This allows one to write:

```rust
#[derive(Serialize, Deserialize)]
struct Struct {
    #[serde(default="123")]
    a: i32,
    #[serde(skip_serializing_if="self.b == 123")]
    b: i32,
    #[serde(serialize_with="(self.b == 123).serialize(serializer)"]
    c: i32,
    #[serde(deserialize_with="Ok(if try!(bool::deserialize(deserializer) { 123) } else { 0 })"]
    d: i32,
}
```

cc @oli-obk, @target-san, @arcnmx