### PR TITLE
tests(readme): Use skeptic to test the readme

### DIFF
--- a/serde_macros/Cargo.toml
+++ b/serde_macros/Cargo.toml
@@ -7,22 +7,33 @@ description = "Macros to auto-generate implementations for the serde framework"
 repository = "https://github.com/serde-rs/serde"
 documentation = "https://github.com/serde-rs/serde"
 keywords = ["serde", "serialization"]
+build = "build.rs"
 
 [lib]
 name = "serde_macros"
 plugin = true
 
 [features]
-nightly-testing = ["clippy", "serde/nightly-testing", "serde_codegen/nightly-testing"]
+nightly-testing = [
+    "clippy",
+    "skeptic",
+    "serde/nightly-testing",
+    "serde_codegen/nightly-testing"
+]
+
+[build-dependencies]
+skeptic = { version = "^0.4.0", optional = true }
 
 [dependencies]
 clippy = { version = "^0.*", optional = true }
 serde_codegen = { version = "^0.7.0", path = "../serde_codegen", default-features = false, features = ["nightly"] }
+skeptic = { version = "^0.4.0", optional = true }
 
 [dev-dependencies]
 compiletest_rs = "^0.0.11"
 rustc-serialize = "^0.3.16"
 serde = { version = "^0.7.0", path = "../serde" }
+serde_json = { version = "^0.7.0" }
 
 [[test]]
 name = "test"

--- a/serde_macros/build.rs
+++ b/serde_macros/build.rs
@@ -1,0 +1,17 @@
+#[cfg(feature = "nightly-testing")]
+mod inner {
+    extern crate skeptic;
+
+    pub fn main() {
+        skeptic::generate_doc_tests(&["../README.md"]);
+    }
+}
+
+#[cfg(not(feature = "nightly-testing"))]
+mod inner {
+    pub fn main() {}
+}
+
+fn main() {
+    inner::main()
+}

--- a/serde_macros/tests/skeptic.rs
+++ b/serde_macros/tests/skeptic.rs
@@ -1,0 +1,3 @@
+#![cfg(feature = "nightly-testing")]
+
+include!(concat!(env!("OUT_DIR"), "/skeptic-tests.rs"));

--- a/serde_macros/tests/test.rs
+++ b/serde_macros/tests/test.rs
@@ -7,3 +7,4 @@ extern crate test;
 include!("../../serde_tests/tests/test.rs.in");
 
 mod compile_tests;
+mod skeptic;


### PR DESCRIPTION
This can't actually be merged in until serde_json 0.7 can be released. 