### PR TITLE
Fix `deserialize_with` in module with Result alias

### DIFF
--- a/serde_codegen/src/attr.rs
+++ b/serde_codegen/src/attr.rs
@@ -619,7 +619,7 @@ fn wrap_deserialize_with(cx: &ExtCtxt,
         }
 
         impl $generics ::serde::de::Deserialize for $ty_path $where_clause {
-            fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
+            fn deserialize<D>(deserializer: &mut D) -> ::std::result::Result<Self, D::Error>
                 where D: ::serde::de::Deserializer
             {
                 let value = try!($path(deserializer));


### PR DESCRIPTION
Result<T, E> aliases usually provide one or both of `T` and `E`. This
would cause an error when using deserialize_with:

    error: wrong number of type arguments: expected 1, found 2

which unhelpfully just pointed to `#[derive(Deserialize)]`