### PR TITLE
Bump aster and syntex in serde_codegen

### DIFF
--- a/serde_codegen/Cargo.toml
+++ b/serde_codegen/Cargo.toml
@@ -25,13 +25,13 @@ with-syntex = [
 
 [build-dependencies]
 quasi_codegen = { version = "^0.12.0", optional = true }
-syntex = { version = "^0.33.0", optional = true }
+syntex = { version = "^0.36.0", optional = true }
 
 [dependencies]
-aster = { version = "^0.18.0", default-features = false }
+aster = { version = "^0.19.0", default-features = false }
 clippy = { version = "^0.*", optional = true }
 quasi = { version = "^0.12.0", default-features = false }
 quasi_macros = { version = "^0.12.0", optional = true }
 serde_item = { version = "0.1", path = "../serde_item", default-features = false }
-syntex = { version = "^0.35.0", optional = true }
-syntex_syntax = { version = "^0.35.0", optional = true }
+syntex = { version = "^0.36.0", optional = true }
+syntex_syntax = { version = "^0.36.0", optional = true }


### PR DESCRIPTION
I think `serde_codegen` needs to be updated to use the latest versions of `syntex` and `aster`.

Include fix for: https://github.com/serde-rs/aster/issues/88

Not sure about `quasi`?