### PR TITLE
Decouple serde_macros from most unstable libsyntax changes

### DIFF
--- a/serde_codegen/src/lib.rs
+++ b/serde_codegen/src/lib.rs
@@ -25,6 +25,8 @@ extern crate rustc_plugin;
 
 #[cfg(feature = "with-syntex")]
 use std::path::Path;
+#[cfg(feature = "with-syntex")]
+use syntax::ast;
 
 #[cfg(not(feature = "with-syntex"))]
 use syntax::feature_gate::AttributeType;
@@ -45,38 +47,58 @@ pub fn expand<S, D>(src: S, dst: D) -> Result<(), syntex::Error>
     registry.expand("", src.as_ref(), dst.as_ref())
 }
 
+/// Strip the serde attributes from the crate.
 #[cfg(feature = "with-syntex")]
-pub fn register(reg: &mut syntex::Registry) {
-    use syntax::{ast, fold};
+fn strip_attributes(krate: ast::Crate) -> ast::Crate {
+    use syntax::fold;
 
-    /// Strip the serde attributes from the crate.
-    #[cfg(feature = "with-syntex")]
-    fn strip_attributes(krate: ast::Crate) -> ast::Crate {
-        /// Helper folder that strips the serde attributes after the extensions have been expanded.
-        struct StripAttributeFolder;
+    /// Helper folder that strips the serde attributes after the extensions have been expanded.
+    struct StripAttributeFolder;
 
-        impl fold::Folder for StripAttributeFolder {
-            fn fold_attribute(&mut self, attr: ast::Attribute) -> Option<ast::Attribute> {
-                match attr.node.value.node {
-                    ast::MetaItemKind::List(ref n, _) if n == &"serde" => { return None; }
-                    _ => {}
-                }
-
-                Some(attr)
+    impl fold::Folder for StripAttributeFolder {
+        fn fold_attribute(&mut self, attr: ast::Attribute) -> Option<ast::Attribute> {
+            match attr.node.value.node {
+                ast::MetaItemKind::List(ref n, _) if n == &"serde" => { return None; }
+                _ => {}
             }
 
-            fn fold_mac(&mut self, mac: ast::Mac) -> ast::Mac {
-                fold::noop_fold_mac(mac, self)
-            }
+            Some(attr)
         }
 
-        fold::Folder::fold_crate(&mut StripAttributeFolder, krate)
+        fn fold_mac(&mut self, mac: ast::Mac) -> ast::Mac {
+            fold::noop_fold_mac(mac, self)
+        }
     }
 
+    fold::Folder::fold_crate(&mut StripAttributeFolder, krate)
+}
+
+#[cfg(feature = "with-syntex")]
+pub fn register(reg: &mut syntex::Registry) {
     reg.add_attr("feature(custom_derive)");
     reg.add_attr("feature(custom_attribute)");
 
     reg.add_decorator("derive_Serialize", ser::expand_derive_serialize);
+    reg.add_decorator("derive_Deserialize", de::expand_derive_deserialize);
+
+    reg.add_post_expansion_pass(strip_attributes);
+}
+
+#[cfg(feature = "with-syntex")]
+pub fn register_serialize(reg: &mut syntex::Registry) {
+    reg.add_attr("feature(custom_derive)");
+    reg.add_attr("feature(custom_attribute)");
+
+    reg.add_decorator("derive_Serialize", ser::expand_derive_serialize);
+
+    reg.add_post_expansion_pass(strip_attributes);
+}
+
+#[cfg(feature = "with-syntex")]
+pub fn register_deserialize(reg: &mut syntex::Registry) {
+    reg.add_attr("feature(custom_derive)");
+    reg.add_attr("feature(custom_attribute)");
+
     reg.add_decorator("derive_Deserialize", de::expand_derive_deserialize);
 
     reg.add_post_expansion_pass(strip_attributes);
@@ -93,6 +115,26 @@ pub fn register(reg: &mut rustc_plugin::Registry) {
         syntax::parse::token::intern("derive_Deserialize"),
         syntax::ext::base::MultiDecorator(
             Box::new(de::expand_derive_deserialize)));
+
+    reg.register_attribute("serde".to_owned(), AttributeType::Normal);
+}
+
+#[cfg(not(feature = "with-syntex"))]
+pub fn register_serialize(reg: &mut rustc_plugin::Registry) {
+    reg.register_syntax_extension(
+        syntax::parse::token::intern("derive_Serialize"),
+        syntax::ext::base::MultiDecorator(
+            Box::new(ser::expand_derive_serialize)));
+
+    reg.register_attribute("serde".to_owned(), AttributeType::Normal);
+}
+
+#[cfg(not(feature = "with-syntex"))]
+pub fn register_deserialize(reg: &mut rustc_plugin::Registry) {
+    reg.register_syntax_extension(
+        syntax::parse::token::intern("derive_Deserialize"),
+        syntax::ext::base::MultiDecorator(
+            Box::new(ser::expand_derive_deserialize)));
 
     reg.register_attribute("serde".to_owned(), AttributeType::Normal);
 }

--- a/serde_macros/Cargo.toml
+++ b/serde_macros/Cargo.toml
@@ -18,7 +18,8 @@ nightly-testing = ["clippy", "serde/nightly-testing", "serde_codegen/nightly-tes
 
 [dependencies]
 clippy = { version = "^0.*", optional = true }
-serde_codegen = { version = "^0.7.11", path = "../serde_codegen", default-features = false, features = ["nightly"] }
+serde_codegen = { version = "^0.7.11", path = "../serde_codegen" }
+syntex = { version = "^0.36.0" }
 
 [dev-dependencies]
 compiletest_rs = "^0.2.0"

--- a/serde_macros/src/lib.rs
+++ b/serde_macros/src/lib.rs
@@ -2,11 +2,153 @@
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 
-extern crate serde_codegen;
 extern crate rustc_plugin;
+extern crate syntax;
+extern crate syntex;
+extern crate serde_codegen;
+
+use syntax::ast::{self, MetaItem};
+use syntax::attr;
+use syntax::codemap::Span;
+use syntax::ext::base::{Annotatable, ExtCtxt};
+use syntax::feature_gate::AttributeType;
+use syntax::parse;
+use syntax::print::pprust;
+
+fn expand_derive_serialize(
+    cx: &mut ExtCtxt,
+    span: Span,
+    meta_item: &MetaItem,
+    annotatable: &Annotatable,
+    push: &mut FnMut(Annotatable)
+) {
+    expand(
+        "Serialize",
+        serde_codegen::register_serialize,
+        cx,
+        span,
+        meta_item,
+        annotatable,
+        push)
+}
+
+fn expand_derive_deserialize(
+    cx: &mut ExtCtxt,
+    span: Span,
+    meta_item: &MetaItem,
+    annotatable: &Annotatable,
+    push: &mut FnMut(Annotatable)
+) {
+    expand(
+        "Deserialize",
+        serde_codegen::register_deserialize,
+        cx,
+        span,
+        meta_item,
+        annotatable,
+        push)
+}
+
+fn expand<F>(derive_name: &str,
+             register: F,
+             cx: &mut ExtCtxt,
+             _span: Span,
+             meta_item: &MetaItem,
+             annotatable: &Annotatable,
+             push: &mut FnMut(Annotatable))
+    where F: Fn(&mut syntex::Registry)
+{
+    let item = match *annotatable {
+        Annotatable::Item(ref item) => item,
+        _ => {
+            cx.span_err(
+                meta_item.span,
+                &format!(
+                    "`#[derive({})]` may only be applied to structs and enums",
+                    &derive_name));
+            return;
+        }
+    };
+
+    let item_str = pprust::item_to_string(&item);
+
+    let mut registry = syntex::Registry::new();
+    register(&mut registry);
+
+    let crate_name = cx.crate_root.clone().unwrap_or("<no source>");
+    let filename = cx.filename.clone().unwrap_or_else(|| "<no source>".to_string());
+
+    let syntex_src = match registry.expand_str(crate_name, &filename, &item_str) {
+        Ok(src) => src,
+        Err(err) => {
+            cx.span_err(meta_item.span, &err.to_string());
+            return;
+        }
+    };
+
+    let mut parser = parse::new_parser_from_source_str(
+        cx.parse_sess(),
+        cx.cfg(),
+        filename,
+        syntex_src);
+
+    // After we've parsed the item, we need to explicitly mark all the serde attributes as used or
+    // else the compiler will report an error.
+    mark_serde_attributes_used(&item);
+
+    // FIXME: This is a horrible hack that works around the fact there is no easy way yet to delete
+    // the item that we're annotating.  At the moment, we know that serde_codegen guarantees that
+    // the first item returned in the string will be will be our annotated item, so just skip it.
+    if let None = parser.parse_item().expect("no items returned?") {
+        cx.span_bug(
+            meta_item.span,
+            &format!(
+                "`#[derive({})]` didn't generate a struct?",
+                &derive_name));
+    }
+
+    while let Some(item) = parser.parse_item().expect("no items returned?") {
+        push(Annotatable::Item(item));
+    }
+}
+
+/// Strip the serde attributes from the crate.
+fn mark_serde_attributes_used(item: &ast::Item) {
+    use syntax::visit;
+
+    /// Helper folder that strips the serde attributes after the extensions have been expanded.
+    struct MarkSerdeAttributeVisitor;
+
+    impl<'a> visit::Visitor<'a> for MarkSerdeAttributeVisitor {
+        fn visit_attribute(&mut self, attr: &'a ast::Attribute) {
+            match attr.node.value.node {
+                ast::MetaItemKind::List(ref n, _) if n == &"serde" => {
+                    attr::mark_used(&attr);
+                }
+                _ => {}
+            }
+        }
+
+        fn visit_mac(&mut self, mac: &'a ast::Mac) {
+            visit::walk_mac(self, mac)
+        }
+    }
+
+    visit::Visitor::visit_item(&mut MarkSerdeAttributeVisitor, item)
+}
 
 #[plugin_registrar]
 #[doc(hidden)]
 pub fn plugin_registrar(reg: &mut rustc_plugin::Registry) {
-    serde_codegen::register(reg);
+    reg.register_syntax_extension(
+        syntax::parse::token::intern("derive_Serialize"),
+        syntax::ext::base::MultiDecorator(
+            Box::new(expand_derive_serialize)));
+
+    reg.register_syntax_extension(
+        syntax::parse::token::intern("derive_Deserialize"),
+        syntax::ext::base::MultiDecorator(
+            Box::new(expand_derive_deserialize)));
+
+    reg.register_attribute("serde".to_owned(), AttributeType::Normal);
 }

--- a/serde_tests/tests/test_gen.rs
+++ b/serde_tests/tests/test_gen.rs
@@ -131,4 +131,3 @@ trait DeserializeWith: Sized {
 struct X;
 fn ser_x<S: Serializer>(_: &X, _: &mut S) -> Result<(), S::Error> { panic!() }
 fn de_x<D: Deserializer>(_: &mut D) -> Result<X, D::Error> { panic!() }
-


### PR DESCRIPTION
This PR rewrites `serde_macros` to decouple it from most libsyntax changes by instead having the annotated item be rendered into text then processed by syntex and serde_codegen.  This means that `serde_macros` users will only be broken by a nightly upgrade if a very small selection of the API is changed.  Unfortunately this does mean that compiling `serde_macros` will now take a minute longer since it'll also be compiling syntex.

Interestingly enough, this is not a breaking change since none of the `serde_macros` API is publicly exposed.