### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Using Serde with Stable Rust, syntex, and serde\_codegen
 
 Stable Rust is a little more complicated because it does not yet support
 compiler plugins. Instead we need to use the code generation library
-[syntex](https://github.com/erickt/rust-syntex) for this:
+[syntex](https://github.com/serde-rs/syntex) for this:
 
 ```toml
 [package]


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/erickt/rust-syntex | https://github.com/serde-rs/syntex 
