### PR TITLE
feat(codegen): Infer Default and Deserialize bounds correctly

### DIFF
--- a/serde_codegen/src/bound.rs
+++ b/serde_codegen/src/bound.rs
@@ -1,0 +1,135 @@
+use std::collections::HashSet;
+
+use aster::AstBuilder;
+
+use syntax::ast;
+use syntax::ext::base::ExtCtxt;
+use syntax::ptr::P;
+use syntax::visit;
+
+pub fn with_bound(
+    cx: &ExtCtxt,
+    builder: &AstBuilder,
+    item: &ast::Item,
+    generics: &ast::Generics,
+    filter: &Fn(&ast::StructField) -> bool,
+    bound: &[&'static str],
+) -> ast::Generics {
+    let path = builder.path().global().ids(bound).build();
+
+    builder.from_generics(generics.clone())
+        .with_predicates(
+            all_variants(cx, item).iter()
+                .flat_map(|variant_data| all_struct_fields(variant_data))
+                .filter(|field| filter(field))
+                .map(|field| &field.ty)
+                // TODO this filter can be removed later, see comment on function
+                .filter(|ty| contains_generic(ty, generics))
+                .map(|ty| strip_reference(ty))
+                .map(|ty| builder.where_predicate()
+                    // the type that is being bounded e.g. T
+                    .bound().build(ty.clone())
+                    // the bound e.g. Serialize
+                    .bound().trait_(path.clone()).build()
+                    .build()))
+        .build()
+}
+
+fn all_variants<'a>(cx: &ExtCtxt, item: &'a ast::Item) -> Vec<&'a ast::VariantData> {
+    match item.node {
+        ast::ItemKind::Struct(ref variant_data, _) => {
+            vec![variant_data]
+        }
+        ast::ItemKind::Enum(ref enum_def, _) => {
+            enum_def.variants.iter()
+                .map(|variant| &variant.node.data)
+                .collect()
+        }
+        _ => {
+            cx.span_bug(item.span, "expected Item to be Struct or Enum");
+        }
+    }
+}
+
+fn all_struct_fields(variant_data: &ast::VariantData) -> &[ast::StructField] {
+    match *variant_data {
+        ast::VariantData::Struct(ref fields, _) |
+        ast::VariantData::Tuple(ref fields, _) => {
+            fields
+        }
+        ast::VariantData::Unit(_) => {
+            &[]
+        }
+    }
+}
+
+// Rust <1.7 enforces that `where` clauses involve generic type parameters. The
+// corresponding compiler error is E0193. It is no longer enforced in Rust >=1.7
+// so this filtering can be removed in the future when we stop supporting <1.7.
+//
+// E0193 means we must not generate a `where` clause like `i32: Serialize`
+// because even though i32 implements Serialize, i32 is not a generic type
+// parameter. Clauses like `T: Serialize` and `Option<T>: Serialize` are okay.
+// This function decides whether a given type references any of the generic type
+// parameters in the input `Generics`.
+fn contains_generic(ty: &ast::Ty, generics: &ast::Generics) -> bool {
+    struct FindGeneric<'a> {
+        generic_names: &'a HashSet<ast::Name>,
+        found_generic: bool,
+    }
+    impl<'a, 'v> visit::Visitor<'v> for FindGeneric<'a> {
+        fn visit_path(&mut self, path: &'v ast::Path, _id: ast::NodeId) {
+            if !path.global
+                    && path.segments.len() == 1
+                    && self.generic_names.contains(&path.segments[0].identifier.name) {
+                self.found_generic = true;
+            } else {
+                visit::walk_path(self, path);
+            }
+        }
+    }
+
+    let generic_names: HashSet<_> = generics.ty_params.iter()
+        .map(|ty_param| ty_param.ident.name)
+        .collect();
+
+    let mut visitor = FindGeneric {
+        generic_names: &generic_names,
+        found_generic: false,
+    };
+    visit::walk_ty(&mut visitor, ty);
+    visitor.found_generic
+}
+
+// This is required to handle types that use both a reference and a value of
+// the same type, as in:
+//
+//    enum Test<'a, T> where T: 'a {
+//        Lifetime(&'a T),
+//        NoLifetime(T),
+//    }
+//
+// Preserving references, we would generate an impl like:
+//
+//    impl<'a, T> Serialize for Test<'a, T>
+//        where &'a T: Serialize,
+//              T: Serialize { ... }
+//
+// And taking a reference to one of the elements would fail with:
+//
+//    error: cannot infer an appropriate lifetime for pattern due
+//    to conflicting requirements [E0495]
+//        Test::NoLifetime(ref v) => { ... }
+//                         ^~~~~
+//
+// Instead, we strip references before adding `T: Serialize` bounds in order to
+// generate:
+//
+//    impl<'a, T> Serialize for Test<'a, T>
+//        where T: Serialize { ... }
+fn strip_reference(ty: &P<ast::Ty>) -> &P<ast::Ty> {
+    match ty.node {
+        ast::TyKind::Rptr(_, ref mut_ty) => &mut_ty.ty,
+        _ => ty
+    }
+}

--- a/serde_codegen/src/lib.rs.in
+++ b/serde_codegen/src/lib.rs.in
@@ -1,4 +1,5 @@
 mod attr;
+mod bound;
 mod de;
 mod error;
 mod ser;

--- a/serde_codegen/src/ser.rs
+++ b/serde_codegen/src/ser.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use aster;
 
 use syntax::ast::{
@@ -10,11 +8,10 @@ use syntax::ast::{
 use syntax::ast;
 use syntax::codemap::Span;
 use syntax::ext::base::{Annotatable, ExtCtxt};
-use syntax::ext::build::AstBuilder;
 use syntax::ptr::P;
-use syntax::visit;
 
 use attr;
+use bound;
 use error::Error;
 
 pub fn expand_derive_serialize(
@@ -96,56 +93,9 @@ fn build_impl_generics(
     item: &Item,
     generics: &ast::Generics,
 ) -> ast::Generics {
-    let serialize_path = builder.path()
-        .global()
-        .ids(&["serde", "ser", "Serialize"])
-        .build();
-
-    builder.from_generics(generics.clone())
-        .with_predicates(
-            all_variants(cx, item).iter()
-                .flat_map(|variant_data| all_struct_fields(variant_data))
-                .filter(|field| serialized_by_us(field))
-                .map(|field| &field.ty)
-                // TODO this filter can be removed later, see comment on function
-                .filter(|ty| contains_generic(ty, generics))
-                .map(|ty| strip_reference(ty))
-                .map(|ty| builder.where_predicate()
-                    // the type that is being bounded i.e. T
-                    .bound().build(ty.clone())
-                    // the bound i.e. Serialize
-                    .bound().trait_(serialize_path.clone()).build()
-                    .build()))
-        .build()
-}
-
-fn all_variants<'a>(cx: &ExtCtxt, item: &'a Item) -> Vec<&'a ast::VariantData> {
-    match item.node {
-        ast::ItemKind::Struct(ref variant_data, _) => {
-            vec![variant_data]
-        }
-        ast::ItemKind::Enum(ref enum_def, _) => {
-            enum_def.variants.iter()
-                .map(|variant| &variant.node.data)
-                .collect()
-        }
-        _ => {
-            cx.span_bug(item.span,
-                        "expected Item to be Struct or Enum in #[derive(Serialize)]");
-        }
-    }
-}
-
-fn all_struct_fields(variant_data: &ast::VariantData) -> &[ast::StructField] {
-    match *variant_data {
-        ast::VariantData::Struct(ref fields, _) |
-        ast::VariantData::Tuple(ref fields, _) => {
-            fields
-        }
-        ast::VariantData::Unit(_) => {
-            &[]
-        }
-    }
+    bound::with_bound(cx, builder, item, generics,
+        &serialized_by_us,
+        &["serde", "ser", "Serialize"])
 }
 
 // Fields with a `skip_serializing` or `serialize_with` attribute are not
@@ -166,77 +116,6 @@ fn serialized_by_us(field: &ast::StructField) -> bool {
         }
     }
     true
-}
-
-// Rust <1.7 enforces that `where` clauses involve generic type parameters. The
-// corresponding compiler error is E0193. It is no longer enforced in Rust >=1.7
-// so this filtering can be removed in the future when we stop supporting <1.7.
-//
-// E0193 means we must not generate a `where` clause like `i32: Serialize`
-// because even though i32 implements Serialize, i32 is not a generic type
-// parameter. Clauses like `T: Serialize` and `Option<T>: Serialize` are okay.
-// This function decides whether a given type references any of the generic type
-// parameters in the input `Generics`.
-fn contains_generic(ty: &ast::Ty, generics: &ast::Generics) -> bool {
-    struct FindGeneric<'a> {
-        generic_names: &'a HashSet<ast::Name>,
-        found_generic: bool,
-    }
-    impl<'a, 'v> visit::Visitor<'v> for FindGeneric<'a> {
-        fn visit_path(&mut self, path: &'v ast::Path, _id: ast::NodeId) {
-            if !path.global
-                    && path.segments.len() == 1
-                    && self.generic_names.contains(&path.segments[0].identifier.name) {
-                self.found_generic = true;
-            } else {
-                visit::walk_path(self, path);
-            }
-        }
-    }
-
-    let generic_names: HashSet<_> = generics.ty_params.iter()
-        .map(|ty_param| ty_param.ident.name)
-        .collect();
-
-    let mut visitor = FindGeneric {
-        generic_names: &generic_names,
-        found_generic: false,
-    };
-    visit::walk_ty(&mut visitor, ty);
-    visitor.found_generic
-}
-
-// This is required to handle types that use both a reference and a value of
-// the same type, as in:
-//
-//    enum Test<'a, T> where T: 'a {
-//        Lifetime(&'a T),
-//        NoLifetime(T),
-//    }
-//
-// Preserving references, we would generate an impl like:
-//
-//    impl<'a, T> Serialize for Test<'a, T>
-//        where &'a T: Serialize,
-//              T: Serialize { ... }
-//
-// And taking a reference to one of the elements would fail with:
-//
-//    error: cannot infer an appropriate lifetime for pattern due
-//    to conflicting requirements [E0495]
-//        Test::NoLifetime(ref v) => { ... }
-//                         ^~~~~
-//
-// Instead, we strip references before adding `T: Serialize` bounds in order to
-// generate:
-//
-//    impl<'a, T> Serialize for Test<'a, T>
-//        where T: Serialize { ... }
-fn strip_reference(ty: &P<ast::Ty>) -> &P<ast::Ty> {
-    match ty.node {
-        ast::TyKind::Rptr(_, ref mut_ty) => &mut_ty.ty,
-        _ => ty
-    }
 }
 
 fn serialize_body(


### PR DESCRIPTION
This PR addresses the remaining part of #197 (following up on my previous PRs #260 and #265) by inferring a `T: Default` bound for fields that (1) have `#[serde(default)]`, or (2) have `#[serde(skip_deserializing)]` and not `#[serde(default=...)]`. I factored out the generics-building code from #260 to share it between ser and de.

This PR also makes progress toward #259, although I have not attempted to resolve the `MapVisitor::missing_field` problem mentioned in that issue.

I would like to add more tests before merging, but the implementation is ready for review.