### PR TITLE
quasi 0.10.0 aster 0.16.0

### DIFF
--- a/serde_codegen/Cargo.toml
+++ b/serde_codegen/Cargo.toml
@@ -20,9 +20,9 @@ quasi_codegen = { version = "^0.9.0", optional = true }
 syntex = { version = "^0.31.0", optional = true }
 
 [dependencies]
-aster = { version = "^0.15.0", default-features = false }
+aster = { version = "^0.16.0", default-features = false }
 clippy = { version = "^0.*", optional = true }
-quasi = { version = "^0.9.0", default-features = false }
-quasi_macros = { version = "^0.9.0", optional = true }
+quasi = { version = "^0.10.0", default-features = false }
+quasi_macros = { version = "^0.10.0", optional = true }
 syntex = { version = "^0.31.0", optional = true }
 syntex_syntax = { version = "^0.31.0", optional = true }


### PR DESCRIPTION
Updating to use the latest `quasi` and `aster` versions.