### PR TITLE
Do not depend on multiple syntex versions

### DIFF
--- a/serde_codegen/Cargo.toml
+++ b/serde_codegen/Cargo.toml
@@ -17,7 +17,7 @@ with-syntex = ["quasi/with-syntex", "quasi_codegen", "quasi_codegen/with-syntex"
 
 [build-dependencies]
 quasi_codegen = { version = "^0.10.0", optional = true }
-syntex = { version = "^0.31.0", optional = true }
+syntex = { version = "^0.32.0", optional = true }
 
 [dependencies]
 aster = { version = "^0.16.0", default-features = false }


### PR DESCRIPTION
serde_codegen has syntex 0.32 under dependencies, but syntex 0.31 under build-dependencies...