### PR TITLE
Factor attr parsing into serde_item crate

### DIFF
--- a/serde_codegen/Cargo.toml
+++ b/serde_codegen/Cargo.toml
@@ -14,7 +14,14 @@ include = ["Cargo.toml", "build.rs", "src/**/*.rs", "src/lib.rs.in"]
 default = ["with-syntex"]
 nightly = ["quasi_macros"]
 nightly-testing = ["clippy"]
-with-syntex = ["quasi/with-syntex", "quasi_codegen", "quasi_codegen/with-syntex", "syntex", "syntex_syntax"]
+with-syntex = [
+    "quasi/with-syntex",
+    "quasi_codegen",
+    "quasi_codegen/with-syntex",
+    "serde_item/with-syntex",
+    "syntex",
+    "syntex_syntax",
+]
 
 [build-dependencies]
 quasi_codegen = { version = "^0.12.0", optional = true }
@@ -25,5 +32,6 @@ aster = { version = "^0.18.0", default-features = false }
 clippy = { version = "^0.*", optional = true }
 quasi = { version = "^0.12.0", default-features = false }
 quasi_macros = { version = "^0.12.0", optional = true }
+serde_item = { version = "0.1", path = "../serde_item", default-features = false }
 syntex = { version = "^0.35.0", optional = true }
 syntex_syntax = { version = "^0.35.0", optional = true }

--- a/serde_codegen/src/bound.rs
+++ b/serde_codegen/src/bound.rs
@@ -6,8 +6,7 @@ use syntax::ast;
 use syntax::ptr::P;
 use syntax::visit;
 
-use attr;
-use item::Item;
+use item::{attr, Item};
 
 // Remove the default from every type parameter because in the generated impls
 // they look like associated types: "error: associated type bindings are not
@@ -39,7 +38,7 @@ pub fn with_where_predicates_from_fields<F>(
     generics: &ast::Generics,
     from_field: F,
 ) -> ast::Generics
-    where F: Fn(&attr::FieldAttrs) -> Option<&[ast::WherePredicate]>,
+    where F: Fn(&attr::Field) -> Option<&[ast::WherePredicate]>,
 {
     builder.from_generics(generics.clone())
         .with_predicates(
@@ -56,7 +55,7 @@ pub fn with_bound<F>(
     filter: F,
     bound: &ast::Path,
 ) -> ast::Generics
-    where F: Fn(&attr::FieldAttrs) -> bool,
+    where F: Fn(&attr::Field) -> bool,
 {
     builder.from_generics(generics.clone())
         .with_predicates(

--- a/serde_codegen/src/lib.rs
+++ b/serde_codegen/src/lib.rs
@@ -7,6 +7,7 @@
 
 extern crate aster;
 extern crate quasi;
+extern crate serde_item as item;
 
 #[cfg(feature = "with-syntex")]
 extern crate syntex;

--- a/serde_codegen/src/lib.rs.in
+++ b/serde_codegen/src/lib.rs.in
@@ -1,6 +1,4 @@
-mod attr;
 mod bound;
 mod de;
 mod error;
-mod item;
 mod ser;

--- a/serde_item/Cargo.toml
+++ b/serde_item/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "serde_item"
+version = "0.1.0"
+authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
+license = "MIT/Apache-2.0"
+description = "AST representation used by Serde codegen. Unstable."
+repository = "https://github.com/serde-rs/serde"
+documentation = "https://github.com/serde-rs/serde"
+keywords = ["serde", "serialization"]
+include = ["Cargo.toml", "src/**/*.rs"]
+
+[features]
+default = ["with-syntex"]
+nightly-testing = ["clippy"]
+with-syntex = ["syntex_syntax"]
+
+[dependencies]
+clippy = { version = "^0.*", optional = true }
+syntex_syntax = { version = "^0.35.0", optional = true }

--- a/serde_item/src/attr.rs
+++ b/serde_item/src/attr.rs
@@ -1,4 +1,5 @@
 use std::rc::Rc;
+
 use syntax::ast::{self, TokenTree};
 use syntax::attr;
 use syntax::codemap::{Span, Spanned, respan};
@@ -10,14 +11,9 @@ use syntax::parse;
 use syntax::print::pprust::{lit_to_string, meta_item_to_string};
 use syntax::ptr::P;
 
-use aster::AstBuilder;
-use aster::ident::ToIdent;
-
-use error::Error;
-
 // This module handles parsing of `#[serde(...)]` attributes. The entrypoints
-// are `ContainerAttrs::from_item`, `VariantAttrs::from_variant`, and
-// `FieldAttrs::from_field`. Each returns an instance of the corresponding
+// are `attr::Item::from_ast`, `attr::Variant::from_ast`, and
+// `attr::Field::from_ast`. Each returns an instance of the corresponding
 // struct. Note that none of them return a Result. Unrecognized, malformed, or
 // duplicated attributes result in a span_err but otherwise are ignored. The
 // user will see errors simultaneously for all bad attributes in the crate
@@ -101,11 +97,6 @@ impl Name {
         }
     }
 
-    /// Return the container name expression for the container when deserializing.
-    pub fn serialize_name_expr(&self) -> P<ast::Expr> {
-        AstBuilder::new().expr().str(self.serialize_name())
-    }
-
     /// Return the container name for the container when deserializing.
     pub fn deserialize_name(&self) -> InternedString {
         match self.deserialize_name {
@@ -113,25 +104,20 @@ impl Name {
             None => self.ident.name.as_str(),
         }
     }
-
-    /// Return the container name expression for the container when deserializing.
-    pub fn deserialize_name_expr(&self) -> P<ast::Expr> {
-        AstBuilder::new().expr().str(self.deserialize_name())
-    }
 }
 
 /// Represents container (e.g. struct) attribute information
 #[derive(Debug)]
-pub struct ContainerAttrs {
+pub struct Item {
     name: Name,
     deny_unknown_fields: bool,
     ser_bound: Option<Vec<ast::WherePredicate>>,
     de_bound: Option<Vec<ast::WherePredicate>>,
 }
 
-impl ContainerAttrs {
+impl Item {
     /// Extract out the `#[serde(...)]` attributes from an item.
-    pub fn from_item(cx: &ExtCtxt, item: &ast::Item) -> Self {
+    pub fn from_ast(cx: &ExtCtxt, item: &ast::Item) -> Self {
         let mut ser_name = Attr::none(cx, "rename");
         let mut de_name = Attr::none(cx, "rename");
         let mut deny_unknown_fields = BoolAttr::none(cx, "deny_unknown_fields");
@@ -189,7 +175,7 @@ impl ContainerAttrs {
             }
         }
 
-        ContainerAttrs {
+        Item {
             name: Name {
                 ident: item.ident,
                 serialize_name: ser_name.get(),
@@ -220,12 +206,12 @@ impl ContainerAttrs {
 
 /// Represents variant attribute information
 #[derive(Debug)]
-pub struct VariantAttrs {
+pub struct Variant {
     name: Name,
 }
 
-impl VariantAttrs {
-    pub fn from_variant(cx: &ExtCtxt, variant: &ast::Variant) -> Self {
+impl Variant {
+    pub fn from_ast(cx: &ExtCtxt, variant: &ast::Variant) -> Self {
         let mut ser_name = Attr::none(cx, "rename");
         let mut de_name = Attr::none(cx, "rename");
 
@@ -259,7 +245,7 @@ impl VariantAttrs {
             }
         }
 
-        VariantAttrs {
+        Variant {
             name: Name {
                 ident: variant.node.name,
                 serialize_name: ser_name.get(),
@@ -275,7 +261,7 @@ impl VariantAttrs {
 
 /// Represents field attribute information
 #[derive(Debug)]
-pub struct FieldAttrs {
+pub struct Field {
     name: Name,
     skip_serializing: bool,
     skip_deserializing: bool,
@@ -298,11 +284,11 @@ pub enum FieldDefault {
     Path(ast::Path),
 }
 
-impl FieldAttrs {
+impl Field {
     /// Extract out the `#[serde(...)]` attributes from a struct field.
-    pub fn from_field(cx: &ExtCtxt,
-                      index: usize,
-                      field: &ast::StructField) -> Self {
+    pub fn from_ast(cx: &ExtCtxt,
+                    index: usize,
+                    field: &ast::StructField) -> Self {
         let mut ser_name = Attr::none(cx, "rename");
         let mut de_name = Attr::none(cx, "rename");
         let mut skip_serializing = BoolAttr::none(cx, "skip_serializing");
@@ -316,7 +302,7 @@ impl FieldAttrs {
 
         let field_ident = match field.ident {
             Some(ident) => ident,
-            None => index.to_string().to_ident(),
+            None => ast::Ident::with_empty_ctxt(token::intern(&index.to_string())),
         };
 
         for meta_items in field.attrs.iter().filter_map(get_serde_meta_items) {
@@ -414,7 +400,7 @@ impl FieldAttrs {
             default.set_if_none(span, FieldDefault::Default);
         }
 
-        FieldAttrs {
+        Field {
             name: Name {
                 ident: field_ident,
                 serialize_name: ser_name.get(),
@@ -473,8 +459,8 @@ fn get_ser_and_de<T, F>(
     attribute: &'static str,
     items: &[P<ast::MetaItem>],
     f: F
-) -> Result<(Option<Spanned<T>>, Option<Spanned<T>>), Error>
-    where F: Fn(&ExtCtxt, &str, &ast::Lit) -> Result<T, Error>,
+) -> Result<(Option<Spanned<T>>, Option<Spanned<T>>), ()>
+    where F: Fn(&ExtCtxt, &str, &ast::Lit) -> Result<T, ()>,
 {
     let mut ser_item = Attr::none(cx, attribute);
     let mut de_item = Attr::none(cx, attribute);
@@ -500,7 +486,7 @@ fn get_ser_and_de<T, F>(
                              attribute,
                              meta_item_to_string(item)));
 
-                return Err(Error);
+                return Err(());
             }
         }
     }
@@ -511,14 +497,14 @@ fn get_ser_and_de<T, F>(
 fn get_renames(
     cx: &ExtCtxt,
     items: &[P<ast::MetaItem>],
-) -> Result<(Option<Spanned<InternedString>>, Option<Spanned<InternedString>>), Error> {
+) -> Result<(Option<Spanned<InternedString>>, Option<Spanned<InternedString>>), ()> {
     get_ser_and_de(cx, "rename", items, get_str_from_lit)
 }
 
 fn get_where_predicates(
     cx: &ExtCtxt,
     items: &[P<ast::MetaItem>],
-) -> Result<(Option<Spanned<Vec<ast::WherePredicate>>>, Option<Spanned<Vec<ast::WherePredicate>>>), Error> {
+) -> Result<(Option<Spanned<Vec<ast::WherePredicate>>>, Option<Spanned<Vec<ast::WherePredicate>>>), ()> {
     get_ser_and_de(cx, "bound", items, parse_lit_into_where)
 }
 
@@ -579,7 +565,7 @@ impl<'a, 'b> Folder for Respanner<'a, 'b> {
     }
 }
 
-fn get_str_from_lit(cx: &ExtCtxt, name: &str, lit: &ast::Lit) -> Result<InternedString, Error> {
+fn get_str_from_lit(cx: &ExtCtxt, name: &str, lit: &ast::Lit) -> Result<InternedString, ()> {
     match lit.node {
         ast::LitKind::Str(ref s, _) => Ok(s.clone()),
         _ => {
@@ -589,7 +575,7 @@ fn get_str_from_lit(cx: &ExtCtxt, name: &str, lit: &ast::Lit) -> Result<Interned
                          name,
                          lit_to_string(lit)));
 
-            return Err(Error);
+            return Err(());
         }
     }
 }
@@ -600,7 +586,7 @@ fn get_str_from_lit(cx: &ExtCtxt, name: &str, lit: &ast::Lit) -> Result<Interned
 // into a token tree. Then we'll update those spans to say they're coming from a
 // macro context that originally came from the attribnute, and then finally
 // parse them into an expression or where-clause.
-fn parse_string_via_tts<T, F>(cx: &ExtCtxt, name: &str, string: String, action: F) -> Result<T, Error>
+fn parse_string_via_tts<T, F>(cx: &ExtCtxt, name: &str, string: String, action: F) -> Result<T, ()>
     where F: for<'a> Fn(&'a mut Parser) -> parse::PResult<'a, T>,
 {
     let tts = panictry!(parse::parse_tts_from_source_str(
@@ -618,7 +604,7 @@ fn parse_string_via_tts<T, F>(cx: &ExtCtxt, name: &str, string: String, action: 
         Ok(path) => path,
         Err(mut e) => {
             e.emit();
-            return Err(Error);
+            return Err(());
         }
     };
 
@@ -627,14 +613,14 @@ fn parse_string_via_tts<T, F>(cx: &ExtCtxt, name: &str, string: String, action: 
         Ok(()) => { }
         Err(mut e) => {
             e.emit();
-            return Err(Error);
+            return Err(());
         }
     }
 
     Ok(path)
 }
 
-fn parse_lit_into_path(cx: &ExtCtxt, name: &str, lit: &ast::Lit) -> Result<ast::Path, Error> {
+fn parse_lit_into_path(cx: &ExtCtxt, name: &str, lit: &ast::Lit) -> Result<ast::Path, ()> {
     let string = try!(get_str_from_lit(cx, name, lit)).to_string();
 
     parse_string_via_tts(cx, name, string, |parser| {
@@ -642,7 +628,7 @@ fn parse_lit_into_path(cx: &ExtCtxt, name: &str, lit: &ast::Lit) -> Result<ast::
     })
 }
 
-fn parse_lit_into_where(cx: &ExtCtxt, name: &str, lit: &ast::Lit) -> Result<Vec<ast::WherePredicate>, Error> {
+fn parse_lit_into_where(cx: &ExtCtxt, name: &str, lit: &ast::Lit) -> Result<Vec<ast::WherePredicate>, ()> {
     let string = try!(get_str_from_lit(cx, name, lit));
     if string.is_empty() {
         return Ok(Vec::new());

--- a/serde_item/src/error.rs
+++ b/serde_item/src/error.rs
@@ -1,0 +1,19 @@
+use std::error;
+use std::fmt;
+
+#[derive(Debug)]
+pub enum Error {
+    UnexpectedItemKind,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "expected a struct or enum")
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        "expected a struct or enum"
+    }
+}


### PR DESCRIPTION
Fixes #396. @KodrAus [let me know whether this fits the bill.](https://github.com/dtolnay/serde/tree/5c6a0e12e95974e3c131386e8e0528b6b9cfa6fa/serde_item/src)

a few other changes to make the API a little more presentable:

- Rename attr::{ContainerAttrs,VariantAttrs,FieldAttrs} to remove the "Attrs" (I see you worked on the corresponding [clippy lint](https://github.com/Manishearth/rust-clippy/issues/904)).
- Rename attr::Container* to attr::Item to correspond with item::Item and ast::Item. The others already had a correspondence (attr::Variant/item::Variant/ast::Variant, attr::Field/item::Field/ast::Field). Also a unit struct isn't much of a "container."
- Change item::Item::from_ast to return a meaningful error enum instead of printing a message that was hard to generalize to other uses.
- Add item::Variant.span for consistency because Item and Field already had span.
- Remove the "ident" field from attr::Name because we can just fold it into the other two fields.
- Remove attr::Name::(de)serialize_name_expr because it wasn't using the right AstBuilder in the first place.
- Rename the attr:: constructors from_item/from_variant/from_field to from_ast to line up with the item:: constructors; the signatures match.
- Remove attr's dependency on aster because we were only using it for two very simple things.