### PR TITLE
Clarify serialize_with and deserialize_with documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -705,18 +705,18 @@ Variant Annotations:
 
 Field Annotations:
 
-| Annotation                              | Function                                                                                                   |
-| ----------                              | --------                                                                                                   |
-| `#[serde(rename="name")]`               | Serialize and deserialize this field with the given name                                                   |
-| `#[serde(rename(serialize="name1"))]`   | Serialize this field with the given name                                                                   |
-| `#[serde(rename(deserialize="name1"))]` | Deserialize this field with the given name                                                                 |
-| `#[serde(default)]`                     | If the value is not specified, use the `Default::default()`                                                |
-| `#[serde(default="$path")]`             | Call the path to a function `fn() -> T` to build the value                                                 |
-| `#[serde(skip_serializing)]`            | Do not serialize this value                                                                                |
-| `#[serde(skip_deserializing)]`          | Always use `Default::default()` or `#[serde(default="$path")]` instead of deserializing this value         |
-| `#[serde(skip_serializing_if="$path")]` | Do not serialize this value if this function `fn(&T) -> bool` returns `true`                               |
-| `#[serde(serialize_with="$path")]`      | Call a function `fn<T, S>(&T, &mut S) -> Result<(), S::Error> where S: Serializer` to serialize this value |
-| `#[serde(deserialize_with="$path")]`    | Call a function `fn<T, D>(&mut D) -> Result<T, D::Error> where D: Deserializer` to deserialize this value  |
+| Annotation                              | Function                                                                                                            |
+| ----------                              | --------                                                                                                            |
+| `#[serde(rename="name")]`               | Serialize and deserialize this field with the given name                                                            |
+| `#[serde(rename(serialize="name1"))]`   | Serialize this field with the given name                                                                            |
+| `#[serde(rename(deserialize="name1"))]` | Deserialize this field with the given name                                                                          |
+| `#[serde(default)]`                     | If the value is not specified, use the `Default::default()`                                                         |
+| `#[serde(default="$path")]`             | Call the path to a function `fn() -> T` to build the value                                                          |
+| `#[serde(skip_serializing)]`            | Do not serialize this value                                                                                         |
+| `#[serde(skip_deserializing)]`          | Always use `Default::default()` or `#[serde(default="$path")]` instead of deserializing this value                  |
+| `#[serde(skip_serializing_if="$path")]` | Do not serialize this value if this function `fn(&T) -> bool` returns `true`                                        |
+| `#[serde(serialize_with="$path")]`      | Call a function `fn<S>(&T, &mut S) -> Result<(), S::Error> where S: Serializer` to serialize this value of type `T` |
+| `#[serde(deserialize_with="$path")]`    | Call a function `fn<D>(&mut D) -> Result<T, D::Error> where D: Deserializer` to deserialize this value of type `T`  |
 
 Upgrading from Serde 0.6
 ========================


### PR DESCRIPTION
The field type `T` does not have to be a generic type parameter of the serialize_with or deserialize_with function.