### PR TITLE
Field with deserialize_with should not implement Deserialize

### DIFF
--- a/serde_codegen/src/attr.rs
+++ b/serde_codegen/src/attr.rs
@@ -308,22 +308,6 @@ impl FieldAttrs {
         &self.name
     }
 
-    /// Predicate for using a field's default value
-    pub fn expr_is_missing(&self) -> P<ast::Expr> {
-        match self.default_expr_if_missing {
-            Some(ref expr) => expr.clone(),
-            None => {
-                let name = self.name.deserialize_name_expr();
-                AstBuilder::new().expr()
-                    .try()
-                    .method_call("missing_field").id("visitor")
-                        .with_arg(name)
-                        .build()
-            }
-        }
-    }
-
-    /// Predicate for ignoring a field when serializing a value
     pub fn skip_serializing_field(&self) -> bool {
         self.skip_serializing_field
     }
@@ -334,6 +318,10 @@ impl FieldAttrs {
 
     pub fn skip_serializing_field_if(&self) -> Option<&P<ast::Expr>> {
         self.skip_serializing_field_if.as_ref()
+    }
+
+    pub fn default_expr_if_missing(&self) -> Option<&P<ast::Expr>> {
+        self.default_expr_if_missing.as_ref()
     }
 
     pub fn serialize_with(&self) -> Option<&P<ast::Expr>> {

--- a/serde_tests/tests/test_annotations.rs
+++ b/serde_tests/tests/test_annotations.rs
@@ -237,6 +237,14 @@ impl Default for NotDeserializeStruct {
     }
 }
 
+impl DeserializeWith for NotDeserializeStruct {
+    fn deserialize_with<D>(_: &mut D) -> Result<Self, D::Error>
+        where D: Deserializer
+    {
+        panic!()
+    }
+}
+
 // Does not implement Deserialize.
 #[derive(Debug, PartialEq)]
 enum NotDeserializeEnum { Trouble }
@@ -248,13 +256,15 @@ impl MyDefault for NotDeserializeEnum {
 }
 
 #[derive(Debug, PartialEq, Deserialize)]
-struct ContainsNotDeserialize<A, B, C: MyDefault> {
+struct ContainsNotDeserialize<A, B, C: DeserializeWith, E: MyDefault> {
     #[serde(skip_deserializing)]
     a: A,
     #[serde(skip_deserializing, default)]
     b: B,
-    #[serde(skip_deserializing, default="MyDefault::my_default")]
+    #[serde(deserialize_with="DeserializeWith::deserialize_with", default)]
     c: C,
+    #[serde(skip_deserializing, default="MyDefault::my_default")]
+    e: E,
 }
 
 // Tests that a struct field does not need to implement Deserialize if it is
@@ -266,7 +276,8 @@ fn test_elt_not_deserialize() {
         &ContainsNotDeserialize {
             a: NotDeserializeStruct(123),
             b: NotDeserializeStruct(123),
-            c: NotDeserializeEnum::Trouble,
+            c: NotDeserializeStruct(123),
+            e: NotDeserializeEnum::Trouble,
         },
         vec![
             Token::StructStart("ContainsNotDeserialize", Some(3)),


### PR DESCRIPTION
Addresses #259.

The solution is, if a field is missing:

- If there is a default expression, use the default expression (this includes `skip_deserializing`).
- If the field has deserialize_with, fail with `Visitor::Error::missing_field(name)`.
- Otherwise call `visitor.missing_field(name)` to possibly handle the field.

This means `deserialize_with` no longer goes through the visitor's `missing_field`, instead failing directly unless there is a default. Thus fields with `deserialize_with` do not require Deserialize as a bound. The missing field behavior can be controlled by setting a default for the field.