### PR TITLE
use iterators instead of a custom `MapVisitor` type

### DIFF
--- a/serde_tests/tests/test_bytes.rs
+++ b/serde_tests/tests/test_bytes.rs
@@ -107,15 +107,8 @@ impl serde::Serializer for BytesSerializer {
         Err(Error)
     }
 
-    fn serialize_map<V>(&mut self, _visitor: V) -> Result<(), Error>
-        where V: serde::ser::MapVisitor,
-    {
-        Err(Error)
-    }
-
-    fn serialize_map_elt<K, V>(&mut self, _key: K, _value: V) -> Result<(), Error>
-        where K: serde::Serialize,
-              V: serde::Serialize,
+    fn serialize_map<K, V, I>(&mut self, _: I) -> Result<(), Error>
+        where I: Iterator<Item = (K, V)>
     {
         Err(Error)
     }


### PR DESCRIPTION
This can be done to `SeqVisitor`, too.

I was mostly wondering about the design. It's shorter (`167 additions and 418 deletions`), but it might be unnecessarily complex, due to the closure indirection.

The interesting part is in `serde/src/ser/mod.rs`, `serde/src/ser/impls.rs` and `serde_tests/tests/token.rs`. (the rest is just codegen)

I'll implement this for json to see a real world example