### PR TITLE
feat(codegen) skip_deserializing

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,6 +714,7 @@ Field Annotations:
 | `#[serde(default)]`                     | If the value is not specified, use the `Default::default()`                                                |
 | `#[serde(default="$path")]`             | Call the path to a function `fn() -> T` to build the value                                                 |
 | `#[serde(skip_serializing)]`            | Do not serialize this value                                                                                |
+| `#[serde(skip_deserializing)]`          | Always use `Default::default()` instead of deserializing this value                                        |
 | `#[serde(skip_serializing_if="$path")]` | Do not serialize this value if this function `fn(&T) -> bool` returns `false`                              |
 | `#[serde(serialize_with="$path")]`      | Call a function `fn<T, S>(&T, &mut S) -> Result<(), S::Error> where S: Serializer` to serialize this value |
 | `#[serde(deserialize_with="$path")]`    | Call a function `fn<T, D>(&mut D) -> Result<T, D::Error> where D: Deserializer` to deserialize this value  |

--- a/serde_codegen/src/attr.rs
+++ b/serde_codegen/src/attr.rs
@@ -181,6 +181,7 @@ impl VariantAttrs {
 pub struct FieldAttrs {
     name: Name,
     skip_serializing_field: bool,
+    skip_deserializing_field: bool,
     skip_serializing_field_if: Option<P<ast::Expr>>,
     default_expr_if_missing: Option<P<ast::Expr>>,
     serialize_with: Option<P<ast::Expr>>,
@@ -204,6 +205,7 @@ impl FieldAttrs {
         let mut field_attrs = FieldAttrs {
             name: Name::new(field_ident),
             skip_serializing_field: false,
+            skip_deserializing_field: false,
             skip_serializing_field_if: None,
             default_expr_if_missing: None,
             serialize_with: None,
@@ -247,6 +249,11 @@ impl FieldAttrs {
                     // Parse `#[serde(skip_serializing)]`
                     ast::MetaItemKind::Word(ref name) if name == &"skip_serializing" => {
                         field_attrs.skip_serializing_field = true;
+                    }
+
+                    // Parse `#[serde(skip_deserializing)]`
+                    ast::MetaItemKind::Word(ref name) if name == &"skip_deserializing" => {
+                        field_attrs.skip_deserializing_field = true;
                     }
 
                     // Parse `#[serde(skip_serializing_if="...")]`
@@ -323,6 +330,10 @@ impl FieldAttrs {
     /// Predicate for ignoring a field when serializing a value
     pub fn skip_serializing_field(&self) -> bool {
         self.skip_serializing_field
+    }
+
+    pub fn skip_deserializing_field(&self) -> bool {
+        self.skip_deserializing_field
     }
 
     pub fn skip_serializing_field_if(&self) -> Option<&P<ast::Expr>> {


### PR DESCRIPTION
Addresses part of #197.

This will be more exciting when I add logic to omit the `T: Deserialize` bound for fields that have `skip_deserializing`, like what #260 does for `skip_serializing`, but I am waiting for a code review on #260 before implementing that.