### PR TITLE
more cfail tests

### DIFF
--- a/serde_macros/tests/compile-fail/duplicate_attributes.rs_
+++ b/serde_macros/tests/compile-fail/duplicate_attributes.rs_
@@ -1,0 +1,13 @@
+#![feature(custom_attribute, custom_derive, plugin)]
+#![plugin(serde_macros)]
+
+#[derive(Serialize, Deserialize)]
+struct S {
+    #[serde(rename(serialize="x"))]
+    #[serde(rename(serialize="y"))] //~ ERROR buldternua
+    #[serde(rename(deserialize="y"))] // ok
+    #[serde(rename="y")] // error
+    z: i32,
+}
+
+fn main() {}

--- a/serde_macros/tests/compile-fail/str_ref_deser.rs
+++ b/serde_macros/tests/compile-fail/str_ref_deser.rs
@@ -1,0 +1,9 @@
+#![feature(custom_attribute, custom_derive, plugin)]
+#![plugin(serde_macros)]
+
+#[derive(Serialize, Deserialize)]
+struct Test<'a> {
+    s: &'a str, //~ ERROR: Serde does not support deserializing fields of type &str
+}
+
+fn main() {}


### PR DESCRIPTION
I tried adding cfail tests to `serde_tests`, but mixing syntex-`serde_codegen` and `serde_macros` doesn't end well. We can't use `serde_codegen` as-is for testing without building our own test harness out of asserting that `expand` runs successful. Luckily there are already compile-fail tests in `serde_macros`. Let's simply continue adding them there.

fixes #341 
