### PR TITLE
Close the map before checking for missing fields

### DIFF
--- a/serde_codegen/src/de.rs
+++ b/serde_codegen/src/de.rs
@@ -1093,9 +1093,9 @@ fn deserialize_map(
             }
         }
 
-        $extract_values
-
         try!(visitor.end());
+
+        $extract_values
 
         Ok($result)
     })


### PR DESCRIPTION
I am working on JSON parser performance. One huge improvement (30-40%) is making the `peek()` function as cheap as possible and doing pessimistic error handling such that line/column is only computed if an error happens.

For context: the `while` loop exits when `peek()` returns a closing brace `}`. `$extract_values` checks for any missing keys. `visitor.end()` consumes the closing brace.

The current `peek()` updates the iterator position so currently "missing field" errors correctly point to the closing brace. The faster `peek()` does not update position. In order for "missing field" errors to point to the closing brace instead of the previous character, we need to consume the closing brace before checking for missing keys.