### PR TITLE
Add support for tagged values.

### DIFF
--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -663,6 +663,13 @@ pub trait Visitor {
     {
         self.visit_bytes(&v)
     }
+    
+    /// `visit_tagged_value` deserializes a tagged value.
+    fn visit_tagged_value<T, D>(&mut self, _tag: T, deserializer: &mut D) -> Result<Self::Value, D::Error>
+        where T: ::Tagger, D: Deserializer 
+    {
+        Deserialize::deserialize(deserializer)
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -39,6 +39,7 @@ mod core {
 
 pub use ser::{Serialize, Serializer};
 pub use de::{Deserialize, Deserializer, Error};
+pub use tagger::Tagger;
 
 #[cfg(not(feature = "std"))]
 macro_rules! format {
@@ -52,4 +53,5 @@ pub mod iter;
 pub mod ser;
 #[cfg(not(feature = "std"))]
 pub mod error;
+mod tagger;
 mod utils;

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -41,7 +41,7 @@ pub trait Serialize {
 ///////////////////////////////////////////////////////////////////////////////
 
 /// A trait that describes a type that can serialize a stream of values into the underlying format.
-pub trait Serializer {
+pub trait Serializer: Sized {
     /// The error type that can be returned if some error occurs during serialization.
     type Error: Error;
 
@@ -345,6 +345,18 @@ pub trait Serializer {
         where V: Serialize,
     {
         self.serialize_struct_elt(key, value)
+    }
+
+    /// Serializes a tagged value.
+    ///
+    /// By default, the tag is discarded and the value is serialized as-is.
+    #[inline]
+    fn serialize_tagged_value<T, V>(&mut self,
+                                    _tag: T,
+                                    value: V) -> Result<(), Self::Error>
+        where T: ::Tagger, V: Serialize,
+    {
+        value.serialize(self)
     }
 }
 

--- a/serde/src/tagger.rs
+++ b/serde/src/tagger.rs
@@ -1,0 +1,32 @@
+/// Provides the correct tag for a given format.
+pub trait Tagger {
+    /// Returns a `u8` tag if available.
+    fn u8_tag(&self, _format: &'static str) -> Option<u8> { None }
+    
+    /// Returns a `u16` tag if available.
+    fn u16_tag(&self, _format: &'static str) -> Option<u16> { None }
+    
+    /// Returns a `u32` tag if available.
+    fn u32_tag(&self, _format: &'static str) -> Option<u32> { None }
+    
+    /// Returns a `u64` tag if available.
+    fn u64_tag(&self, _format: &'static str) -> Option<u64> { None }
+    
+    /// Returns an `i8` tag if available.
+    fn i8_tag(&self, _format: &'static str) -> Option<i8> { None }
+    
+    /// Returns an `i16` tag if available.
+    fn i16_tag(&self, _format: &'static str) -> Option<i16> { None }
+    
+    /// Returns an `i32` tag if available.
+    fn i32_tag(&self, _format: &'static str) -> Option<i32> { None }
+    
+    /// Returns an `i64` tag if available.
+    fn i64_tag(&self, _format: &'static str) -> Option<i64> { None }
+    
+    /// Provides a string tag if available.
+    fn string_tag(&self, _format: &'static str) -> Option<&str> { None }
+    
+    /// Provides a binary tag if available.
+    fn bytes_tag(&self, _format: &'static str) -> Option<&[u8]> { None }
+}


### PR DESCRIPTION
Some serialization formats allow the addition of "tags"
to values to add additional information. These formats
include CBOR, BSON and YAML.

This commit introduces serialization and deserialization
of tags. It introduces a trait Tagger that resolves
the tag for a specific format. It supports integer,
binary, and string tags and is extensible to cover
more yet unknown formats.

By default tags are discarded at deserialization
except when the user has implemented visit_tagged_value
function.

To serialize tags the user has to call
serialize_tagged_value.

Tagged values may be of any type.

Thanks to @dtolnay, @oli-obk and @erickt for their comments on tags.

Supersedes #301