### PR TITLE
WIP: Parsing and emitting tagged values

### DIFF
--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -30,7 +30,7 @@ pub trait Serialize {
 ///////////////////////////////////////////////////////////////////////////////
 
 /// A trait that describes a type that can serialize a stream of values into the underlying format.
-pub trait Serializer {
+pub trait Serializer: Sized {
     /// The error type that can be returned if some error occurs during serialization.
     type Error: Error;
 
@@ -326,6 +326,23 @@ pub trait Serializer {
         where V: Serialize,
     {
         self.serialize_struct_elt(key, value)
+    }
+    
+    /// Serializes a tagged value.
+    ///
+    /// By default, the tag is discarded and the value is serialized as-is.
+    /// 
+    /// The tags are provided as a pair of format (like `cbor`) and a numeric
+    /// tag. It is possible to supply different tags for different formats.
+    /// The serialization library will select an appropriate tag if available
+    /// and otherwise will serialize the raw value.
+    #[inline]
+    fn serialize_tagged_value<V>(&mut self,
+                                 _tags: &[(&'static str, u64)],
+                                 value: V) -> Result<(), Self::Error>
+        where V: Serialize,
+    {
+        value.serialize(self)
     }
 }
 


### PR DESCRIPTION
Some serialization formats like [CBOR](http://cbor.io/) or [BSON](http://bsonspec.org/) allow the definition of "tagged values" or "subtypes" to extend the format or to add additional type information to values. They can only supported with some help from serde.

This patch should add support to deserialize and serialize these tagged values. The default behavior will be to discard the tag and only use the value so they are completely optional to use.

For now the patch only supports serialization but I would like to get early feedback about the inclusion in serde.

See also #163 and pyfisch/cbor#3