### PR TITLE
fix(codegen): Support `extern crate serde` not in toplevel module

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ serde_macros = "*"
 #![feature(custom_derive, plugin)]
 #![plugin(serde_macros)]
 
-extern crate serde;
 extern crate serde_json;
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/serde_codegen/src/attr.rs
+++ b/serde_codegen/src/attr.rs
@@ -572,14 +572,14 @@ fn wrap_serialize_with(cx: &ExtCtxt,
     quote_expr!(cx, {
         trait __SerdeSerializeWith {
             fn __serde_serialize_with<S>(&self, serializer: &mut S) -> Result<(), S::Error>
-                where S: ::serde::ser::Serializer;
+                where S: _serde::ser::Serializer;
         }
 
         impl<'a, T> __SerdeSerializeWith for &'a T
             where T: 'a + __SerdeSerializeWith,
         {
             fn __serde_serialize_with<S>(&self, serializer: &mut S) -> Result<(), S::Error>
-                where S: ::serde::ser::Serializer
+                where S: _serde::ser::Serializer
             {
                 (**self).__serde_serialize_with(serializer)
             }
@@ -587,7 +587,7 @@ fn wrap_serialize_with(cx: &ExtCtxt,
 
         impl $generics __SerdeSerializeWith for $container_ty $where_clause {
             fn __serde_serialize_with<S>(&self, serializer: &mut S) -> Result<(), S::Error>
-                where S: ::serde::ser::Serializer
+                where S: _serde::ser::Serializer
             {
                 $expr
             }
@@ -597,11 +597,11 @@ fn wrap_serialize_with(cx: &ExtCtxt,
             value: &'a T,
         }
 
-        impl<'a, T> ::serde::ser::Serialize for __SerdeSerializeWithStruct<'a, T>
+        impl<'a, T> _serde::ser::Serialize for __SerdeSerializeWithStruct<'a, T>
             where T: 'a + __SerdeSerializeWith
         {
             fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
-                where S: ::serde::ser::Serializer
+                where S: _serde::ser::Serializer
             {
                 self.value.__serde_serialize_with(serializer)
             }
@@ -633,9 +633,9 @@ fn wrap_deserialize_with(cx: &ExtCtxt,
             value: $field_ty,
         }
 
-        impl $generics ::serde::de::Deserialize for $ty_path $where_clause {
+        impl $generics _serde::de::Deserialize for $ty_path $where_clause {
             fn deserialize<D>(deserializer: &mut D) -> ::std::result::Result<Self, D::Error>
-                where D: ::serde::de::Deserializer
+                where D: _serde::de::Deserializer
             {
                 let value = try!($path(deserializer));
                 Ok(__SerdeDeserializeWithStruct { value: value })

--- a/serde_codegen/src/bound.rs
+++ b/serde_codegen/src/bound.rs
@@ -27,10 +27,8 @@ pub fn with_bound(
     item: &ast::Item,
     generics: &ast::Generics,
     filter: &Fn(&ast::StructField) -> bool,
-    bound: &[&'static str],
+    bound: &ast::Path,
 ) -> ast::Generics {
-    let path = builder.path().global().ids(bound).build();
-
     builder.from_generics(generics.clone())
         .with_predicates(
             all_variants(cx, item).iter()
@@ -44,7 +42,7 @@ pub fn with_bound(
                     // the type that is being bounded e.g. T
                     .bound().build(ty.clone())
                     // the bound e.g. Serialize
-                    .bound().trait_(path.clone()).build()
+                    .bound().trait_(bound.clone()).build()
                     .build()))
         .build()
 }

--- a/serde_tests/tests/test.rs
+++ b/serde_tests/tests/test.rs
@@ -1,6 +1,4 @@
 #![cfg_attr(feature = "nightly", feature(plugin))]
 #![cfg_attr(feature = "nightly", plugin(clippy))]
 
-extern crate serde;
-
 include!(concat!(env!("OUT_DIR"), "/test.rs"));

--- a/serde_tests/tests/test_annotations.rs
+++ b/serde_tests/tests/test_annotations.rs
@@ -1,4 +1,5 @@
-use serde::{Serialize, Serializer, Deserialize, Deserializer};
+extern crate serde;
+use self::serde::{Serialize, Serializer, Deserialize, Deserializer};
 
 use token::{
     Error,

--- a/serde_tests/tests/test_bytes.rs
+++ b/serde_tests/tests/test_bytes.rs
@@ -1,8 +1,9 @@
-use serde;
 use std::fmt;
 use std::error;
-use serde::Serialize;
-use serde::bytes::{ByteBuf, Bytes};
+
+extern crate serde;
+use self::serde::Serialize;
+use self::serde::bytes::{ByteBuf, Bytes};
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/serde_tests/tests/test_de.rs
+++ b/serde_tests/tests/test_de.rs
@@ -2,7 +2,8 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::net;
 use std::path::PathBuf;
 
-use serde::de::{Deserializer, Visitor};
+extern crate serde;
+use self::serde::de::{Deserializer, Visitor};
 
 use token::{
     Error,

--- a/serde_tests/tests/token.rs
+++ b/serde_tests/tests/token.rs
@@ -2,9 +2,10 @@ use std::fmt;
 use std::iter;
 use std::error;
 
-use serde::ser::{self, Serialize};
-use serde::de;
-use serde::de::value::{self, ValueDeserializer};
+extern crate serde;
+use self::serde::ser::{self, Serialize};
+use self::serde::de;
+use self::serde::de::value::{self, ValueDeserializer};
 
 #[derive(Clone, PartialEq, Debug)]
 pub enum Token<'a> {


### PR DESCRIPTION
Addresses #159.

The generated code looks like:

```rust
#[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
const _IMPL_DESERIALIZE_FOR_MyStruct: () = {
    extern crate serde as _serde;
    #[automatically_derived]
    impl _serde::de::Deserialize for MyStruct {
        // ...
    }
};
```