### PR TITLE
feat(codegen): Detect repeated struct field when deserializing

### DIFF
--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -46,6 +46,12 @@ pub trait Error: Sized + error::Error {
     fn missing_field(field: &'static str) -> Self {
         Error::custom(format!("Missing field `{}`", field))
     }
+
+    /// Raised when a `Deserialize` struct type received more than one of the
+    /// same struct field.
+    fn duplicate_field(field: &'static str) -> Self {
+        Error::custom(format!("Duplicate field `{}`", field))
+    }
 }
 
 /// `Type` represents all the primitive types that can be deserialized. This is used by

--- a/serde_tests/tests/test_de.rs
+++ b/serde_tests/tests/test_de.rs
@@ -725,4 +725,32 @@ declare_error_tests! {
         ],
         Error::UnexpectedToken(Token::SeqSep),
     }
+    test_duplicate_field_struct<Struct> {
+        vec![
+            Token::MapStart(Some(3)),
+                Token::MapSep,
+                Token::Str("a"),
+                Token::I32(1),
+
+                Token::MapSep,
+                Token::Str("a"),
+                Token::I32(3),
+            Token::MapEnd,
+        ],
+        Error::DuplicateFieldError("a"),
+    }
+    test_duplicate_field_enum<Enum> {
+        vec![
+            Token::EnumMapStart("Enum", "Map", Some(3)),
+                Token::EnumMapSep,
+                Token::Str("a"),
+                Token::I32(1),
+
+                Token::EnumMapSep,
+                Token::Str("a"),
+                Token::I32(3),
+            Token::EnumMapEnd,
+        ],
+        Error::DuplicateFieldError("a"),
+    }
 }

--- a/serde_tests/tests/token.rs
+++ b/serde_tests/tests/token.rs
@@ -410,6 +410,7 @@ pub enum Error {
     UnknownFieldError(String),
     UnknownVariantError(String),
     MissingFieldError(&'static str),
+    DuplicateFieldError(&'static str),
     InvalidName(&'static str),
     InvalidValue(String),
     UnexpectedToken(Token<'static>),
@@ -429,6 +430,10 @@ impl de::Error for Error {
 
     fn end_of_stream() -> Error { Error::EndOfStreamError }
 
+    fn invalid_value(msg: &str) -> Error {
+        Error::InvalidValue(msg.to_owned())
+    }
+
     fn unknown_field(field: &str) -> Error {
         Error::UnknownFieldError(field.to_owned())
     }
@@ -439,6 +444,10 @@ impl de::Error for Error {
 
     fn missing_field(field: &'static str) -> Error {
         Error::MissingFieldError(field)
+    }
+
+    fn duplicate_field(field: &'static str) -> Error {
+        Error::DuplicateFieldError(field)
     }
 }
 


### PR DESCRIPTION
Addresses #59. Let me know whether you think we need an escape hatch to opt out of this check.