### PR TITLE
Revamp Map/Seq serialization

### DIFF
--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -156,7 +156,7 @@ impl<T> Serialize for [T]
         for e in self.iter() {
             try!(serializer.serialize_seq_elt(e));
         }
-        serializer.serialize_seq_end()
+        serializer.serialize_seq_end(Some(self.len()))
     }
 }
 
@@ -173,7 +173,7 @@ macro_rules! array_impls {
                 for e in self.iter() {
                     try!(serializer.serialize_seq_elt(e));
                 }
-                serializer.serialize_seq_end()
+                serializer.serialize_seq_end(Some(self.len()))
             }
         }
     }
@@ -227,7 +227,7 @@ impl<T> Serialize for BinaryHeap<T>
         for e in self.iter() {
             try!(serializer.serialize_seq_elt(e));
         }
-        serializer.serialize_seq_end()
+        serializer.serialize_seq_end(Some(self.len()))
     }
 }
 
@@ -243,7 +243,7 @@ impl<T> Serialize for BTreeSet<T>
         for e in self.iter() {
             try!(serializer.serialize_seq_elt(e));
         }
-        serializer.serialize_seq_end()
+        serializer.serialize_seq_end(Some(self.len()))
     }
 }
 
@@ -259,7 +259,7 @@ impl<T> Serialize for EnumSet<T>
         for e in self.iter() {
             try!(serializer.serialize_seq_elt(e));
         }
-        serializer.serialize_seq_end()
+        serializer.serialize_seq_end(Some(self.len()))
     }
 }
 
@@ -276,7 +276,7 @@ impl<T, H> Serialize for HashSet<T, H>
         for e in self.iter() {
             try!(serializer.serialize_seq_elt(e));
         }
-        serializer.serialize_seq_end()
+        serializer.serialize_seq_end(Some(self.len()))
     }
 }
 
@@ -292,7 +292,7 @@ impl<T> Serialize for LinkedList<T>
         for e in self.iter() {
             try!(serializer.serialize_seq_elt(e));
         }
-        serializer.serialize_seq_end()
+        serializer.serialize_seq_end(Some(self.len()))
     }
 }
 
@@ -333,7 +333,7 @@ impl<T> Serialize for VecDeque<T> where T: Serialize {
         for e in self.iter() {
             try!(serializer.serialize_seq_elt(e));
         }
-        serializer.serialize_seq_end()
+        serializer.serialize_seq_end(Some(self.len()))
     }
 }
 
@@ -373,7 +373,7 @@ macro_rules! tuple_impls {
                     $(
                         try!(serializer.serialize_tuple_elt(&e!(self.$idx)));
                     )+
-                    serializer.serialize_tuple_end()
+                    serializer.serialize_tuple_end($len)
                 }
             }
         )+
@@ -566,7 +566,7 @@ impl<K, V> Serialize for BTreeMap<K, V>
         for (k, v) in self.iter() {
             try!(serializer.serialize_map_elt(k, v));
         }
-        serializer.serialize_map_end()
+        serializer.serialize_map_end(Some(self.len()))
     }
 }
 
@@ -584,7 +584,7 @@ impl<K, V, H> Serialize for HashMap<K, V, H>
         for (k, v) in self.iter() {
             try!(serializer.serialize_map_elt(k, v));
         }
-        serializer.serialize_map_end()
+        serializer.serialize_map_end(Some(self.len()))
     }
 }
 

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -169,7 +169,7 @@ macro_rules! array_impls {
             fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
                 where S: Serializer,
             {
-                let mut state = try!(serializer.serialize_seq(Some($len)));
+                let mut state = try!(serializer.serialize_seq_fixed_size($len));
                 for e in self.iter() {
                     try!(serializer.serialize_seq_elt(&mut state, e));
                 }

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -152,12 +152,11 @@ impl<T> Serialize for [T]
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: Serializer,
     {
-
-        let mut seq_serializer = try!(serializer.serialize_seq(Some(self.len())));
+        try!(serializer.serialize_seq(Some(self.len())));
         for e in self.iter() {
-            try!(seq_serializer.serialize_elt(e));
+            try!(serializer.serialize_seq_elt(e));
         }
-        seq_serializer.drop()
+        serializer.serialize_seq_end()
     }
 }
 
@@ -170,11 +169,11 @@ macro_rules! array_impls {
             fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
                 where S: Serializer,
             {
-                let mut seq_serializer = try!(serializer.serialize_fixed_size_array($len));
+                try!(serializer.serialize_fixed_size_array($len));
                 for e in self.iter() {
-                    try!(seq_serializer.serialize_elt(e));
+                    try!(serializer.serialize_seq_elt(e));
                 }
-                seq_serializer.drop()
+                serializer.serialize_seq_end()
             }
         }
     }
@@ -224,11 +223,11 @@ impl<T> Serialize for BinaryHeap<T>
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: Serializer,
     {
-        let mut seq_serializer = try!(serializer.serialize_seq(Some(self.len())));
+        try!(serializer.serialize_seq(Some(self.len())));
         for e in self.iter() {
-            try!(seq_serializer.serialize_elt(e));
+            try!(serializer.serialize_seq_elt(e));
         }
-        seq_serializer.drop()
+        serializer.serialize_seq_end()
     }
 }
 
@@ -240,11 +239,11 @@ impl<T> Serialize for BTreeSet<T>
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: Serializer,
     {
-        let mut seq_serializer = try!(serializer.serialize_seq(Some(self.len())));
+        try!(serializer.serialize_seq(Some(self.len())));
         for e in self.iter() {
-            try!(seq_serializer.serialize_elt(e));
+            try!(serializer.serialize_seq_elt(e));
         }
-        seq_serializer.drop()
+        serializer.serialize_seq_end()
     }
 }
 
@@ -256,11 +255,11 @@ impl<T> Serialize for EnumSet<T>
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: Serializer,
     {
-        let mut seq_serializer = try!(serializer.serialize_seq(Some(self.len())));
+        try!(serializer.serialize_seq(Some(self.len())));
         for e in self.iter() {
-            try!(seq_serializer.serialize_elt(e));
+            try!(serializer.serialize_seq_elt(e));
         }
-        seq_serializer.drop()
+        serializer.serialize_seq_end()
     }
 }
 
@@ -273,11 +272,11 @@ impl<T, H> Serialize for HashSet<T, H>
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: Serializer,
     {
-        let mut seq_serializer = try!(serializer.serialize_seq(Some(self.len())));
+        try!(serializer.serialize_seq(Some(self.len())));
         for e in self.iter() {
-            try!(seq_serializer.serialize_elt(e));
+            try!(serializer.serialize_seq_elt(e));
         }
-        seq_serializer.drop()
+        serializer.serialize_seq_end()
     }
 }
 
@@ -289,11 +288,11 @@ impl<T> Serialize for LinkedList<T>
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: Serializer,
     {
-        let mut seq_serializer = try!(serializer.serialize_seq(Some(self.len())));
+        try!(serializer.serialize_seq(Some(self.len())));
         for e in self.iter() {
-            try!(seq_serializer.serialize_elt(e));
+            try!(serializer.serialize_seq_elt(e));
         }
-        seq_serializer.drop()
+        serializer.serialize_seq_end()
     }
 }
 
@@ -330,11 +329,11 @@ impl<T> Serialize for VecDeque<T> where T: Serialize {
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: Serializer,
     {
-        let mut seq_serializer = try!(serializer.serialize_seq(Some(self.len())));
+        try!(serializer.serialize_seq(Some(self.len())));
         for e in self.iter() {
-            try!(seq_serializer.serialize_elt(e));
+            try!(serializer.serialize_seq_elt(e));
         }
-        seq_serializer.drop()
+        serializer.serialize_seq_end()
     }
 }
 
@@ -370,11 +369,11 @@ macro_rules! tuple_impls {
                 fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
                     where S: Serializer,
                 {
-                    let mut ser = try!(serializer.serialize_tuple($len));
+                    try!(serializer.serialize_tuple($len));
                     $(
-                        try!(ser.serialize_elt(&e!(self.$idx)));
+                        try!(serializer.serialize_tuple_elt(&e!(self.$idx)));
                     )+
-                    ser.drop()
+                    serializer.serialize_tuple_end()
                 }
             }
         )+
@@ -563,11 +562,11 @@ impl<K, V> Serialize for BTreeMap<K, V>
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: Serializer,
     {
-        let mut map_serializer = try!(serializer.serialize_map(Some(self.len())));
+        try!(serializer.serialize_map(Some(self.len())));
         for (k, v) in self.iter() {
-            try!(map_serializer.serialize_elt(k, v));
+            try!(serializer.serialize_map_elt(k, v));
         }
-        map_serializer.drop()
+        serializer.serialize_map_end()
     }
 }
 
@@ -581,11 +580,11 @@ impl<K, V, H> Serialize for HashMap<K, V, H>
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: Serializer,
     {
-        let mut map_serializer = try!(serializer.serialize_map(Some(self.len())));
+        try!(serializer.serialize_map(Some(self.len())));
         for (k, v) in self.iter() {
-            try!(map_serializer.serialize_elt(k, v));
+            try!(serializer.serialize_map_elt(k, v));
         }
-        map_serializer.drop()
+        serializer.serialize_map_end()
     }
 }
 

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -152,11 +152,11 @@ impl<T> Serialize for [T]
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: Serializer,
     {
-        try!(serializer.serialize_seq(Some(self.len())));
+        let state = try!(serializer.serialize_seq(Some(self.len())));
         for e in self.iter() {
             try!(serializer.serialize_seq_elt(e));
         }
-        serializer.serialize_seq_end(Some(self.len()))
+        serializer.serialize_seq_end(Some(self.len()), state)
     }
 }
 
@@ -169,11 +169,11 @@ macro_rules! array_impls {
             fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
                 where S: Serializer,
             {
-                try!(serializer.serialize_fixed_size_array($len));
+                let state = try!(serializer.serialize_fixed_size_array($len));
                 for e in self.iter() {
                     try!(serializer.serialize_seq_elt(e));
                 }
-                serializer.serialize_seq_end(Some(self.len()))
+                serializer.serialize_seq_end(Some(self.len()), state)
             }
         }
     }
@@ -223,11 +223,11 @@ impl<T> Serialize for BinaryHeap<T>
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: Serializer,
     {
-        try!(serializer.serialize_seq(Some(self.len())));
+        let state = try!(serializer.serialize_seq(Some(self.len())));
         for e in self.iter() {
             try!(serializer.serialize_seq_elt(e));
         }
-        serializer.serialize_seq_end(Some(self.len()))
+        serializer.serialize_seq_end(Some(self.len()), state)
     }
 }
 
@@ -239,11 +239,11 @@ impl<T> Serialize for BTreeSet<T>
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: Serializer,
     {
-        try!(serializer.serialize_seq(Some(self.len())));
+        let state = try!(serializer.serialize_seq(Some(self.len())));
         for e in self.iter() {
             try!(serializer.serialize_seq_elt(e));
         }
-        serializer.serialize_seq_end(Some(self.len()))
+        serializer.serialize_seq_end(Some(self.len()), state)
     }
 }
 
@@ -272,11 +272,11 @@ impl<T, H> Serialize for HashSet<T, H>
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: Serializer,
     {
-        try!(serializer.serialize_seq(Some(self.len())));
+        let state = try!(serializer.serialize_seq(Some(self.len())));
         for e in self.iter() {
             try!(serializer.serialize_seq_elt(e));
         }
-        serializer.serialize_seq_end(Some(self.len()))
+        serializer.serialize_seq_end(Some(self.len()), state)
     }
 }
 
@@ -288,11 +288,11 @@ impl<T> Serialize for LinkedList<T>
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: Serializer,
     {
-        try!(serializer.serialize_seq(Some(self.len())));
+        let state = try!(serializer.serialize_seq(Some(self.len())));
         for e in self.iter() {
             try!(serializer.serialize_seq_elt(e));
         }
-        serializer.serialize_seq_end(Some(self.len()))
+        serializer.serialize_seq_end(Some(self.len()), state)
     }
 }
 
@@ -329,11 +329,11 @@ impl<T> Serialize for VecDeque<T> where T: Serialize {
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: Serializer,
     {
-        try!(serializer.serialize_seq(Some(self.len())));
+        let state = try!(serializer.serialize_seq(Some(self.len())));
         for e in self.iter() {
             try!(serializer.serialize_seq_elt(e));
         }
-        serializer.serialize_seq_end(Some(self.len()))
+        serializer.serialize_seq_end(Some(self.len()), state)
     }
 }
 
@@ -369,11 +369,11 @@ macro_rules! tuple_impls {
                 fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
                     where S: Serializer,
                 {
-                    try!(serializer.serialize_tuple($len));
+                    let state = try!(serializer.serialize_tuple($len));
                     $(
                         try!(serializer.serialize_tuple_elt(&e!(self.$idx)));
                     )+
-                    serializer.serialize_tuple_end($len)
+                    serializer.serialize_tuple_end($len, state)
                 }
             }
         )+
@@ -562,11 +562,11 @@ impl<K, V> Serialize for BTreeMap<K, V>
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: Serializer,
     {
-        try!(serializer.serialize_map(Some(self.len())));
+        let state = try!(serializer.serialize_map(Some(self.len())));
         for (k, v) in self.iter() {
             try!(serializer.serialize_map_elt(k, v));
         }
-        serializer.serialize_map_end(Some(self.len()))
+        serializer.serialize_map_end(Some(self.len()), state)
     }
 }
 
@@ -580,11 +580,11 @@ impl<K, V, H> Serialize for HashMap<K, V, H>
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: Serializer,
     {
-        try!(serializer.serialize_map(Some(self.len())));
+        let state = try!(serializer.serialize_map(Some(self.len())));
         for (k, v) in self.iter() {
             try!(serializer.serialize_map_elt(k, v));
         }
-        serializer.serialize_map_end(Some(self.len()))
+        serializer.serialize_map_end(Some(self.len()), state)
     }
 }
 

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -306,11 +306,11 @@ impl<A> Serialize for ops::Range<A>
         where S: Serializer,
     {
         let len = iter::Step::steps_between(&self.start, &self.end, &A::one());
-        let state = try!(serializer.serialize_seq(Some(len)));
-        for e in self.iter() {
+        let state = try!(serializer.serialize_seq(len));
+        for e in self.clone() {
             try!(serializer.serialize_seq_elt(e));
         }
-        serializer.serialize_seq_end(Some(len), state);
+        serializer.serialize_seq_end(len, state);
     }
 }
 

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -305,11 +305,12 @@ impl<A> Serialize for ops::Range<A>
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: Serializer,
     {
-        let mut seq_serializer = try!(serializer.serialize_seq(Some(self.len())));
+        let len = iter::Step::steps_between(&self.start, &self.end, &A::one());
+        let state = try!(serializer.serialize_seq(Some(len)));
         for e in self.iter() {
-            try!(seq_serializer.serialize_elt(e));
+            try!(serializer.serialize_seq_elt(e));
         }
-        seq_serializer.drop()
+        serializer.serialize_seq_end(Some(len), state);
     }
 }
 

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -260,6 +260,7 @@ impl<T> Serialize for EnumSet<T>
         for e in self.iter() {
             try!(seq_serializer.serialize_elt(e));
         }
+        seq_serializer.drop()
     }
 }
 

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -304,7 +304,7 @@ impl<A> Serialize for ops::Range<A>
 {
     #[inline]
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
-        where S: Serialize,
+        where S: Serializer,
     {
         let mut seq_serializer = try!(serializer.serialize_seq(Some(self.len())));
         for e in self.iter() {

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -44,9 +44,14 @@ pub trait MapSerializer : Sized {
     type Error: Error;
 
     /// Serializes an element of a map (key-value pair).
-    fn serialize_elt<K, V>(&mut self, key: K, value: V) -> Result<(), Self::Error>
+    fn serialize_elt<S: ?Sized, K, V>(&mut self, serializer: &mut S, key: K, value: V) -> Result<(), Self::Error>
         where K: Serialize,
-              V: Serialize;
+              V: Serialize,
+              S: Serializer<Error = Self::Error>;
+
+    /// Finish serializing the map
+    fn drop<S: ?Sized>(self, serializer: &mut S) -> Result<(), Self::Error>
+        where S: Serializer<Error = Self::Error>;
 }
 
 /// A trait that described a type that can serialize elements of a Sequence
@@ -55,8 +60,58 @@ pub trait SeqSerializer : Sized {
     type Error: Error;
 
     /// Serializes an element of a sequence.
-    fn serialize_elt<T>(&mut self, value: T) -> Result<(), Self::Error>
-        where T: Serialize;
+    fn serialize_elt<S: ?Sized, T>(&mut self, serializer: &mut S, value: T) -> Result<(), Self::Error>
+        where T: Serialize,
+              S: Serializer<Error = Self::Error>;
+
+    /// Finish serializing the map
+    fn drop<S: ?Sized>(self, serializer: &mut S) -> Result<(), Self::Error>
+        where S: Serializer<Error = Self::Error>;
+}
+
+/// A helper type for serializing maps. This is a workaround for HKL associated types
+pub struct MapHelper<'a, S: Serializer + 'a + ?Sized>(&'a mut S, S::MapSerializer);
+
+impl<'a, S: Serializer + 'a + ?Sized> MapHelper<'a, S> {
+    /// Create a new MapHelper
+    pub fn new(s: &'a mut S, ms: S::MapSerializer) -> Self {
+        MapHelper(s, ms)
+    }
+}
+
+impl<'a, S: Serializer + ?Sized> MapHelper<'a, S> {
+    /// Serializes an element of a map (key-value pair).
+    pub fn serialize_elt<K, V>(&mut self, key: K, value: V) -> Result<(), S::Error>
+        where K: Serialize,
+              V: Serialize {
+        self.1.serialize_elt(self.0, key, value)
+    }
+    /// Closes the sequence
+    pub fn drop(self) -> Result<(), S::Error> {
+        self.1.drop(self.0)
+    }
+}
+
+/// A helper type for serializing sequences. This is a workaround for HKL associated types
+pub struct SeqHelper<'a, S: Serializer + 'a + ?Sized>(&'a mut S, S::SeqSerializer);
+
+impl<'a, S: Serializer + 'a + ?Sized> SeqHelper<'a, S> {
+    /// Create a new SeqHelper
+    pub fn new(s: &'a mut S, ms: S::SeqSerializer) -> Self {
+        SeqHelper(s, ms)
+    }
+}
+
+impl<'a, S: Serializer + ?Sized> SeqHelper<'a, S> {
+    /// Serializes an element of a sequence.
+    pub fn serialize_elt<V>(&mut self, value: V) -> Result<(), S::Error>
+        where V: Serialize {
+        self.1.serialize_elt(self.0, value)
+    }
+    /// Closes the sequence
+    pub fn drop(self) -> Result<(), S::Error> {
+        self.1.drop(self.0)
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -162,11 +217,11 @@ pub trait Serializer {
     /// byte slices separately from generic arrays. By default it serializes as a regular array.
     #[inline]
     fn serialize_bytes(&mut self, value: &[u8]) -> Result<(), Self::Error> {
-        let mut seq_serializer = try!(self.serialize_seq());
+        let mut seq_serializer = try!(self.serialize_seq(Some(value.len())));
         for b in value.iter() {
             try!(seq_serializer.serialize_elt(b));
         }
-        Ok(())
+        seq_serializer.drop()
     }
 
     /// Serializes a `()` value.
@@ -200,7 +255,9 @@ pub trait Serializer {
                                    value: T) -> Result<(), Self::Error>
         where T: Serialize,
     {
-        self.serialize_tuple_struct(name).and_then(|mut s| s.serialize_elt(Some(value)))
+        let mut ser = try!(self.serialize_tuple_struct(name, 1));
+        try!(ser.serialize_elt((value,)));
+        ser.drop()
     }
 
     /// Allows a variant with a single item to be more efficiently
@@ -214,10 +271,9 @@ pub trait Serializer {
                                     value: T) -> Result<(), Self::Error>
         where T: Serialize,
     {
-        self.serialize_tuple_variant(
-            name,
-            variant_index,
-            variant).and_then(|mut s| s.serialize_elt(Some(value)))
+        let mut ser = try!(self.serialize_tuple_variant(name, variant_index, variant, 1));
+        try!(ser.serialize_elt((value,)));
+        ser.drop()
     }
 
     /// Serializes a `None` value..serialize
@@ -231,15 +287,22 @@ pub trait Serializer {
     ///
     /// Callees of this method need to construct a `SeqVisitor`, which iterates through each item
     /// in the sequence.
-    fn serialize_seq(&mut self) -> Result<Self::SeqSerializer, Self::Error>;
+    fn serialize_seq<'a>(&'a mut self, len: Option<usize>) -> Result<SeqHelper<'a, Self>, Self::Error>;
+
+    /// Serializes a sequence element.
+    fn serialize_seq_elt<T>(&mut self, value: T) -> Result<(), Self::Error>
+        where T: Serialize;
+
+    /// Finish serializing a sequence.
+    fn serialize_seq_end(&mut self) -> Result<(), Self::Error>;
 
     /// Serializes a tuple.
     ///
     /// By default this serializes a tuple as a sequence.
     #[inline]
-    fn serialize_tuple(&mut self) -> Result<Self::SeqSerializer, Self::Error>
+    fn serialize_tuple<'a>(&'a mut self, len: usize) -> Result<SeqHelper<'a, Self>, Self::Error>
     {
-        self.serialize_seq()
+        self.serialize_seq(Some(len))
     }
 
     /// Serializes a tuple element.
@@ -247,32 +310,37 @@ pub trait Serializer {
     /// By default, tuples are serialized as a sequence.
     #[inline]
     fn serialize_tuple_elt<T>(&mut self, value: T) -> Result<(), Self::Error>
-        where T: Serialize
-    {
-        self.serialize_seq().and_then(|mut s| s.serialize_elt(value))
+        where T: Serialize {
+        self.serialize_seq_elt(value)
     }
 
-    /*
-      TODO: Fixed-sized visitor would kind of make sense here
+    /// Finishes serialization of a tuple.
+    ///
+    /// By default, tuples are serialized as a sequence.
+    #[inline]
+    fn serialize_tuple_end(&mut self) -> Result<(), Self::Error> {
+        self.serialize_seq_end()
+    }
+
     /// Serializes a fixed-size array.
     ///
     /// By default this serializes an array as a sequence.
     #[inline]
-    fn serialize_fixed_size_array(&mut self, visitor: V) -> Result<(), Self::Error>
+    fn serialize_fixed_size_array<'a>(&'a mut self, size: usize) -> Result<SeqHelper<'a, Self>, Self::Error>
     {
-        self.serialize_seq(visitor)
+        self.serialize_seq(Some(size))
     }
-    */
 
     /// Serializes a tuple struct.
     ///
     /// By default, tuple structs are serialized as a tuple.
     #[inline]
-    fn serialize_tuple_struct(&mut self,
+    fn serialize_tuple_struct<'a>(&'a mut self,
                                  _name: &'static str,
-                                 ) -> Result<Self::SeqSerializer, Self::Error>
+                                 len: usize,
+                                 ) -> Result<SeqHelper<'a, Self>, Self::Error>
     {
-        self.serialize_tuple()
+        self.serialize_tuple(len)
     }
 
     /// Serializes a tuple struct element.
@@ -285,53 +353,106 @@ pub trait Serializer {
         self.serialize_tuple_elt(value)
     }
 
+    /// Finishes serialization of a tuple struct.
+    ///
+    /// By default, tuple structs are serialized as a sequence.
+    #[inline]
+    fn serialize_tuple_struct_end(&mut self) -> Result<(), Self::Error> {
+        self.serialize_tuple_end()
+    }
+
     /// Serializes a tuple variant.
     ///
     /// By default, tuple variants are serialized as a tuple struct.
     #[inline]
-    fn serialize_tuple_variant(&mut self,
+    fn serialize_tuple_variant<'a>(&'a mut self,
                                   _name: &'static str,
                                   _variant_index: usize,
                                   variant: &'static str,
-                                  ) -> Result<Self::SeqSerializer, Self::Error>
+                                  len: usize,
+                                  ) -> Result<SeqHelper<'a, Self>, Self::Error>
     {
-        self.serialize_tuple_struct(variant)
+        self.serialize_tuple_struct(variant, len)
     }
 
-    /// Serializes a tuple element.
+    /// Serializes a tuple variant element.
     ///
-    /// By default, tuples are serialized as a sequence.
+    /// By default, tuple variants are serialized as tuples.
     #[inline]
     fn serialize_tuple_variant_elt<T>(&mut self, value: T) -> Result<(), Self::Error>
         where T: Serialize
     {
-        self.serialize_tuple_struct_elt(value)
+        self.serialize_tuple_elt(value)
+    }
+
+    /// Finishes serialization of a tuple variant.
+    ///
+    /// By default, tuple variants are serialized as tuples.
+    #[inline]
+    fn serialize_tuple_variant_end(&mut self) -> Result<(), Self::Error> {
+        self.serialize_tuple_end()
     }
 
     /// Serialize a map.
-    fn serialize_map(&mut self) -> Result<Self::MapSerializer, Self::Error>;
+    fn serialize_map<'a>(&'a mut self, len: Option<usize>) -> Result<MapHelper<'a, Self>, Self::Error>;
+
+    /// Serialize a map element
+    fn serialize_map_elt<'a, K, V>(&'a mut self, key: K, value: V) -> Result<(), Self::Error> where K: Serialize, V: Serialize;
+
+    /// Finishes serializing a map
+    fn serialize_map_end<'a>(&'a mut self) -> Result<(), Self::Error>;
 
     /// Serializes a struct.
     ///
     /// By default, structs are serialized as a map with the field name as the key.
     #[inline]
-    fn serialize_struct(&mut self,
+    fn serialize_struct<'a>(&'a mut self,
                            _name: &'static str,
-                           ) -> Result<Self::MapSerializer, Self::Error>
+                           len: usize,
+                           ) -> Result<MapHelper<'a, Self>, Self::Error>
     {
-        self.serialize_map()
+        self.serialize_map(Some(len))
+    }
+
+    /// Serialize a struct field
+    ///
+    /// By default, structs are serialized as a map with the field name as the key.
+    fn serialize_struct_elt<'a, K, V>(&'a mut self, key: K, value: V) -> Result<(), Self::Error> where K: Serialize, V: Serialize {
+        self.serialize_map_elt(key, value)
+    }
+
+    /// Finishes serializing a struct
+    ///
+    /// By default, structs are serialized as a map with the field name as the key.
+    fn serialize_struct_end<'a>(&'a mut self) -> Result<(), Self::Error> {
+        self.serialize_map_end()
     }
 
     /// Serializes a struct variant.
     ///
     /// By default, struct variants are serialized as a struct.
     #[inline]
-    fn serialize_struct_variant(&mut self,
+    fn serialize_struct_variant<'a>(&'a mut self,
                                    _name: &'static str,
                                    _variant_index: usize,
-                                   variant: &'static str
-                                   ) -> Result<Self::MapSerializer, Self::Error>
+                                   variant: &'static str,
+                                   len: usize,
+                                   ) -> Result<MapHelper<'a, Self>, Self::Error>
     {
-        self.serialize_struct(variant)
+        self.serialize_struct(variant, len)
+    }
+
+    /// Serialize a struct variant element
+    ///
+    /// By default, structs are serialized as a map with the field name as the key.
+    fn serialize_struct_variant_elt<'a, K, V>(&'a mut self, key: K, value: V) -> Result<(), Self::Error> where K: Serialize, V: Serialize {
+        self.serialize_struct_elt(key, value)
+    }
+
+    /// Finishes serializing a struct variant
+    ///
+    /// By default, structs are serialized as a map with the field name as the key.
+    fn serialize_struct_variant_end<'a>(&'a mut self) -> Result<(), Self::Error> {
+        self.serialize_struct_end()
     }
 }

--- a/serde_codegen/src/ser.rs
+++ b/serde_codegen/src/ser.rs
@@ -538,7 +538,7 @@ fn serialize_tuple_struct_visitor(
             let mut field_expr = if is_enum {
                 builder.expr().path().id(format!("__field{}", i)).build()
             } else {
-                builder.expr().tup_field(i).ref_().self_()
+                builder.expr().ref_().tup_field(i).self_()
             };
 
             let skip = field.attrs.skip_serializing_if()

--- a/serde_codegen/src/ser.rs
+++ b/serde_codegen/src/ser.rs
@@ -230,9 +230,9 @@ fn serialize_tuple_struct(
     let len = serialize_stmts.len();
 
     quote_expr!(cx, {
-        try!(_serializer.serialize_tuple_struct($type_name, $len));
+        let state = try!(_serializer.serialize_tuple_struct($type_name, $len));
         $serialize_stmts
-        _serializer.serialize_tuple_struct_end($type_name, $len)
+        _serializer.serialize_tuple_struct_end($type_name, $len, state)
     })
 }
 
@@ -270,9 +270,9 @@ fn serialize_struct(
 
     quote_expr!(cx, {
         let len = $len;
-        try!(_serializer.serialize_struct($type_name, len));
+        let state = try!(_serializer.serialize_struct($type_name, len));
         $serialize_fields
-        _serializer.serialize_struct_end($type_name, len)
+        _serializer.serialize_struct_end($type_name, len, state)
     })
 }
 
@@ -464,9 +464,9 @@ fn serialize_tuple_variant(
     let len = serialize_stmts.len();
 
     quote_expr!(cx, {
-        try!(_serializer.serialize_tuple_variant($type_name, $variant_index, $variant_name, $len));
+        let state = try!(_serializer.serialize_tuple_variant($type_name, $variant_index, $variant_name, $len));
         $serialize_stmts
-        _serializer.serialize_tuple_variant_end($type_name, $variant_index, $variant_name, $len)
+        _serializer.serialize_tuple_variant_end($type_name, $variant_index, $variant_name, $len, state)
     })
 }
 
@@ -507,7 +507,7 @@ fn serialize_struct_variant(
 
     quote_expr!(cx, {
         let len = $len;
-        try!(_serializer.serialize_struct_variant(
+        let state = try!(_serializer.serialize_struct_variant(
             $item_name,
             $variant_index,
             $variant_name,
@@ -519,6 +519,7 @@ fn serialize_struct_variant(
             $variant_index,
             $variant_name,
             len,
+            state,
         )
     })
 }

--- a/serde_codegen/src/ser.rs
+++ b/serde_codegen/src/ser.rs
@@ -232,7 +232,7 @@ fn serialize_tuple_struct(
     quote_expr!(cx, {
         try!(_serializer.serialize_tuple_struct($type_name, $len));
         $serialize_stmts
-        _serializer.serialize_tuple_struct_end()
+        _serializer.serialize_tuple_struct_end($type_name, $len)
     })
 }
 
@@ -269,9 +269,10 @@ fn serialize_struct(
         .fold(quote_expr!(cx, 0), |sum, expr| quote_expr!(cx, $sum + $expr));
 
     quote_expr!(cx, {
-        try!(_serializer.serialize_struct($type_name, $len));
+        let len = $len;
+        try!(_serializer.serialize_struct($type_name, len));
         $serialize_fields
-        _serializer.serialize_struct_end()
+        _serializer.serialize_struct_end($type_name, len)
     })
 }
 
@@ -465,7 +466,7 @@ fn serialize_tuple_variant(
     quote_expr!(cx, {
         try!(_serializer.serialize_tuple_variant($type_name, $variant_index, $variant_name, $len));
         $serialize_stmts
-        _serializer.serialize_tuple_variant_end()
+        _serializer.serialize_tuple_variant_end($type_name, $variant_index, $variant_name, $len)
     })
 }
 
@@ -505,14 +506,20 @@ fn serialize_struct_variant(
         .fold(quote_expr!(cx, 0), |sum, expr| quote_expr!(cx, $sum + $expr));
 
     quote_expr!(cx, {
+        let len = $len;
         try!(_serializer.serialize_struct_variant(
             $item_name,
             $variant_index,
             $variant_name,
-            $len,
+            len,
         ));
         $serialize_fields
-        _serializer.serialize_struct_variant_end()
+        _serializer.serialize_struct_variant_end(
+            $item_name,
+            $variant_index,
+            $variant_name,
+            len,
+        )
     })
 }
 

--- a/serde_test/src/de.rs
+++ b/serde_test/src/de.rs
@@ -135,14 +135,17 @@ impl<I> de::Deserializer for Deserializer<I>
             Some(Token::Option(true)) => visitor.visit_some(self),
             Some(Token::Unit) => visitor.visit_unit(),
             Some(Token::UnitStruct(name)) => visitor.visit_unit_struct(name),
-            Some(Token::SeqStart(len)) | Some(Token::TupleStructStart(_, len)) => {
+            Some(Token::SeqStart(len)) => {
                 self.visit_seq(len, visitor)
             }
-            Some(Token::SeqArrayStart(len)) => {
+            Some(Token::SeqArrayStart(len))| Some(Token::TupleStructStart(_, len)) => {
                 self.visit_seq(Some(len), visitor)
             }
-            Some(Token::MapStart(len)) | Some(Token::StructStart(_, len)) => {
+            Some(Token::MapStart(len)) => {
                 self.visit_map(len, visitor)
+            }
+            Some(Token::StructStart(_, len)) => {
+                self.visit_map(Some(len), visitor)
             }
             Some(token) => Err(Error::UnexpectedToken(token)),
             None => Err(Error::EndOfStream),
@@ -745,7 +748,7 @@ impl<'a, I> VariantVisitor for DeserializerVariantVisitor<'a, I>
         where V: Visitor,
     {
         match self.de.tokens.peek() {
-            Some(&Token::EnumSeqStart(_, _, Some(enum_len))) => {
+            Some(&Token::EnumSeqStart(_, _, enum_len)) => {
                 let token = self.de.tokens.next().unwrap();
 
                 if len == enum_len {
@@ -776,7 +779,7 @@ impl<'a, I> VariantVisitor for DeserializerVariantVisitor<'a, I>
         where V: Visitor,
     {
         match self.de.tokens.peek() {
-            Some(&Token::EnumMapStart(_, _, Some(enum_len))) => {
+            Some(&Token::EnumMapStart(_, _, enum_len)) => {
                 let token = self.de.tokens.next().unwrap();
 
                 if fields.len() == enum_len {

--- a/serde_test/src/ser.rs
+++ b/serde_test/src/ser.rs
@@ -34,6 +34,8 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
     where I: Iterator<Item=&'a Token<'a>>,
 {
     type Error = Error;
+    type MapState = ();
+    type SeqState = ();
 
     fn serialize_unit(&mut self) -> Result<(), Error> {
         assert_eq!(self.tokens.next(), Some(&Token::Unit));
@@ -165,7 +167,7 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
         value.serialize(self)
     }
 
-    fn serialize_seq_end(&mut self, _len: Option<usize>) -> Result<(), Error> {
+    fn serialize_seq_end(&mut self, _len: Option<usize>, _: ()) -> Result<(), Error> {
         assert_eq!(self.tokens.next(), Some(&Token::SeqEnd));
         Ok(())
     }
@@ -189,7 +191,7 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
         value.serialize(self)
     }
 
-    fn serialize_tuple_end(&mut self, _len: usize) -> Result<(), Error> {
+    fn serialize_tuple_end(&mut self, _len: usize, _: ()) -> Result<(), Error> {
         assert_eq!(self.tokens.next(), Some(&Token::TupleEnd));
         Ok(())
     }
@@ -217,7 +219,7 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
         value.serialize(self)
     }
 
-    fn serialize_tuple_struct_end(&mut self, _name: &str, _len: usize) -> Result<(), Error> {
+    fn serialize_tuple_struct_end(&mut self, _name: &str, _len: usize, _: ()) -> Result<(), Error> {
         assert_eq!(self.tokens.next(), Some(&Token::TupleStructEnd));
         Ok(())
     }
@@ -244,7 +246,7 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
                                _name: &str,
                                _variant_index: usize,
                                _variant: &str,
-                               _len: usize) -> Result<(), Error> {
+                               _len: usize, _: ()) -> Result<(), Error> {
         assert_eq!(self.tokens.next(), Some(&Token::EnumSeqEnd));
         Ok(())
     }
@@ -262,7 +264,7 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
         value.serialize(self)
     }
 
-    fn serialize_map_end(&mut self, _len: Option<usize>) -> Result<(), Self::Error> {
+    fn serialize_map_end(&mut self, _len: Option<usize>, _: ()) -> Result<(), Self::Error> {
         assert_eq!(self.tokens.next(), Some(&Token::MapEnd));
         Ok(())
     }
@@ -280,7 +282,7 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
         value.serialize(self)
     }
 
-    fn serialize_struct_end(&mut self, _name: &str, _len: usize) -> Result<(), Self::Error> {
+    fn serialize_struct_end(&mut self, _name: &str, _len: usize, _: ()) -> Result<(), Self::Error> {
         assert_eq!(self.tokens.next(), Some(&Token::StructEnd));
         Ok(())
     }
@@ -306,7 +308,7 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
                                 _name: &str,
                                 _variant_index: usize,
                                 _variant: &str,
-                                _len: usize) -> Result<(), Self::Error> {
+                                _len: usize, _: ()) -> Result<(), Self::Error> {
         assert_eq!(self.tokens.next(), Some(&Token::EnumMapEnd));
         Ok(())
     }

--- a/serde_test/src/ser.rs
+++ b/serde_test/src/ser.rs
@@ -165,7 +165,7 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
         value.serialize(self)
     }
 
-    fn serialize_seq_end(&mut self) -> Result<(), Error> {
+    fn serialize_seq_end(&mut self, _len: Option<usize>) -> Result<(), Error> {
         assert_eq!(self.tokens.next(), Some(&Token::SeqEnd));
         Ok(())
     }
@@ -189,7 +189,7 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
         value.serialize(self)
     }
 
-    fn serialize_tuple_end(&mut self) -> Result<(), Error> {
+    fn serialize_tuple_end(&mut self, _len: usize) -> Result<(), Error> {
         assert_eq!(self.tokens.next(), Some(&Token::TupleEnd));
         Ok(())
     }
@@ -217,12 +217,12 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
         value.serialize(self)
     }
 
-    fn serialize_tuple_struct_end(&mut self) -> Result<(), Error> {
+    fn serialize_tuple_struct_end(&mut self, _name: &str, _len: usize) -> Result<(), Error> {
         assert_eq!(self.tokens.next(), Some(&Token::TupleStructEnd));
         Ok(())
     }
 
-    fn serialize_tuple_variant<'b>(&'b mut self,
+    fn serialize_tuple_variant(&mut self,
                                name: &str,
                                _variant_index: usize,
                                variant: &str,
@@ -240,12 +240,16 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
         value.serialize(self)
     }
 
-    fn serialize_tuple_variant_end(&mut self) -> Result<(), Error> {
+    fn serialize_tuple_variant_end(&mut self,
+                               _name: &str,
+                               _variant_index: usize,
+                               _variant: &str,
+                               _len: usize) -> Result<(), Error> {
         assert_eq!(self.tokens.next(), Some(&Token::EnumSeqEnd));
         Ok(())
     }
 
-    fn serialize_map<'b>(&'b mut self, len: Option<usize>) -> Result<(), Error>
+    fn serialize_map(&mut self, len: Option<usize>) -> Result<(), Error>
     {
         assert_eq!(self.tokens.next(), Some(&Token::MapStart(len)));
 
@@ -258,12 +262,12 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
         value.serialize(self)
     }
 
-    fn serialize_map_end(&mut self) -> Result<(), Self::Error> {
+    fn serialize_map_end(&mut self, _len: Option<usize>) -> Result<(), Self::Error> {
         assert_eq!(self.tokens.next(), Some(&Token::MapEnd));
         Ok(())
     }
 
-    fn serialize_struct<'b>(&'b mut self, name: &str, len: usize) -> Result<(), Error>
+    fn serialize_struct(&mut self, name: &str, len: usize) -> Result<(), Error>
     {
         assert_eq!(self.tokens.next(), Some(&Token::StructStart(name, len)));
 
@@ -276,7 +280,7 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
         value.serialize(self)
     }
 
-    fn serialize_struct_end(&mut self) -> Result<(), Self::Error> {
+    fn serialize_struct_end(&mut self, _name: &str, _len: usize) -> Result<(), Self::Error> {
         assert_eq!(self.tokens.next(), Some(&Token::StructEnd));
         Ok(())
     }
@@ -298,7 +302,11 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
         value.serialize(self)
     }
 
-    fn serialize_struct_variant_end(&mut self) -> Result<(), Self::Error> {
+    fn serialize_struct_variant_end(&mut self,
+                                _name: &str,
+                                _variant_index: usize,
+                                _variant: &str,
+                                _len: usize) -> Result<(), Self::Error> {
         assert_eq!(self.tokens.next(), Some(&Token::EnumMapEnd));
         Ok(())
     }

--- a/serde_test/src/ser.rs
+++ b/serde_test/src/ser.rs
@@ -36,6 +36,11 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
     type Error = Error;
     type MapState = ();
     type SeqState = ();
+    type TupleState = ();
+    type TupleStructState = ();
+    type TupleVariantState = ();
+    type StructState = ();
+    type StructVariantState = ();
 
     fn serialize_unit(&mut self) -> Result<(), Error> {
         assert_eq!(self.tokens.next(), Some(&Token::Unit));
@@ -160,38 +165,38 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
         Ok(())
     }
 
-    fn serialize_seq_elt<T>(&mut self, value: T) -> Result<(), Error>
+    fn serialize_seq_elt<T>(&mut self, _: &mut (), value: T) -> Result<(), Error>
         where T: Serialize
     {
         assert_eq!(self.tokens.next(), Some(&Token::SeqSep));
         value.serialize(self)
     }
 
-    fn serialize_seq_end(&mut self, _len: Option<usize>, _: ()) -> Result<(), Error> {
+    fn serialize_seq_end(&mut self, _: ()) -> Result<(), Error> {
         assert_eq!(self.tokens.next(), Some(&Token::SeqEnd));
         Ok(())
     }
 
-    fn serialize_fixed_size_array<'b>(&'b mut self, len: usize) -> Result<(), Error>
+    fn serialize_seq_fixed_size(&mut self, len: usize) -> Result<(), Error>
     {
         assert_eq!(self.tokens.next(), Some(&Token::SeqArrayStart(len)));
         Ok(())
     }
 
-    fn serialize_tuple<'b>(&'b mut self, len: usize) -> Result<(), Error>
+    fn serialize_tuple(&mut self, len: usize) -> Result<(), Error>
     {
         assert_eq!(self.tokens.next(), Some(&Token::TupleStart(len)));
         Ok(())
     }
 
-    fn serialize_tuple_elt<T>(&mut self, value: T) -> Result<(), Error>
+    fn serialize_tuple_elt<T>(&mut self, _: &mut (), value: T) -> Result<(), Error>
         where T: Serialize
     {
         assert_eq!(self.tokens.next(), Some(&Token::TupleSep));
         value.serialize(self)
     }
 
-    fn serialize_tuple_end(&mut self, _len: usize, _: ()) -> Result<(), Error> {
+    fn serialize_tuple_end(&mut self, _: ()) -> Result<(), Error> {
         assert_eq!(self.tokens.next(), Some(&Token::TupleEnd));
         Ok(())
     }
@@ -205,21 +210,21 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
         value.serialize(self)
     }
 
-    fn serialize_tuple_struct<'b>(&'b mut self, name: &str, len: usize) -> Result<(), Error>
+    fn serialize_tuple_struct(&mut self, name: &'static str, len: usize) -> Result<(), Error>
     {
         assert_eq!(self.tokens.next(), Some(&Token::TupleStructStart(name, len)));
 
         Ok(())
     }
 
-    fn serialize_tuple_struct_elt<T>(&mut self, value: T) -> Result<(), Error>
+    fn serialize_tuple_struct_elt<T>(&mut self, _: &mut (), value: T) -> Result<(), Error>
         where T: Serialize
     {
         assert_eq!(self.tokens.next(), Some(&Token::TupleStructSep));
         value.serialize(self)
     }
 
-    fn serialize_tuple_struct_end(&mut self, _name: &str, _len: usize, _: ()) -> Result<(), Error> {
+    fn serialize_tuple_struct_end(&mut self, _: ()) -> Result<(), Error> {
         assert_eq!(self.tokens.next(), Some(&Token::TupleStructEnd));
         Ok(())
     }
@@ -235,18 +240,14 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
         Ok(())
     }
 
-    fn serialize_tuple_variant_elt<T>(&mut self, value: T) -> Result<(), Error>
+    fn serialize_tuple_variant_elt<T>(&mut self, _: &mut (), value: T) -> Result<(), Error>
         where T: Serialize
     {
         assert_eq!(self.tokens.next(), Some(&Token::EnumSeqSep));
         value.serialize(self)
     }
 
-    fn serialize_tuple_variant_end(&mut self,
-                               _name: &str,
-                               _variant_index: usize,
-                               _variant: &str,
-                               _len: usize, _: ()) -> Result<(), Error> {
+    fn serialize_tuple_variant_end(&mut self, _: ()) -> Result<(), Error> {
         assert_eq!(self.tokens.next(), Some(&Token::EnumSeqEnd));
         Ok(())
     }
@@ -258,13 +259,13 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
         Ok(())
     }
 
-    fn serialize_map_elt<K, V>(&mut self, key: K, value: V) -> Result<(), Self::Error> where K: Serialize, V: Serialize {
+    fn serialize_map_elt<K, V>(&mut self, _: &mut (), key: K, value: V) -> Result<(), Self::Error> where K: Serialize, V: Serialize {
         assert_eq!(self.tokens.next(), Some(&Token::MapSep));
         try!(key.serialize(self));
         value.serialize(self)
     }
 
-    fn serialize_map_end(&mut self, _len: Option<usize>, _: ()) -> Result<(), Self::Error> {
+    fn serialize_map_end(&mut self, _: ()) -> Result<(), Self::Error> {
         assert_eq!(self.tokens.next(), Some(&Token::MapEnd));
         Ok(())
     }
@@ -276,18 +277,18 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
         Ok(())
     }
 
-    fn serialize_struct_elt<K, V>(&mut self, key: K, value: V) -> Result<(), Self::Error> where K: Serialize, V: Serialize {
+    fn serialize_struct_elt<V>(&mut self, _: &mut (), key: &'static str, value: V) -> Result<(), Self::Error> where V: Serialize {
         assert_eq!(self.tokens.next(), Some(&Token::StructSep));
         try!(key.serialize(self));
         value.serialize(self)
     }
 
-    fn serialize_struct_end(&mut self, _name: &str, _len: usize, _: ()) -> Result<(), Self::Error> {
+    fn serialize_struct_end(&mut self, _: ()) -> Result<(), Self::Error> {
         assert_eq!(self.tokens.next(), Some(&Token::StructEnd));
         Ok(())
     }
 
-    fn serialize_struct_variant<'b>(&'b mut self,
+    fn serialize_struct_variant(&mut self,
                                 name: &str,
                                 _variant_index: usize,
                                 variant: &str,
@@ -298,18 +299,22 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
         Ok(())
     }
 
-    fn serialize_struct_variant_elt<K, V>(&mut self, key: K, value: V) -> Result<(), Self::Error> where K: Serialize, V: Serialize {
+    fn serialize_struct_variant_elt<V>(&mut self, _: &mut (), key: &'static str, value: V) -> Result<(), Self::Error> where V: Serialize {
         assert_eq!(self.tokens.next(), Some(&Token::EnumMapSep));
         try!(key.serialize(self));
         value.serialize(self)
     }
 
-    fn serialize_struct_variant_end(&mut self,
-                                _name: &str,
-                                _variant_index: usize,
-                                _variant: &str,
-                                _len: usize, _: ()) -> Result<(), Self::Error> {
+    fn serialize_struct_variant_end(&mut self, _: ()) -> Result<(), Self::Error> {
         assert_eq!(self.tokens.next(), Some(&Token::EnumMapEnd));
         Ok(())
+    }
+
+    fn serialize_bytes(&mut self, value: &[u8]) -> Result<(), Self::Error> {
+        let mut state = try!(self.serialize_seq(Some(value.len())));
+        for c in value {
+            try!(self.serialize_seq_elt(&mut state, c));
+        }
+        self.serialize_seq_end(state)
     }
 }

--- a/serde_test/src/token.rs
+++ b/serde_test/src/token.rs
@@ -38,7 +38,7 @@ pub enum Token<'a> {
     TupleSep,
     TupleEnd,
 
-    TupleStructStart(&'a str, Option<usize>),
+    TupleStructStart(&'a str, usize),
     TupleStructSep,
     TupleStructEnd,
 
@@ -46,15 +46,15 @@ pub enum Token<'a> {
     MapSep,
     MapEnd,
 
-    StructStart(&'a str, Option<usize>),
+    StructStart(&'a str, usize),
     StructSep,
     StructEnd,
 
-    EnumSeqStart(&'a str, &'a str, Option<usize>),
+    EnumSeqStart(&'a str, &'a str, usize),
     EnumSeqSep,
     EnumSeqEnd,
 
-    EnumMapStart(&'a str, &'a str, Option<usize>),
+    EnumMapStart(&'a str, &'a str, usize),
     EnumMapSep,
     EnumMapEnd,
 }

--- a/testing/tests/test_annotations.rs
+++ b/testing/tests/test_annotations.rs
@@ -82,7 +82,7 @@ fn test_default_struct() {
     assert_de_tokens(
         &DefaultStruct { a1: 1, a2: 2, a3: 3, a4: 0, a5: 123 },
         &[
-            Token::StructStart("DefaultStruct", Some(3)),
+            Token::StructStart("DefaultStruct", 3),
 
             Token::StructSep,
             Token::Str("a1"),
@@ -111,7 +111,7 @@ fn test_default_struct() {
     assert_de_tokens(
         &DefaultStruct { a1: 1, a2: 0, a3: 123, a4: 0, a5: 123 },
         &[
-            Token::StructStart("DefaultStruct", Some(1)),
+            Token::StructStart("DefaultStruct", 1),
 
             Token::StructSep,
             Token::Str("a1"),
@@ -145,7 +145,7 @@ fn test_default_enum() {
     assert_de_tokens(
         &DefaultEnum::Struct { a1: 1, a2: 2, a3: 3, a4: 0, a5: 123 },
         &[
-            Token::EnumMapStart("DefaultEnum", "Struct", Some(5)),
+            Token::EnumMapStart("DefaultEnum", "Struct", 5),
 
             Token::EnumMapSep,
             Token::Str("a1"),
@@ -174,7 +174,7 @@ fn test_default_enum() {
     assert_de_tokens(
         &DefaultEnum::Struct { a1: 1, a2: 0, a3: 123, a4: 0, a5: 123 },
         &[
-            Token::EnumMapStart("DefaultEnum", "Struct", Some(5)),
+            Token::EnumMapStart("DefaultEnum", "Struct", 5),
 
             Token::EnumMapSep,
             Token::Str("a1"),
@@ -208,7 +208,7 @@ fn test_no_std_default() {
     assert_de_tokens(
         &ContainsNoStdDefault { a: NoStdDefault(123) },
         &[
-            Token::StructStart("ContainsNoStdDefault", Some(1)),
+            Token::StructStart("ContainsNoStdDefault", 1),
             Token::StructEnd,
         ]
     );
@@ -216,7 +216,7 @@ fn test_no_std_default() {
     assert_de_tokens(
         &ContainsNoStdDefault { a: NoStdDefault(8) },
         &[
-            Token::StructStart("ContainsNoStdDefault", Some(1)),
+            Token::StructStart("ContainsNoStdDefault", 1),
 
             Token::StructSep,
             Token::Str("a"),
@@ -281,7 +281,7 @@ fn test_elt_not_deserialize() {
             e: NotDeserializeEnum::Trouble,
         },
         &[
-            Token::StructStart("ContainsNotDeserialize", Some(3)),
+            Token::StructStart("ContainsNotDeserialize", 3),
             Token::StructEnd,
         ]
     );
@@ -299,7 +299,7 @@ fn test_ignore_unknown() {
     assert_de_tokens(
         &DefaultStruct { a1: 1, a2: 2, a3: 3, a4: 0, a5: 123 },
         &[
-            Token::StructStart("DefaultStruct", Some(5)),
+            Token::StructStart("DefaultStruct", 5),
 
             Token::StructSep,
             Token::Str("whoops1"),
@@ -334,7 +334,7 @@ fn test_ignore_unknown() {
 
     assert_de_tokens_error::<DenyUnknown>(
         &[
-            Token::StructStart("DenyUnknown", Some(2)),
+            Token::StructStart("DenyUnknown", 2),
 
             Token::StructSep,
             Token::Str("a1"),
@@ -368,7 +368,7 @@ fn test_rename_struct() {
     assert_tokens(
         &RenameStruct { a1: 1, a2: 2 },
         &[
-            Token::StructStart("Superhero", Some(2)),
+            Token::StructStart("Superhero", 2),
 
             Token::StructSep,
             Token::Str("a1"),
@@ -385,7 +385,7 @@ fn test_rename_struct() {
     assert_ser_tokens(
         &RenameStructSerializeDeserialize { a1: 1, a2: 2 },
         &[
-            Token::StructStart("SuperheroSer", Some(2)),
+            Token::StructStart("SuperheroSer", 2),
 
             Token::StructSep,
             Token::Str("a1"),
@@ -402,7 +402,7 @@ fn test_rename_struct() {
     assert_de_tokens(
         &RenameStructSerializeDeserialize { a1: 1, a2: 2 },
         &[
-            Token::StructStart("SuperheroDe", Some(2)),
+            Token::StructStart("SuperheroDe", 2),
 
             Token::StructSep,
             Token::Str("a1"),
@@ -465,7 +465,7 @@ fn test_rename_enum() {
     assert_tokens(
         &RenameEnum::WonderWoman(0, 1),
         &[
-            Token::EnumSeqStart("Superhero", "diana_prince", Some(2)),
+            Token::EnumSeqStart("Superhero", "diana_prince", 2),
 
             Token::EnumSeqSep,
             Token::I8(0),
@@ -480,7 +480,7 @@ fn test_rename_enum() {
     assert_tokens(
         &RenameEnum::Flash { a: 1 },
         &[
-            Token::EnumMapStart("Superhero", "barry_allan", Some(1)),
+            Token::EnumMapStart("Superhero", "barry_allan", 1),
 
             Token::EnumMapSep,
             Token::Str("b"),
@@ -496,7 +496,7 @@ fn test_rename_enum() {
             b: String::new(),
         },
         &[
-            Token::EnumMapStart("SuperheroSer", "dick_grayson", Some(2)),
+            Token::EnumMapStart("SuperheroSer", "dick_grayson", 2),
 
             Token::EnumMapSep,
             Token::Str("a"),
@@ -516,7 +516,7 @@ fn test_rename_enum() {
             b: String::new(),
         },
         &[
-            Token::EnumMapStart("SuperheroDe", "jason_todd", Some(2)),
+            Token::EnumMapStart("SuperheroDe", "jason_todd", 2),
 
             Token::EnumMapSep,
             Token::Str("a"),
@@ -550,7 +550,7 @@ fn test_skip_serializing_struct() {
             c: 3,
         },
         &[
-            Token::StructStart("SkipSerializingStruct", Some(2)),
+            Token::StructStart("SkipSerializingStruct", 2),
 
             Token::StructSep,
             Token::Str("a"),
@@ -571,7 +571,7 @@ fn test_skip_serializing_struct() {
             c: 123,
         },
         &[
-            Token::StructStart("SkipSerializingStruct", Some(1)),
+            Token::StructStart("SkipSerializingStruct", 1),
 
             Token::StructSep,
             Token::Str("a"),
@@ -603,7 +603,7 @@ fn test_skip_serializing_enum() {
             c: 3,
         },
         &[
-            Token::EnumMapStart("SkipSerializingEnum", "Struct", Some(2)),
+            Token::EnumMapStart("SkipSerializingEnum", "Struct", 2),
 
             Token::EnumMapSep,
             Token::Str("a"),
@@ -624,7 +624,7 @@ fn test_skip_serializing_enum() {
             c: 123,
         },
         &[
-            Token::EnumMapStart("SkipSerializingEnum", "Struct", Some(1)),
+            Token::EnumMapStart("SkipSerializingEnum", "Struct", 1),
 
             Token::EnumMapSep,
             Token::Str("a"),
@@ -671,7 +671,7 @@ fn test_elt_not_serialize() {
             d: NotSerializeEnum::Trouble,
         },
         &[
-            Token::StructStart("ContainsNotSerialize", Some(2)),
+            Token::StructStart("ContainsNotSerialize", 2),
 
             Token::StructSep,
             Token::Str("a"),
@@ -703,7 +703,7 @@ fn test_serialize_with_struct() {
             b: 2,
         },
         &[
-            Token::StructStart("SerializeWithStruct", Some(2)),
+            Token::StructStart("SerializeWithStruct", 2),
 
             Token::StructSep,
             Token::Str("a"),
@@ -723,7 +723,7 @@ fn test_serialize_with_struct() {
             b: 123,
         },
         &[
-            Token::StructStart("SerializeWithStruct", Some(2)),
+            Token::StructStart("SerializeWithStruct", 2),
 
             Token::StructSep,
             Token::Str("a"),
@@ -756,7 +756,7 @@ fn test_serialize_with_enum() {
             b: 2,
         },
         &[
-            Token::EnumMapStart("SerializeWithEnum", "Struct", Some(2)),
+            Token::EnumMapStart("SerializeWithEnum", "Struct", 2),
 
             Token::EnumMapSep,
             Token::Str("a"),
@@ -776,7 +776,7 @@ fn test_serialize_with_enum() {
             b: 123,
         },
         &[
-            Token::EnumMapStart("SerializeWithEnum", "Struct", Some(2)),
+            Token::EnumMapStart("SerializeWithEnum", "Struct", 2),
 
             Token::EnumMapSep,
             Token::Str("a"),
@@ -806,7 +806,7 @@ fn test_deserialize_with_struct() {
             b: 2,
         },
         &[
-            Token::StructStart("DeserializeWithStruct", Some(2)),
+            Token::StructStart("DeserializeWithStruct", 2),
 
             Token::StructSep,
             Token::Str("a"),
@@ -826,7 +826,7 @@ fn test_deserialize_with_struct() {
             b: 123,
         },
         &[
-            Token::StructStart("DeserializeWithStruct", Some(2)),
+            Token::StructStart("DeserializeWithStruct", 2),
 
             Token::StructSep,
             Token::Str("a"),
@@ -858,7 +858,7 @@ fn test_deserialize_with_enum() {
             b: 2,
         },
         &[
-            Token::EnumMapStart("DeserializeWithEnum", "Struct", Some(2)),
+            Token::EnumMapStart("DeserializeWithEnum", "Struct", 2),
 
             Token::EnumMapSep,
             Token::Str("a"),
@@ -878,7 +878,7 @@ fn test_deserialize_with_enum() {
             b: 123,
         },
         &[
-            Token::EnumMapStart("DeserializeWithEnum", "Struct", Some(2)),
+            Token::EnumMapStart("DeserializeWithEnum", "Struct", 2),
 
             Token::EnumMapSep,
             Token::Str("a"),
@@ -897,7 +897,7 @@ fn test_deserialize_with_enum() {
 fn test_missing_renamed_field_struct() {
     assert_de_tokens_error::<RenameStruct>(
         &[
-            Token::StructStart("Superhero", Some(2)),
+            Token::StructStart("Superhero", 2),
 
             Token::StructSep,
             Token::Str("a1"),
@@ -910,7 +910,7 @@ fn test_missing_renamed_field_struct() {
 
     assert_de_tokens_error::<RenameStructSerializeDeserialize>(
         &[
-            Token::StructStart("SuperheroDe", Some(2)),
+            Token::StructStart("SuperheroDe", 2),
 
             Token::StructSep,
             Token::Str("a1"),
@@ -926,7 +926,7 @@ fn test_missing_renamed_field_struct() {
 fn test_missing_renamed_field_enum() {
     assert_de_tokens_error::<RenameEnum>(
         &[
-            Token::EnumMapStart("Superhero", "barry_allan", Some(1)),
+            Token::EnumMapStart("Superhero", "barry_allan", 1),
 
             Token::EnumMapEnd,
         ],
@@ -935,7 +935,7 @@ fn test_missing_renamed_field_enum() {
 
     assert_de_tokens_error::<RenameEnumSerializeDeserialize<i8>>(
         &[
-            Token::EnumMapStart("SuperheroDe", "jason_todd", Some(2)),
+            Token::EnumMapStart("SuperheroDe", "jason_todd", 2),
 
             Token::EnumMapSep,
             Token::Str("a"),
@@ -957,7 +957,7 @@ enum InvalidLengthEnum {
 fn test_invalid_length_enum() {
     assert_de_tokens_error::<InvalidLengthEnum>(
         &[
-            Token::EnumSeqStart("InvalidLengthEnum", "A", Some(3)),
+            Token::EnumSeqStart("InvalidLengthEnum", "A", 3),
                 Token::EnumSeqSep,
                 Token::I32(1),
             Token::EnumSeqEnd,
@@ -966,7 +966,7 @@ fn test_invalid_length_enum() {
     );
     assert_de_tokens_error::<InvalidLengthEnum>(
         &[
-            Token::EnumSeqStart("InvalidLengthEnum", "B", Some(3)),
+            Token::EnumSeqStart("InvalidLengthEnum", "B", 3),
                 Token::EnumSeqSep,
                 Token::I32(1),
             Token::EnumSeqEnd,

--- a/testing/tests/test_bytes.rs
+++ b/testing/tests/test_bytes.rs
@@ -50,42 +50,8 @@ impl BytesSerializer {
     }
 }
 
-struct SeqSerializer;
-
-impl serde::ser::SeqSerializer for SeqSerializer {
-    type Error = Error;
-
-    fn serialize_elt<S: ?Sized, T>(&mut self, _serializer: &mut S, _value: T) -> Result<(), Self::Error>
-        where T: Serialize, S: serde::ser::Serializer<Error = Error> {
-        Err(Error)
-    }
-
-    fn drop<S: ?Sized>(self, _serializer: &mut S) -> Result<(), Self::Error> where S: serde::ser::Serializer<Error = Error> {
-        Err(Error)
-    }
-}
-
-struct MapSerializer;
-
-impl serde::ser::MapSerializer for MapSerializer {
-    type Error = Error;
-
-    fn serialize_elt<S: ?Sized, K, V>(&mut self, _serializer: &mut S, _key: K, _value: V) -> Result<(), Self::Error>
-        where K: Serialize,
-              V: Serialize,
-              S: serde::ser::Serializer<Error = Error> {
-        Err(Error)
-    }
-
-    fn drop<S: ?Sized>(self, _serializer: &mut S) -> Result<(), Self::Error> where S: serde::ser::Serializer<Error = Error> {
-        Err(Error)
-    }
-}
-
 impl serde::Serializer for BytesSerializer {
     type Error = Error;
-    type SeqSerializer = SeqSerializer;
-    type MapSerializer = MapSerializer;
 
     fn serialize_unit(&mut self) -> Result<(), Error> {
         Err(Error)
@@ -129,7 +95,7 @@ impl serde::Serializer for BytesSerializer {
         Err(Error)
     }
 
-    fn serialize_seq<'a>(&'a mut self, _len: Option<usize>) -> Result<serde::ser::SeqHelper<'a, Self>, Error>
+    fn serialize_seq<'a>(&'a mut self, _len: Option<usize>) -> Result<(), Error>
     {
         Err(Error)
     }
@@ -145,7 +111,7 @@ impl serde::Serializer for BytesSerializer {
         Err(Error)
     }
 
-    fn serialize_map<'a>(&mut self, _: Option<usize>) -> Result<serde::ser::MapHelper<'a, Self>, Error>
+    fn serialize_map<'a>(&mut self, _: Option<usize>) -> Result<(), Error>
     {
         Err(Error)
     }

--- a/testing/tests/test_bytes.rs
+++ b/testing/tests/test_bytes.rs
@@ -54,12 +54,57 @@ impl serde::Serializer for BytesSerializer {
     type Error = Error;
     type SeqState = ();
     type MapState = ();
+    type TupleState = ();
+    type TupleStructState = ();
+    type TupleVariantState = ();
+    type StructState = ();
+    type StructVariantState = ();
 
     fn serialize_unit(&mut self) -> Result<(), Error> {
         Err(Error)
     }
 
+    fn serialize_unit_struct(&mut self, _name: &'static str) -> Result<(), Error> {
+        Err(Error)
+    }
+
+    fn serialize_unit_variant(&mut self, _: &'static str, _: usize, _: &'static str) -> Result<(), Error> {
+        Err(Error)
+    }
+
     fn serialize_bool(&mut self, _v: bool) -> Result<(), Error> {
+        Err(Error)
+    }
+
+    fn serialize_isize(&mut self, _v: isize) -> Result<(), Error> {
+        Err(Error)
+    }
+
+    fn serialize_usize(&mut self, _v: usize) -> Result<(), Error> {
+        Err(Error)
+    }
+
+    fn serialize_i8(&mut self, _v: i8) -> Result<(), Error> {
+        Err(Error)
+    }
+
+    fn serialize_u8(&mut self, _v: u8) -> Result<(), Error> {
+        Err(Error)
+    }
+
+    fn serialize_i16(&mut self, _v: i16) -> Result<(), Error> {
+        Err(Error)
+    }
+
+    fn serialize_u16(&mut self, _v: u16) -> Result<(), Error> {
+        Err(Error)
+    }
+
+    fn serialize_i32(&mut self, _v: i32) -> Result<(), Error> {
+        Err(Error)
+    }
+
+    fn serialize_u32(&mut self, _v: u32) -> Result<(), Error> {
         Err(Error)
     }
 
@@ -97,18 +142,83 @@ impl serde::Serializer for BytesSerializer {
         Err(Error)
     }
 
+    fn serialize_newtype_struct<V>(&mut self, _: &'static str, _value: V) -> Result<(), Error>
+        where V: serde::Serialize,
+    {
+        Err(Error)
+    }
+
+    fn serialize_newtype_variant<V>(&mut self, _: &'static str, _: usize, _: &'static str, _value: V) -> Result<(), Error>
+        where V: serde::Serialize,
+    {
+        Err(Error)
+    }
+
     fn serialize_seq(&mut self, _len: Option<usize>) -> Result<(), Error>
     {
         Err(Error)
     }
 
-    fn serialize_seq_elt<T>(&mut self, _value: T) -> Result<(), Error>
+    fn serialize_seq_fixed_size(&mut self, _len: usize) -> Result<(), Error>
+    {
+        Err(Error)
+    }
+
+    fn serialize_seq_elt<T>(&mut self, _: &mut (), _value: T) -> Result<(), Error>
         where T: serde::Serialize
     {
         Err(Error)
     }
 
-    fn serialize_seq_end(&mut self, _: Option<usize>, _: ()) -> Result<(), Error>
+    fn serialize_seq_end(&mut self, _: ()) -> Result<(), Error>
+    {
+        Err(Error)
+    }
+
+    fn serialize_tuple(&mut self, _len: usize) -> Result<(), Error>
+    {
+        Err(Error)
+    }
+
+    fn serialize_tuple_elt<T>(&mut self, _: &mut (), _value: T) -> Result<(), Error>
+        where T: serde::Serialize
+    {
+        Err(Error)
+    }
+
+    fn serialize_tuple_end(&mut self, _: ()) -> Result<(), Error>
+    {
+        Err(Error)
+    }
+
+    fn serialize_tuple_struct(&mut self, _: &'static str, _len: usize) -> Result<(), Error>
+    {
+        Err(Error)
+    }
+
+    fn serialize_tuple_struct_elt<T>(&mut self, _: &mut (), _value: T) -> Result<(), Error>
+        where T: serde::Serialize
+    {
+        Err(Error)
+    }
+
+    fn serialize_tuple_struct_end(&mut self, _: ()) -> Result<(), Error>
+    {
+        Err(Error)
+    }
+
+    fn serialize_tuple_variant(&mut self, _: &'static str, _: usize, _: &'static str, _len: usize) -> Result<(), Error>
+    {
+        Err(Error)
+    }
+
+    fn serialize_tuple_variant_elt<T>(&mut self, _: &mut (), _value: T) -> Result<(), Error>
+        where T: serde::Serialize
+    {
+        Err(Error)
+    }
+
+    fn serialize_tuple_variant_end(&mut self, _: ()) -> Result<(), Error>
     {
         Err(Error)
     }
@@ -118,14 +228,46 @@ impl serde::Serializer for BytesSerializer {
         Err(Error)
     }
 
-    fn serialize_map_elt<K, V>(&mut self, _key: K, _value: V) -> Result<(), Error>
+    fn serialize_map_elt<K, V>(&mut self, _: &mut (), _key: K, _value: V) -> Result<(), Error>
         where K: serde::Serialize,
               V: serde::Serialize,
     {
         Err(Error)
     }
 
-    fn serialize_map_end(&mut self, _: Option<usize>, _: ()) -> Result<(), Error>
+    fn serialize_map_end(&mut self, _: ()) -> Result<(), Error>
+    {
+        Err(Error)
+    }
+
+    fn serialize_struct(&mut self, _: &'static str, _: usize) -> Result<(), Error>
+    {
+        Err(Error)
+    }
+
+    fn serialize_struct_elt<V>(&mut self, _: &mut (), _key: &'static str, _value: V) -> Result<(), Error>
+        where V: serde::Serialize,
+    {
+        Err(Error)
+    }
+
+    fn serialize_struct_end(&mut self, _: ()) -> Result<(), Error>
+    {
+        Err(Error)
+    }
+
+    fn serialize_struct_variant(&mut self, _: &'static str, _: usize, _: &'static str, _: usize) -> Result<(), Error>
+    {
+        Err(Error)
+    }
+
+    fn serialize_struct_variant_elt<V>(&mut self, _: &mut (), _key: &'static str, _value: V) -> Result<(), Error>
+        where V: serde::Serialize,
+    {
+        Err(Error)
+    }
+
+    fn serialize_struct_variant_end(&mut self, _: ()) -> Result<(), Error>
     {
         Err(Error)
     }

--- a/testing/tests/test_bytes.rs
+++ b/testing/tests/test_bytes.rs
@@ -50,8 +50,42 @@ impl BytesSerializer {
     }
 }
 
+struct SeqSerializer;
+
+impl serde::ser::SeqSerializer for SeqSerializer {
+    type Error = Error;
+
+    fn serialize_elt<S: ?Sized, T>(&mut self, _serializer: &mut S, _value: T) -> Result<(), Self::Error>
+        where T: Serialize, S: serde::ser::Serializer<Error = Error> {
+        Err(Error)
+    }
+
+    fn drop<S: ?Sized>(self, _serializer: &mut S) -> Result<(), Self::Error> where S: serde::ser::Serializer<Error = Error> {
+        Err(Error)
+    }
+}
+
+struct MapSerializer;
+
+impl serde::ser::MapSerializer for MapSerializer {
+    type Error = Error;
+
+    fn serialize_elt<S: ?Sized, K, V>(&mut self, _serializer: &mut S, _key: K, _value: V) -> Result<(), Self::Error>
+        where K: Serialize,
+              V: Serialize,
+              S: serde::ser::Serializer<Error = Error> {
+        Err(Error)
+    }
+
+    fn drop<S: ?Sized>(self, _serializer: &mut S) -> Result<(), Self::Error> where S: serde::ser::Serializer<Error = Error> {
+        Err(Error)
+    }
+}
+
 impl serde::Serializer for BytesSerializer {
     type Error = Error;
+    type SeqSerializer = SeqSerializer;
+    type MapSerializer = MapSerializer;
 
     fn serialize_unit(&mut self) -> Result<(), Error> {
         Err(Error)
@@ -95,8 +129,7 @@ impl serde::Serializer for BytesSerializer {
         Err(Error)
     }
 
-    fn serialize_seq<V>(&mut self, _visitor: V) -> Result<(), Error>
-        where V: serde::ser::SeqVisitor,
+    fn serialize_seq<'a>(&'a mut self, _len: Option<usize>) -> Result<serde::ser::SeqHelper<'a, Self>, Error>
     {
         Err(Error)
     }
@@ -107,8 +140,12 @@ impl serde::Serializer for BytesSerializer {
         Err(Error)
     }
 
-    fn serialize_map<V>(&mut self, _visitor: V) -> Result<(), Error>
-        where V: serde::ser::MapVisitor,
+    fn serialize_seq_end(&mut self) -> Result<(), Error>
+    {
+        Err(Error)
+    }
+
+    fn serialize_map<'a>(&mut self, _: Option<usize>) -> Result<serde::ser::MapHelper<'a, Self>, Error>
     {
         Err(Error)
     }
@@ -116,6 +153,11 @@ impl serde::Serializer for BytesSerializer {
     fn serialize_map_elt<K, V>(&mut self, _key: K, _value: V) -> Result<(), Error>
         where K: serde::Serialize,
               V: serde::Serialize,
+    {
+        Err(Error)
+    }
+
+    fn serialize_map_end(&mut self) -> Result<(), Error>
     {
         Err(Error)
     }

--- a/testing/tests/test_bytes.rs
+++ b/testing/tests/test_bytes.rs
@@ -52,6 +52,8 @@ impl BytesSerializer {
 
 impl serde::Serializer for BytesSerializer {
     type Error = Error;
+    type SeqState = ();
+    type MapState = ();
 
     fn serialize_unit(&mut self) -> Result<(), Error> {
         Err(Error)
@@ -106,7 +108,7 @@ impl serde::Serializer for BytesSerializer {
         Err(Error)
     }
 
-    fn serialize_seq_end(&mut self, _: Option<usize>) -> Result<(), Error>
+    fn serialize_seq_end(&mut self, _: Option<usize>, _: ()) -> Result<(), Error>
     {
         Err(Error)
     }
@@ -123,7 +125,7 @@ impl serde::Serializer for BytesSerializer {
         Err(Error)
     }
 
-    fn serialize_map_end(&mut self, _: Option<usize>) -> Result<(), Error>
+    fn serialize_map_end(&mut self, _: Option<usize>, _: ()) -> Result<(), Error>
     {
         Err(Error)
     }

--- a/testing/tests/test_bytes.rs
+++ b/testing/tests/test_bytes.rs
@@ -95,7 +95,7 @@ impl serde::Serializer for BytesSerializer {
         Err(Error)
     }
 
-    fn serialize_seq<'a>(&'a mut self, _len: Option<usize>) -> Result<(), Error>
+    fn serialize_seq(&mut self, _len: Option<usize>) -> Result<(), Error>
     {
         Err(Error)
     }
@@ -106,12 +106,12 @@ impl serde::Serializer for BytesSerializer {
         Err(Error)
     }
 
-    fn serialize_seq_end(&mut self) -> Result<(), Error>
+    fn serialize_seq_end(&mut self, _: Option<usize>) -> Result<(), Error>
     {
         Err(Error)
     }
 
-    fn serialize_map<'a>(&mut self, _: Option<usize>) -> Result<(), Error>
+    fn serialize_map(&mut self, _: Option<usize>) -> Result<(), Error>
     {
         Err(Error)
     }
@@ -123,7 +123,7 @@ impl serde::Serializer for BytesSerializer {
         Err(Error)
     }
 
-    fn serialize_map_end(&mut self) -> Result<(), Error>
+    fn serialize_map_end(&mut self, _: Option<usize>) -> Result<(), Error>
     {
         Err(Error)
     }

--- a/testing/tests/test_de.rs
+++ b/testing/tests/test_de.rs
@@ -81,9 +81,9 @@ fn assert_de_tokens_ignore(ignorable_tokens: &[Token<'static>]) {
     struct IgnoreBase {
         a: i32,
     }
- 
+
     let expected = IgnoreBase{a: 1};
- 
+
     // Embed the tokens to be ignored in the normal token
     // stream for an IgnoreBase type
     let concated_tokens : Vec<Token<'static>> = vec![
@@ -91,7 +91,7 @@ fn assert_de_tokens_ignore(ignorable_tokens: &[Token<'static>]) {
                 Token::MapSep,
                 Token::Str("a"),
                 Token::I32(1),
- 
+
                 Token::MapSep,
                 Token::Str("ignored")
         ]
@@ -101,17 +101,17 @@ fn assert_de_tokens_ignore(ignorable_tokens: &[Token<'static>]) {
             Token::MapEnd,
         ].into_iter())
         .collect();
- 
+
     let mut de = serde_test::Deserializer::new(concated_tokens.into_iter());
     let v: Result<IgnoreBase, Error> = Deserialize::deserialize(&mut de);
- 
+
     // We run this test on every token stream for convenience, but
     // some token streams don't make sense embedded as a map value,
     // so we ignore those. SyntaxError is the real sign of trouble.
     if let Err(Error::UnexpectedToken(_)) = v {
         return;
     }
- 
+
     assert_eq!(v.as_ref(), Ok(&expected));
     assert_eq!(de.next_token(), None);
 }
@@ -197,7 +197,7 @@ declare_tests! {
             Token::SeqEnd,
         ],
         () => &[
-            Token::TupleStructStart("Anything", Some(0)),
+            Token::TupleStructStart("Anything", 0),
             Token::SeqEnd,
         ],
     }
@@ -241,7 +241,7 @@ declare_tests! {
             Token::SeqEnd,
         ],
         TupleStruct(1, 2, 3) => &[
-            Token::TupleStructStart("TupleStruct", Some(3)),
+            Token::TupleStructStart("TupleStruct", 3),
                 Token::TupleStructSep,
                 Token::I32(1),
 
@@ -253,7 +253,7 @@ declare_tests! {
             Token::TupleStructEnd,
         ],
         TupleStruct(1, 2, 3) => &[
-            Token::TupleStructStart("TupleStruct", None),
+            Token::TupleStructStart("TupleStruct", 3),
                 Token::TupleStructSep,
                 Token::I32(1),
 
@@ -299,7 +299,7 @@ declare_tests! {
             Token::UnitStruct("Anything"),
         ],
         BTreeSet::<isize>::new() => &[
-            Token::TupleStructStart("Anything", Some(0)),
+            Token::TupleStructStart("Anything", 0),
             Token::SeqEnd,
         ],
     }
@@ -327,7 +327,7 @@ declare_tests! {
             Token::UnitStruct("Anything"),
         ],
         HashSet::<isize>::new() => &[
-            Token::TupleStructStart("Anything", Some(0)),
+            Token::TupleStructStart("Anything", 0),
             Token::SeqEnd,
         ],
         hashset![FnvHasher @ 1, 2, 3] => &[
@@ -377,7 +377,7 @@ declare_tests! {
             Token::UnitStruct("Anything"),
         ],
         Vec::<isize>::new() => &[
-            Token::TupleStructStart("Anything", Some(0)),
+            Token::TupleStructStart("Anything", 0),
             Token::SeqEnd,
         ],
     }
@@ -441,7 +441,7 @@ declare_tests! {
             Token::UnitStruct("Anything"),
         ],
         [0; 0] => &[
-            Token::TupleStructStart("Anything", Some(0)),
+            Token::TupleStructStart("Anything", 0),
             Token::SeqEnd,
         ],
     }
@@ -533,7 +533,7 @@ declare_tests! {
             Token::UnitStruct("Anything"),
         ],
         BTreeMap::<isize, isize>::new() => &[
-            Token::StructStart("Anything", Some(0)),
+            Token::StructStart("Anything", 0),
             Token::MapEnd,
         ],
     }
@@ -587,7 +587,7 @@ declare_tests! {
             Token::UnitStruct("Anything"),
         ],
         HashMap::<isize, isize>::new() => &[
-            Token::StructStart("Anything", Some(0)),
+            Token::StructStart("Anything", 0),
             Token::MapEnd,
         ],
         hashmap![FnvHasher @ 1 => 2, 3 => 4] => &[
@@ -615,7 +615,7 @@ declare_tests! {
             Token::MapEnd,
         ],
         Struct { a: 1, b: 2, c: 0 } => &[
-            Token::StructStart("Struct", Some(3)),
+            Token::StructStart("Struct", 3),
                 Token::StructSep,
                 Token::Str("a"),
                 Token::I32(1),
@@ -656,7 +656,7 @@ declare_tests! {
             Token::MapEnd,
         ],
         Struct { a: 1, b: 2, c: 0 } => &[
-            Token::StructStart("Struct", Some(3)),
+            Token::StructStart("Struct", 3),
                 Token::StructSep,
                 Token::Str("a"),
                 Token::I32(1),
@@ -688,7 +688,7 @@ declare_tests! {
     }
     test_enum_seq {
         Enum::Seq(1, 2, 3) => &[
-            Token::EnumSeqStart("Enum", "Seq", Some(3)),
+            Token::EnumSeqStart("Enum", "Seq", 3),
                 Token::EnumSeqSep,
                 Token::I32(1),
 
@@ -702,7 +702,7 @@ declare_tests! {
     }
     test_enum_map {
         Enum::Map { a: 1, b: 2, c: 3 } => &[
-            Token::EnumMapStart("Enum", "Map", Some(3)),
+            Token::EnumMapStart("Enum", "Map", 3),
                 Token::EnumMapSep,
                 Token::Str("a"),
                 Token::I32(1),
@@ -803,7 +803,7 @@ declare_error_tests! {
     }
     test_duplicate_field_enum<Enum> {
         &[
-            Token::EnumMapStart("Enum", "Map", Some(3)),
+            Token::EnumMapStart("Enum", "Map", 3),
                 Token::EnumMapSep,
                 Token::Str("a"),
                 Token::I32(1),

--- a/testing/tests/test_macros.rs
+++ b/testing/tests/test_macros.rs
@@ -174,7 +174,7 @@ fn test_ser_named_tuple() {
     assert_ser_tokens(
         &SerNamedTuple(&a, &mut b, c),
         &[
-            Token::TupleStructStart("SerNamedTuple", Some(3)),
+            Token::TupleStructStart("SerNamedTuple", 3),
             Token::TupleStructSep,
             Token::I32(5),
 
@@ -211,7 +211,7 @@ fn test_de_named_tuple() {
     assert_de_tokens(
         &DeNamedTuple(5, 6, 7),
         &[
-            Token::TupleStructStart("DeNamedTuple", Some(3)),
+            Token::TupleStructStart("DeNamedTuple", 3),
             Token::TupleStructSep,
             Token::I32(5),
 
@@ -239,7 +239,7 @@ fn test_ser_named_map() {
             c: c,
         },
         &[
-            Token::StructStart("SerNamedMap", Some(3)),
+            Token::StructStart("SerNamedMap", 3),
 
             Token::StructSep,
             Token::Str("a"),
@@ -267,7 +267,7 @@ fn test_de_named_map() {
             c: 7,
         },
         &[
-            Token::StructStart("DeNamedMap", Some(3)),
+            Token::StructStart("DeNamedMap", 3),
 
             Token::StructSep,
             Token::Str("a"),
@@ -315,7 +315,7 @@ fn test_ser_enum_seq() {
             //f,
         ),
         &[
-            Token::EnumSeqStart("SerEnum", "Seq", Some(4)),
+            Token::EnumSeqStart("SerEnum", "Seq", 4),
 
             Token::EnumSeqSep,
             Token::I8(1),
@@ -353,7 +353,7 @@ fn test_ser_enum_map() {
             //f: f,
         },
         &[
-            Token::EnumMapStart("SerEnum", "Map", Some(4)),
+            Token::EnumMapStart("SerEnum", "Map", 4),
 
             Token::EnumMapSep,
             Token::Str("a"),
@@ -405,7 +405,7 @@ fn test_de_enum_seq() {
             //f,
         ),
         &[
-            Token::EnumSeqStart("DeEnum", "Seq", Some(4)),
+            Token::EnumSeqStart("DeEnum", "Seq", 4),
 
             Token::EnumSeqSep,
             Token::I8(1),
@@ -443,7 +443,7 @@ fn test_de_enum_map() {
             //f: f,
         },
         &[
-            Token::EnumMapStart("DeEnum", "Map", Some(4)),
+            Token::EnumMapStart("DeEnum", "Map", 4),
 
             Token::EnumMapSep,
             Token::Str("a"),
@@ -489,7 +489,7 @@ fn test_lifetimes() {
     assert_ser_tokens(
         &Lifetimes::LifetimeMap { a: &value },
         &[
-            Token::EnumMapStart("Lifetimes", "LifetimeMap", Some(1)),
+            Token::EnumMapStart("Lifetimes", "LifetimeMap", 1),
 
             Token::EnumMapSep,
             Token::Str("a"),
@@ -502,7 +502,7 @@ fn test_lifetimes() {
     assert_ser_tokens(
         &Lifetimes::NoLifetimeMap { a: 5 },
         &[
-            Token::EnumMapStart("Lifetimes", "NoLifetimeMap", Some(1)),
+            Token::EnumMapStart("Lifetimes", "NoLifetimeMap", 1),
 
             Token::EnumMapSep,
             Token::Str("a"),
@@ -518,7 +518,7 @@ fn test_generic_struct() {
     assert_tokens(
         &GenericStruct { x: 5u32 },
         &[
-            Token::StructStart("GenericStruct", Some(1)),
+            Token::StructStart("GenericStruct", 1),
 
             Token::StructSep,
             Token::Str("x"),
@@ -545,7 +545,7 @@ fn test_generic_tuple_struct() {
     assert_tokens(
         &GenericTupleStruct(5u32, 6u32),
         &[
-            Token::TupleStructStart("GenericTupleStruct", Some(2)),
+            Token::TupleStructStart("GenericTupleStruct", 2),
 
             Token::TupleStructSep,
             Token::U32(5),
@@ -584,7 +584,7 @@ fn test_generic_enum_seq() {
     assert_tokens(
         &GenericEnum::Seq::<u32, u32>(5, 6),
         &[
-            Token::EnumSeqStart("GenericEnum", "Seq", Some(2)),
+            Token::EnumSeqStart("GenericEnum", "Seq", 2),
 
             Token::EnumSeqSep,
             Token::U32(5),
@@ -602,7 +602,7 @@ fn test_generic_enum_map() {
     assert_tokens(
         &GenericEnum::Map::<u32, u32> { x: 5, y: 6 },
         &[
-            Token::EnumMapStart("GenericEnum", "Map", Some(2)),
+            Token::EnumMapStart("GenericEnum", "Map", 2),
 
             Token::EnumMapSep,
             Token::Str("x"),
@@ -622,7 +622,7 @@ fn test_default_ty_param() {
     assert_tokens(
         &DefaultTyParam::<i32> { phantom: PhantomData },
         &[
-            Token::StructStart("DefaultTyParam", Some(1)),
+            Token::StructStart("DefaultTyParam", 1),
 
             Token::StructSep,
             Token::Str("phantom"),

--- a/testing/tests/test_ser.rs
+++ b/testing/tests/test_ser.rs
@@ -256,7 +256,7 @@ declare_ser_tests! {
     }
     test_tuple_struct {
         TupleStruct(1, 2, 3) => &[
-            Token::TupleStructStart("TupleStruct", Some(3)),
+            Token::TupleStructStart("TupleStruct", 3),
                 Token::TupleStructSep,
                 Token::I32(1),
 
@@ -270,7 +270,7 @@ declare_ser_tests! {
     }
     test_struct {
         Struct { a: 1, b: 2, c: 3 } => &[
-            Token::StructStart("Struct", Some(3)),
+            Token::StructStart("Struct", 3),
                 Token::StructSep,
                 Token::Str("a"),
                 Token::I32(1),
@@ -289,7 +289,7 @@ declare_ser_tests! {
         Enum::Unit => &[Token::EnumUnit("Enum", "Unit")],
         Enum::One(42) => &[Token::EnumNewType("Enum", "One"), Token::I32(42)],
         Enum::Seq(1, 2) => &[
-            Token::EnumSeqStart("Enum", "Seq", Some(2)),
+            Token::EnumSeqStart("Enum", "Seq", 2),
                 Token::EnumSeqSep,
                 Token::I32(1),
 
@@ -298,7 +298,7 @@ declare_ser_tests! {
             Token::EnumSeqEnd,
         ],
         Enum::Map { a: 1, b: 2 } => &[
-            Token::EnumMapStart("Enum", "Map", Some(2)),
+            Token::EnumMapStart("Enum", "Map", 2),
                 Token::EnumMapSep,
                 Token::Str("a"),
                 Token::I32(1),


### PR DESCRIPTION
I took the liberty of also simplifying some of serde codegen (mainly the parts where we do a lot of effort to create types that are going to get optimized out). I think all that was necessary to fit the visitor pattern. The new system as imagined by @dpc is much easier to implement, although it requires additional helper objects

fixes #386

cc @dpc

# Serializers compatible with the new API

* [x] serde_json https://github.com/serde-rs/json/pull/116
* [x] bincode https://github.com/TyOverby/bincode/pull/83
* [x] serde_yaml https://github.com/dtolnay/serde-yaml/pull/22
* [x] toml https://github.com/alexcrichton/toml-rs/pull/104