### PR TITLE
Fix cargo `nightly` feature

### DIFF
--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -10,7 +10,8 @@ readme = "../README.md"
 keywords = ["serde", "serialization"]
 
 [features]
-nightly-testing = ["clippy"]
+nightly = []
+nightly-testing = ["clippy", "nightly"]
 num-bigint = ["num/bigint"]
 num-complex = ["num/complex"]
 num-impls = ["num-bigint", "num-complex", "num-rational"]

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -12,8 +12,8 @@
 #![doc(html_root_url="https://serde-rs.github.io/serde/serde")]
 #![cfg_attr(feature = "nightly", feature(collections, enumset, nonzero, plugin, step_trait,
                                          zero_one))]
-#![cfg_attr(feature = "nightly", plugin(clippy))]
-#![cfg_attr(feature = "nightly", allow(linkedlist))]
+#![cfg_attr(feature = "nightly-testing", plugin(clippy))]
+#![cfg_attr(feature = "nightly-testing", allow(linkedlist))]
 
 #![deny(missing_docs)]
 

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -322,7 +322,7 @@ pub trait Serializer {
 }
 
 /// A trait that is used by a `Serialize` to iterate through a sequence.
-#[cfg_attr(feature = "nightly", allow(len_without_is_empty))]
+#[cfg_attr(feature = "nightly-testing", allow(len_without_is_empty))]
 pub trait SeqVisitor {
     /// Serializes a sequence item in the serializer.
     ///
@@ -339,7 +339,7 @@ pub trait SeqVisitor {
 }
 
 /// A trait that is used by a `Serialize` to iterate through a map.
-#[cfg_attr(feature = "nightly", allow(len_without_is_empty))]
+#[cfg_attr(feature = "nightly-testing", allow(len_without_is_empty))]
 pub trait MapVisitor {
     /// Serializes a map item in the serializer.
     ///


### PR DESCRIPTION
517c2f79b70 renamed the `nightly` feature to `nightly-testing` to
reflect that the `clippy` dependency is only required when testing.
However, the code also uses `#[cfg(feature = "nightly")]` to enable
trait impls for feature-gated types. This commit restores that
functionality and fixes a few `cfg_attr`s that refer to clippy lints.