### PR TITLE
YAML serde based on yaml-rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,10 +704,10 @@ Field Annotations:
 Serialization Formats Using Serde
 =================================
 
-| Format      | Name                                               |
-| ------      | ----                                               |
-| Bincode     | [bincode](https://crates.io/crates/bincode)        |
-| JSON        | [serde\_json](https://crates.io/crates/serde_json) |
-| MessagePack | [rmp](https://crates.io/crates/rmp)                |
-| XML         | [serde\_xml](https://github.com/serde-rs/xml)      |
-| YAML        | [serde\_yaml](https://github.com/serde-rs/yaml/)   |
+| Format      | Name                                                 |
+| ------      | ----                                                 |
+| Bincode     | [bincode](https://crates.io/crates/bincode)          |
+| JSON        | [serde\_json](https://crates.io/crates/serde_json)   |
+| MessagePack | [rmp](https://crates.io/crates/rmp)                  |
+| XML         | [serde\_xml](https://github.com/serde-rs/xml)        |
+| YAML        | [serde\_yaml](https://github.com/dtolnay/serde-yaml) |


### PR DESCRIPTION
Just opening this PR for discussion.

I noticed that [serde-rs/yaml](https://github.com/serde-rs/yaml/) seems pretty dead. The missing pieces are a YAML emitter (partially implemented) and parser (not started).

I found a reasonably complete YAML emitter and parser at [yaml-rust](https://crates.io/crates/yaml-rust) so I threw together [a serde that uses it](https://github.com/dtolnay/serde-yaml).

Is this something that would be valuable to contribute to serde-rs so that YAML is supported despite being theoretically slower than possible? Later we can swap in our own emitter and parser as the pieces materialize.