### PR TITLE
Release 0.7.6

### DIFF
--- a/examples/serde-syntex-example/Cargo.toml
+++ b/examples/serde-syntex-example/Cargo.toml
@@ -9,10 +9,10 @@ default = ["serde_codegen"]
 nightly = ["serde_macros"]
 
 [build-dependencies]
-serde_codegen = { version = "^0.7.5", optional = true }
+serde_codegen = { version = "^0.7.6", optional = true }
 syntex = "^0.32.0"
 
 [dependencies]
-serde = "^0.7.5"
+serde = "^0.7.6"
 serde_json = "^0.7.0"
-serde_macros = { version = "^0.7.5", optional = true }
+serde_macros = { version = "^0.7.6", optional = true }

--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde"
-version = "0.7.5"
+version = "0.7.6"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "A generic serialization/deserialization framework"

--- a/serde_codegen/Cargo.toml
+++ b/serde_codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_codegen"
-version = "0.7.5"
+version = "0.7.6"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Macros to auto-generate implementations for the serde framework"

--- a/serde_macros/Cargo.toml
+++ b/serde_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_macros"
-version = "0.7.5"
+version = "0.7.6"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Macros to auto-generate implementations for the serde framework"
@@ -17,12 +17,12 @@ nightly-testing = ["clippy", "serde/nightly-testing", "serde_codegen/nightly-tes
 
 [dependencies]
 clippy = { version = "^0.*", optional = true }
-serde_codegen = { version = "^0.7.5", path = "../serde_codegen", default-features = false, features = ["nightly"] }
+serde_codegen = { version = "^0.7.6", path = "../serde_codegen", default-features = false, features = ["nightly"] }
 
 [dev-dependencies]
 compiletest_rs = "^0.1.1"
 rustc-serialize = "^0.3.16"
-serde = { version = "^0.7.5", path = "../serde" }
+serde = { version = "^0.7.6", path = "../serde" }
 
 [[test]]
 name = "test"

--- a/serde_tests/Cargo.toml
+++ b/serde_tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_tests"
-version = "0.7.5"
+version = "0.7.6"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "A generic serialization/deserialization framework"


### PR DESCRIPTION
Changelog for this release:

- Enables use in no_std environments (#316)
- Fixes some compiler warnings that snuck into 0.7.5 (#322)
- Serializes double-references to generic types correctly (#337)