### PR TITLE
Reduce dependence on type inference

### DIFF
--- a/serde_tests/tests/test.rs.in
+++ b/serde_tests/tests/test.rs.in
@@ -6,5 +6,6 @@ mod token;
 mod test_annotations;
 mod test_bytes;
 mod test_de;
+mod test_gen;
 mod test_macros;
 mod test_ser;

--- a/serde_tests/tests/test_de.rs
+++ b/serde_tests/tests/test_de.rs
@@ -3,7 +3,7 @@ use std::net;
 use std::path::PathBuf;
 
 extern crate serde;
-use self::serde::de::{Deserializer, Visitor};
+use self::serde::de::Deserializer;
 
 use token::{
     Error,

--- a/serde_tests/tests/test_gen.rs
+++ b/serde_tests/tests/test_gen.rs
@@ -1,0 +1,56 @@
+// These just test that serde_codegen is able to produce code that compiles
+// successfully when there are a variety of generics involved.
+
+extern crate serde;
+use self::serde::ser::{Serialize, Serializer};
+use self::serde::de::{Deserialize, Deserializer};
+
+//////////////////////////////////////////////////////////////////////////
+
+#[derive(Serialize, Deserialize)]
+struct With<T> {
+    t: T,
+    #[serde(serialize_with="ser_i32", deserialize_with="de_i32")]
+    i: i32,
+}
+
+#[derive(Serialize, Deserialize)]
+struct WithRef<'a, T: 'a> {
+    #[serde(skip_deserializing)]
+    t: Option<&'a T>,
+    #[serde(serialize_with="ser_i32", deserialize_with="de_i32")]
+    i: i32,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Bounds<T: Serialize + Deserialize> {
+    t: T,
+    option: Option<T>,
+    boxed: Box<T>,
+    option_boxed: Option<Box<T>>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct NoBounds<T> {
+    t: T,
+    option: Option<T>,
+    boxed: Box<T>,
+    option_boxed: Option<Box<T>>,
+}
+
+#[derive(Serialize, Deserialize)]
+enum EnumWith<T> {
+    A(
+        #[serde(serialize_with="ser_i32", deserialize_with="de_i32")]
+        i32),
+    B {
+        t: T,
+        #[serde(serialize_with="ser_i32", deserialize_with="de_i32")]
+        i: i32 },
+}
+
+//////////////////////////////////////////////////////////////////////////
+
+fn ser_i32<S: Serializer>(_: &i32, _: &mut S) -> Result<(), S::Error> { panic!() }
+
+fn de_i32<D: Deserializer>(_: &mut D) -> Result<i32, D::Error> { panic!() }


### PR DESCRIPTION
Addresses both #305 and #307.

To fix #305, this PR adds turbofish to SeqVisitor and MapVisitor calls where type inference can fail due to https://github.com/rust-lang/rust/issues/33449.

To fix #307, this PR adds a PhantomData in the deserialize_with implementation as explained in that ticket.

I did both in one PR because they touch the same code.