### PR TITLE
Add serde_codegen::expand to avoid public Syntex dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,7 @@ pub fn main() {
     let src = Path::new("src/main.rs.in");
     let dst = Path::new(&out_dir).join("main.rs");
 
-    let mut registry = syntex::Registry::new();
-
-    serde_codegen::register(&mut registry);
-    registry.expand("", &src, &dst).unwrap();
+    serde_codegen::expand(&src, &dst).unwrap();
 }
 ```
 
@@ -203,10 +200,7 @@ mod inner {
         let src = Path::new("src/main.rs.in");
         let dst = Path::new(&out_dir).join("main.rs");
 
-        let mut registry = syntex::Registry::new();
-
-        serde_codegen::register(&mut registry);
-        registry.expand("", &src, &dst).unwrap();
+        serde_codegen::expand(&src, &dst).unwrap();
     }
 }
 

--- a/examples/.cargo/config
+++ b/examples/.cargo/config
@@ -1,0 +1,5 @@
+paths = [
+    "../serde",
+    "../serde_codegen",
+    "../serde_macros",
+]

--- a/examples/serde-syntex-example/build.rs
+++ b/examples/serde-syntex-example/build.rs
@@ -12,10 +12,7 @@ mod inner {
         let src = Path::new("src/main.rs.in");
         let dst = Path::new(&out_dir).join("main.rs");
 
-        let mut registry = syntex::Registry::new();
-
-        serde_codegen::register(&mut registry);
-        registry.expand("", &src, &dst).unwrap();
+        serde_codegen::expand(&src, &dst).unwrap();
     }
 }
 

--- a/serde_codegen/src/lib.rs
+++ b/serde_codegen/src/lib.rs
@@ -22,6 +22,11 @@ extern crate syntax;
 #[cfg(not(feature = "with-syntex"))]
 extern crate rustc_plugin;
 
+#[cfg(feature = "with-syntex")]
+use std::io;
+#[cfg(feature = "with-syntex")]
+use std::path::Path;
+
 #[cfg(not(feature = "with-syntex"))]
 use syntax::feature_gate::AttributeType;
 
@@ -30,6 +35,13 @@ include!(concat!(env!("OUT_DIR"), "/lib.rs"));
 
 #[cfg(not(feature = "with-syntex"))]
 include!("lib.rs.in");
+
+#[cfg(feature = "with-syntex")]
+pub fn expand(src: &Path, dst: &Path) -> io::Result<()> {
+    let mut registry = syntex::Registry::new();
+    register(&mut registry);
+    registry.expand("", src, dst)
+}
 
 #[cfg(feature = "with-syntex")]
 pub fn register(reg: &mut syntex::Registry) {

--- a/serde_codegen/src/lib.rs
+++ b/serde_codegen/src/lib.rs
@@ -37,10 +37,13 @@ include!(concat!(env!("OUT_DIR"), "/lib.rs"));
 include!("lib.rs.in");
 
 #[cfg(feature = "with-syntex")]
-pub fn expand(src: &Path, dst: &Path) -> io::Result<()> {
+pub fn expand<S, D>(src: S, dst: D) -> io::Result<()>
+    where S: AsRef<Path>,
+          D: AsRef<Path>,
+{
     let mut registry = syntex::Registry::new();
     register(&mut registry);
-    registry.expand("", src, dst)
+    registry.expand("", src.as_ref(), dst.as_ref())
 }
 
 #[cfg(feature = "with-syntex")]


### PR DESCRIPTION
Required for #358. We can remove `serde_codegen::register` in the next breaking release.

This allows Syntex users to avoid being broken by Serde bumping its Syntex dependency.