### PR TITLE
Use rustfmt

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,4 @@
+fn_args_layout = "Block"
+reorder_imports = true
+struct_lit_multiline_style = "ForceMulti"
+where_trailing_comma = true

--- a/serde/src/bytes.rs
+++ b/serde/src/bytes.rs
@@ -1,6 +1,6 @@
 //! Helper module to enable serializing bytes more efficiently
 
-use core::{ops, fmt, char, iter, slice};
+use core::{char, fmt, iter, ops, slice};
 use core::fmt::Write;
 
 use ser;
@@ -11,7 +11,7 @@ pub use self::bytebuf::{ByteBuf, ByteBufVisitor};
 #[cfg(feature = "collections")]
 use collections::Vec;
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 /// `Bytes` wraps a `&[u8]` in order to serialize into a byte array.
 #[derive(Clone, Copy, Eq, Hash, PartialEq, PartialOrd, Ord)]
@@ -55,20 +55,21 @@ impl<'a> Into<&'a [u8]> for Bytes<'a> {
 impl<'a> ops::Deref for Bytes<'a> {
     type Target = [u8];
 
-    fn deref(&self) -> &[u8] { self.bytes }
+    fn deref(&self) -> &[u8] {
+        self.bytes
+    }
 }
 
 impl<'a> ser::Serialize for Bytes<'a> {
     #[inline]
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
-        where S: ser::Serializer
+        where S: ser::Serializer,
     {
         serializer.serialize_bytes(self.bytes)
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
-
+/// ////////////////////////////////////////////////////////////////////////////
 #[cfg(any(feature = "std", feature = "collections"))]
 mod bytebuf {
     use core::ops;
@@ -98,7 +99,7 @@ mod bytebuf {
         /// Construct a new, empty `ByteBuf` with the specified capacity.
         pub fn with_capacity(cap: usize) -> Self {
             ByteBuf {
-                bytes: Vec::with_capacity(cap)
+                bytes: Vec::with_capacity(cap),
             }
         }
     }
@@ -154,16 +155,20 @@ mod bytebuf {
     impl ops::Deref for ByteBuf {
         type Target = [u8];
 
-        fn deref(&self) -> &[u8] { &self.bytes[..] }
+        fn deref(&self) -> &[u8] {
+            &self.bytes[..]
+        }
     }
 
     impl ops::DerefMut for ByteBuf {
-        fn deref_mut(&mut self) -> &mut [u8] { &mut self.bytes[..] }
+        fn deref_mut(&mut self) -> &mut [u8] {
+            &mut self.bytes[..]
+        }
     }
 
     impl ser::Serialize for ByteBuf {
         fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
-            where S: ser::Serializer
+            where S: ser::Serializer,
         {
             serializer.serialize_bytes(self)
         }
@@ -222,17 +227,18 @@ mod bytebuf {
     impl de::Deserialize for ByteBuf {
         #[inline]
         fn deserialize<D>(deserializer: &mut D) -> Result<ByteBuf, D::Error>
-            where D: de::Deserializer
+            where D: de::Deserializer,
         {
             deserializer.deserialize_bytes(ByteBufVisitor)
         }
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
-
+/// ////////////////////////////////////////////////////////////////////////////
 #[inline]
-fn escape_bytestring<'a>(bytes: &'a [u8]) -> iter::FlatMap<slice::Iter<'a, u8>, char::EscapeDefault, fn(&u8) -> char::EscapeDefault> {
+fn escape_bytestring<'a>
+    (bytes: &'a [u8])
+     -> iter::FlatMap<slice::Iter<'a, u8>, char::EscapeDefault, fn(&u8) -> char::EscapeDefault> {
     fn f(b: &u8) -> char::EscapeDefault {
         char::from_u32(*b as u32).unwrap().escape_default()
     }

--- a/serde/src/de/from_primitive.rs
+++ b/serde/src/de/from_primitive.rs
@@ -13,8 +13,8 @@
 // Rust 1.5 is unhappy that this private module is undocumented.
 #![allow(missing_docs)]
 
-use core::{usize, u8, u16, u32, u64};
-use core::{isize, i8, i16, i32, i64};
+use core::{u16, u32, u64, u8, usize};
+use core::{i16, i32, i64, i8, isize};
 use core::{f32, f64};
 use core::mem::size_of;
 

--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -6,33 +6,17 @@ use std::borrow::Cow;
 use collections::borrow::Cow;
 
 #[cfg(all(feature = "collections", not(feature = "std")))]
-use collections::{
-    BinaryHeap,
-    BTreeMap,
-    BTreeSet,
-    LinkedList,
-    VecDeque,
-    Vec,
-    String,
-};
+use collections::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, String, Vec, VecDeque};
 
 #[cfg(feature = "std")]
-use std::collections::{
-    HashMap,
-    HashSet,
-    BinaryHeap,
-    BTreeMap,
-    BTreeSet,
-    LinkedList,
-    VecDeque,
-};
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque};
 
 #[cfg(all(feature = "nightly", feature = "collections"))]
 use collections::enum_set::{CLike, EnumSet};
 #[cfg(all(feature = "nightly", feature = "collections"))]
 use collections::borrow::ToOwned;
 
-use core::hash::{Hash, BuildHasher};
+use core::hash::{BuildHasher, Hash};
 use core::marker::PhantomData;
 #[cfg(feature = "std")]
 use std::net;
@@ -59,20 +43,11 @@ use core::nonzero::{NonZero, Zeroable};
 #[cfg(feature = "nightly")]
 use core::num::Zero;
 
-use de::{
-    Deserialize,
-    Deserializer,
-    EnumVisitor,
-    Error,
-    MapVisitor,
-    SeqVisitor,
-    Type,
-    VariantVisitor,
-    Visitor,
-};
+use de::{Deserialize, Deserializer, EnumVisitor, Error, MapVisitor, SeqVisitor, Type,
+         VariantVisitor, Visitor};
 use de::from_primitive::FromPrimitive;
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 /// A visitor that produces a `()`.
 pub struct UnitVisitor;
@@ -101,7 +76,7 @@ impl Deserialize for () {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 /// A visitor that produces a `bool`.
 pub struct BoolVisitor;
@@ -134,7 +109,7 @@ impl Deserialize for bool {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 macro_rules! impl_deserialize_num_method {
     ($src_ty:ty, $method:ident, $from_method:ident, $ty:expr) => {
@@ -166,7 +141,7 @@ impl<T> PrimitiveVisitor<T> {
 }
 
 impl<T> Visitor for PrimitiveVisitor<T>
-    where T: Deserialize + FromPrimitive + str::FromStr
+    where T: Deserialize + FromPrimitive + str::FromStr,
 {
     type Value = T;
 
@@ -187,9 +162,8 @@ impl<T> Visitor for PrimitiveVisitor<T>
     fn visit_str<E>(&mut self, s: &str) -> Result<T, E>
         where E: Error,
     {
-        str::FromStr::from_str(s.trim_matches(::utils::Pattern_White_Space)).or_else(|_| {
-            Err(Error::invalid_type(Type::Str))
-        })
+        str::FromStr::from_str(s.trim_matches(::utils::Pattern_White_Space))
+            .or_else(|_| Err(Error::invalid_type(Type::Str)))
     }
 }
 
@@ -219,7 +193,7 @@ impl_deserialize_num!(u64, deserialize_u64);
 impl_deserialize_num!(f32, deserialize_f32);
 impl_deserialize_num!(f64, deserialize_f64);
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 struct CharVisitor;
 
@@ -259,8 +233,7 @@ impl Deserialize for char {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
-
+/// ////////////////////////////////////////////////////////////////////////////
 #[cfg(any(feature = "std", feature = "collections"))]
 struct StringVisitor;
 
@@ -308,15 +281,13 @@ impl Deserialize for String {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 struct OptionVisitor<T> {
     marker: PhantomData<T>,
 }
 
-impl<
-    T: Deserialize,
-> Visitor for OptionVisitor<T> {
+impl<T: Deserialize> Visitor for OptionVisitor<T> {
     type Value = Option<T>;
 
     #[inline]
@@ -341,22 +312,28 @@ impl<
     }
 }
 
-impl<T> Deserialize for Option<T> where T: Deserialize {
+impl<T> Deserialize for Option<T>
+    where T: Deserialize,
+{
     fn deserialize<D>(deserializer: &mut D) -> Result<Option<T>, D::Error>
         where D: Deserializer,
     {
-        deserializer.deserialize_option(OptionVisitor { marker: PhantomData })
+        deserializer.deserialize_option(OptionVisitor {
+            marker: PhantomData,
+        })
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 /// A visitor that produces a `PhantomData`.
 pub struct PhantomDataVisitor<T> {
     marker: PhantomData<T>,
 }
 
-impl<T> Visitor for PhantomDataVisitor<T> where T: Deserialize {
+impl<T> Visitor for PhantomDataVisitor<T>
+    where T: Deserialize,
+{
     type Value = PhantomData<T>;
 
     #[inline]
@@ -367,16 +344,20 @@ impl<T> Visitor for PhantomDataVisitor<T> where T: Deserialize {
     }
 }
 
-impl<T> Deserialize for PhantomData<T> where T: Deserialize {
+impl<T> Deserialize for PhantomData<T>
+    where T: Deserialize,
+{
     fn deserialize<D>(deserializer: &mut D) -> Result<PhantomData<T>, D::Error>
         where D: Deserializer,
     {
-        let visitor = PhantomDataVisitor { marker: PhantomData };
+        let visitor = PhantomDataVisitor {
+            marker: PhantomData,
+        };
         deserializer.deserialize_unit_struct("PhantomData", visitor)
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 macro_rules! seq_impl {
     (
@@ -507,7 +488,7 @@ seq_impl!(
     VecDeque::with_capacity(visitor.size_hint().0),
     VecDeque::push_back);
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 struct ArrayVisitor0<T> {
     marker: PhantomData<T>,
@@ -522,7 +503,9 @@ impl<T> ArrayVisitor0<T> {
     }
 }
 
-impl<T> Visitor for ArrayVisitor0<T> where T: Deserialize + Default {
+impl<T> Visitor for ArrayVisitor0<T>
+    where T: Deserialize + Default,
+{
     type Value = [T; 0];
 
     #[inline]
@@ -542,7 +525,7 @@ impl<T> Visitor for ArrayVisitor0<T> where T: Deserialize + Default {
 }
 
 impl<T> Deserialize for [T; 0]
-    where T: Deserialize + Default
+    where T: Deserialize + Default,
 {
     fn deserialize<D>(deserializer: &mut D) -> Result<[T; 0], D::Error>
         where D: Deserializer,
@@ -643,7 +626,7 @@ array_impls! {
                            y, z, aa, ab, ac, ad, ae, af),
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 macro_rules! tuple_impls {
     ($($len:expr => $visitor:ident => ($($name:ident),+),)+) => {
@@ -719,7 +702,7 @@ tuple_impls! {
     16 => TupleVisitor16 => (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15),
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 macro_rules! map_impl {
     (
@@ -804,8 +787,7 @@ map_impl!(
     HashMap::with_hasher(S::default()),
     HashMap::with_capacity_and_hasher(visitor.size_hint().0, S::default()));
 
-///////////////////////////////////////////////////////////////////////////////
-
+/// ////////////////////////////////////////////////////////////////////////////
 #[cfg(all(feature = "nightly", feature = "std"))]
 impl Deserialize for net::IpAddr {
     fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
@@ -845,8 +827,7 @@ impl Deserialize for net::Ipv6Addr {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
-
+/// ////////////////////////////////////////////////////////////////////////////
 #[cfg(feature = "std")]
 impl Deserialize for net::SocketAddr {
     fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
@@ -886,8 +867,7 @@ impl Deserialize for net::SocketAddrV6 {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
-
+/// ////////////////////////////////////////////////////////////////////////////
 #[cfg(feature = "std")]
 struct PathBufVisitor;
 
@@ -917,8 +897,7 @@ impl Deserialize for path::PathBuf {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
-
+/// ////////////////////////////////////////////////////////////////////////////
 #[cfg(any(feature = "std", feature = "alloc"))]
 impl<T: Deserialize> Deserialize for Box<T> {
     fn deserialize<D>(deserializer: &mut D) -> Result<Box<T>, D::Error>
@@ -960,7 +939,10 @@ impl<T: Deserialize> Deserialize for Rc<T> {
 }
 
 #[cfg(any(feature = "std", feature = "collections"))]
-impl<'a, T: ?Sized> Deserialize for Cow<'a, T> where T: ToOwned, T::Owned: Deserialize, {
+impl<'a, T: ?Sized> Deserialize for Cow<'a, T>
+    where T: ToOwned,
+          T::Owned: Deserialize,
+{
     #[inline]
     fn deserialize<D>(deserializer: &mut D) -> Result<Cow<'a, T>, D::Error>
         where D: Deserializer,
@@ -970,27 +952,32 @@ impl<'a, T: ?Sized> Deserialize for Cow<'a, T> where T: ToOwned, T::Owned: Deser
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
-
+/// ////////////////////////////////////////////////////////////////////////////
 #[cfg(feature = "nightly")]
-impl<T> Deserialize for NonZero<T> where T: Deserialize + PartialEq + Zeroable + Zero {
-    fn deserialize<D>(deserializer: &mut D) -> Result<NonZero<T>, D::Error> where D: Deserializer {
+impl<T> Deserialize for NonZero<T>
+    where T: Deserialize + PartialEq + Zeroable + Zero,
+{
+    fn deserialize<D>(deserializer: &mut D) -> Result<NonZero<T>, D::Error>
+        where D: Deserializer,
+    {
         let value = try!(Deserialize::deserialize(deserializer));
         if value == Zero::zero() {
-            return Err(Error::invalid_value("expected a non-zero value"))
+            return Err(Error::invalid_value("expected a non-zero value"));
         }
-        unsafe {
-            Ok(NonZero::new(value))
-        }
+        unsafe { Ok(NonZero::new(value)) }
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 
-impl<T, E> Deserialize for Result<T, E> where T: Deserialize, E: Deserialize {
+impl<T, E> Deserialize for Result<T, E>
+    where T: Deserialize,
+          E: Deserialize,
+{
     fn deserialize<D>(deserializer: &mut D) -> Result<Result<T, E>, D::Error>
-                      where D: Deserializer {
+        where D: Deserializer,
+    {
         enum Field {
             Ok,
             Err,
@@ -999,7 +986,7 @@ impl<T, E> Deserialize for Result<T, E> where T: Deserialize, E: Deserialize {
         impl Deserialize for Field {
             #[inline]
             fn deserialize<D>(deserializer: &mut D) -> Result<Field, D::Error>
-                where D: Deserializer
+                where D: Deserializer,
             {
                 struct FieldVisitor;
 
@@ -1007,7 +994,9 @@ impl<T, E> Deserialize for Result<T, E> where T: Deserialize, E: Deserialize {
                     type Value = Field;
 
                     #[cfg(any(feature = "std", feature = "collections"))]
-                    fn visit_usize<E>(&mut self, value: usize) -> Result<Field, E> where E: Error {
+                    fn visit_usize<E>(&mut self, value: usize) -> Result<Field, E>
+                        where E: Error,
+                    {
                         #[cfg(feature = "collections")]
                         use collections::string::ToString;
                         match value {
@@ -1018,7 +1007,9 @@ impl<T, E> Deserialize for Result<T, E> where T: Deserialize, E: Deserialize {
                     }
 
                     #[cfg(all(not(feature = "std"), not(feature = "collections")))]
-                    fn visit_usize<E>(&mut self, value: usize) -> Result<Field, E> where E: Error {
+                    fn visit_usize<E>(&mut self, value: usize) -> Result<Field, E>
+                        where E: Error,
+                    {
                         match value {
                             0 => Ok(Field::Ok),
                             1 => Ok(Field::Err),
@@ -1026,7 +1017,9 @@ impl<T, E> Deserialize for Result<T, E> where T: Deserialize, E: Deserialize {
                         }
                     }
 
-                    fn visit_str<E>(&mut self, value: &str) -> Result<Field, E> where E: Error {
+                    fn visit_str<E>(&mut self, value: &str) -> Result<Field, E>
+                        where E: Error,
+                    {
                         match value {
                             "Ok" => Ok(Field::Ok),
                             "Err" => Ok(Field::Err),
@@ -1034,7 +1027,9 @@ impl<T, E> Deserialize for Result<T, E> where T: Deserialize, E: Deserialize {
                         }
                     }
 
-                    fn visit_bytes<E>(&mut self, value: &[u8]) -> Result<Field, E> where E: Error {
+                    fn visit_bytes<E>(&mut self, value: &[u8]) -> Result<Field, E>
+                        where E: Error,
+                    {
                         match value {
                             b"Ok" => Ok(Field::Ok),
                             b"Err" => Ok(Field::Err),
@@ -1056,12 +1051,12 @@ impl<T, E> Deserialize for Result<T, E> where T: Deserialize, E: Deserialize {
 
         impl<T, E> EnumVisitor for Visitor<T, E>
             where T: Deserialize,
-                  E: Deserialize
+                  E: Deserialize,
         {
             type Value = Result<T, E>;
 
             fn visit<V>(&mut self, mut visitor: V) -> Result<Result<T, E>, V::Error>
-                where V: VariantVisitor
+                where V: VariantVisitor,
             {
                 match try!(visitor.visit_variant()) {
                     Field::Ok => {
@@ -1082,7 +1077,7 @@ impl<T, E> Deserialize for Result<T, E> where T: Deserialize, E: Deserialize {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 /// A target for deserializers that want to ignore data. Implements
 /// Deserialize and silently eats data given to it.

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -14,7 +14,7 @@ pub mod impls;
 pub mod value;
 mod from_primitive;
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 /// `Error` is a trait that allows a `Deserialize` to generically create a
 /// `Deserializer` error.
@@ -174,53 +174,52 @@ pub enum Type {
 impl fmt::Display for Type {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         let display = match *self {
-            Type::Bool          => "bool",
-            Type::Usize         => "usize",
-            Type::U8            => "u8",
-            Type::U16           => "u16",
-            Type::U32           => "u32",
-            Type::U64           => "u64",
-            Type::Isize         => "isize",
-            Type::I8            => "i8",
-            Type::I16           => "i16",
-            Type::I32           => "i32",
-            Type::I64           => "i64",
-            Type::F32           => "f32",
-            Type::F64           => "f64",
-            Type::Char          => "char",
-            Type::Str           => "str",
-            Type::String        => "string",
-            Type::Unit          => "unit",
-            Type::Option        => "option",
-            Type::Seq           => "seq",
-            Type::Map           => "map",
-            Type::UnitStruct    => "unit struct",
+            Type::Bool => "bool",
+            Type::Usize => "usize",
+            Type::U8 => "u8",
+            Type::U16 => "u16",
+            Type::U32 => "u32",
+            Type::U64 => "u64",
+            Type::Isize => "isize",
+            Type::I8 => "i8",
+            Type::I16 => "i16",
+            Type::I32 => "i32",
+            Type::I64 => "i64",
+            Type::F32 => "f32",
+            Type::F64 => "f64",
+            Type::Char => "char",
+            Type::Str => "str",
+            Type::String => "string",
+            Type::Unit => "unit",
+            Type::Option => "option",
+            Type::Seq => "seq",
+            Type::Map => "map",
+            Type::UnitStruct => "unit struct",
             Type::NewtypeStruct => "newtype struct",
-            Type::TupleStruct   => "tuple struct",
-            Type::Struct        => "struct",
-            Type::FieldName     => "field name",
-            Type::Tuple         => "tuple",
-            Type::Enum          => "enum",
-            Type::VariantName   => "variant name",
+            Type::TupleStruct => "tuple struct",
+            Type::Struct => "struct",
+            Type::FieldName => "field name",
+            Type::Tuple => "tuple",
+            Type::Enum => "enum",
+            Type::VariantName => "variant name",
             Type::StructVariant => "struct variant",
-            Type::TupleVariant  => "tuple variant",
-            Type::UnitVariant   => "unit variant",
-            Type::Bytes         => "bytes",
+            Type::TupleVariant => "tuple variant",
+            Type::UnitVariant => "unit variant",
+            Type::Bytes => "bytes",
         };
         display.fmt(formatter)
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 /// `Deserialize` represents a type that can be deserialized.
 pub trait Deserialize: Sized {
     /// Deserialize this value given this `Deserializer`.
-    fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
-        where D: Deserializer;
+    fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error> where D: Deserializer;
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 /// `Deserializer` is a trait that can deserialize values by threading a `Visitor` trait through a
 /// value. It supports two entry point styles which enables different kinds of deserialization.
@@ -239,8 +238,7 @@ pub trait Deserializer {
     type Error: Error;
 
     /// This method walks a visitor through a value as it is being deserialized.
-    fn deserialize<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
-        where V: Visitor;
+    fn deserialize<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor;
 
     /// This method hints that the `Deserialize` type is expecting a `bool` value.
     #[inline]
@@ -402,9 +400,11 @@ pub trait Deserializer {
     ///
     /// By default, this deserializes arrays from a sequence.
     #[inline]
-    fn deserialize_fixed_size_array<V>(&mut self,
-                                       _len: usize,
-                                       visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_fixed_size_array<V>(
+        &mut self,
+        _len: usize,
+        visitor: V
+    ) -> Result<V::Value, Self::Error>
         where V: Visitor,
     {
         self.deserialize(visitor)
@@ -432,9 +432,11 @@ pub trait Deserializer {
     /// This method hints that the `Deserialize` type is expecting a unit struct. This allows
     /// deserializers to a unit struct that aren't tagged as a unit struct.
     #[inline]
-    fn deserialize_unit_struct<V>(&mut self,
-                                  _name: &'static str,
-                                  visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_unit_struct<V>(
+        &mut self,
+        _name: &'static str,
+        visitor: V
+    ) -> Result<V::Value, Self::Error>
         where V: Visitor,
     {
         self.deserialize_unit(visitor)
@@ -443,9 +445,11 @@ pub trait Deserializer {
     /// This method hints that the `Deserialize` type is expecting a newtype struct. This allows
     /// deserializers to a newtype struct that aren't tagged as a newtype struct.
     #[inline]
-    fn deserialize_newtype_struct<V>(&mut self,
-                                     name: &'static str,
-                                     visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_newtype_struct<V>(
+        &mut self,
+        name: &'static str,
+        visitor: V
+    ) -> Result<V::Value, Self::Error>
         where V: Visitor,
     {
         self.deserialize_tuple_struct(name, 1, visitor)
@@ -454,10 +458,12 @@ pub trait Deserializer {
     /// This method hints that the `Deserialize` type is expecting a tuple struct. This allows
     /// deserializers to parse sequences that aren't tagged as sequences.
     #[inline]
-    fn deserialize_tuple_struct<V>(&mut self,
-                                   _name: &'static str,
-                                   len: usize,
-                                   visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_tuple_struct<V>(
+        &mut self,
+        _name: &'static str,
+        len: usize,
+        visitor: V
+    ) -> Result<V::Value, Self::Error>
         where V: Visitor,
     {
         self.deserialize_tuple(len, visitor)
@@ -466,10 +472,12 @@ pub trait Deserializer {
     /// This method hints that the `Deserialize` type is expecting a struct. This allows
     /// deserializers to parse sequences that aren't tagged as maps.
     #[inline]
-    fn deserialize_struct<V>(&mut self,
-                             _name: &'static str,
-                             _fields: &'static [&'static str],
-                             visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_struct<V>(
+        &mut self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V
+    ) -> Result<V::Value, Self::Error>
         where V: Visitor,
     {
         self.deserialize_map(visitor)
@@ -498,10 +506,12 @@ pub trait Deserializer {
     /// deserializers that provide a custom enumeration serialization to properly deserialize the
     /// type.
     #[inline]
-    fn deserialize_enum<V>(&mut self,
-                           _enum: &'static str,
-                           _variants: &'static [&'static str],
-                           _visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_enum<V>(
+        &mut self,
+        _enum: &'static str,
+        _variants: &'static [&'static str],
+        _visitor: V
+    ) -> Result<V::Value, Self::Error>
         where V: EnumVisitor,
     {
         Err(Error::invalid_type(Type::Enum))
@@ -511,13 +521,13 @@ pub trait Deserializer {
     /// doesn't matter because it is ignored.
     #[inline]
     fn deserialize_ignored_any<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
-        where V: Visitor
+        where V: Visitor,
     {
         self.deserialize(visitor)
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 /// This trait represents a visitor that walks through a deserializer.
 pub trait Visitor {
@@ -707,7 +717,7 @@ pub trait Visitor {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 /// `SeqVisitor` visits each item in a sequence.
 ///
@@ -719,8 +729,7 @@ pub trait SeqVisitor {
 
     /// This returns a `Ok(Some(value))` for the next value in the sequence, or `Ok(None)` if there
     /// are no more remaining items.
-    fn visit<T>(&mut self) -> Result<Option<T>, Self::Error>
-        where T: Deserialize;
+    fn visit<T>(&mut self) -> Result<Option<T>, Self::Error> where T: Deserialize;
 
     /// This signals to the `SeqVisitor` that the `Visitor` does not expect any more items.
     fn end(&mut self) -> Result<(), Self::Error>;
@@ -732,12 +741,14 @@ pub trait SeqVisitor {
     }
 }
 
-impl<'a, V> SeqVisitor for &'a mut V where V: SeqVisitor {
+impl<'a, V> SeqVisitor for &'a mut V
+    where V: SeqVisitor,
+{
     type Error = V::Error;
 
     #[inline]
     fn visit<T>(&mut self) -> Result<Option<T>, V::Error>
-        where T: Deserialize
+        where T: Deserialize,
     {
         (**self).visit()
     }
@@ -753,7 +764,7 @@ impl<'a, V> SeqVisitor for &'a mut V where V: SeqVisitor {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 /// `MapVisitor` visits each item in a sequence.
 ///
@@ -774,18 +785,16 @@ pub trait MapVisitor {
                 let value = try!(self.visit_value());
                 Ok(Some((key, value)))
             }
-            None => Ok(None)
+            None => Ok(None),
         }
     }
 
     /// This returns a `Ok(Some(key))` for the next key in the map, or `Ok(None)` if there are no
     /// more remaining items.
-    fn visit_key<K>(&mut self) -> Result<Option<K>, Self::Error>
-        where K: Deserialize;
+    fn visit_key<K>(&mut self) -> Result<Option<K>, Self::Error> where K: Deserialize;
 
     /// This returns a `Ok(value)` for the next value in the map.
-    fn visit_value<V>(&mut self) -> Result<V, Self::Error>
-        where V: Deserialize;
+    fn visit_value<V>(&mut self) -> Result<V, Self::Error> where V: Deserialize;
 
     /// This signals to the `MapVisitor` that the `Visitor` does not expect any more items.
     fn end(&mut self) -> Result<(), Self::Error>;
@@ -804,7 +813,9 @@ pub trait MapVisitor {
     }
 }
 
-impl<'a, V_> MapVisitor for &'a mut V_ where V_: MapVisitor {
+impl<'a, V_> MapVisitor for &'a mut V_
+    where V_: MapVisitor,
+{
     type Error = V_::Error;
 
     #[inline]
@@ -817,14 +828,14 @@ impl<'a, V_> MapVisitor for &'a mut V_ where V_: MapVisitor {
 
     #[inline]
     fn visit_key<K>(&mut self) -> Result<Option<K>, V_::Error>
-        where K: Deserialize
+        where K: Deserialize,
     {
         (**self).visit_key()
     }
 
     #[inline]
     fn visit_value<V>(&mut self) -> Result<V, V_::Error>
-        where V: Deserialize
+        where V: Deserialize,
     {
         (**self).visit_value()
     }
@@ -840,7 +851,7 @@ impl<'a, V_> MapVisitor for &'a mut V_ where V_: MapVisitor {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 /// `EnumVisitor` is a visitor that is created by the `Deserialize` and passed to the
 /// `Deserializer` in order to deserialize enums.
@@ -849,11 +860,10 @@ pub trait EnumVisitor {
     type Value;
 
     /// Visit the specific variant with the `VariantVisitor`.
-    fn visit<V>(&mut self, visitor: V) -> Result<Self::Value, V::Error>
-        where V: VariantVisitor;
+    fn visit<V>(&mut self, visitor: V) -> Result<Self::Value, V::Error> where V: VariantVisitor;
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 /// `VariantVisitor` is a visitor that is created by the `Deserializer` and passed to the
 /// `Deserialize` in order to deserialize a specific enum variant.
@@ -862,8 +872,7 @@ pub trait VariantVisitor {
     type Error: Error;
 
     /// `visit_variant` is called to identify which variant to deserialize.
-    fn visit_variant<V>(&mut self) -> Result<V, Self::Error>
-        where V: Deserialize;
+    fn visit_variant<V>(&mut self) -> Result<V, Self::Error> where V: Deserialize;
 
     /// `visit_unit` is called when deserializing a variant with no values.
     fn visit_unit(&mut self) -> Result<(), Self::Error> {
@@ -881,29 +890,31 @@ pub trait VariantVisitor {
     }
 
     /// `visit_tuple` is called when deserializing a tuple-like variant.
-    fn visit_tuple<V>(&mut self,
-                      _len: usize,
-                      _visitor: V) -> Result<V::Value, Self::Error>
-        where V: Visitor
+    fn visit_tuple<V>(&mut self, _len: usize, _visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor,
     {
         Err(Error::invalid_type(Type::TupleVariant))
     }
 
     /// `visit_struct` is called when deserializing a struct-like variant.
-    fn visit_struct<V>(&mut self,
-                       _fields: &'static [&'static str],
-                       _visitor: V) -> Result<V::Value, Self::Error>
-        where V: Visitor
+    fn visit_struct<V>(
+        &mut self,
+        _fields: &'static [&'static str],
+        _visitor: V
+    ) -> Result<V::Value, Self::Error>
+        where V: Visitor,
     {
         Err(Error::invalid_type(Type::StructVariant))
     }
 }
 
-impl<'a, T> VariantVisitor for &'a mut T where T: VariantVisitor {
+impl<'a, T> VariantVisitor for &'a mut T
+    where T: VariantVisitor,
+{
     type Error = T::Error;
 
     fn visit_variant<V>(&mut self) -> Result<V, T::Error>
-        where V: Deserialize
+        where V: Deserialize,
     {
         (**self).visit_variant()
     }
@@ -918,17 +929,17 @@ impl<'a, T> VariantVisitor for &'a mut T where T: VariantVisitor {
         (**self).visit_newtype()
     }
 
-    fn visit_tuple<V>(&mut self,
-                      len: usize,
-                      visitor: V) -> Result<V::Value, T::Error>
+    fn visit_tuple<V>(&mut self, len: usize, visitor: V) -> Result<V::Value, T::Error>
         where V: Visitor,
     {
         (**self).visit_tuple(len, visitor)
     }
 
-    fn visit_struct<V>(&mut self,
-                       fields: &'static [&'static str],
-                       visitor: V) -> Result<V::Value, T::Error>
+    fn visit_struct<V>(
+        &mut self,
+        fields: &'static [&'static str],
+        visitor: V
+    ) -> Result<V::Value, T::Error>
         where V: Visitor,
     {
         (**self).visit_struct(fields, visitor)

--- a/serde/src/de/value.rs
+++ b/serde/src/de/value.rs
@@ -1,29 +1,13 @@
 //! This module supports deserializing from primitives with the `ValueDeserializer` trait.
 
 #[cfg(feature = "std")]
-use std::collections::{
-    BTreeMap,
-    BTreeSet,
-    HashMap,
-    HashSet,
-    btree_map,
-    btree_set,
-    hash_map,
-    hash_set,
-};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, btree_map, btree_set, hash_map,
+                       hash_set};
 #[cfg(feature = "std")]
 use std::vec;
 
 #[cfg(all(feature = "collections", not(feature = "std")))]
-use collections::{
-    BTreeMap,
-    BTreeSet,
-    Vec,
-    String,
-    btree_map,
-    btree_set,
-    vec,
-};
+use collections::{BTreeMap, BTreeSet, String, Vec, btree_map, btree_set, vec};
 
 #[cfg(all(feature = "nightly", feature = "collections"))]
 use collections::borrow::ToOwned;
@@ -40,7 +24,7 @@ use core::marker::PhantomData;
 use de;
 use bytes;
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 /// This represents all the possible errors that can occur using the `ValueDeserializer`.
 #[derive(Clone, Debug, PartialEq)]
@@ -88,32 +72,56 @@ pub enum Error {
 
 impl de::Error for Error {
     #[cfg(any(feature = "std", feature = "collections"))]
-    fn custom<T: Into<String>>(msg: T) -> Self { Error::Custom(msg.into()) }
+    fn custom<T: Into<String>>(msg: T) -> Self {
+        Error::Custom(msg.into())
+    }
 
     #[cfg(all(not(feature = "std"), not(feature = "collections")))]
-    fn custom<T: Into<&'static str>>(msg: T) -> Self { Error::Custom(msg.into()) }
+    fn custom<T: Into<&'static str>>(msg: T) -> Self {
+        Error::Custom(msg.into())
+    }
 
-    fn end_of_stream() -> Self { Error::EndOfStream }
-    fn invalid_type(ty: de::Type) -> Self { Error::InvalidType(ty) }
+    fn end_of_stream() -> Self {
+        Error::EndOfStream
+    }
+    fn invalid_type(ty: de::Type) -> Self {
+        Error::InvalidType(ty)
+    }
 
     #[cfg(any(feature = "std", feature = "collections"))]
-    fn invalid_value(msg: &str) -> Self { Error::InvalidValue(msg.to_owned()) }
+    fn invalid_value(msg: &str) -> Self {
+        Error::InvalidValue(msg.to_owned())
+    }
 
     #[cfg(all(not(feature = "std"), not(feature = "collections")))]
-    fn invalid_value(msg: &str) -> Self { Error::InvalidValue("invalid value") }
+    fn invalid_value(msg: &str) -> Self {
+        Error::InvalidValue("invalid value")
+    }
 
-    fn invalid_length(len: usize) -> Self { Error::InvalidLength(len) }
+    fn invalid_length(len: usize) -> Self {
+        Error::InvalidLength(len)
+    }
 
     #[cfg(any(feature = "std", feature = "collections"))]
-    fn unknown_variant(variant: &str) -> Self { Error::UnknownVariant(String::from(variant)) }
+    fn unknown_variant(variant: &str) -> Self {
+        Error::UnknownVariant(String::from(variant))
+    }
     #[cfg(any(feature = "std", feature = "collections"))]
-    fn unknown_field(field: &str) -> Self { Error::UnknownField(String::from(field)) }
+    fn unknown_field(field: &str) -> Self {
+        Error::UnknownField(String::from(field))
+    }
 
     #[cfg(all(not(feature = "std"), not(feature = "collections")))]
-    fn unknown_variant(variant: &str) -> Self { Error::UnknownVariant("unknown variant") }
+    fn unknown_variant(variant: &str) -> Self {
+        Error::UnknownVariant("unknown variant")
+    }
     #[cfg(all(not(feature = "std"), not(feature = "collections")))]
-    fn unknown_field(field: &str) -> Self { Error::UnknownField("unknown field") }
-    fn missing_field(field: &'static str) -> Self { Error::MissingField(field) }
+    fn unknown_field(field: &str) -> Self {
+        Error::UnknownField("unknown field")
+    }
+    fn missing_field(field: &'static str) -> Self {
+        Error::MissingField(field)
+    }
 }
 
 impl fmt::Display for Error {
@@ -124,9 +132,7 @@ impl fmt::Display for Error {
             Error::InvalidType(ty) => write!(formatter, "Invalid type, expected `{:?}`", ty),
             Error::InvalidValue(ref value) => write!(formatter, "Invalid value: {}", value),
             Error::InvalidLength(len) => write!(formatter, "Invalid length: {}", len),
-            Error::UnknownVariant(ref variant) => {
-                write!(formatter, "Unknown variant: {}", variant)
-            }
+            Error::UnknownVariant(ref variant) => write!(formatter, "Unknown variant: {}", variant),
             Error::UnknownField(ref field) => write!(formatter, "Unknown field: {}", field),
             Error::MissingField(ref field) => write!(formatter, "Missing field: {}", field),
         }
@@ -143,18 +149,18 @@ impl error::Error for Error {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 /// This trait converts primitive types into a deserializer.
 pub trait ValueDeserializer<E: de::Error = Error> {
     /// The actual deserializer type.
-    type Deserializer: de::Deserializer<Error=E>;
+    type Deserializer: de::Deserializer<Error = E>;
 
     /// Convert this value into a deserializer.
     fn into_deserializer(self) -> Self::Deserializer;
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 impl<E> ValueDeserializer<E> for ()
     where E: de::Error,
@@ -170,7 +176,7 @@ impl<E> ValueDeserializer<E> for ()
 pub struct UnitDeserializer<E>(PhantomData<E>);
 
 impl<E> de::Deserializer for UnitDeserializer<E>
-    where E: de::Error
+    where E: de::Error,
 {
     type Error = E;
 
@@ -187,7 +193,7 @@ impl<E> de::Deserializer for UnitDeserializer<E>
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 macro_rules! primitive_deserializer {
     ($ty:ty, $name:ident, $method:ident) => {
@@ -236,7 +242,7 @@ primitive_deserializer!(f32, F32Deserializer, visit_f32);
 primitive_deserializer!(f64, F64Deserializer, visit_f64);
 primitive_deserializer!(char, CharDeserializer, visit_char);
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 /// A helper deserializer that deserializes a `&str`.
 pub struct StrDeserializer<'a, E>(Option<&'a str>, PhantomData<E>);
@@ -265,10 +271,12 @@ impl<'a, E> de::Deserializer for StrDeserializer<'a, E>
         }
     }
 
-    fn deserialize_enum<V>(&mut self,
-                     _name: &str,
-                     _variants: &'static [&'static str],
-                     mut visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_enum<V>(
+        &mut self,
+        _name: &str,
+        _variants: &'static [&'static str],
+        mut visitor: V
+    ) -> Result<V::Value, Self::Error>
         where V: de::EnumVisitor,
     {
         visitor.visit(self)
@@ -291,7 +299,7 @@ impl<'a, E> de::VariantVisitor for StrDeserializer<'a, E>
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 /// A helper deserializer that deserializes a `String`.
 #[cfg(any(feature = "std", feature = "collections"))]
@@ -323,10 +331,12 @@ impl<E> de::Deserializer for StringDeserializer<E>
         }
     }
 
-    fn deserialize_enum<V>(&mut self,
-                     _name: &str,
-                     _variants: &'static [&'static str],
-                     mut visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_enum<V>(
+        &mut self,
+        _name: &str,
+        _variants: &'static [&'static str],
+        mut visitor: V
+    ) -> Result<V::Value, Self::Error>
         where V: de::EnumVisitor,
     {
         visitor.visit(self)
@@ -350,7 +360,7 @@ impl<'a, E> de::VariantVisitor for StringDeserializer<E>
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 /// A helper deserializer that deserializes a sequence.
 pub struct SeqDeserializer<I, E> {
@@ -373,7 +383,7 @@ impl<I, E> SeqDeserializer<I, E>
 }
 
 impl<I, T, E> de::Deserializer for SeqDeserializer<I, E>
-    where I: Iterator<Item=T>,
+    where I: Iterator<Item = T>,
           T: ValueDeserializer<E>,
           E: de::Error,
 {
@@ -387,14 +397,14 @@ impl<I, T, E> de::Deserializer for SeqDeserializer<I, E>
 }
 
 impl<I, T, E> de::SeqVisitor for SeqDeserializer<I, E>
-    where I: Iterator<Item=T>,
+    where I: Iterator<Item = T>,
           T: ValueDeserializer<E>,
           E: de::Error,
 {
     type Error = E;
 
     fn visit<V>(&mut self) -> Result<Option<V>, Self::Error>
-        where V: de::Deserialize
+        where V: de::Deserialize,
     {
         match self.iter.next() {
             Some(value) => {
@@ -419,8 +429,7 @@ impl<I, T, E> de::SeqVisitor for SeqDeserializer<I, E>
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
-
+/// ////////////////////////////////////////////////////////////////////////////
 #[cfg(any(feature = "std", feature = "collections"))]
 impl<T, E> ValueDeserializer<E> for Vec<T>
     where T: ValueDeserializer<E>,
@@ -460,7 +469,7 @@ impl<T, E> ValueDeserializer<E> for HashSet<T>
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 /// A helper deserializer that deserializes a sequence using a `SeqVisitor`.
 pub struct SeqVisitorDeserializer<V_, E> {
@@ -474,9 +483,9 @@ impl<V_, E> SeqVisitorDeserializer<V_, E>
 {
     /// Construct a new `SeqVisitorDeserializer<V_, E>`.
     pub fn new(visitor: V_) -> Self {
-        SeqVisitorDeserializer{
+        SeqVisitorDeserializer {
             visitor: visitor,
-            marker: PhantomData
+            marker: PhantomData,
         }
     }
 }
@@ -492,11 +501,11 @@ impl<V_, E> de::Deserializer for SeqVisitorDeserializer<V_, E>
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 /// A helper deserializer that deserializes a map.
 pub struct MapDeserializer<I, K, V, E>
-    where I: Iterator<Item=(K, V)>,
+    where I: Iterator<Item = (K, V)>,
           K: ValueDeserializer<E>,
           V: ValueDeserializer<E>,
           E: de::Error,
@@ -508,7 +517,7 @@ pub struct MapDeserializer<I, K, V, E>
 }
 
 impl<I, K, V, E> MapDeserializer<I, K, V, E>
-    where I: Iterator<Item=(K, V)>,
+    where I: Iterator<Item = (K, V)>,
           K: ValueDeserializer<E>,
           V: ValueDeserializer<E>,
           E: de::Error,
@@ -525,7 +534,7 @@ impl<I, K, V, E> MapDeserializer<I, K, V, E>
 }
 
 impl<I, K, V, E> de::Deserializer for MapDeserializer<I, K, V, E>
-    where I: Iterator<Item=(K, V)>,
+    where I: Iterator<Item = (K, V)>,
           K: ValueDeserializer<E>,
           V: ValueDeserializer<E>,
           E: de::Error,
@@ -540,7 +549,7 @@ impl<I, K, V, E> de::Deserializer for MapDeserializer<I, K, V, E>
 }
 
 impl<I, K, V, E> de::MapVisitor for MapDeserializer<I, K, V, E>
-    where I: Iterator<Item=(K, V)>,
+    where I: Iterator<Item = (K, V)>,
           K: ValueDeserializer<E>,
           V: ValueDeserializer<E>,
           E: de::Error,
@@ -569,9 +578,7 @@ impl<I, K, V, E> de::MapVisitor for MapDeserializer<I, K, V, E>
                 let mut de = value.into_deserializer();
                 de::Deserialize::deserialize(&mut de)
             }
-            None => {
-                Err(de::Error::end_of_stream())
-            }
+            None => Err(de::Error::end_of_stream()),
         }
     }
 
@@ -588,8 +595,7 @@ impl<I, K, V, E> de::MapVisitor for MapDeserializer<I, K, V, E>
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
-
+/// ////////////////////////////////////////////////////////////////////////////
 #[cfg(any(feature = "std", feature = "collections"))]
 impl<K, V, E> ValueDeserializer<E> for BTreeMap<K, V>
     where K: ValueDeserializer<E> + Eq + Ord,
@@ -618,7 +624,7 @@ impl<K, V, E> ValueDeserializer<E> for HashMap<K, V>
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 /// A helper deserializer that deserializes a map using a `MapVisitor`.
 pub struct MapVisitorDeserializer<V_, E> {
@@ -632,9 +638,9 @@ impl<V_, E> MapVisitorDeserializer<V_, E>
 {
     /// Construct a new `MapVisitorDeserializer<V_, E>`.
     pub fn new(visitor: V_) -> Self {
-        MapVisitorDeserializer{
+        MapVisitorDeserializer {
             visitor: visitor,
-            marker: PhantomData
+            marker: PhantomData,
         }
     }
 }
@@ -650,7 +656,7 @@ impl<V_, E> de::Deserializer for MapVisitorDeserializer<V_, E>
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 impl<'a, E> ValueDeserializer<E> for bytes::Bytes<'a>
     where E: de::Error,
@@ -663,10 +669,10 @@ impl<'a, E> ValueDeserializer<E> for bytes::Bytes<'a>
 }
 
 /// A helper deserializer that deserializes a `&[u8]`.
-pub struct BytesDeserializer<'a, E> (Option<&'a [u8]>, PhantomData<E>);
+pub struct BytesDeserializer<'a, E>(Option<&'a [u8]>, PhantomData<E>);
 
 impl<'a, E> de::Deserializer for BytesDeserializer<'a, E>
-    where E: de::Error
+    where E: de::Error,
 {
     type Error = E;
 
@@ -681,8 +687,7 @@ impl<'a, E> de::Deserializer for BytesDeserializer<'a, E>
 }
 
 
-///////////////////////////////////////////////////////////////////////////////
-
+/// ////////////////////////////////////////////////////////////////////////////
 #[cfg(any(feature = "std", feature = "collections"))]
 impl<E> ValueDeserializer<E> for bytes::ByteBuf
     where E: de::Error,

--- a/serde/src/error.rs
+++ b/serde/src/error.rs
@@ -14,11 +14,15 @@ pub trait Error: Debug + Display + ::core::marker::Reflect {
     fn description(&self) -> &str;
 
     /// The lower-level cause of this error, if any.
-    fn cause(&self) -> Option<&Error> { None }
+    fn cause(&self) -> Option<&Error> {
+        None
+    }
 
     /// Get the `TypeId` of `self`
     #[doc(hidden)]
-    fn type_id(&self) -> TypeId where Self: 'static {
+    fn type_id(&self) -> TypeId
+        where Self: 'static,
+    {
         TypeId::of::<Self>()
     }
 }
@@ -34,11 +38,15 @@ pub trait Error: Debug + Display {
     fn description(&self) -> &str;
 
     /// The lower-level cause of this error, if any.
-    fn cause(&self) -> Option<&Error> { None }
+    fn cause(&self) -> Option<&Error> {
+        None
+    }
 
     /// Stubbed! Returns type_id of `()`
     #[doc(hidden)]
-    fn type_id(&self) -> TypeId where Self: 'static {
+    fn type_id(&self) -> TypeId
+        where Self: 'static,
+    {
         TypeId::of::<()>()
     }
 }

--- a/serde/src/iter.rs
+++ b/serde/src/iter.rs
@@ -4,13 +4,13 @@ use std::io;
 use std::iter::Peekable;
 
 /// Iterator over a byte stream that tracks the current position's line and column.
-pub struct LineColIterator<Iter: Iterator<Item=io::Result<u8>>> {
+pub struct LineColIterator<Iter: Iterator<Item = io::Result<u8>>> {
     iter: Iter,
     line: usize,
     col: usize,
 }
 
-impl<Iter: Iterator<Item=io::Result<u8>>> LineColIterator<Iter> {
+impl<Iter: Iterator<Item = io::Result<u8>>> LineColIterator<Iter> {
     /// Construct a new `LineColIterator<Iter>`.
     pub fn new(iter: Iter) -> LineColIterator<Iter> {
         LineColIterator {
@@ -21,27 +21,39 @@ impl<Iter: Iterator<Item=io::Result<u8>>> LineColIterator<Iter> {
     }
 
     /// Report the current line inside the iterator.
-    pub fn line(&self) -> usize { self.line }
+    pub fn line(&self) -> usize {
+        self.line
+    }
 
     /// Report the current column inside the iterator.
-    pub fn col(&self) -> usize { self.col }
+    pub fn col(&self) -> usize {
+        self.col
+    }
 
     /// Gets a reference to the underlying iterator.
-    pub fn get_ref(&self) -> &Iter { &self.iter }
+    pub fn get_ref(&self) -> &Iter {
+        &self.iter
+    }
 
     /// Gets a mutable reference to the underlying iterator.
-    pub fn get_mut(&mut self) -> &mut Iter { &mut self.iter }
+    pub fn get_mut(&mut self) -> &mut Iter {
+        &mut self.iter
+    }
 
     /// Unwraps this `LineColIterator`, returning the underlying iterator.
-    pub fn into_inner(self) -> Iter { self.iter }
+    pub fn into_inner(self) -> Iter {
+        self.iter
+    }
 }
 
-impl<Iter: Iterator<Item=io::Result<u8>>> LineColIterator<Peekable<Iter>> {
+impl<Iter: Iterator<Item = io::Result<u8>>> LineColIterator<Peekable<Iter>> {
     /// peeks at the next value
-    pub fn peek(&mut self) -> Option<&io::Result<u8>> { self.iter.peek() }
+    pub fn peek(&mut self) -> Option<&io::Result<u8>> {
+        self.iter.peek()
+    }
 }
 
-impl<Iter: Iterator<Item=io::Result<u8>>> Iterator for LineColIterator<Iter> {
+impl<Iter: Iterator<Item = io::Result<u8>>> Iterator for LineColIterator<Iter> {
     type Item = io::Result<u8>;
     fn next(&mut self) -> Option<io::Result<u8>> {
         match self.iter.next() {
@@ -50,11 +62,11 @@ impl<Iter: Iterator<Item=io::Result<u8>>> Iterator for LineColIterator<Iter> {
                 self.line += 1;
                 self.col = 0;
                 Some(Ok(b'\n'))
-            },
+            }
             Some(Ok(c)) => {
                 self.col += 1;
                 Some(Ok(c))
-            },
+            }
             Some(Err(e)) => Some(Err(e)),
         }
     }

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -5,7 +5,7 @@
 //! handshake protocol between serializers and serializees can be completely optimized away,
 //! leaving serde to perform roughly the same speed as a hand written serializer for a specific
 //! type.
-//! 
+//!
 //! For a detailed tutorial on the different ways to use serde please check out the
 //! [github repository](https://github.com/serde-rs/serde)
 
@@ -29,8 +29,8 @@ extern crate alloc;
 
 #[cfg(feature = "std")]
 mod core {
-    pub use std::{ops, hash, fmt, cmp, marker, mem, i8, i16, i32, i64, u8, u16, u32, u64, isize,
-            usize, f32, f64, char, str, num, slice, iter};
+    pub use std::{char, cmp, f32, f64, fmt, hash, i16, i32, i64, i8, isize, iter, marker, mem,
+                  num, ops, slice, str, u16, u32, u64, u8, usize};
     #[cfg(feature = "nightly")]
     extern crate core;
     #[cfg(feature = "nightly")]

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -6,32 +6,16 @@ use std::borrow::Cow;
 use collections::borrow::Cow;
 
 #[cfg(feature = "std")]
-use std::collections::{
-    BinaryHeap,
-    BTreeMap,
-    BTreeSet,
-    LinkedList,
-    HashMap,
-    HashSet,
-    VecDeque,
-};
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque};
 #[cfg(all(feature = "collections", not(feature = "std")))]
-use collections::{
-    BinaryHeap,
-    BTreeMap,
-    BTreeSet,
-    LinkedList,
-    VecDeque,
-    String,
-    Vec,
-};
+use collections::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, String, Vec, VecDeque};
 
 #[cfg(all(feature = "nightly", feature = "collections"))]
 use collections::enum_set::{CLike, EnumSet};
 #[cfg(all(feature = "nightly", feature = "collections"))]
 use collections::borrow::ToOwned;
 
-use core::hash::{Hash, BuildHasher};
+use core::hash::{BuildHasher, Hash};
 #[cfg(feature = "nightly")]
 use core::iter;
 #[cfg(feature = "std")]
@@ -60,15 +44,9 @@ use core::marker::PhantomData;
 #[cfg(feature = "nightly")]
 use core::nonzero::{NonZero, Zeroable};
 
-use super::{
-    Error,
-    Serialize,
-    Serializer,
-    SeqVisitor,
-    MapVisitor,
-};
+use super::{Error, MapVisitor, SeqVisitor, Serialize, Serializer};
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 macro_rules! impl_visit {
     ($ty:ty, $method:ident) => {
@@ -98,7 +76,7 @@ impl_visit!(f32, serialize_f32);
 impl_visit!(f64, serialize_f64);
 impl_visit!(char, serialize_char);
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 impl Serialize for str {
     #[inline]
@@ -119,9 +97,11 @@ impl Serialize for String {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
-impl<T> Serialize for Option<T> where T: Serialize {
+impl<T> Serialize for Option<T>
+    where T: Serialize,
+{
     #[inline]
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: Serializer,
@@ -133,7 +113,9 @@ impl<T> Serialize for Option<T> where T: Serialize {
     }
 }
 
-impl<T> SeqVisitor for Option<T> where T: Serialize {
+impl<T> SeqVisitor for Option<T>
+    where T: Serialize,
+{
     #[inline]
     fn visit<S>(&mut self, serializer: &mut S) -> Result<Option<()>, S::Error>
         where S: Serializer,
@@ -149,11 +131,15 @@ impl<T> SeqVisitor for Option<T> where T: Serialize {
 
     #[inline]
     fn len(&self) -> Option<usize> {
-        Some(if self.is_some() { 1 } else { 0 })
+        Some(if self.is_some() {
+            1
+        } else {
+            0
+        })
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 impl<T> Serialize for PhantomData<T> {
     #[inline]
@@ -164,7 +150,7 @@ impl<T> Serialize for PhantomData<T> {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 /// A `serde::Visitor` for sequence iterators.
 ///
@@ -193,7 +179,7 @@ pub struct SeqIteratorVisitor<Iter> {
 }
 
 impl<T, Iter> SeqIteratorVisitor<Iter>
-    where Iter: Iterator<Item=T>
+    where Iter: Iterator<Item = T>,
 {
     /// Construct a new `SeqIteratorVisitor<Iter>`.
     #[inline]
@@ -207,7 +193,7 @@ impl<T, Iter> SeqIteratorVisitor<Iter>
 
 impl<T, Iter> SeqVisitor for SeqIteratorVisitor<Iter>
     where T: Serialize,
-          Iter: Iterator<Item=T>,
+          Iter: Iterator<Item = T>,
 {
     #[inline]
     fn visit<S>(&mut self, serializer: &mut S) -> Result<Option<()>, S::Error>
@@ -228,7 +214,7 @@ impl<T, Iter> SeqVisitor for SeqIteratorVisitor<Iter>
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 impl<T> Serialize for [T]
     where T: Serialize,
@@ -241,7 +227,7 @@ impl<T> Serialize for [T]
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 macro_rules! array_impls {
     ($len:expr) => {
@@ -291,11 +277,10 @@ array_impls!(30);
 array_impls!(31);
 array_impls!(32);
 
-///////////////////////////////////////////////////////////////////////////////
-
+/// ////////////////////////////////////////////////////////////////////////////
 #[cfg(any(feature = "std", feature = "collections"))]
 impl<T> Serialize for BinaryHeap<T>
-    where T: Serialize + Ord
+    where T: Serialize + Ord,
 {
     #[inline]
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
@@ -319,7 +304,7 @@ impl<T> Serialize for BTreeSet<T>
 
 #[cfg(all(feature = "nightly", feature = "collections"))]
 impl<T> Serialize for EnumSet<T>
-    where T: Serialize + CLike
+    where T: Serialize + CLike,
 {
     #[inline]
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
@@ -369,7 +354,9 @@ impl<A> Serialize for ops::Range<A>
 }
 
 #[cfg(any(feature = "std", feature = "collections"))]
-impl<T> Serialize for Vec<T> where T: Serialize {
+impl<T> Serialize for Vec<T>
+    where T: Serialize,
+{
     #[inline]
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: Serializer,
@@ -379,7 +366,9 @@ impl<T> Serialize for Vec<T> where T: Serialize {
 }
 
 #[cfg(any(feature = "std", feature = "collections"))]
-impl<T> Serialize for VecDeque<T> where T: Serialize {
+impl<T> Serialize for VecDeque<T>
+    where T: Serialize,
+{
     #[inline]
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: Serializer,
@@ -388,7 +377,7 @@ impl<T> Serialize for VecDeque<T> where T: Serialize {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 impl Serialize for () {
     #[inline]
@@ -399,7 +388,7 @@ impl Serialize for () {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 // FIXME(rust #19630) Remove this work-around
 macro_rules! e {
@@ -636,7 +625,7 @@ tuple_impls! {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 /// A `serde::Visitor` for (key, value) map iterators.
 ///
@@ -666,7 +655,7 @@ pub struct MapIteratorVisitor<Iter> {
 }
 
 impl<K, V, Iter> MapIteratorVisitor<Iter>
-    where Iter: Iterator<Item=(K, V)>
+    where Iter: Iterator<Item = (K, V)>,
 {
     /// Construct a new `MapIteratorVisitor<Iter>`.
     #[inline]
@@ -681,7 +670,7 @@ impl<K, V, Iter> MapIteratorVisitor<Iter>
 impl<K, V, I> MapVisitor for MapIteratorVisitor<I>
     where K: Serialize,
           V: Serialize,
-          I: Iterator<Item=(K, V)>,
+          I: Iterator<Item = (K, V)>,
 {
     #[inline]
     fn visit<S>(&mut self, serializer: &mut S) -> Result<Option<()>, S::Error>
@@ -692,7 +681,7 @@ impl<K, V, I> MapVisitor for MapIteratorVisitor<I>
                 try!(serializer.serialize_map_elt(key, value));
                 Ok(Some(()))
             }
-            None => Ok(None)
+            None => Ok(None),
         }
     }
 
@@ -702,8 +691,7 @@ impl<K, V, I> MapVisitor for MapIteratorVisitor<I>
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
-
+/// ////////////////////////////////////////////////////////////////////////////
 #[cfg(any(feature = "std", feature = "collections"))]
 impl<K, V> Serialize for BTreeMap<K, V>
     where K: Serialize + Ord,
@@ -731,9 +719,11 @@ impl<K, V, H> Serialize for HashMap<K, V, H>
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
-impl<'a, T: ?Sized> Serialize for &'a T where T: Serialize {
+impl<'a, T: ?Sized> Serialize for &'a T
+    where T: Serialize,
+{
     #[inline]
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: Serializer,
@@ -742,27 +732,9 @@ impl<'a, T: ?Sized> Serialize for &'a T where T: Serialize {
     }
 }
 
-impl<'a, T: ?Sized> Serialize for &'a mut T where T: Serialize {
-    #[inline]
-    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
-        where S: Serializer,
-    {
-        (**self).serialize(serializer)
-    }
-}
-
-#[cfg(any(feature = "std", feature = "alloc"))]
-impl<T: ?Sized> Serialize for Box<T> where T: Serialize {
-    #[inline]
-    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
-        where S: Serializer,
-    {
-        (**self).serialize(serializer)
-    }
-}
-
-#[cfg(any(feature = "std", feature = "alloc"))]
-impl<T> Serialize for Rc<T> where T: Serialize, {
+impl<'a, T: ?Sized> Serialize for &'a mut T
+    where T: Serialize,
+{
     #[inline]
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: Serializer,
@@ -772,7 +744,33 @@ impl<T> Serialize for Rc<T> where T: Serialize, {
 }
 
 #[cfg(any(feature = "std", feature = "alloc"))]
-impl<T> Serialize for Arc<T> where T: Serialize, {
+impl<T: ?Sized> Serialize for Box<T>
+    where T: Serialize,
+{
+    #[inline]
+    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
+        where S: Serializer,
+    {
+        (**self).serialize(serializer)
+    }
+}
+
+#[cfg(any(feature = "std", feature = "alloc"))]
+impl<T> Serialize for Rc<T>
+    where T: Serialize,
+{
+    #[inline]
+    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
+        where S: Serializer,
+    {
+        (**self).serialize(serializer)
+    }
+}
+
+#[cfg(any(feature = "std", feature = "alloc"))]
+impl<T> Serialize for Arc<T>
+    where T: Serialize,
+{
     #[inline]
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: Serializer,
@@ -782,7 +780,9 @@ impl<T> Serialize for Arc<T> where T: Serialize, {
 }
 
 #[cfg(any(feature = "std", feature = "collections"))]
-impl<'a, T: ?Sized> Serialize for Cow<'a, T> where T: Serialize + ToOwned, {
+impl<'a, T: ?Sized> Serialize for Cow<'a, T>
+    where T: Serialize + ToOwned,
+{
     #[inline]
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: Serializer,
@@ -791,14 +791,17 @@ impl<'a, T: ?Sized> Serialize for Cow<'a, T> where T: Serialize + ToOwned, {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
-impl<T, E> Serialize for Result<T, E> where T: Serialize, E: Serialize {
-    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error> where S: Serializer {
+impl<T, E> Serialize for Result<T, E>
+    where T: Serialize,
+          E: Serialize,
+{
+    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
+        where S: Serializer,
+    {
         match *self {
-            Result::Ok(ref value) => {
-                serializer.serialize_newtype_variant("Result", 0, "Ok", value)
-            }
+            Result::Ok(ref value) => serializer.serialize_newtype_variant("Result", 0, "Ok", value),
             Result::Err(ref value) => {
                 serializer.serialize_newtype_variant("Result", 1, "Err", value)
             }
@@ -806,8 +809,7 @@ impl<T, E> Serialize for Result<T, E> where T: Serialize, E: Serialize {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
-
+/// ////////////////////////////////////////////////////////////////////////////
 #[cfg(all(feature = "std", feature = "nightly"))]
 impl Serialize for net::IpAddr {
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
@@ -838,8 +840,7 @@ impl Serialize for net::Ipv6Addr {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
-
+/// ////////////////////////////////////////////////////////////////////////////
 #[cfg(feature = "std")]
 impl Serialize for net::SocketAddr {
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
@@ -870,8 +871,7 @@ impl Serialize for net::SocketAddrV6 {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
-
+/// ////////////////////////////////////////////////////////////////////////////
 #[cfg(feature = "std")]
 impl Serialize for path::Path {
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
@@ -894,8 +894,12 @@ impl Serialize for path::PathBuf {
 }
 
 #[cfg(feature = "nightly")]
-impl<T> Serialize for NonZero<T> where T: Serialize + Zeroable {
-    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error> where S: Serializer {
+impl<T> Serialize for NonZero<T>
+    where T: Serialize + Zeroable,
+{
+    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
+        where S: Serializer,
+    {
         (**self).serialize(serializer)
     }
 }

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -10,7 +10,7 @@ use collections::String;
 
 pub mod impls;
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 /// `Error` is a trait that allows a `Serialize` to generically create a
 /// `Serializer` error.
@@ -29,16 +29,15 @@ pub trait Error: Sized + error::Error {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 /// A trait that describes a type that can be serialized by a `Serializer`.
 pub trait Serialize {
     /// Serializes this value into this serializer.
-    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
-        where S: Serializer;
+    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error> where S: Serializer;
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 /// A trait that describes a type that can serialize a stream of values into the underlying format.
 pub trait Serializer {
@@ -154,10 +153,12 @@ pub trait Serializer {
     ///
     /// By default, unit variants are serialized as a `()`.
     #[inline]
-    fn serialize_unit_variant(&mut self,
-                              _name: &'static str,
-                              _variant_index: usize,
-                              _variant: &'static str) -> Result<(), Self::Error> {
+    fn serialize_unit_variant(
+        &mut self,
+        _name: &'static str,
+        _variant_index: usize,
+        _variant: &'static str
+    ) -> Result<(), Self::Error> {
         self.serialize_unit()
     }
 
@@ -165,9 +166,11 @@ pub trait Serializer {
     /// newtyped value, to be more efficiently serialized than a tuple struct with multiple items.
     /// By default it just serializes the value as a tuple struct sequence.
     #[inline]
-    fn serialize_newtype_struct<T>(&mut self,
-                                   name: &'static str,
-                                   value: T) -> Result<(), Self::Error>
+    fn serialize_newtype_struct<T>(
+        &mut self,
+        name: &'static str,
+        value: T
+    ) -> Result<(), Self::Error>
         where T: Serialize,
     {
         self.serialize_tuple_struct(name, Some(value))
@@ -177,37 +180,32 @@ pub trait Serializer {
     /// serialized than a variant with multiple items. By default it just serializes the value as a
     /// tuple variant sequence.
     #[inline]
-    fn serialize_newtype_variant<T>(&mut self,
-                                    name: &'static str,
-                                    variant_index: usize,
-                                    variant: &'static str,
-                                    value: T) -> Result<(), Self::Error>
+    fn serialize_newtype_variant<T>(
+        &mut self,
+        name: &'static str,
+        variant_index: usize,
+        variant: &'static str,
+        value: T
+    ) -> Result<(), Self::Error>
         where T: Serialize,
     {
-        self.serialize_tuple_variant(
-            name,
-            variant_index,
-            variant,
-            Some(value))
+        self.serialize_tuple_variant(name, variant_index, variant, Some(value))
     }
 
     /// Serializes a `None` value..serialize
     fn serialize_none(&mut self) -> Result<(), Self::Error>;
 
     /// Serializes a `Some(...)` value.
-    fn serialize_some<V>(&mut self, value: V) -> Result<(), Self::Error>
-        where V: Serialize;
+    fn serialize_some<V>(&mut self, value: V) -> Result<(), Self::Error> where V: Serialize;
 
     /// Serializes a sequence.
     ///
     /// Callees of this method need to construct a `SeqVisitor`, which iterates through each item
     /// in the sequence.
-    fn serialize_seq<V>(&mut self, visitor: V) -> Result<(), Self::Error>
-        where V: SeqVisitor;
+    fn serialize_seq<V>(&mut self, visitor: V) -> Result<(), Self::Error> where V: SeqVisitor;
 
     /// Serializes a sequence element.
-    fn serialize_seq_elt<T>(&mut self, value: T) -> Result<(), Self::Error>
-        where T: Serialize;
+    fn serialize_seq_elt<T>(&mut self, value: T) -> Result<(), Self::Error> where T: Serialize;
 
     /// Serializes a tuple.
     ///
@@ -224,7 +222,7 @@ pub trait Serializer {
     /// By default, tuples are serialized as a sequence.
     #[inline]
     fn serialize_tuple_elt<T>(&mut self, value: T) -> Result<(), Self::Error>
-        where T: Serialize
+        where T: Serialize,
     {
         self.serialize_seq_elt(value)
     }
@@ -243,9 +241,11 @@ pub trait Serializer {
     ///
     /// By default, tuple structs are serialized as a tuple.
     #[inline]
-    fn serialize_tuple_struct<V>(&mut self,
-                                 _name: &'static str,
-                                 visitor: V) -> Result<(), Self::Error>
+    fn serialize_tuple_struct<V>(
+        &mut self,
+        _name: &'static str,
+        visitor: V
+    ) -> Result<(), Self::Error>
         where V: SeqVisitor,
     {
         self.serialize_tuple(visitor)
@@ -256,7 +256,7 @@ pub trait Serializer {
     /// By default, tuple struct elements are serialized as a tuple element.
     #[inline]
     fn serialize_tuple_struct_elt<T>(&mut self, value: T) -> Result<(), Self::Error>
-        where T: Serialize
+        where T: Serialize,
     {
         self.serialize_tuple_elt(value)
     }
@@ -265,11 +265,13 @@ pub trait Serializer {
     ///
     /// By default, tuple variants are serialized as a tuple struct.
     #[inline]
-    fn serialize_tuple_variant<V>(&mut self,
-                                  _name: &'static str,
-                                  _variant_index: usize,
-                                  variant: &'static str,
-                                  visitor: V) -> Result<(), Self::Error>
+    fn serialize_tuple_variant<V>(
+        &mut self,
+        _name: &'static str,
+        _variant_index: usize,
+        variant: &'static str,
+        visitor: V
+    ) -> Result<(), Self::Error>
         where V: SeqVisitor,
     {
         self.serialize_tuple_struct(variant, visitor)
@@ -280,7 +282,7 @@ pub trait Serializer {
     /// By default, tuples are serialized as a sequence.
     #[inline]
     fn serialize_tuple_variant_elt<T>(&mut self, value: T) -> Result<(), Self::Error>
-        where T: Serialize
+        where T: Serialize,
     {
         self.serialize_tuple_struct_elt(value)
     }
@@ -289,8 +291,7 @@ pub trait Serializer {
     ///
     /// Callees of this method need to construct a `MapVisitor`, which iterates through each item
     /// in the map.
-    fn serialize_map<V>(&mut self, visitor: V) -> Result<(), Self::Error>
-        where V: MapVisitor;
+    fn serialize_map<V>(&mut self, visitor: V) -> Result<(), Self::Error> where V: MapVisitor;
 
     /// Serializes a map element (key-value pair).
     fn serialize_map_elt<K, V>(&mut self, key: K, value: V) -> Result<(), Self::Error>
@@ -301,9 +302,7 @@ pub trait Serializer {
     ///
     /// By default, structs are serialized as a map with the field name as the key.
     #[inline]
-    fn serialize_struct<V>(&mut self,
-                           _name: &'static str,
-                           visitor: V) -> Result<(), Self::Error>
+    fn serialize_struct<V>(&mut self, _name: &'static str, visitor: V) -> Result<(), Self::Error>
         where V: MapVisitor,
     {
         self.serialize_map(visitor)
@@ -313,9 +312,7 @@ pub trait Serializer {
     ///
     /// By default, struct elements are serialized as a map element with the field name as the key.
     #[inline]
-    fn serialize_struct_elt<V>(&mut self,
-                               key: &'static str,
-                               value: V) -> Result<(), Self::Error>
+    fn serialize_struct_elt<V>(&mut self, key: &'static str, value: V) -> Result<(), Self::Error>
         where V: Serialize,
     {
         self.serialize_map_elt(key, value)
@@ -325,11 +322,13 @@ pub trait Serializer {
     ///
     /// By default, struct variants are serialized as a struct.
     #[inline]
-    fn serialize_struct_variant<V>(&mut self,
-                                   _name: &'static str,
-                                   _variant_index: usize,
-                                   variant: &'static str,
-                                   visitor: V) -> Result<(), Self::Error>
+    fn serialize_struct_variant<V>(
+        &mut self,
+        _name: &'static str,
+        _variant_index: usize,
+        variant: &'static str,
+        visitor: V
+    ) -> Result<(), Self::Error>
         where V: MapVisitor,
     {
         self.serialize_struct(variant, visitor)
@@ -339,9 +338,11 @@ pub trait Serializer {
     ///
     /// By default, struct variant elements are serialized as a struct element.
     #[inline]
-    fn serialize_struct_variant_elt<V>(&mut self,
-                                       key: &'static str,
-                                       value: V) -> Result<(), Self::Error>
+    fn serialize_struct_variant_elt<V>(
+        &mut self,
+        key: &'static str,
+        value: V
+    ) -> Result<(), Self::Error>
         where V: Serialize,
     {
         self.serialize_struct_elt(key, value)
@@ -355,8 +356,7 @@ pub trait SeqVisitor {
     ///
     /// This returns `Ok(Some(()))` when there are more items to serialize, or `Ok(None)` when
     /// complete.
-    fn visit<S>(&mut self, serializer: &mut S) -> Result<Option<()>, S::Error>
-        where S: Serializer;
+    fn visit<S>(&mut self, serializer: &mut S) -> Result<Option<()>, S::Error> where S: Serializer;
 
     /// Return the length of the sequence if known.
     #[inline]
@@ -372,8 +372,7 @@ pub trait MapVisitor {
     ///
     /// This returns `Ok(Some(()))` when there are more items to serialize, or `Ok(None)` when
     /// complete.
-    fn visit<S>(&mut self, serializer: &mut S) -> Result<Option<()>, S::Error>
-        where S: Serializer;
+    fn visit<S>(&mut self, serializer: &mut S) -> Result<Option<()>, S::Error> where S: Serializer;
 
     /// Return the length of the map if known.
     #[inline]

--- a/serde/src/utils.rs
+++ b/serde/src/utils.rs
@@ -1,12 +1,12 @@
 //! Private utility functions
 
-const TAG_CONT: u8    = 0b1000_0000;
-const TAG_TWO_B: u8   = 0b1100_0000;
+const TAG_CONT: u8 = 0b1000_0000;
+const TAG_TWO_B: u8 = 0b1100_0000;
 const TAG_THREE_B: u8 = 0b1110_0000;
-const TAG_FOUR_B: u8  = 0b1111_0000;
-const MAX_ONE_B: u32   =     0x80;
-const MAX_TWO_B: u32   =    0x800;
-const MAX_THREE_B: u32 =  0x10000;
+const TAG_FOUR_B: u8 = 0b1111_0000;
+const MAX_ONE_B: u32 = 0x80;
+const MAX_TWO_B: u32 = 0x800;
+const MAX_THREE_B: u32 = 0x10000;
 
 #[inline]
 pub fn encode_utf8(c: char) -> EncodeUtf8 {
@@ -21,17 +21,20 @@ pub fn encode_utf8(c: char) -> EncodeUtf8 {
         2
     } else if code < MAX_THREE_B {
         buf[1] = (code >> 12 & 0x0F) as u8 | TAG_THREE_B;
-        buf[2] = (code >>  6 & 0x3F) as u8 | TAG_CONT;
+        buf[2] = (code >> 6 & 0x3F) as u8 | TAG_CONT;
         buf[3] = (code & 0x3F) as u8 | TAG_CONT;
         1
     } else {
         buf[0] = (code >> 18 & 0x07) as u8 | TAG_FOUR_B;
         buf[1] = (code >> 12 & 0x3F) as u8 | TAG_CONT;
-        buf[2] = (code >>  6 & 0x3F) as u8 | TAG_CONT;
+        buf[2] = (code >> 6 & 0x3F) as u8 | TAG_CONT;
         buf[3] = (code & 0x3F) as u8 | TAG_CONT;
         0
     };
-    EncodeUtf8 { buf: buf, pos: pos }
+    EncodeUtf8 {
+        buf: buf,
+        pos: pos,
+    }
 }
 
 pub struct EncodeUtf8 {
@@ -47,23 +50,24 @@ impl EncodeUtf8 {
 }
 
 #[allow(non_upper_case_globals)]
-const Pattern_White_Space_table: &'static [(char, char)] = &[
-    ('\u{9}', '\u{d}'), ('\u{20}', '\u{20}'), ('\u{85}', '\u{85}'), ('\u{200e}', '\u{200f}'),
-    ('\u{2028}', '\u{2029}')
-];
+const Pattern_White_Space_table: &'static [(char, char)] = &[('\u{9}', '\u{d}'),
+                                                             ('\u{20}', '\u{20}'),
+                                                             ('\u{85}', '\u{85}'),
+                                                             ('\u{200e}', '\u{200f}'),
+                                                             ('\u{2028}', '\u{2029}')];
 
 fn bsearch_range_table(c: char, r: &'static [(char, char)]) -> bool {
-    use core::cmp::Ordering::{Equal, Less, Greater};
+    use core::cmp::Ordering::{Equal, Greater, Less};
     r.binary_search_by(|&(lo, hi)| {
-        if c < lo {
-            Greater
-        } else if hi < c {
-            Less
-        } else {
-            Equal
-        }
-    })
-    .is_ok()
+            if c < lo {
+                Greater
+            } else if hi < c {
+                Less
+            } else {
+                Equal
+            }
+        })
+        .is_ok()
 }
 
 #[allow(non_snake_case)]

--- a/serde_codegen/src/lib.rs
+++ b/serde_codegen/src/lib.rs
@@ -58,7 +58,9 @@ pub fn register(reg: &mut syntex::Registry) {
         impl fold::Folder for StripAttributeFolder {
             fn fold_attribute(&mut self, attr: ast::Attribute) -> Option<ast::Attribute> {
                 match attr.node.value.node {
-                    ast::MetaItemKind::List(ref n, _) if n == &"serde" => { return None; }
+                    ast::MetaItemKind::List(ref n, _) if n == &"serde" => {
+                        return None;
+                    }
                     _ => {}
                 }
 

--- a/serde_codegen/src/span.rs
+++ b/serde_codegen/src/span.rs
@@ -5,11 +5,7 @@ use syntax::fold::{self, Folder};
 use syntax::parse::token::intern;
 use syntax::ptr::P;
 
-pub fn record_expansion(
-    cx: &ExtCtxt,
-    item: P<ast::Item>,
-    derive: &str,
-) -> Annotatable {
+pub fn record_expansion(cx: &ExtCtxt, item: P<ast::Item>, derive: &str) -> Annotatable {
     let info = codemap::ExpnInfo {
         call_site: codemap::DUMMY_SP,
         callee: codemap::NameAndSpan {
@@ -20,7 +16,9 @@ pub fn record_expansion(
     };
     let expn_id = cx.codemap().record_expansion(info);
 
-    let mut respanner = Respanner { expn_id: expn_id };
+    let mut respanner = Respanner {
+        expn_id: expn_id,
+    };
     let item = item.map(|item| respanner.fold_item_simple(item));
     Annotatable::Item(item)
 }
@@ -33,7 +31,7 @@ impl Folder for Respanner {
     fn new_span(&mut self, span: Span) -> Span {
         Span {
             expn_id: self.expn_id,
-            .. span
+            ..span
         }
     }
 

--- a/serde_macros/tests/compile_tests.rs
+++ b/serde_macros/tests/compile_tests.rs
@@ -10,7 +10,7 @@ fn run_mode(mode: &'static str) {
 
     config.target_rustcflags = Some("-L target/debug/ -L target/debug/deps/".to_owned());
     if let Ok(name) = var::<&str>("TESTNAME") {
-        let s : String = name.to_owned();
+        let s: String = name.to_owned();
         config.filter = Some(s)
     }
     config.mode = cfg_mode;

--- a/serde_test/src/assert.rs
+++ b/serde_test/src/assert.rs
@@ -1,4 +1,4 @@
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 use de::Deserializer;
 use error::Error;

--- a/serde_test/src/error.rs
+++ b/serde_test/src/error.rs
@@ -1,6 +1,6 @@
 use std::{error, fmt};
 
-use serde::{ser, de};
+use serde::{de, ser};
 
 use token::Token;
 

--- a/serde_test/src/lib.rs
+++ b/serde_test/src/lib.rs
@@ -1,13 +1,8 @@
 extern crate serde;
 
 mod assert;
-pub use assert::{
-    assert_tokens,
-    assert_ser_tokens,
-    assert_ser_tokens_error,
-    assert_de_tokens,
-    assert_de_tokens_error,
-};
+pub use assert::{assert_de_tokens, assert_de_tokens_error, assert_ser_tokens,
+                 assert_ser_tokens_error, assert_tokens};
 
 mod ser;
 pub use ser::Serializer;

--- a/serde_test/src/ser.rs
+++ b/serde_test/src/ser.rs
@@ -1,24 +1,19 @@
 use std::marker::PhantomData;
 
-use serde::ser::{
-    self,
-    MapVisitor,
-    SeqVisitor,
-    Serialize,
-};
+use serde::ser::{self, MapVisitor, SeqVisitor, Serialize};
 
 use error::Error;
 use token::Token;
 
 pub struct Serializer<'a, I>
-    where I: Iterator<Item=&'a Token<'a>>,
+    where I: Iterator<Item = &'a Token<'a>>,
 {
     tokens: I,
     phantom: PhantomData<&'a Token<'a>>,
 }
 
 impl<'a, I> Serializer<'a, I>
-    where I: Iterator<Item=&'a Token<'a>>,
+    where I: Iterator<Item = &'a Token<'a>>,
 {
     pub fn new(tokens: I) -> Serializer<'a, I> {
         Serializer {
@@ -32,9 +27,10 @@ impl<'a, I> Serializer<'a, I>
     }
 
     fn visit_seq<V>(&mut self, mut visitor: V) -> Result<(), Error>
-        where V: SeqVisitor
+        where V: SeqVisitor,
     {
-        while let Some(()) = try!(visitor.visit(self)) { }
+        while let Some(()) = try!(visitor.visit(self)) {
+        }
 
         assert_eq!(self.tokens.next(), Some(&Token::SeqEnd));
 
@@ -42,9 +38,10 @@ impl<'a, I> Serializer<'a, I>
     }
 
     fn visit_map<V>(&mut self, mut visitor: V) -> Result<(), Error>
-        where V: MapVisitor
+        where V: MapVisitor,
     {
-        while let Some(()) = try!(visitor.visit(self)) { }
+        while let Some(()) = try!(visitor.visit(self)) {
+        }
 
         assert_eq!(self.tokens.next(), Some(&Token::MapEnd));
 
@@ -53,7 +50,7 @@ impl<'a, I> Serializer<'a, I>
 }
 
 impl<'a, I> ser::Serializer for Serializer<'a, I>
-    where I: Iterator<Item=&'a Token<'a>>,
+    where I: Iterator<Item = &'a Token<'a>>,
 {
     type Error = Error;
 
@@ -62,11 +59,13 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
         Ok(())
     }
 
-    fn serialize_newtype_variant<T>(&mut self,
-                                name: &str,
-                                _variant_index: usize,
-                                variant: &str,
-                                value: T) -> Result<(), Error>
+    fn serialize_newtype_variant<T>(
+        &mut self,
+        name: &str,
+        _variant_index: usize,
+        variant: &str,
+        value: T
+    ) -> Result<(), Error>
         where T: Serialize,
     {
         assert_eq!(self.tokens.next(), Some(&Token::EnumNewType(name, variant)));
@@ -78,10 +77,12 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
         Ok(())
     }
 
-    fn serialize_unit_variant(&mut self,
-                          name: &str,
-                          _variant_index: usize,
-                          variant: &str) -> Result<(), Error> {
+    fn serialize_unit_variant(
+        &mut self,
+        name: &str,
+        _variant_index: usize,
+        variant: &str
+    ) -> Result<(), Error> {
         assert_eq!(self.tokens.next(), Some(&Token::EnumUnit(name, variant)));
 
         Ok(())
@@ -176,7 +177,7 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
 
 
     fn serialize_seq<V>(&mut self, visitor: V) -> Result<(), Error>
-        where V: SeqVisitor
+        where V: SeqVisitor,
     {
         let len = visitor.len();
 
@@ -186,7 +187,7 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
     }
 
     fn serialize_fixed_size_array<V>(&mut self, visitor: V) -> Result<(), Error>
-        where V: SeqVisitor
+        where V: SeqVisitor,
     {
         let len = visitor.len().expect("arrays must have a length");
 
@@ -196,20 +197,21 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
     }
 
     fn serialize_seq_elt<T>(&mut self, value: T) -> Result<(), Error>
-        where T: Serialize
+        where T: Serialize,
     {
         assert_eq!(self.tokens.next(), Some(&Token::SeqSep));
         value.serialize(self)
     }
 
     fn serialize_tuple<V>(&mut self, mut visitor: V) -> Result<(), Error>
-        where V: SeqVisitor
+        where V: SeqVisitor,
     {
         let len = visitor.len().expect("arrays must have a length");
 
         assert_eq!(self.tokens.next(), Some(&Token::TupleStart(len)));
 
-        while let Some(()) = try!(visitor.visit(self)) { }
+        while let Some(()) = try!(visitor.visit(self)) {
+        }
 
         assert_eq!(self.tokens.next(), Some(&Token::TupleEnd));
 
@@ -217,15 +219,13 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
     }
 
     fn serialize_tuple_elt<T>(&mut self, value: T) -> Result<(), Error>
-        where T: Serialize
+        where T: Serialize,
     {
         assert_eq!(self.tokens.next(), Some(&Token::TupleSep));
         value.serialize(self)
     }
 
-    fn serialize_newtype_struct<T>(&mut self,
-                               name: &'static str,
-                               value: T) -> Result<(), Error>
+    fn serialize_newtype_struct<T>(&mut self, name: &'static str, value: T) -> Result<(), Error>
         where T: Serialize,
     {
         assert_eq!(self.tokens.next(), Some(&Token::StructNewType(name)));
@@ -233,13 +233,15 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
     }
 
     fn serialize_tuple_struct<V>(&mut self, name: &str, mut visitor: V) -> Result<(), Error>
-        where V: SeqVisitor
+        where V: SeqVisitor,
     {
         let len = visitor.len();
 
-        assert_eq!(self.tokens.next(), Some(&Token::TupleStructStart(name, len)));
+        assert_eq!(self.tokens.next(),
+                   Some(&Token::TupleStructStart(name, len)));
 
-        while let Some(()) = try!(visitor.visit(self)) { }
+        while let Some(()) = try!(visitor.visit(self)) {
+        }
 
         assert_eq!(self.tokens.next(), Some(&Token::TupleStructEnd));
 
@@ -253,18 +255,22 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
         value.serialize(self)
     }
 
-    fn serialize_tuple_variant<V>(&mut self,
-                                  name: &str,
-                                  _variant_index: usize,
-                                  variant: &str,
-                                  mut visitor: V) -> Result<(), Error>
-        where V: SeqVisitor
+    fn serialize_tuple_variant<V>(
+        &mut self,
+        name: &str,
+        _variant_index: usize,
+        variant: &str,
+        mut visitor: V
+    ) -> Result<(), Error>
+        where V: SeqVisitor,
     {
         let len = visitor.len();
 
-        assert_eq!(self.tokens.next(), Some(&Token::EnumSeqStart(name, variant, len)));
+        assert_eq!(self.tokens.next(),
+                   Some(&Token::EnumSeqStart(name, variant, len)));
 
-        while let Some(()) = try!(visitor.visit(self)) { }
+        while let Some(()) = try!(visitor.visit(self)) {
+        }
 
         assert_eq!(self.tokens.next(), Some(&Token::EnumSeqEnd));
 
@@ -279,7 +285,7 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
     }
 
     fn serialize_map<V>(&mut self, visitor: V) -> Result<(), Error>
-        where V: MapVisitor
+        where V: MapVisitor,
     {
         let len = visitor.len();
 
@@ -299,13 +305,14 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
     }
 
     fn serialize_struct<V>(&mut self, name: &str, mut visitor: V) -> Result<(), Error>
-        where V: MapVisitor
+        where V: MapVisitor,
     {
         let len = visitor.len();
 
         assert_eq!(self.tokens.next(), Some(&Token::StructStart(name, len)));
 
-        while let Some(()) = try!(visitor.visit(self)) { }
+        while let Some(()) = try!(visitor.visit(self)) {
+        }
 
         assert_eq!(self.tokens.next(), Some(&Token::StructEnd));
 
@@ -321,18 +328,22 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
         value.serialize(self)
     }
 
-    fn serialize_struct_variant<V>(&mut self,
-                                   name: &str,
-                                   _variant_index: usize,
-                                   variant: &str,
-                                   mut visitor: V) -> Result<(), Error>
-        where V: MapVisitor
+    fn serialize_struct_variant<V>(
+        &mut self,
+        name: &str,
+        _variant_index: usize,
+        variant: &str,
+        mut visitor: V
+    ) -> Result<(), Error>
+        where V: MapVisitor,
     {
         let len = visitor.len();
 
-        assert_eq!(self.tokens.next(), Some(&Token::EnumMapStart(name, variant, len)));
+        assert_eq!(self.tokens.next(),
+                   Some(&Token::EnumMapStart(name, variant, len)));
 
-        while let Some(()) = try!(visitor.visit(self)) { }
+        while let Some(()) = try!(visitor.visit(self)) {
+        }
 
         assert_eq!(self.tokens.next(), Some(&Token::EnumMapEnd));
 

--- a/testing/benches/bench_enum.rs
+++ b/testing/benches/bench_enum.rs
@@ -5,15 +5,15 @@ use rustc_serialize::Decodable;
 use serde;
 use serde::de::Deserialize;
 
-//////////////////////////////////////////////////////////////////////////////
+/// ///////////////////////////////////////////////////////////////////////////
 
 #[derive(Clone, PartialEq, Debug, RustcDecodable, Deserialize)]
 pub enum Animal {
     Dog,
-    Frog(String, isize)
+    Frog(String, isize),
 }
 
-//////////////////////////////////////////////////////////////////////////////
+/// ///////////////////////////////////////////////////////////////////////////
 
 #[derive(Debug)]
 pub enum Error {
@@ -22,13 +22,21 @@ pub enum Error {
 }
 
 impl serde::de::Error for Error {
-    fn custom<T: Into<String>>(_: T) -> Error { Error::Syntax }
+    fn custom<T: Into<String>>(_: T) -> Error {
+        Error::Syntax
+    }
 
-    fn end_of_stream() -> Error { Error::EndOfStream }
+    fn end_of_stream() -> Error {
+        Error::EndOfStream
+    }
 
-    fn unknown_field(_: &str) -> Error { Error::Syntax }
+    fn unknown_field(_: &str) -> Error {
+        Error::Syntax
+    }
 
-    fn missing_field(_: &'static str) -> Error { Error::Syntax }
+    fn missing_field(_: &'static str) -> Error {
+        Error::Syntax
+    }
 }
 
 impl fmt::Display for Error {
@@ -47,7 +55,7 @@ impl error::Error for Error {
     }
 }
 
-//////////////////////////////////////////////////////////////////////////////
+/// ///////////////////////////////////////////////////////////////////////////
 
 mod decoder {
     use rustc_serialize::Decoder;
@@ -63,14 +71,13 @@ mod decoder {
 
     pub struct AnimalDecoder {
         stack: Vec<State>,
-
     }
 
     impl AnimalDecoder {
         #[inline]
         pub fn new(animal: Animal) -> AnimalDecoder {
             AnimalDecoder {
-                stack: vec!(State::Animal(animal)),
+                stack: vec![State::Animal(animal)],
             }
         }
     }
@@ -78,15 +85,29 @@ mod decoder {
     impl Decoder for AnimalDecoder {
         type Error = Error;
 
-        fn error(&mut self, _: &str) -> Error { Error::Syntax }
+        fn error(&mut self, _: &str) -> Error {
+            Error::Syntax
+        }
 
         // Primitive types:
-        fn read_nil(&mut self) -> Result<(), Error> { Err(Error::Syntax) }
-        fn read_usize(&mut self) -> Result<usize, Error> { Err(Error::Syntax) }
-        fn read_u64(&mut self) -> Result<u64, Error> { Err(Error::Syntax) }
-        fn read_u32(&mut self) -> Result<u32, Error> { Err(Error::Syntax) }
-        fn read_u16(&mut self) -> Result<u16, Error> { Err(Error::Syntax) }
-        fn read_u8(&mut self) -> Result<u8, Error> { Err(Error::Syntax) }
+        fn read_nil(&mut self) -> Result<(), Error> {
+            Err(Error::Syntax)
+        }
+        fn read_usize(&mut self) -> Result<usize, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_u64(&mut self) -> Result<u64, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_u32(&mut self) -> Result<u32, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_u16(&mut self) -> Result<u16, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_u8(&mut self) -> Result<u8, Error> {
+            Err(Error::Syntax)
+        }
         #[inline]
         fn read_isize(&mut self) -> Result<isize, Error> {
             match self.stack.pop() {
@@ -94,14 +115,30 @@ mod decoder {
                 _ => Err(Error::Syntax),
             }
         }
-        fn read_i64(&mut self) -> Result<i64, Error> { Err(Error::Syntax) }
-        fn read_i32(&mut self) -> Result<i32, Error> { Err(Error::Syntax) }
-        fn read_i16(&mut self) -> Result<i16, Error> { Err(Error::Syntax) }
-        fn read_i8(&mut self) -> Result<i8, Error> { Err(Error::Syntax) }
-        fn read_bool(&mut self) -> Result<bool, Error> { Err(Error::Syntax) }
-        fn read_f64(&mut self) -> Result<f64, Error> { Err(Error::Syntax) }
-        fn read_f32(&mut self) -> Result<f32, Error> { Err(Error::Syntax) }
-        fn read_char(&mut self) -> Result<char, Error> { Err(Error::Syntax) }
+        fn read_i64(&mut self) -> Result<i64, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_i32(&mut self) -> Result<i32, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_i16(&mut self) -> Result<i16, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_i8(&mut self) -> Result<i8, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_bool(&mut self) -> Result<bool, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_f64(&mut self) -> Result<f64, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_f32(&mut self) -> Result<f32, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_char(&mut self) -> Result<char, Error> {
+            Err(Error::Syntax)
+        }
         #[inline]
         fn read_str(&mut self) -> Result<String, Error> {
             match self.stack.pop() {
@@ -112,8 +149,8 @@ mod decoder {
 
         // Compound types:
         #[inline]
-        fn read_enum<T, F>(&mut self, name: &str, f: F) -> Result<T, Error> where
-            F: FnOnce(&mut AnimalDecoder) -> Result<T, Error>,
+        fn read_enum<T, F>(&mut self, name: &str, f: F) -> Result<T, Error>
+            where F: FnOnce(&mut AnimalDecoder) -> Result<T, Error>,
         {
             match self.stack.pop() {
                 Some(State::Animal(animal)) => {
@@ -124,13 +161,13 @@ mod decoder {
                         Err(Error::Syntax)
                     }
                 }
-                _ => Err(Error::Syntax)
+                _ => Err(Error::Syntax),
             }
         }
 
         #[inline]
-        fn read_enum_variant<T, F>(&mut self, names: &[&str], f: F) -> Result<T, Error> where
-            F: FnOnce(&mut AnimalDecoder, usize) -> Result<T, Error>,
+        fn read_enum_variant<T, F>(&mut self, names: &[&str], f: F) -> Result<T, Error>
+            where F: FnOnce(&mut AnimalDecoder, usize) -> Result<T, Error>,
         {
             let name = match self.stack.pop() {
                 Some(State::Animal(Dog)) => "Dog",
@@ -139,114 +176,128 @@ mod decoder {
                     self.stack.push(State::String(x0));
                     "Frog"
                 }
-                _ => { return Err(Error::Syntax); }
+                _ => {
+                    return Err(Error::Syntax);
+                }
             };
 
             let idx = match names.iter().position(|n| *n == name) {
                 Some(idx) => idx,
-                None => { return Err(Error::Syntax); }
+                None => {
+                    return Err(Error::Syntax);
+                }
             };
 
             f(self, idx)
         }
 
         #[inline]
-        fn read_enum_variant_arg<T, F>(&mut self, _a_idx: usize, f: F) -> Result<T, Error> where
-            F: FnOnce(&mut AnimalDecoder) -> Result<T, Error>,
+        fn read_enum_variant_arg<T, F>(&mut self, _a_idx: usize, f: F) -> Result<T, Error>
+            where F: FnOnce(&mut AnimalDecoder) -> Result<T, Error>,
         {
             f(self)
         }
 
-        fn read_enum_struct_variant<T, F>(&mut self, _names: &[&str], _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut AnimalDecoder, usize) -> Result<T, Error>,
+        fn read_enum_struct_variant<T, F>(&mut self, _names: &[&str], _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut AnimalDecoder, usize) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_enum_struct_variant_field<T, F>(&mut self, _f_name: &str, _f_idx: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut AnimalDecoder) -> Result<T, Error>,
+        fn read_enum_struct_variant_field<T, F>(
+            &mut self,
+            _f_name: &str,
+            _f_idx: usize,
+            _f: F
+        ) -> Result<T, Error>
+            where F: FnOnce(&mut AnimalDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_struct<T, F>(&mut self, _s_name: &str, _len: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut AnimalDecoder) -> Result<T, Error>,
+        fn read_struct<T, F>(&mut self, _s_name: &str, _len: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut AnimalDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_struct_field<T, F>(&mut self, _f_name: &str, _f_idx: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut AnimalDecoder) -> Result<T, Error>,
+        fn read_struct_field<T, F>(
+            &mut self,
+            _f_name: &str,
+            _f_idx: usize,
+            _f: F
+        ) -> Result<T, Error>
+            where F: FnOnce(&mut AnimalDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_tuple<T, F>(&mut self, _len: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut AnimalDecoder) -> Result<T, Error>,
+        fn read_tuple<T, F>(&mut self, _len: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut AnimalDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_tuple_arg<T, F>(&mut self, _a_idx: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut AnimalDecoder) -> Result<T, Error>,
+        fn read_tuple_arg<T, F>(&mut self, _a_idx: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut AnimalDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_tuple_struct<T, F>(&mut self, _s_name: &str, _len: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut AnimalDecoder) -> Result<T, Error>,
+        fn read_tuple_struct<T, F>(&mut self, _s_name: &str, _len: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut AnimalDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_tuple_struct_arg<T, F>(&mut self, _a_idx: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut AnimalDecoder) -> Result<T, Error>,
+        fn read_tuple_struct_arg<T, F>(&mut self, _a_idx: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut AnimalDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
         // Specialized types:
-        fn read_option<T, F>(&mut self, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut AnimalDecoder, bool) -> Result<T, Error>,
+        fn read_option<T, F>(&mut self, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut AnimalDecoder, bool) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
         #[inline]
-        fn read_seq<T, F>(&mut self, f: F) -> Result<T, Error> where
-            F: FnOnce(&mut AnimalDecoder, usize) -> Result<T, Error>,
+        fn read_seq<T, F>(&mut self, f: F) -> Result<T, Error>
+            where F: FnOnce(&mut AnimalDecoder, usize) -> Result<T, Error>,
         {
             f(self, 3)
         }
 
         #[inline]
-        fn read_seq_elt<T, F>(&mut self, _idx: usize, f: F) -> Result<T, Error> where
-            F: FnOnce(&mut AnimalDecoder) -> Result<T, Error>,
+        fn read_seq_elt<T, F>(&mut self, _idx: usize, f: F) -> Result<T, Error>
+            where F: FnOnce(&mut AnimalDecoder) -> Result<T, Error>,
         {
             f(self)
         }
 
-        fn read_map<T, F>(&mut self, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut AnimalDecoder, usize) -> Result<T, Error>,
+        fn read_map<T, F>(&mut self, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut AnimalDecoder, usize) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_map_elt_key<T, F>(&mut self, _idx: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut AnimalDecoder) -> Result<T, Error>,
+        fn read_map_elt_key<T, F>(&mut self, _idx: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut AnimalDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_map_elt_val<T, F>(&mut self, _idx: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut AnimalDecoder) -> Result<T, Error>,
+        fn read_map_elt_val<T, F>(&mut self, _idx: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut AnimalDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
     }
 }
 
-//////////////////////////////////////////////////////////////////////////////
+/// ///////////////////////////////////////////////////////////////////////////
 
 mod deserializer {
     use super::{Animal, Error};
@@ -270,7 +321,7 @@ mod deserializer {
         #[inline]
         pub fn new(animal: Animal) -> AnimalDeserializer {
             AnimalDeserializer {
-                stack: vec!(State::Animal(animal)),
+                stack: vec![State::Animal(animal)],
             }
         }
     }
@@ -283,32 +334,22 @@ mod deserializer {
             where V: de::Visitor,
         {
             match self.stack.pop() {
-                Some(State::Isize(value)) => {
-                    visitor.visit_isize(value)
-                }
-                Some(State::String(value)) => {
-                    visitor.visit_string(value)
-                }
-                Some(State::Str(value)) => {
-                    visitor.visit_str(value)
-                }
-                Some(State::UnitState) => {
-                    visitor.visit_unit()
-                }
-                Some(_) => {
-                    Err(Error::Syntax)
-                }
-                None => {
-                    Err(Error::EndOfStream)
-                }
+                Some(State::Isize(value)) => visitor.visit_isize(value),
+                Some(State::String(value)) => visitor.visit_string(value),
+                Some(State::Str(value)) => visitor.visit_str(value),
+                Some(State::UnitState) => visitor.visit_unit(),
+                Some(_) => Err(Error::Syntax),
+                None => Err(Error::EndOfStream),
             }
         }
 
         #[inline]
-        fn deserialize_enum<V>(&mut self,
-                         _name: &str,
-                         _variants: &[&str],
-                         mut visitor: V) -> Result<V::Value, Error>
+        fn deserialize_enum<V>(
+            &mut self,
+            _name: &str,
+            _variants: &[&str],
+            mut visitor: V
+        ) -> Result<V::Value, Error>
             where V: de::EnumVisitor,
         {
             match self.stack.pop() {
@@ -328,12 +369,8 @@ mod deserializer {
                         state: 0,
                     })
                 }
-                Some(_) => {
-                    Err(Error::Syntax)
-                }
-                None => {
-                    Err(Error::EndOfStream)
-                }
+                Some(_) => Err(Error::Syntax),
+                None => Err(Error::EndOfStream),
             }
         }
     }
@@ -346,7 +383,7 @@ mod deserializer {
         type Error = Error;
 
         fn visit_variant<V>(&mut self) -> Result<V, Error>
-            where V: de::Deserialize
+            where V: de::Deserialize,
         {
             de::Deserialize::deserialize(self.de)
         }
@@ -365,14 +402,12 @@ mod deserializer {
         type Error = Error;
 
         fn visit_variant<V>(&mut self) -> Result<V, Error>
-            where V: de::Deserialize
+            where V: de::Deserialize,
         {
             de::Deserialize::deserialize(self.de)
         }
 
-        fn visit_tuple<V>(&mut self,
-                          _len: usize,
-                          mut visitor: V) -> Result<V::Value, Error>
+        fn visit_tuple<V>(&mut self, _len: usize, mut visitor: V) -> Result<V::Value, Error>
             where V: de::Visitor,
         {
             visitor.visit_seq(self)
@@ -394,9 +429,7 @@ mod deserializer {
                     self.state += 1;
                     Ok(Some(try!(de::Deserialize::deserialize(self.de))))
                 }
-                _ => {
-                    Ok(None)
-                }
+                _ => Ok(None),
             }
         }
 
@@ -415,7 +448,7 @@ mod deserializer {
     }
 }
 
-//////////////////////////////////////////////////////////////////////////////
+/// ///////////////////////////////////////////////////////////////////////////
 
 #[bench]
 fn bench_decoder_dog(b: &mut Bencher) {

--- a/testing/benches/bench_map.rs
+++ b/testing/benches/bench_map.rs
@@ -4,12 +4,12 @@ use std::error;
 use std::collections::HashMap;
 use test::Bencher;
 
-use rustc_serialize::{Decoder, Decodable};
+use rustc_serialize::{Decodable, Decoder};
 
 use serde;
-use serde::de::{Deserializer, Deserialize};
+use serde::de::{Deserialize, Deserializer};
 
-//////////////////////////////////////////////////////////////////////////////
+/// ///////////////////////////////////////////////////////////////////////////
 
 #[derive(PartialEq, Debug)]
 pub enum Error {
@@ -19,11 +19,17 @@ pub enum Error {
 }
 
 impl serde::de::Error for Error {
-    fn custom<T: Into<String>>(_: T) -> Error { Error::Syntax }
+    fn custom<T: Into<String>>(_: T) -> Error {
+        Error::Syntax
+    }
 
-    fn end_of_stream() -> Error { Error::EndOfStream }
+    fn end_of_stream() -> Error {
+        Error::EndOfStream
+    }
 
-    fn unknown_field(_: &str) -> Error { Error::Syntax }
+    fn unknown_field(_: &str) -> Error {
+        Error::Syntax
+    }
 
     fn missing_field(_: &'static str) -> Error {
         Error::MissingField
@@ -45,7 +51,7 @@ impl error::Error for Error {
         None
     }
 }
-//////////////////////////////////////////////////////////////////////////////
+/// ///////////////////////////////////////////////////////////////////////////
 
 mod decoder {
     use std::collections::HashMap;
@@ -71,7 +77,7 @@ mod decoder {
             IsizeDecoder {
                 len: values.len(),
                 iter: values.into_iter(),
-                stack: vec!(),
+                stack: vec![],
             }
         }
     }
@@ -84,12 +90,24 @@ mod decoder {
         }
 
         // Primitive types:
-        fn read_nil(&mut self) -> Result<(), Error> { Err(Error::Syntax) }
-        fn read_usize(&mut self) -> Result<usize, Error> { Err(Error::Syntax) }
-        fn read_u64(&mut self) -> Result<u64, Error> { Err(Error::Syntax) }
-        fn read_u32(&mut self) -> Result<u32, Error> { Err(Error::Syntax) }
-        fn read_u16(&mut self) -> Result<u16, Error> { Err(Error::Syntax) }
-        fn read_u8(&mut self) -> Result<u8, Error> { Err(Error::Syntax) }
+        fn read_nil(&mut self) -> Result<(), Error> {
+            Err(Error::Syntax)
+        }
+        fn read_usize(&mut self) -> Result<usize, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_u64(&mut self) -> Result<u64, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_u32(&mut self) -> Result<u32, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_u16(&mut self) -> Result<u16, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_u8(&mut self) -> Result<u8, Error> {
+            Err(Error::Syntax)
+        }
         #[inline]
         fn read_isize(&mut self) -> Result<isize, Error> {
             match self.stack.pop() {
@@ -98,14 +116,30 @@ mod decoder {
                 None => Err(Error::EndOfStream),
             }
         }
-        fn read_i64(&mut self) -> Result<i64, Error> { Err(Error::Syntax) }
-        fn read_i32(&mut self) -> Result<i32, Error> { Err(Error::Syntax) }
-        fn read_i16(&mut self) -> Result<i16, Error> { Err(Error::Syntax) }
-        fn read_i8(&mut self) -> Result<i8, Error> { Err(Error::Syntax) }
-        fn read_bool(&mut self) -> Result<bool, Error> { Err(Error::Syntax) }
-        fn read_f64(&mut self) -> Result<f64, Error> { Err(Error::Syntax) }
-        fn read_f32(&mut self) -> Result<f32, Error> { Err(Error::Syntax) }
-        fn read_char(&mut self) -> Result<char, Error> { Err(Error::Syntax) }
+        fn read_i64(&mut self) -> Result<i64, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_i32(&mut self) -> Result<i32, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_i16(&mut self) -> Result<i16, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_i8(&mut self) -> Result<i8, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_bool(&mut self) -> Result<bool, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_f64(&mut self) -> Result<f64, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_f32(&mut self) -> Result<f32, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_char(&mut self) -> Result<char, Error> {
+            Err(Error::Syntax)
+        }
         #[inline]
         fn read_str(&mut self) -> Result<String, Error> {
             match self.stack.pop() {
@@ -116,101 +150,111 @@ mod decoder {
         }
 
         // Compound types:
-        fn read_enum<T, F>(&mut self, _name: &str, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut IsizeDecoder) -> Result<T, Error>,
+        fn read_enum<T, F>(&mut self, _name: &str, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut IsizeDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_enum_variant<T, F>(&mut self, _names: &[&str], _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut IsizeDecoder, usize) -> Result<T, Error>,
+        fn read_enum_variant<T, F>(&mut self, _names: &[&str], _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut IsizeDecoder, usize) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_enum_variant_arg<T, F>(&mut self, _a_idx: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut IsizeDecoder) -> Result<T, Error>,
+        fn read_enum_variant_arg<T, F>(&mut self, _a_idx: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut IsizeDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_enum_struct_variant<T, F>(&mut self, _names: &[&str], _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut IsizeDecoder, usize) -> Result<T, Error>,
+        fn read_enum_struct_variant<T, F>(&mut self, _names: &[&str], _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut IsizeDecoder, usize) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_enum_struct_variant_field<T, F>(&mut self, _f_name: &str, _f_idx: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut IsizeDecoder) -> Result<T, Error>,
+        fn read_enum_struct_variant_field<T, F>(
+            &mut self,
+            _f_name: &str,
+            _f_idx: usize,
+            _f: F
+        ) -> Result<T, Error>
+            where F: FnOnce(&mut IsizeDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_struct<T, F>(&mut self, _s_name: &str, _len: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut IsizeDecoder) -> Result<T, Error>,
+        fn read_struct<T, F>(&mut self, _s_name: &str, _len: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut IsizeDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_struct_field<T, F>(&mut self, _f_name: &str, _f_idx: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut IsizeDecoder) -> Result<T, Error>,
+        fn read_struct_field<T, F>(
+            &mut self,
+            _f_name: &str,
+            _f_idx: usize,
+            _f: F
+        ) -> Result<T, Error>
+            where F: FnOnce(&mut IsizeDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_tuple<T, F>(&mut self, _len: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut IsizeDecoder) -> Result<T, Error>,
+        fn read_tuple<T, F>(&mut self, _len: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut IsizeDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_tuple_arg<T, F>(&mut self, _a_idx: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut IsizeDecoder) -> Result<T, Error>,
+        fn read_tuple_arg<T, F>(&mut self, _a_idx: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut IsizeDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_tuple_struct<T, F>(&mut self, _s_name: &str, _len: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut IsizeDecoder) -> Result<T, Error>,
+        fn read_tuple_struct<T, F>(&mut self, _s_name: &str, _len: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut IsizeDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_tuple_struct_arg<T, F>(&mut self, _a_idx: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut IsizeDecoder) -> Result<T, Error>,
+        fn read_tuple_struct_arg<T, F>(&mut self, _a_idx: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut IsizeDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
         // Specialized types:
-        fn read_option<T, F>(&mut self, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut IsizeDecoder, bool) -> Result<T, Error>,
+        fn read_option<T, F>(&mut self, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut IsizeDecoder, bool) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_seq<T, F>(&mut self, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut IsizeDecoder, usize) -> Result<T, Error>,
+        fn read_seq<T, F>(&mut self, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut IsizeDecoder, usize) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_seq_elt<T, F>(&mut self, _idx: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut IsizeDecoder) -> Result<T, Error>,
+        fn read_seq_elt<T, F>(&mut self, _idx: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut IsizeDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
         #[inline]
-        fn read_map<T, F>(&mut self, f: F) -> Result<T, Error> where
-            F: FnOnce(&mut IsizeDecoder, usize) -> Result<T, Error>,
+        fn read_map<T, F>(&mut self, f: F) -> Result<T, Error>
+            where F: FnOnce(&mut IsizeDecoder, usize) -> Result<T, Error>,
         {
             let len = self.len;
             f(self, len)
         }
         #[inline]
-        fn read_map_elt_key<T, F>(&mut self, _idx: usize, f: F) -> Result<T, Error> where
-            F: FnOnce(&mut IsizeDecoder) -> Result<T, Error>,
+        fn read_map_elt_key<T, F>(&mut self, _idx: usize, f: F) -> Result<T, Error>
+            where F: FnOnce(&mut IsizeDecoder) -> Result<T, Error>,
         {
             match self.iter.next() {
                 Some((key, value)) => {
@@ -218,22 +262,20 @@ mod decoder {
                     self.stack.push(Value::String(key));
                     f(self)
                 }
-                None => {
-                    Err(Error::Syntax)
-                }
+                None => Err(Error::Syntax),
             }
         }
 
         #[inline]
-        fn read_map_elt_val<T, F>(&mut self, _idx: usize, f: F) -> Result<T, Error> where
-            F: FnOnce(&mut IsizeDecoder) -> Result<T, Error>,
+        fn read_map_elt_val<T, F>(&mut self, _idx: usize, f: F) -> Result<T, Error>
+            where F: FnOnce(&mut IsizeDecoder) -> Result<T, Error>,
         {
             f(self)
         }
     }
 }
 
-//////////////////////////////////////////////////////////////////////////////
+/// ///////////////////////////////////////////////////////////////////////////
 
 mod deserializer {
     use std::collections::HashMap;
@@ -259,7 +301,7 @@ mod deserializer {
         #[inline]
         pub fn new(values: HashMap<String, isize>) -> IsizeDeserializer {
             IsizeDeserializer {
-                stack: vec!(State::StartState),
+                stack: vec![State::StartState],
                 iter: values.into_iter(),
             }
         }
@@ -272,18 +314,10 @@ mod deserializer {
             where V: de::Visitor,
         {
             match self.stack.pop() {
-                Some(State::StartState) => {
-                    visitor.visit_map(self)
-                }
-                Some(State::Key(key)) => {
-                    visitor.visit_string(key)
-                }
-                Some(State::Value(value)) => {
-                    visitor.visit_isize(value)
-                }
-                None => {
-                    Err(Error::EndOfStream)
-                }
+                Some(State::StartState) => visitor.visit_map(self),
+                Some(State::Key(key)) => visitor.visit_string(key),
+                Some(State::Value(value)) => visitor.visit_isize(value),
+                None => Err(Error::EndOfStream),
             }
         }
     }
@@ -300,9 +334,7 @@ mod deserializer {
                     self.stack.push(State::Key(key));
                     Ok(Some(try!(de::Deserialize::deserialize(self))))
                 }
-                None => {
-                    Ok(None)
-                }
+                None => Ok(None),
             }
         }
 
@@ -324,80 +356,79 @@ mod deserializer {
         }
     }
 
-/*
-    impl Iterator for IsizeDeserializer {
-        type Item = Result<de::Token, Error>;
-
-        #[inline]
-        fn next(&mut self) -> Option<Result<de::Token, Error>> {
-            match self.stack.pop() {
-                Some(State::StartState) => {
-                    self.stack.push(KeyOrEndState);
-                    Some(Ok(de::Token::MapStart(self.len)))
-                }
-                Some(State::KeyOrEndState) => {
-                    match self.iter.next() {
-                        Some((key, value)) => {
-                            self.stack.push(Value(value));
-                            Some(Ok(de::Token::String(key)))
-                        }
-                        None => {
-                            self.stack.push(EndState);
-                            Some(Ok(de::Token::End))
-                        }
-                    }
-                }
-                Some(State::Value(x)) => {
-                    self.stack.push(KeyOrEndState);
-                    Some(Ok(de::Token::Isize(x)))
-                }
-                Some(EndState) => {
-                    None
-                }
-                None => {
-                    None
-                }
-            }
-        }
-    }
-
-    impl de::Deserializer<Error> for IsizeDeserializer {
-        #[inline]
-        fn end_of_stream(&mut self) -> Error {
-            EndOfStream
-        }
-
-        #[inline]
-        fn syntax(&mut self, _token: de::Token, _expected: &[de::TokenKind]) -> Error {
-            Syntax
-        }
-
-        #[inline]
-        fn unexpected_name(&mut self, _token: de::Token) -> Error {
-            Syntax
-        }
-
-        #[inline]
-        fn conversion_error(&mut self, _token: de::Token) -> Error {
-            Syntax
-        }
-
-        #[inline]
-        fn missing_field<
-            T: de::Deserialize<IsizeDeserializer, Error>
-        >(&mut self, _field: &'static str) -> Result<T, Error> {
-            Err(Error::Syntax)
-        }
-    }
-*/
+    // impl Iterator for IsizeDeserializer {
+    // type Item = Result<de::Token, Error>;
+    //
+    // #[inline]
+    // fn next(&mut self) -> Option<Result<de::Token, Error>> {
+    // match self.stack.pop() {
+    // Some(State::StartState) => {
+    // self.stack.push(KeyOrEndState);
+    // Some(Ok(de::Token::MapStart(self.len)))
+    // }
+    // Some(State::KeyOrEndState) => {
+    // match self.iter.next() {
+    // Some((key, value)) => {
+    // self.stack.push(Value(value));
+    // Some(Ok(de::Token::String(key)))
+    // }
+    // None => {
+    // self.stack.push(EndState);
+    // Some(Ok(de::Token::End))
+    // }
+    // }
+    // }
+    // Some(State::Value(x)) => {
+    // self.stack.push(KeyOrEndState);
+    // Some(Ok(de::Token::Isize(x)))
+    // }
+    // Some(EndState) => {
+    // None
+    // }
+    // None => {
+    // None
+    // }
+    // }
+    // }
+    // }
+    //
+    // impl de::Deserializer<Error> for IsizeDeserializer {
+    // #[inline]
+    // fn end_of_stream(&mut self) -> Error {
+    // EndOfStream
+    // }
+    //
+    // #[inline]
+    // fn syntax(&mut self, _token: de::Token, _expected: &[de::TokenKind]) -> Error {
+    // Syntax
+    // }
+    //
+    // #[inline]
+    // fn unexpected_name(&mut self, _token: de::Token) -> Error {
+    // Syntax
+    // }
+    //
+    // #[inline]
+    // fn conversion_error(&mut self, _token: de::Token) -> Error {
+    // Syntax
+    // }
+    //
+    // #[inline]
+    // fn missing_field<
+    // T: de::Deserialize<IsizeDeserializer, Error>
+    // >(&mut self, _field: &'static str) -> Result<T, Error> {
+    // Err(Error::Syntax)
+    // }
+    // }
+    //
 }
 
-//////////////////////////////////////////////////////////////////////////////
+/// ///////////////////////////////////////////////////////////////////////////
 
-fn run_decoder<
-    D: Decoder<Error=Error>,
-    T: Clone + PartialEq + Debug + Decodable
->(mut d: D, value: T) {
+fn run_decoder<D: Decoder<Error = Error>, T: Clone + PartialEq + Debug + Decodable>(
+    mut d: D,
+    value: T
+) {
     let v = Decodable::decode(&mut d);
 
     assert_eq!(Ok(value), v);
@@ -415,7 +446,7 @@ fn bench_decoder_000(b: &mut Bencher) {
 fn bench_decoder_003(b: &mut Bencher) {
     b.iter(|| {
         let mut m: HashMap<String, isize> = HashMap::new();
-        for i in 0 .. 3 {
+        for i in 0..3 {
             m.insert(i.to_string(), i);
         }
         run_decoder(decoder::IsizeDecoder::new(m.clone()), m)
@@ -426,7 +457,7 @@ fn bench_decoder_003(b: &mut Bencher) {
 fn bench_decoder_100(b: &mut Bencher) {
     b.iter(|| {
         let mut m: HashMap<String, isize> = HashMap::new();
-        for i in 0 .. 100 {
+        for i in 0..100 {
             m.insert(i.to_string(), i);
         }
         run_decoder(decoder::IsizeDecoder::new(m.clone()), m)
@@ -436,7 +467,7 @@ fn bench_decoder_100(b: &mut Bencher) {
 fn run_deserializer<D, T>(mut d: D, value: T)
     where D: Deserializer,
           D::Error: Debug + PartialEq,
-          T: Clone + PartialEq + Debug + Deserialize
+          T: Clone + PartialEq + Debug + Deserialize,
 {
     let v = T::deserialize(&mut d);
 
@@ -455,7 +486,7 @@ fn bench_deserializer_000(b: &mut Bencher) {
 fn bench_deserializer_003(b: &mut Bencher) {
     b.iter(|| {
         let mut m: HashMap<String, isize> = HashMap::new();
-        for i in 0 .. 3 {
+        for i in 0..3 {
             m.insert(i.to_string(), i);
         }
         run_deserializer(deserializer::IsizeDeserializer::new(m.clone()), m)
@@ -466,7 +497,7 @@ fn bench_deserializer_003(b: &mut Bencher) {
 fn bench_deserializer_100(b: &mut Bencher) {
     b.iter(|| {
         let mut m: HashMap<String, isize> = HashMap::new();
-        for i in 0 .. 100 {
+        for i in 0..100 {
             m.insert(i.to_string(), i);
         }
         run_deserializer(deserializer::IsizeDeserializer::new(m.clone()), m)

--- a/testing/benches/bench_struct.rs
+++ b/testing/benches/bench_struct.rs
@@ -8,7 +8,7 @@ use rustc_serialize::Decodable;
 use serde;
 use serde::de::Deserialize;
 
-//////////////////////////////////////////////////////////////////////////////
+/// ///////////////////////////////////////////////////////////////////////////
 
 #[derive(Clone, PartialEq, Debug, RustcDecodable, Deserialize)]
 pub struct Inner {
@@ -17,14 +17,14 @@ pub struct Inner {
     c: HashMap<String, Option<char>>,
 }
 
-//////////////////////////////////////////////////////////////////////////////
+/// ///////////////////////////////////////////////////////////////////////////
 
 #[derive(Clone, PartialEq, Debug, RustcDecodable, Deserialize)]
 pub struct Outer {
     inner: Vec<Inner>,
 }
 
-//////////////////////////////////////////////////////////////////////////////
+/// ///////////////////////////////////////////////////////////////////////////
 
 #[derive(Debug, PartialEq)]
 pub enum Error {
@@ -35,11 +35,17 @@ pub enum Error {
 }
 
 impl serde::de::Error for Error {
-    fn custom<T: Into<String>>(_: T) -> Error { Error::Syntax }
+    fn custom<T: Into<String>>(_: T) -> Error {
+        Error::Syntax
+    }
 
-    fn end_of_stream() -> Error { Error::EndOfStream }
+    fn end_of_stream() -> Error {
+        Error::EndOfStream
+    }
 
-    fn unknown_field(_: &str) -> Error { Error::Syntax }
+    fn unknown_field(_: &str) -> Error {
+        Error::Syntax
+    }
 
     fn missing_field(_: &'static str) -> Error {
         Error::MissingField
@@ -66,7 +72,7 @@ mod decoder {
     use std::collections::HashMap;
     use rustc_serialize::Decoder;
 
-    use super::{Outer, Inner, Error};
+    use super::{Error, Inner, Outer};
 
     #[derive(Debug)]
     enum State {
@@ -84,14 +90,13 @@ mod decoder {
 
     pub struct OuterDecoder {
         stack: Vec<State>,
-
     }
 
     impl OuterDecoder {
         #[inline]
         pub fn new(animal: Outer) -> OuterDecoder {
             OuterDecoder {
-                stack: vec!(State::Outer(animal)),
+                stack: vec![State::Outer(animal)],
             }
         }
     }
@@ -118,18 +123,42 @@ mod decoder {
                 _ => Err(Error::Syntax),
             }
         }
-        fn read_u64(&mut self) -> Result<u64, Error> { Err(Error::Syntax) }
-        fn read_u32(&mut self) -> Result<u32, Error> { Err(Error::Syntax) }
-        fn read_u16(&mut self) -> Result<u16, Error> { Err(Error::Syntax) }
-        fn read_u8(&mut self) -> Result<u8, Error> { Err(Error::Syntax) }
-        fn read_isize(&mut self) -> Result<isize, Error> { Err(Error::Syntax) }
-        fn read_i64(&mut self) -> Result<i64, Error> { Err(Error::Syntax) }
-        fn read_i32(&mut self) -> Result<i32, Error> { Err(Error::Syntax) }
-        fn read_i16(&mut self) -> Result<i16, Error> { Err(Error::Syntax) }
-        fn read_i8(&mut self) -> Result<i8, Error> { Err(Error::Syntax) }
-        fn read_bool(&mut self) -> Result<bool, Error> { Err(Error::Syntax) }
-        fn read_f64(&mut self) -> Result<f64, Error> { Err(Error::Syntax) }
-        fn read_f32(&mut self) -> Result<f32, Error> { Err(Error::Syntax) }
+        fn read_u64(&mut self) -> Result<u64, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_u32(&mut self) -> Result<u32, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_u16(&mut self) -> Result<u16, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_u8(&mut self) -> Result<u8, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_isize(&mut self) -> Result<isize, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_i64(&mut self) -> Result<i64, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_i32(&mut self) -> Result<i32, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_i16(&mut self) -> Result<i16, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_i8(&mut self) -> Result<i8, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_bool(&mut self) -> Result<bool, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_f64(&mut self) -> Result<f64, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_f32(&mut self) -> Result<f32, Error> {
+            Err(Error::Syntax)
+        }
         #[inline]
         fn read_char(&mut self) -> Result<char, Error> {
             match self.stack.pop() {
@@ -146,39 +175,44 @@ mod decoder {
         }
 
         // Compound types:
-        fn read_enum<T, F>(&mut self, _name: &str, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut OuterDecoder) -> Result<T, Error>,
+        fn read_enum<T, F>(&mut self, _name: &str, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut OuterDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_enum_variant<T, F>(&mut self, _names: &[&str], _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut OuterDecoder, usize) -> Result<T, Error>,
+        fn read_enum_variant<T, F>(&mut self, _names: &[&str], _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut OuterDecoder, usize) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_enum_variant_arg<T, F>(&mut self, _a_idx: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut OuterDecoder) -> Result<T, Error>,
+        fn read_enum_variant_arg<T, F>(&mut self, _a_idx: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut OuterDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_enum_struct_variant<T, F>(&mut self, _names: &[&str], _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut OuterDecoder, usize) -> Result<T, Error>,
+        fn read_enum_struct_variant<T, F>(&mut self, _names: &[&str], _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut OuterDecoder, usize) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_enum_struct_variant_field<T, F>(&mut self, _f_name: &str, _f_idx: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut OuterDecoder) -> Result<T, Error>,
+        fn read_enum_struct_variant_field<T, F>(
+            &mut self,
+            _f_name: &str,
+            _f_idx: usize,
+            _f: F
+        ) -> Result<T, Error>
+            where F: FnOnce(&mut OuterDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
         #[inline]
-        fn read_struct<T, F>(&mut self, s_name: &str, _len: usize, f: F) -> Result<T, Error> where
-            F: FnOnce(&mut OuterDecoder) -> Result<T, Error>,
+        fn read_struct<T, F>(&mut self, s_name: &str, _len: usize, f: F) -> Result<T, Error>
+            where F: FnOnce(&mut OuterDecoder) -> Result<T, Error>,
         {
             match self.stack.pop() {
                 Some(State::Outer(Outer { inner })) => {
@@ -209,8 +243,8 @@ mod decoder {
             }
         }
         #[inline]
-        fn read_struct_field<T, F>(&mut self, f_name: &str, _f_idx: usize, f: F) -> Result<T, Error> where
-            F: FnOnce(&mut OuterDecoder) -> Result<T, Error>,
+        fn read_struct_field<T, F>(&mut self, f_name: &str, _f_idx: usize, f: F) -> Result<T, Error>
+            where F: FnOnce(&mut OuterDecoder) -> Result<T, Error>,
         {
             match self.stack.pop() {
                 Some(State::Field(name)) => {
@@ -220,38 +254,38 @@ mod decoder {
                         Err(Error::Syntax)
                     }
                 }
-                _ => Err(Error::Syntax)
+                _ => Err(Error::Syntax),
             }
         }
 
-        fn read_tuple<T, F>(&mut self, _len: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut OuterDecoder) -> Result<T, Error>,
+        fn read_tuple<T, F>(&mut self, _len: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut OuterDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_tuple_arg<T, F>(&mut self, _a_idx: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut OuterDecoder) -> Result<T, Error>,
+        fn read_tuple_arg<T, F>(&mut self, _a_idx: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut OuterDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_tuple_struct<T, F>(&mut self, _s_name: &str, _len: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut OuterDecoder) -> Result<T, Error>,
+        fn read_tuple_struct<T, F>(&mut self, _s_name: &str, _len: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut OuterDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_tuple_struct_arg<T, F>(&mut self, _a_idx: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut OuterDecoder) -> Result<T, Error>,
+        fn read_tuple_struct_arg<T, F>(&mut self, _a_idx: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut OuterDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
         // Specialized types:
         #[inline]
-        fn read_option<T, F>(&mut self, f: F) -> Result<T, Error> where
-            F: FnOnce(&mut OuterDecoder, bool) -> Result<T, Error>,
+        fn read_option<T, F>(&mut self, f: F) -> Result<T, Error>
+            where F: FnOnce(&mut OuterDecoder, bool) -> Result<T, Error>,
         {
             match self.stack.pop() {
                 Some(State::Option(b)) => f(self, b),
@@ -260,8 +294,8 @@ mod decoder {
         }
 
         #[inline]
-        fn read_seq<T, F>(&mut self, f: F) -> Result<T, Error> where
-            F: FnOnce(&mut OuterDecoder, usize) -> Result<T, Error>,
+        fn read_seq<T, F>(&mut self, f: F) -> Result<T, Error>
+            where F: FnOnce(&mut OuterDecoder, usize) -> Result<T, Error>,
         {
             match self.stack.pop() {
                 Some(State::Vec(value)) => {
@@ -271,19 +305,19 @@ mod decoder {
                     }
                     f(self, len)
                 }
-                _ => Err(Error::Syntax)
+                _ => Err(Error::Syntax),
             }
         }
         #[inline]
-        fn read_seq_elt<T, F>(&mut self, _idx: usize, f: F) -> Result<T, Error> where
-            F: FnOnce(&mut OuterDecoder) -> Result<T, Error>,
+        fn read_seq_elt<T, F>(&mut self, _idx: usize, f: F) -> Result<T, Error>
+            where F: FnOnce(&mut OuterDecoder) -> Result<T, Error>,
         {
             f(self)
         }
 
         #[inline]
-        fn read_map<T, F>(&mut self, f: F) -> Result<T, Error> where
-            F: FnOnce(&mut OuterDecoder, usize) -> Result<T, Error>,
+        fn read_map<T, F>(&mut self, f: F) -> Result<T, Error>
+            where F: FnOnce(&mut OuterDecoder, usize) -> Result<T, Error>,
         {
             match self.stack.pop() {
                 Some(State::Map(map)) => {
@@ -306,28 +340,28 @@ mod decoder {
             }
         }
         #[inline]
-        fn read_map_elt_key<T, F>(&mut self, _idx: usize, f: F) -> Result<T, Error> where
-            F: FnOnce(&mut OuterDecoder) -> Result<T, Error>,
+        fn read_map_elt_key<T, F>(&mut self, _idx: usize, f: F) -> Result<T, Error>
+            where F: FnOnce(&mut OuterDecoder) -> Result<T, Error>,
         {
             f(self)
         }
 
         #[inline]
-        fn read_map_elt_val<T, F>(&mut self, _idx: usize, f: F) -> Result<T, Error> where
-            F: FnOnce(&mut OuterDecoder) -> Result<T, Error>,
+        fn read_map_elt_val<T, F>(&mut self, _idx: usize, f: F) -> Result<T, Error>
+            where F: FnOnce(&mut OuterDecoder) -> Result<T, Error>,
         {
             f(self)
         }
     }
 }
 
-//////////////////////////////////////////////////////////////////////////////
+/// ///////////////////////////////////////////////////////////////////////////
 
 mod deserializer {
     use std::collections::HashMap;
     use std::collections::hash_map;
     use std::vec;
-    use super::{Outer, Inner};
+    use super::{Inner, Outer};
     use super::Error;
     use serde::de;
 
@@ -353,7 +387,7 @@ mod deserializer {
         #[inline]
         pub fn new(outer: Outer) -> OuterDeserializer {
             OuterDeserializer {
-                stack: vec!(State::Outer(outer)),
+                stack: vec![State::Outer(outer)],
             }
         }
     }
@@ -377,36 +411,24 @@ mod deserializer {
                         iter: value.into_iter(),
                     })
                 }
-                Some(State::Null) => {
-                    visitor.visit_unit()
-                }
-                Some(State::Usize(x)) => {
-                    visitor.visit_usize(x)
-                }
-                Some(State::Char(x)) => {
-                    visitor.visit_char(x)
-                }
-                Some(State::Str(x)) => {
-                    visitor.visit_str(x)
-                }
-                Some(State::String(x)) => {
-                    visitor.visit_string(x)
-                }
-                Some(State::Option(false)) => {
-                    visitor.visit_none()
-                }
-                Some(State::Option(true)) => {
-                    visitor.visit_some(self)
-                }
+                Some(State::Null) => visitor.visit_unit(),
+                Some(State::Usize(x)) => visitor.visit_usize(x),
+                Some(State::Char(x)) => visitor.visit_char(x),
+                Some(State::Str(x)) => visitor.visit_str(x),
+                Some(State::String(x)) => visitor.visit_string(x),
+                Some(State::Option(false)) => visitor.visit_none(),
+                Some(State::Option(true)) => visitor.visit_some(self),
                 Some(_) => Err(Error::Syntax),
                 None => Err(Error::EndOfStream),
             }
         }
 
-        fn deserialize_struct<V>(&mut self,
-                           name: &str,
-                           _fields: &'static [&'static str],
-                           mut visitor: V) -> Result<V::Value, Error>
+        fn deserialize_struct<V>(
+            &mut self,
+            name: &str,
+            _fields: &'static [&'static str],
+            mut visitor: V
+        ) -> Result<V::Value, Error>
             where V: de::Visitor,
         {
             match self.stack.pop() {
@@ -442,9 +464,7 @@ mod deserializer {
                         state: 0,
                     })
                 }
-                _ => {
-                    Err(Error::Syntax)
-                }
+                _ => Err(Error::Syntax),
             }
         }
     }
@@ -465,9 +485,7 @@ mod deserializer {
                     self.state += 1;
                     Ok(Some(try!(de::Deserialize::deserialize(self.de))))
                 }
-                _ => {
-                    Ok(None)
-                }
+                _ => Ok(None),
             }
         }
 
@@ -507,9 +525,7 @@ mod deserializer {
                     self.de.stack.push(State::Inner(value));
                     Ok(Some(try!(de::Deserialize::deserialize(self.de))))
                 }
-                None => {
-                    Ok(None)
-                }
+                None => Ok(None),
             }
         }
 
@@ -537,13 +553,11 @@ mod deserializer {
             where K: de::Deserialize,
         {
             match self.state {
-                0 ... 2 => {
+                0...2 => {
                     self.state += 1;
                     Ok(Some(try!(de::Deserialize::deserialize(self.de))))
                 }
-                _ => {
-                    Ok(None)
-                }
+                _ => Ok(None),
             }
         }
 
@@ -590,9 +604,7 @@ mod deserializer {
                     self.de.stack.push(State::String(key));
                     Ok(Some(try!(de::Deserialize::deserialize(self.de))))
                 }
-                None => {
-                    Ok(None)
-                }
+                None => Ok(None),
             }
         }
 
@@ -622,7 +634,7 @@ fn bench_decoder_0_0(b: &mut Bencher) {
         map.insert("abc".to_owned(), Some('c'));
 
         let outer = Outer {
-            inner: vec!(),
+            inner: vec![],
         };
 
         let mut d = decoder::OuterDecoder::new(outer.clone());
@@ -644,7 +656,7 @@ fn bench_decoder_1_0(b: &mut Bencher) {
                     b: 5,
                     c: map,
                 },
-            )
+            ),
         };
 
         let mut d = decoder::OuterDecoder::new(outer.clone());
@@ -671,7 +683,7 @@ fn bench_decoder_1_5(b: &mut Bencher) {
                     b: 5,
                     c: map,
                 },
-            )
+            ),
         };
 
         let mut d = decoder::OuterDecoder::new(outer.clone());
@@ -685,7 +697,7 @@ fn bench_decoder_1_5(b: &mut Bencher) {
 fn bench_deserializer_0_0(b: &mut Bencher) {
     b.iter(|| {
         let outer = Outer {
-            inner: vec!(),
+            inner: vec![],
         };
 
         let mut d = deserializer::OuterDeserializer::new(outer.clone());
@@ -707,7 +719,7 @@ fn bench_deserializer_1_0(b: &mut Bencher) {
                     b: 5,
                     c: map,
                 },
-            )
+            ),
         };
 
         let mut d = deserializer::OuterDeserializer::new(outer.clone());
@@ -734,7 +746,7 @@ fn bench_deserializer_1_5(b: &mut Bencher) {
                     b: 5,
                     c: map,
                 },
-            )
+            ),
         };
 
         let mut d = deserializer::OuterDeserializer::new(outer.clone());

--- a/testing/benches/bench_vec.rs
+++ b/testing/benches/bench_vec.rs
@@ -3,12 +3,12 @@ use std::fmt;
 use std::error;
 use test::Bencher;
 
-use rustc_serialize::{Decoder, Decodable};
+use rustc_serialize::{Decodable, Decoder};
 
 use serde;
-use serde::de::{Deserializer, Deserialize};
+use serde::de::{Deserialize, Deserializer};
 
-//////////////////////////////////////////////////////////////////////////////
+/// ///////////////////////////////////////////////////////////////////////////
 
 #[derive(PartialEq, Debug)]
 pub enum Error {
@@ -17,13 +17,21 @@ pub enum Error {
 }
 
 impl serde::de::Error for Error {
-    fn custom<T: Into<String>>(_: T) -> Error { Error::Syntax }
+    fn custom<T: Into<String>>(_: T) -> Error {
+        Error::Syntax
+    }
 
-    fn end_of_stream() -> Error { Error::EndOfStream }
+    fn end_of_stream() -> Error {
+        Error::EndOfStream
+    }
 
-    fn unknown_field(_: &str) -> Error { Error::Syntax }
+    fn unknown_field(_: &str) -> Error {
+        Error::Syntax
+    }
 
-    fn missing_field(_: &'static str) -> Error { Error::Syntax }
+    fn missing_field(_: &'static str) -> Error {
+        Error::Syntax
+    }
 }
 
 impl fmt::Display for Error {
@@ -41,7 +49,7 @@ impl error::Error for Error {
         None
     }
 }
-//////////////////////////////////////////////////////////////////////////////
+/// ///////////////////////////////////////////////////////////////////////////
 
 mod decoder {
     use std::vec;
@@ -67,10 +75,14 @@ mod decoder {
     impl rustc_serialize::Decoder for UsizeDecoder {
         type Error = Error;
 
-        fn error(&mut self, _: &str) -> Error { Error::Syntax }
+        fn error(&mut self, _: &str) -> Error {
+            Error::Syntax
+        }
 
         // Primitive types:
-        fn read_nil(&mut self) -> Result<(), Error> { Err(Error::Syntax) }
+        fn read_nil(&mut self) -> Result<(), Error> {
+            Err(Error::Syntax)
+        }
         #[inline]
         fn read_usize(&mut self) -> Result<usize, Error> {
             match self.iter.next() {
@@ -78,123 +90,161 @@ mod decoder {
                 None => Err(Error::EndOfStream),
             }
         }
-        fn read_u64(&mut self) -> Result<u64, Error> { Err(Error::Syntax) }
-        fn read_u32(&mut self) -> Result<u32, Error> { Err(Error::Syntax) }
-        fn read_u16(&mut self) -> Result<u16, Error> { Err(Error::Syntax) }
-        fn read_u8(&mut self) -> Result<u8, Error> { Err(Error::Syntax) }
-        fn read_isize(&mut self) -> Result<isize, Error> { Err(Error::Syntax) }
-        fn read_i64(&mut self) -> Result<i64, Error> { Err(Error::Syntax) }
-        fn read_i32(&mut self) -> Result<i32, Error> { Err(Error::Syntax) }
-        fn read_i16(&mut self) -> Result<i16, Error> { Err(Error::Syntax) }
-        fn read_i8(&mut self) -> Result<i8, Error> { Err(Error::Syntax) }
-        fn read_bool(&mut self) -> Result<bool, Error> { Err(Error::Syntax) }
-        fn read_f64(&mut self) -> Result<f64, Error> { Err(Error::Syntax) }
-        fn read_f32(&mut self) -> Result<f32, Error> { Err(Error::Syntax) }
-        fn read_char(&mut self) -> Result<char, Error> { Err(Error::Syntax) }
-        fn read_str(&mut self) -> Result<String, Error> { Err(Error::Syntax) }
+        fn read_u64(&mut self) -> Result<u64, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_u32(&mut self) -> Result<u32, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_u16(&mut self) -> Result<u16, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_u8(&mut self) -> Result<u8, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_isize(&mut self) -> Result<isize, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_i64(&mut self) -> Result<i64, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_i32(&mut self) -> Result<i32, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_i16(&mut self) -> Result<i16, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_i8(&mut self) -> Result<i8, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_bool(&mut self) -> Result<bool, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_f64(&mut self) -> Result<f64, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_f32(&mut self) -> Result<f32, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_char(&mut self) -> Result<char, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_str(&mut self) -> Result<String, Error> {
+            Err(Error::Syntax)
+        }
 
         // Compound types:
-        fn read_enum<T, F>(&mut self, _name: &str, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut UsizeDecoder) -> Result<T, Error>,
+        fn read_enum<T, F>(&mut self, _name: &str, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut UsizeDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_enum_variant<T, F>(&mut self, _names: &[&str], _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut UsizeDecoder, usize) -> Result<T, Error>,
+        fn read_enum_variant<T, F>(&mut self, _names: &[&str], _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut UsizeDecoder, usize) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_enum_variant_arg<T, F>(&mut self, _a_idx: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut UsizeDecoder) -> Result<T, Error>,
+        fn read_enum_variant_arg<T, F>(&mut self, _a_idx: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut UsizeDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_enum_struct_variant<T, F>(&mut self, _names: &[&str], _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut UsizeDecoder, usize) -> Result<T, Error>,
+        fn read_enum_struct_variant<T, F>(&mut self, _names: &[&str], _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut UsizeDecoder, usize) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_enum_struct_variant_field<T, F>(&mut self, _f_name: &str, _f_idx: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut UsizeDecoder) -> Result<T, Error>,
+        fn read_enum_struct_variant_field<T, F>(
+            &mut self,
+            _f_name: &str,
+            _f_idx: usize,
+            _f: F
+        ) -> Result<T, Error>
+            where F: FnOnce(&mut UsizeDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_struct<T, F>(&mut self, _s_name: &str, _len: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut UsizeDecoder) -> Result<T, Error>,
+        fn read_struct<T, F>(&mut self, _s_name: &str, _len: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut UsizeDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_struct_field<T, F>(&mut self, _f_name: &str, _f_idx: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut UsizeDecoder) -> Result<T, Error>,
+        fn read_struct_field<T, F>(
+            &mut self,
+            _f_name: &str,
+            _f_idx: usize,
+            _f: F
+        ) -> Result<T, Error>
+            where F: FnOnce(&mut UsizeDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_tuple<T, F>(&mut self, _len: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut UsizeDecoder) -> Result<T, Error>,
+        fn read_tuple<T, F>(&mut self, _len: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut UsizeDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_tuple_arg<T, F>(&mut self, _a_idx: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut UsizeDecoder) -> Result<T, Error>,
+        fn read_tuple_arg<T, F>(&mut self, _a_idx: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut UsizeDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_tuple_struct<T, F>(&mut self, _s_name: &str, _len: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut UsizeDecoder) -> Result<T, Error>,
+        fn read_tuple_struct<T, F>(&mut self, _s_name: &str, _len: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut UsizeDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_tuple_struct_arg<T, F>(&mut self, _a_idx: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut UsizeDecoder) -> Result<T, Error>,
+        fn read_tuple_struct_arg<T, F>(&mut self, _a_idx: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut UsizeDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
         // Specialized types:
-        fn read_option<T, F>(&mut self, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut UsizeDecoder, bool) -> Result<T, Error>,
+        fn read_option<T, F>(&mut self, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut UsizeDecoder, bool) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
         #[inline]
-        fn read_seq<T, F>(&mut self, f: F) -> Result<T, Error> where
-            F: FnOnce(&mut UsizeDecoder, usize) -> Result<T, Error>,
+        fn read_seq<T, F>(&mut self, f: F) -> Result<T, Error>
+            where F: FnOnce(&mut UsizeDecoder, usize) -> Result<T, Error>,
         {
             let len = self.len;
             f(self, len)
         }
         #[inline]
-        fn read_seq_elt<T, F>(&mut self, _idx: usize, f: F) -> Result<T, Error> where
-            F: FnOnce(&mut UsizeDecoder) -> Result<T, Error>,
+        fn read_seq_elt<T, F>(&mut self, _idx: usize, f: F) -> Result<T, Error>
+            where F: FnOnce(&mut UsizeDecoder) -> Result<T, Error>,
         {
             f(self)
         }
 
-        fn read_map<T, F>(&mut self, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut UsizeDecoder, usize) -> Result<T, Error>,
+        fn read_map<T, F>(&mut self, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut UsizeDecoder, usize) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_map_elt_key<T, F>(&mut self, _idx: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut UsizeDecoder) -> Result<T, Error>,
+        fn read_map_elt_key<T, F>(&mut self, _idx: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut UsizeDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_map_elt_val<T, F>(&mut self, _idx: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut UsizeDecoder) -> Result<T, Error>,
+        fn read_map_elt_val<T, F>(&mut self, _idx: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut UsizeDecoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
@@ -219,14 +269,26 @@ mod decoder {
     impl rustc_serialize::Decoder for U8Decoder {
         type Error = Error;
 
-        fn error(&mut self, _: &str) -> Error { Error::Syntax }
+        fn error(&mut self, _: &str) -> Error {
+            Error::Syntax
+        }
 
         // Primitive types:
-        fn read_nil(&mut self) -> Result<(), Error> { Err(Error::Syntax) }
-        fn read_usize(&mut self) -> Result<usize, Error> { Err(Error::Syntax) }
-        fn read_u64(&mut self) -> Result<u64, Error> { Err(Error::Syntax) }
-        fn read_u32(&mut self) -> Result<u32, Error> { Err(Error::Syntax) }
-        fn read_u16(&mut self) -> Result<u16, Error> { Err(Error::Syntax) }
+        fn read_nil(&mut self) -> Result<(), Error> {
+            Err(Error::Syntax)
+        }
+        fn read_usize(&mut self) -> Result<usize, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_u64(&mut self) -> Result<u64, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_u32(&mut self) -> Result<u32, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_u16(&mut self) -> Result<u16, Error> {
+            Err(Error::Syntax)
+        }
         #[inline]
         fn read_u8(&mut self) -> Result<u8, Error> {
             match self.iter.next() {
@@ -235,129 +297,159 @@ mod decoder {
             }
         }
         #[inline]
-        fn read_isize(&mut self) -> Result<isize, Error> { Err(Error::Syntax) }
-        fn read_i64(&mut self) -> Result<i64, Error> { Err(Error::Syntax) }
-        fn read_i32(&mut self) -> Result<i32, Error> { Err(Error::Syntax) }
-        fn read_i16(&mut self) -> Result<i16, Error> { Err(Error::Syntax) }
-        fn read_i8(&mut self) -> Result<i8, Error> { Err(Error::Syntax) }
-        fn read_bool(&mut self) -> Result<bool, Error> { Err(Error::Syntax) }
-        fn read_f64(&mut self) -> Result<f64, Error> { Err(Error::Syntax) }
-        fn read_f32(&mut self) -> Result<f32, Error> { Err(Error::Syntax) }
-        fn read_char(&mut self) -> Result<char, Error> { Err(Error::Syntax) }
-        fn read_str(&mut self) -> Result<String, Error> { Err(Error::Syntax) }
+        fn read_isize(&mut self) -> Result<isize, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_i64(&mut self) -> Result<i64, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_i32(&mut self) -> Result<i32, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_i16(&mut self) -> Result<i16, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_i8(&mut self) -> Result<i8, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_bool(&mut self) -> Result<bool, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_f64(&mut self) -> Result<f64, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_f32(&mut self) -> Result<f32, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_char(&mut self) -> Result<char, Error> {
+            Err(Error::Syntax)
+        }
+        fn read_str(&mut self) -> Result<String, Error> {
+            Err(Error::Syntax)
+        }
 
         // Compound types:
-        fn read_enum<T, F>(&mut self, _name: &str, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut U8Decoder) -> Result<T, Error>,
+        fn read_enum<T, F>(&mut self, _name: &str, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut U8Decoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_enum_variant<T, F>(&mut self, _names: &[&str], _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut U8Decoder, usize) -> Result<T, Error>,
+        fn read_enum_variant<T, F>(&mut self, _names: &[&str], _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut U8Decoder, usize) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_enum_variant_arg<T, F>(&mut self, _a_idx: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut U8Decoder) -> Result<T, Error>,
+        fn read_enum_variant_arg<T, F>(&mut self, _a_idx: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut U8Decoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_enum_struct_variant<T, F>(&mut self, _names: &[&str], _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut U8Decoder, usize) -> Result<T, Error>,
+        fn read_enum_struct_variant<T, F>(&mut self, _names: &[&str], _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut U8Decoder, usize) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_enum_struct_variant_field<T, F>(&mut self, _f_name: &str, _f_idx: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut U8Decoder) -> Result<T, Error>,
+        fn read_enum_struct_variant_field<T, F>(
+            &mut self,
+            _f_name: &str,
+            _f_idx: usize,
+            _f: F
+        ) -> Result<T, Error>
+            where F: FnOnce(&mut U8Decoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_struct<T, F>(&mut self, _s_name: &str, _len: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut U8Decoder) -> Result<T, Error>,
+        fn read_struct<T, F>(&mut self, _s_name: &str, _len: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut U8Decoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_struct_field<T, F>(&mut self, _f_name: &str, _f_idx: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut U8Decoder) -> Result<T, Error>,
+        fn read_struct_field<T, F>(
+            &mut self,
+            _f_name: &str,
+            _f_idx: usize,
+            _f: F
+        ) -> Result<T, Error>
+            where F: FnOnce(&mut U8Decoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_tuple<T, F>(&mut self, _len: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut U8Decoder) -> Result<T, Error>,
+        fn read_tuple<T, F>(&mut self, _len: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut U8Decoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_tuple_arg<T, F>(&mut self, _a_idx: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut U8Decoder) -> Result<T, Error>,
+        fn read_tuple_arg<T, F>(&mut self, _a_idx: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut U8Decoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_tuple_struct<T, F>(&mut self, _s_name: &str, _len: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut U8Decoder) -> Result<T, Error>,
+        fn read_tuple_struct<T, F>(&mut self, _s_name: &str, _len: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut U8Decoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_tuple_struct_arg<T, F>(&mut self, _a_idx: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut U8Decoder) -> Result<T, Error>,
+        fn read_tuple_struct_arg<T, F>(&mut self, _a_idx: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut U8Decoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
         // Specialized types:
-        fn read_option<T, F>(&mut self, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut U8Decoder, bool) -> Result<T, Error>,
+        fn read_option<T, F>(&mut self, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut U8Decoder, bool) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
         #[inline]
-        fn read_seq<T, F>(&mut self, f: F) -> Result<T, Error> where
-            F: FnOnce(&mut U8Decoder, usize) -> Result<T, Error>,
+        fn read_seq<T, F>(&mut self, f: F) -> Result<T, Error>
+            where F: FnOnce(&mut U8Decoder, usize) -> Result<T, Error>,
         {
             let len = self.len;
             f(self, len)
         }
         #[inline]
-        fn read_seq_elt<T, F>(&mut self, _idx: usize, f: F) -> Result<T, Error> where
-            F: FnOnce(&mut U8Decoder) -> Result<T, Error>,
+        fn read_seq_elt<T, F>(&mut self, _idx: usize, f: F) -> Result<T, Error>
+            where F: FnOnce(&mut U8Decoder) -> Result<T, Error>,
         {
             f(self)
         }
 
-        fn read_map<T, F>(&mut self, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut U8Decoder, usize) -> Result<T, Error>,
+        fn read_map<T, F>(&mut self, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut U8Decoder, usize) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_map_elt_key<T, F>(&mut self, _idx: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut U8Decoder) -> Result<T, Error>,
+        fn read_map_elt_key<T, F>(&mut self, _idx: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut U8Decoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
 
-        fn read_map_elt_val<T, F>(&mut self, _idx: usize, _f: F) -> Result<T, Error> where
-            F: FnOnce(&mut U8Decoder) -> Result<T, Error>,
+        fn read_map_elt_val<T, F>(&mut self, _idx: usize, _f: F) -> Result<T, Error>
+            where F: FnOnce(&mut U8Decoder) -> Result<T, Error>,
         {
             Err(Error::Syntax)
         }
     }
 }
 
-//////////////////////////////////////////////////////////////////////////////
+/// ///////////////////////////////////////////////////////////////////////////
 
 mod deserializer {
-    //use std::num;
+    // use std::num;
     use std::vec;
 
     use super::Error;
@@ -403,12 +495,8 @@ mod deserializer {
                     self.state = State::SepOrEnd;
                     visitor.visit_seq(self)
                 }
-                State::SepOrEnd => {
-                    visitor.visit_usize(self.value.take().unwrap())
-                }
-                State::End => {
-                    Err(Error::EndOfStream)
-                }
+                State::SepOrEnd => visitor.visit_usize(self.value.take().unwrap()),
+                State::End => Err(Error::EndOfStream),
             }
         }
     }
@@ -462,12 +550,8 @@ mod deserializer {
                     self.state = State::SepOrEnd;
                     visitor.visit_seq(self)
                 }
-                State::SepOrEnd => {
-                    visitor.visit_u8(self.value.take().unwrap())
-                }
-                State::End => {
-                    Err(Error::EndOfStream)
-                }
+                State::SepOrEnd => visitor.visit_u8(self.value.take().unwrap()),
+                State::End => Err(Error::EndOfStream),
             }
         }
     }
@@ -510,12 +594,12 @@ mod deserializer {
     }
 }
 
-//////////////////////////////////////////////////////////////////////////////
+/// ///////////////////////////////////////////////////////////////////////////
 
-fn run_decoder<
-    D: Decoder<Error=Error>,
-    T: Clone + PartialEq + Debug + Decodable
->(mut d: D, value: T) {
+fn run_decoder<D: Decoder<Error = Error>, T: Clone + PartialEq + Debug + Decodable>(
+    mut d: D,
+    value: T
+) {
     let v = Decodable::decode(&mut d);
 
     assert_eq!(Ok(value), v);
@@ -524,7 +608,7 @@ fn run_decoder<
 fn run_deserializer<D, T>(mut d: D, value: T)
     where D: Deserializer,
           D::Error: Debug + PartialEq,
-          T: Clone + PartialEq + Debug + Deserialize
+          T: Clone + PartialEq + Debug + Deserialize,
 {
     let v = T::deserialize(&mut d);
 
@@ -534,7 +618,7 @@ fn run_deserializer<D, T>(mut d: D, value: T)
 #[bench]
 fn bench_decoder_usize_000(b: &mut Bencher) {
     b.iter(|| {
-        let v: Vec<usize> = vec!();
+        let v: Vec<usize> = vec![];
         run_decoder(decoder::UsizeDecoder::new(v.clone()), v)
     })
 }
@@ -542,7 +626,7 @@ fn bench_decoder_usize_000(b: &mut Bencher) {
 #[bench]
 fn bench_decoder_usize_003(b: &mut Bencher) {
     b.iter(|| {
-        let v: Vec<usize> = vec!(1, 2, 3);
+        let v: Vec<usize> = vec![1, 2, 3];
         run_decoder(decoder::UsizeDecoder::new(v.clone()), v)
     })
 }
@@ -550,7 +634,7 @@ fn bench_decoder_usize_003(b: &mut Bencher) {
 #[bench]
 fn bench_decoder_usize_100(b: &mut Bencher) {
     b.iter(|| {
-        let v: Vec<usize> = (0 .. 100).collect();
+        let v: Vec<usize> = (0..100).collect();
         run_decoder(decoder::UsizeDecoder::new(v.clone()), v)
     })
 }
@@ -558,7 +642,7 @@ fn bench_decoder_usize_100(b: &mut Bencher) {
 #[bench]
 fn bench_decoder_u8_000(b: &mut Bencher) {
     b.iter(|| {
-        let v: Vec<u8> = vec!();
+        let v: Vec<u8> = vec![];
         run_decoder(decoder::U8Decoder::new(v.clone()), v)
     })
 }
@@ -566,7 +650,7 @@ fn bench_decoder_u8_000(b: &mut Bencher) {
 #[bench]
 fn bench_decoder_u8_003(b: &mut Bencher) {
     b.iter(|| {
-        let v: Vec<u8> = vec!(1, 2, 3);
+        let v: Vec<u8> = vec![1, 2, 3];
         run_decoder(decoder::U8Decoder::new(v.clone()), v)
     })
 }
@@ -574,7 +658,7 @@ fn bench_decoder_u8_003(b: &mut Bencher) {
 #[bench]
 fn bench_decoder_u8_100(b: &mut Bencher) {
     b.iter(|| {
-        let v: Vec<u8> = (0 .. 100).collect();
+        let v: Vec<u8> = (0..100).collect();
         run_decoder(decoder::U8Decoder::new(v.clone()), v)
     })
 }
@@ -582,7 +666,7 @@ fn bench_decoder_u8_100(b: &mut Bencher) {
 #[bench]
 fn bench_deserializer_usize_000(b: &mut Bencher) {
     b.iter(|| {
-        let v: Vec<usize> = vec!();
+        let v: Vec<usize> = vec![];
         run_deserializer(deserializer::Deserializer::new(v.clone()), v)
     })
 }
@@ -590,7 +674,7 @@ fn bench_deserializer_usize_000(b: &mut Bencher) {
 #[bench]
 fn bench_deserializer_usize_003(b: &mut Bencher) {
     b.iter(|| {
-        let v: Vec<usize> = vec!(1, 2, 3);
+        let v: Vec<usize> = vec![1, 2, 3];
         run_deserializer(deserializer::Deserializer::new(v.clone()), v)
     })
 }
@@ -598,7 +682,7 @@ fn bench_deserializer_usize_003(b: &mut Bencher) {
 #[bench]
 fn bench_deserializer_usize_100(b: &mut Bencher) {
     b.iter(|| {
-        let v: Vec<usize> = (0 .. 100).collect();
+        let v: Vec<usize> = (0..100).collect();
         run_deserializer(deserializer::Deserializer::new(v.clone()), v)
     })
 }
@@ -606,7 +690,7 @@ fn bench_deserializer_usize_100(b: &mut Bencher) {
 #[bench]
 fn bench_deserializer_u8_000(b: &mut Bencher) {
     b.iter(|| {
-        let v: Vec<u8> = vec!();
+        let v: Vec<u8> = vec![];
         run_deserializer(deserializer::Deserializer::new(v.clone()), v)
     })
 }
@@ -614,7 +698,7 @@ fn bench_deserializer_u8_000(b: &mut Bencher) {
 #[bench]
 fn bench_deserializer_u8_003(b: &mut Bencher) {
     b.iter(|| {
-        let v: Vec<u8> = vec!(1, 2, 3);
+        let v: Vec<u8> = vec![1, 2, 3];
         run_deserializer(deserializer::Deserializer::new(v.clone()), v)
     })
 }
@@ -622,7 +706,7 @@ fn bench_deserializer_u8_003(b: &mut Bencher) {
 #[bench]
 fn bench_deserializer_u8_100(b: &mut Bencher) {
     b.iter(|| {
-        let v: Vec<u8> = (0 .. 100).collect();
+        let v: Vec<u8> = (0..100).collect();
         run_deserializer(deserializer::Deserializer::new(v.clone()), v)
     })
 }

--- a/testing/tests/test_annotations.rs
+++ b/testing/tests/test_annotations.rs
@@ -1,15 +1,9 @@
 extern crate serde;
-use self::serde::{Serialize, Serializer, Deserialize, Deserializer};
+use self::serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 extern crate serde_test;
-use self::serde_test::{
-    Error,
-    Token,
-    assert_tokens,
-    assert_ser_tokens,
-    assert_de_tokens,
-    assert_de_tokens_error
-};
+use self::serde_test::{Error, Token, assert_de_tokens, assert_de_tokens_error, assert_ser_tokens,
+                       assert_tokens};
 
 trait MyDefault: Sized {
     fn my_default() -> Self;
@@ -20,26 +14,28 @@ trait ShouldSkip: Sized {
 }
 
 trait SerializeWith: Sized {
-    fn serialize_with<S>(&self, ser: &mut S) -> Result<(), S::Error>
-        where S: Serializer;
+    fn serialize_with<S>(&self, ser: &mut S) -> Result<(), S::Error> where S: Serializer;
 }
 
 trait DeserializeWith: Sized {
-    fn deserialize_with<D>(de: &mut D) -> Result<Self, D::Error>
-        where D: Deserializer;
+    fn deserialize_with<D>(de: &mut D) -> Result<Self, D::Error> where D: Deserializer;
 }
 
 impl MyDefault for i32 {
-    fn my_default() -> Self { 123 }
+    fn my_default() -> Self {
+        123
+    }
 }
 
 impl ShouldSkip for i32 {
-    fn should_skip(&self) -> bool { *self == 123 }
+    fn should_skip(&self) -> bool {
+        *self == 123
+    }
 }
 
 impl SerializeWith for i32 {
     fn serialize_with<S>(&self, ser: &mut S) -> Result<(), S::Error>
-        where S: Serializer
+        where S: Serializer,
     {
         if *self == 123 {
             true.serialize(ser)
@@ -51,7 +47,7 @@ impl SerializeWith for i32 {
 
 impl DeserializeWith for i32 {
     fn deserialize_with<D>(de: &mut D) -> Result<Self, D::Error>
-        where D: Deserializer
+        where D: Deserializer,
     {
         if try!(Deserialize::deserialize(de)) {
             Ok(123)
@@ -79,53 +75,57 @@ struct DefaultStruct<A, B, C, D, E>
 
 #[test]
 fn test_default_struct() {
-    assert_de_tokens(
-        &DefaultStruct { a1: 1, a2: 2, a3: 3, a4: 0, a5: 123 },
-        &[
-            Token::StructStart("DefaultStruct", Some(3)),
+    assert_de_tokens(&DefaultStruct {
+                         a1: 1,
+                         a2: 2,
+                         a3: 3,
+                         a4: 0,
+                         a5: 123,
+                     },
+                     &[Token::StructStart("DefaultStruct", Some(3)),
 
-            Token::StructSep,
-            Token::Str("a1"),
-            Token::I32(1),
+                       Token::StructSep,
+                       Token::Str("a1"),
+                       Token::I32(1),
 
-            Token::StructSep,
-            Token::Str("a2"),
-            Token::I32(2),
+                       Token::StructSep,
+                       Token::Str("a2"),
+                       Token::I32(2),
 
-            Token::StructSep,
-            Token::Str("a3"),
-            Token::I32(3),
+                       Token::StructSep,
+                       Token::Str("a3"),
+                       Token::I32(3),
 
-            Token::StructSep,
-            Token::Str("a4"),
-            Token::I32(4),
+                       Token::StructSep,
+                       Token::Str("a4"),
+                       Token::I32(4),
 
-            Token::StructSep,
-            Token::Str("a5"),
-            Token::I32(5),
+                       Token::StructSep,
+                       Token::Str("a5"),
+                       Token::I32(5),
 
-            Token::StructEnd,
-        ]
-    );
+                       Token::StructEnd]);
 
-    assert_de_tokens(
-        &DefaultStruct { a1: 1, a2: 0, a3: 123, a4: 0, a5: 123 },
-        &[
-            Token::StructStart("DefaultStruct", Some(1)),
+    assert_de_tokens(&DefaultStruct {
+                         a1: 1,
+                         a2: 0,
+                         a3: 123,
+                         a4: 0,
+                         a5: 123,
+                     },
+                     &[Token::StructStart("DefaultStruct", Some(1)),
 
-            Token::StructSep,
-            Token::Str("a1"),
-            Token::I32(1),
+                       Token::StructSep,
+                       Token::Str("a1"),
+                       Token::I32(1),
 
-            Token::StructEnd,
-        ]
-    );
+                       Token::StructEnd]);
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 enum DefaultEnum<A, B, C, D, E>
     where C: MyDefault,
-          E: MyDefault
+          E: MyDefault,
 {
     Struct {
         a1: A,
@@ -137,52 +137,56 @@ enum DefaultEnum<A, B, C, D, E>
         a4: D,
         #[serde(skip_deserializing, default="MyDefault::my_default")]
         a5: E,
-    }
+    },
 }
 
 #[test]
 fn test_default_enum() {
-    assert_de_tokens(
-        &DefaultEnum::Struct { a1: 1, a2: 2, a3: 3, a4: 0, a5: 123 },
-        &[
-            Token::EnumMapStart("DefaultEnum", "Struct", Some(5)),
+    assert_de_tokens(&DefaultEnum::Struct {
+                         a1: 1,
+                         a2: 2,
+                         a3: 3,
+                         a4: 0,
+                         a5: 123,
+                     },
+                     &[Token::EnumMapStart("DefaultEnum", "Struct", Some(5)),
 
-            Token::EnumMapSep,
-            Token::Str("a1"),
-            Token::I32(1),
+                       Token::EnumMapSep,
+                       Token::Str("a1"),
+                       Token::I32(1),
 
-            Token::EnumMapSep,
-            Token::Str("a2"),
-            Token::I32(2),
+                       Token::EnumMapSep,
+                       Token::Str("a2"),
+                       Token::I32(2),
 
-            Token::EnumMapSep,
-            Token::Str("a3"),
-            Token::I32(3),
+                       Token::EnumMapSep,
+                       Token::Str("a3"),
+                       Token::I32(3),
 
-            Token::EnumMapSep,
-            Token::Str("a4"),
-            Token::I32(4),
+                       Token::EnumMapSep,
+                       Token::Str("a4"),
+                       Token::I32(4),
 
-            Token::EnumMapSep,
-            Token::Str("a5"),
-            Token::I32(5),
+                       Token::EnumMapSep,
+                       Token::Str("a5"),
+                       Token::I32(5),
 
-            Token::EnumMapEnd,
-        ]
-    );
+                       Token::EnumMapEnd]);
 
-    assert_de_tokens(
-        &DefaultEnum::Struct { a1: 1, a2: 0, a3: 123, a4: 0, a5: 123 },
-        &[
-            Token::EnumMapStart("DefaultEnum", "Struct", Some(5)),
+    assert_de_tokens(&DefaultEnum::Struct {
+                         a1: 1,
+                         a2: 0,
+                         a3: 123,
+                         a4: 0,
+                         a5: 123,
+                     },
+                     &[Token::EnumMapStart("DefaultEnum", "Struct", Some(5)),
 
-            Token::EnumMapSep,
-            Token::Str("a1"),
-            Token::I32(1),
+                       Token::EnumMapSep,
+                       Token::Str("a1"),
+                       Token::I32(1),
 
-            Token::EnumMapEnd,
-        ]
-    );
+                       Token::EnumMapEnd]);
 }
 
 // Does not implement std::default::Default.
@@ -205,27 +209,22 @@ struct ContainsNoStdDefault<A: MyDefault> {
 // it is annotated with `default=...`.
 #[test]
 fn test_no_std_default() {
-    assert_de_tokens(
-        &ContainsNoStdDefault { a: NoStdDefault(123) },
-        &[
-            Token::StructStart("ContainsNoStdDefault", Some(1)),
-            Token::StructEnd,
-        ]
-    );
+    assert_de_tokens(&ContainsNoStdDefault {
+                         a: NoStdDefault(123),
+                     },
+                     &[Token::StructStart("ContainsNoStdDefault", Some(1)), Token::StructEnd]);
 
-    assert_de_tokens(
-        &ContainsNoStdDefault { a: NoStdDefault(8) },
-        &[
-            Token::StructStart("ContainsNoStdDefault", Some(1)),
+    assert_de_tokens(&ContainsNoStdDefault {
+                         a: NoStdDefault(8),
+                     },
+                     &[Token::StructStart("ContainsNoStdDefault", Some(1)),
 
-            Token::StructSep,
-            Token::Str("a"),
-            Token::StructNewType("NoStdDefault"),
-            Token::I8(8),
+                       Token::StructSep,
+                       Token::Str("a"),
+                       Token::StructNewType("NoStdDefault"),
+                       Token::I8(8),
 
-            Token::StructEnd,
-        ]
-    );
+                       Token::StructEnd]);
 }
 
 // Does not implement Deserialize.
@@ -240,7 +239,7 @@ impl Default for NotDeserializeStruct {
 
 impl DeserializeWith for NotDeserializeStruct {
     fn deserialize_with<D>(_: &mut D) -> Result<Self, D::Error>
-        where D: Deserializer
+        where D: Deserializer,
     {
         panic!()
     }
@@ -248,7 +247,9 @@ impl DeserializeWith for NotDeserializeStruct {
 
 // Does not implement Deserialize.
 #[derive(Debug, PartialEq)]
-enum NotDeserializeEnum { Trouble }
+enum NotDeserializeEnum {
+    Trouble,
+}
 
 impl MyDefault for NotDeserializeEnum {
     fn my_default() -> Self {
@@ -273,18 +274,13 @@ struct ContainsNotDeserialize<A, B, C: DeserializeWith, E: MyDefault> {
 // custom default.
 #[test]
 fn test_elt_not_deserialize() {
-    assert_de_tokens(
-        &ContainsNotDeserialize {
-            a: NotDeserializeStruct(123),
-            b: NotDeserializeStruct(123),
-            c: NotDeserializeStruct(123),
-            e: NotDeserializeEnum::Trouble,
-        },
-        &[
-            Token::StructStart("ContainsNotDeserialize", Some(3)),
-            Token::StructEnd,
-        ]
-    );
+    assert_de_tokens(&ContainsNotDeserialize {
+                         a: NotDeserializeStruct(123),
+                         b: NotDeserializeStruct(123),
+                         c: NotDeserializeStruct(123),
+                         e: NotDeserializeEnum::Trouble,
+                     },
+                     &[Token::StructStart("ContainsNotDeserialize", Some(3)), Token::StructEnd]);
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -296,55 +292,53 @@ struct DenyUnknown {
 #[test]
 fn test_ignore_unknown() {
     // 'Default' allows unknown. Basic smoke test of ignore...
-    assert_de_tokens(
-        &DefaultStruct { a1: 1, a2: 2, a3: 3, a4: 0, a5: 123 },
-        &[
-            Token::StructStart("DefaultStruct", Some(5)),
+    assert_de_tokens(&DefaultStruct {
+                         a1: 1,
+                         a2: 2,
+                         a3: 3,
+                         a4: 0,
+                         a5: 123,
+                     },
+                     &[Token::StructStart("DefaultStruct", Some(5)),
 
-            Token::StructSep,
-            Token::Str("whoops1"),
-            Token::I32(2),
+                       Token::StructSep,
+                       Token::Str("whoops1"),
+                       Token::I32(2),
 
-            Token::StructSep,
-            Token::Str("a1"),
-            Token::I32(1),
+                       Token::StructSep,
+                       Token::Str("a1"),
+                       Token::I32(1),
 
-            Token::StructSep,
-            Token::Str("whoops2"),
-            Token::SeqStart(Some(1)),
-            Token::SeqSep,
-            Token::I32(2),
-            Token::SeqEnd,
+                       Token::StructSep,
+                       Token::Str("whoops2"),
+                       Token::SeqStart(Some(1)),
+                       Token::SeqSep,
+                       Token::I32(2),
+                       Token::SeqEnd,
 
-            Token::StructSep,
-            Token::Str("a2"),
-            Token::I32(2),
+                       Token::StructSep,
+                       Token::Str("a2"),
+                       Token::I32(2),
 
-            Token::StructSep,
-            Token::Str("whoops3"),
-            Token::I32(2),
+                       Token::StructSep,
+                       Token::Str("whoops3"),
+                       Token::I32(2),
 
-            Token::StructSep,
-            Token::Str("a3"),
-            Token::I32(3),
+                       Token::StructSep,
+                       Token::Str("a3"),
+                       Token::I32(3),
 
-            Token::StructEnd,
-        ]
-    );
+                       Token::StructEnd]);
 
-    assert_de_tokens_error::<DenyUnknown>(
-        &[
-            Token::StructStart("DenyUnknown", Some(2)),
+    assert_de_tokens_error::<DenyUnknown>(&[Token::StructStart("DenyUnknown", Some(2)),
 
-            Token::StructSep,
-            Token::Str("a1"),
-            Token::I32(1),
+                                            Token::StructSep,
+                                            Token::Str("a1"),
+                                            Token::I32(1),
 
-            Token::StructSep,
-            Token::Str("whoops"),
-        ],
-        Error::UnknownField("whoops".to_owned())
-    );
+                                            Token::StructSep,
+                                            Token::Str("whoops")],
+                                          Error::UnknownField("whoops".to_owned()));
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -365,56 +359,53 @@ struct RenameStructSerializeDeserialize {
 
 #[test]
 fn test_rename_struct() {
-    assert_tokens(
-        &RenameStruct { a1: 1, a2: 2 },
-        &[
-            Token::StructStart("Superhero", Some(2)),
+    assert_tokens(&RenameStruct {
+                      a1: 1,
+                      a2: 2,
+                  },
+                  &[Token::StructStart("Superhero", Some(2)),
 
-            Token::StructSep,
-            Token::Str("a1"),
-            Token::I32(1),
+                    Token::StructSep,
+                    Token::Str("a1"),
+                    Token::I32(1),
 
-            Token::StructSep,
-            Token::Str("a3"),
-            Token::I32(2),
+                    Token::StructSep,
+                    Token::Str("a3"),
+                    Token::I32(2),
 
-            Token::StructEnd,
-        ]
-    );
+                    Token::StructEnd]);
 
-    assert_ser_tokens(
-        &RenameStructSerializeDeserialize { a1: 1, a2: 2 },
-        &[
-            Token::StructStart("SuperheroSer", Some(2)),
+    assert_ser_tokens(&RenameStructSerializeDeserialize {
+                          a1: 1,
+                          a2: 2,
+                      },
+                      &[Token::StructStart("SuperheroSer", Some(2)),
 
-            Token::StructSep,
-            Token::Str("a1"),
-            Token::I32(1),
+                        Token::StructSep,
+                        Token::Str("a1"),
+                        Token::I32(1),
 
-            Token::StructSep,
-            Token::Str("a4"),
-            Token::I32(2),
+                        Token::StructSep,
+                        Token::Str("a4"),
+                        Token::I32(2),
 
-            Token::StructEnd,
-        ]
-    );
+                        Token::StructEnd]);
 
-    assert_de_tokens(
-        &RenameStructSerializeDeserialize { a1: 1, a2: 2 },
-        &[
-            Token::StructStart("SuperheroDe", Some(2)),
+    assert_de_tokens(&RenameStructSerializeDeserialize {
+                         a1: 1,
+                         a2: 2,
+                     },
+                     &[Token::StructStart("SuperheroDe", Some(2)),
 
-            Token::StructSep,
-            Token::Str("a1"),
-            Token::I32(1),
+                       Token::StructSep,
+                       Token::Str("a1"),
+                       Token::I32(1),
 
-            Token::StructSep,
-            Token::Str("a5"),
-            Token::I32(2),
+                       Token::StructSep,
+                       Token::Str("a5"),
+                       Token::I32(2),
 
-            Token::StructEnd,
-        ]
-    );
+                       Token::StructEnd]);
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -447,92 +438,71 @@ enum RenameEnumSerializeDeserialize<A> {
 
 #[test]
 fn test_rename_enum() {
-    assert_tokens(
-        &RenameEnum::Batman,
-        &[
-            Token::EnumUnit("Superhero", "bruce_wayne"),
-        ]
-    );
+    assert_tokens(&RenameEnum::Batman,
+                  &[Token::EnumUnit("Superhero", "bruce_wayne")]);
 
-    assert_tokens(
-        &RenameEnum::Superman(0),
-        &[
-            Token::EnumNewType("Superhero", "clark_kent"),
-            Token::I8(0),
-        ]
-    );
+    assert_tokens(&RenameEnum::Superman(0),
+                  &[Token::EnumNewType("Superhero", "clark_kent"), Token::I8(0)]);
 
-    assert_tokens(
-        &RenameEnum::WonderWoman(0, 1),
-        &[
-            Token::EnumSeqStart("Superhero", "diana_prince", Some(2)),
+    assert_tokens(&RenameEnum::WonderWoman(0, 1),
+                  &[Token::EnumSeqStart("Superhero", "diana_prince", Some(2)),
 
-            Token::EnumSeqSep,
-            Token::I8(0),
+                    Token::EnumSeqSep,
+                    Token::I8(0),
 
-            Token::EnumSeqSep,
-            Token::I8(1),
+                    Token::EnumSeqSep,
+                    Token::I8(1),
 
-            Token::EnumSeqEnd,
-        ]
-    );
+                    Token::EnumSeqEnd]);
 
-    assert_tokens(
-        &RenameEnum::Flash { a: 1 },
-        &[
-            Token::EnumMapStart("Superhero", "barry_allan", Some(1)),
+    assert_tokens(&RenameEnum::Flash {
+                      a: 1,
+                  },
+                  &[Token::EnumMapStart("Superhero", "barry_allan", Some(1)),
 
-            Token::EnumMapSep,
-            Token::Str("b"),
-            Token::I32(1),
+                    Token::EnumMapSep,
+                    Token::Str("b"),
+                    Token::I32(1),
 
-            Token::EnumMapEnd,
-        ]
-    );
+                    Token::EnumMapEnd]);
 
-    assert_ser_tokens(
-        &RenameEnumSerializeDeserialize::Robin {
-            a: 0,
-            b: String::new(),
-        },
-        &[
-            Token::EnumMapStart("SuperheroSer", "dick_grayson", Some(2)),
+    assert_ser_tokens(&RenameEnumSerializeDeserialize::Robin {
+                          a: 0,
+                          b: String::new(),
+                      },
+                      &[Token::EnumMapStart("SuperheroSer", "dick_grayson", Some(2)),
 
-            Token::EnumMapSep,
-            Token::Str("a"),
-            Token::I8(0),
+                        Token::EnumMapSep,
+                        Token::Str("a"),
+                        Token::I8(0),
 
-            Token::EnumMapSep,
-            Token::Str("c"),
-            Token::Str(""),
+                        Token::EnumMapSep,
+                        Token::Str("c"),
+                        Token::Str(""),
 
-            Token::EnumMapEnd,
-        ]
-    );
+                        Token::EnumMapEnd]);
 
-    assert_de_tokens(
-        &RenameEnumSerializeDeserialize::Robin {
-            a: 0,
-            b: String::new(),
-        },
-        &[
-            Token::EnumMapStart("SuperheroDe", "jason_todd", Some(2)),
+    assert_de_tokens(&RenameEnumSerializeDeserialize::Robin {
+                         a: 0,
+                         b: String::new(),
+                     },
+                     &[Token::EnumMapStart("SuperheroDe", "jason_todd", Some(2)),
 
-            Token::EnumMapSep,
-            Token::Str("a"),
-            Token::I8(0),
+                       Token::EnumMapSep,
+                       Token::Str("a"),
+                       Token::I8(0),
 
-            Token::EnumMapSep,
-            Token::Str("d"),
-            Token::Str(""),
+                       Token::EnumMapSep,
+                       Token::Str("d"),
+                       Token::Str(""),
 
-            Token::EnumMapEnd,
-        ]
-    );
+                       Token::EnumMapEnd]);
 }
 
 #[derive(Debug, PartialEq, Serialize)]
-struct SkipSerializingStruct<'a, B, C> where C: ShouldSkip {
+struct SkipSerializingStruct<'a, B, C>
+    where C: ShouldSkip,
+{
     a: &'a i8,
     #[serde(skip_serializing)]
     b: B,
@@ -543,114 +513,105 @@ struct SkipSerializingStruct<'a, B, C> where C: ShouldSkip {
 #[test]
 fn test_skip_serializing_struct() {
     let a = 1;
-    assert_ser_tokens(
-        &SkipSerializingStruct {
-            a: &a,
-            b: 2,
-            c: 3,
-        },
-        &[
-            Token::StructStart("SkipSerializingStruct", Some(2)),
+    assert_ser_tokens(&SkipSerializingStruct {
+                          a: &a,
+                          b: 2,
+                          c: 3,
+                      },
+                      &[Token::StructStart("SkipSerializingStruct", Some(2)),
 
-            Token::StructSep,
-            Token::Str("a"),
-            Token::I8(1),
+                        Token::StructSep,
+                        Token::Str("a"),
+                        Token::I8(1),
 
-            Token::StructSep,
-            Token::Str("c"),
-            Token::I32(3),
+                        Token::StructSep,
+                        Token::Str("c"),
+                        Token::I32(3),
 
-            Token::StructEnd,
-        ]
-    );
+                        Token::StructEnd]);
 
-    assert_ser_tokens(
-        &SkipSerializingStruct {
-            a: &a,
-            b: 2,
-            c: 123,
-        },
-        &[
-            Token::StructStart("SkipSerializingStruct", Some(1)),
+    assert_ser_tokens(&SkipSerializingStruct {
+                          a: &a,
+                          b: 2,
+                          c: 123,
+                      },
+                      &[Token::StructStart("SkipSerializingStruct", Some(1)),
 
-            Token::StructSep,
-            Token::Str("a"),
-            Token::I8(1),
+                        Token::StructSep,
+                        Token::Str("a"),
+                        Token::I8(1),
 
-            Token::StructEnd,
-        ]
-    );
+                        Token::StructEnd]);
 }
 
 #[derive(Debug, PartialEq, Serialize)]
-enum SkipSerializingEnum<'a, B, C> where C: ShouldSkip {
+enum SkipSerializingEnum<'a, B, C>
+    where C: ShouldSkip,
+{
     Struct {
         a: &'a i8,
         #[serde(skip_serializing)]
         _b: B,
         #[serde(skip_serializing_if="ShouldSkip::should_skip")]
         c: C,
-    }
+    },
 }
 
 #[test]
 fn test_skip_serializing_enum() {
     let a = 1;
-    assert_ser_tokens(
-        &SkipSerializingEnum::Struct {
-            a: &a,
-            _b: 2,
-            c: 3,
-        },
-        &[
-            Token::EnumMapStart("SkipSerializingEnum", "Struct", Some(2)),
+    assert_ser_tokens(&SkipSerializingEnum::Struct {
+                          a: &a,
+                          _b: 2,
+                          c: 3,
+                      },
+                      &[Token::EnumMapStart("SkipSerializingEnum", "Struct", Some(2)),
 
-            Token::EnumMapSep,
-            Token::Str("a"),
-            Token::I8(1),
+                        Token::EnumMapSep,
+                        Token::Str("a"),
+                        Token::I8(1),
 
-            Token::EnumMapSep,
-            Token::Str("c"),
-            Token::I32(3),
+                        Token::EnumMapSep,
+                        Token::Str("c"),
+                        Token::I32(3),
 
-            Token::EnumMapEnd,
-        ]
-    );
+                        Token::EnumMapEnd]);
 
-    assert_ser_tokens(
-        &SkipSerializingEnum::Struct {
-            a: &a,
-            _b: 2,
-            c: 123,
-        },
-        &[
-            Token::EnumMapStart("SkipSerializingEnum", "Struct", Some(1)),
+    assert_ser_tokens(&SkipSerializingEnum::Struct {
+                          a: &a,
+                          _b: 2,
+                          c: 123,
+                      },
+                      &[Token::EnumMapStart("SkipSerializingEnum", "Struct", Some(1)),
 
-            Token::EnumMapSep,
-            Token::Str("a"),
-            Token::I8(1),
+                        Token::EnumMapSep,
+                        Token::Str("a"),
+                        Token::I8(1),
 
-            Token::EnumMapEnd,
-        ]
-    );
+                        Token::EnumMapEnd]);
 }
 
 #[derive(Debug, PartialEq)]
 struct NotSerializeStruct(i8);
 
 #[derive(Debug, PartialEq)]
-enum NotSerializeEnum { Trouble }
+enum NotSerializeEnum {
+    Trouble,
+}
 
 impl SerializeWith for NotSerializeEnum {
     fn serialize_with<S>(&self, ser: &mut S) -> Result<(), S::Error>
-        where S: Serializer
+        where S: Serializer,
     {
         "trouble".serialize(ser)
     }
 }
 
 #[derive(Debug, PartialEq, Serialize)]
-struct ContainsNotSerialize<'a, B, C, D> where B: 'a, D: SerializeWith {
+struct ContainsNotSerialize<'a, B, C, D>
+    where B: 'a,
+          D: SerializeWith,
+{
     a: &'a Option<i8>,
     #[serde(skip_serializing)]
     b: &'a B,
@@ -663,32 +624,30 @@ struct ContainsNotSerialize<'a, B, C, D> where B: 'a, D: SerializeWith {
 #[test]
 fn test_elt_not_serialize() {
     let a = 1;
-    assert_ser_tokens(
-        &ContainsNotSerialize {
-            a: &Some(a),
-            b: &NotSerializeStruct(2),
-            c: Some(NotSerializeEnum::Trouble),
-            d: NotSerializeEnum::Trouble,
-        },
-        &[
-            Token::StructStart("ContainsNotSerialize", Some(2)),
+    assert_ser_tokens(&ContainsNotSerialize {
+                          a: &Some(a),
+                          b: &NotSerializeStruct(2),
+                          c: Some(NotSerializeEnum::Trouble),
+                          d: NotSerializeEnum::Trouble,
+                      },
+                      &[Token::StructStart("ContainsNotSerialize", Some(2)),
 
-            Token::StructSep,
-            Token::Str("a"),
-            Token::Option(true),
-            Token::I8(1),
+                        Token::StructSep,
+                        Token::Str("a"),
+                        Token::Option(true),
+                        Token::I8(1),
 
-            Token::StructSep,
-            Token::Str("d"),
-            Token::Str("trouble"),
+                        Token::StructSep,
+                        Token::Str("d"),
+                        Token::Str("trouble"),
 
-            Token::StructEnd,
-        ]
-    );
+                        Token::StructEnd]);
 }
 
 #[derive(Debug, PartialEq, Serialize)]
-struct SerializeWithStruct<'a, B> where B: SerializeWith {
+struct SerializeWithStruct<'a, B>
+    where B: SerializeWith,
+{
     a: &'a i8,
     #[serde(serialize_with="SerializeWith::serialize_with")]
     b: B,
@@ -697,102 +656,90 @@ struct SerializeWithStruct<'a, B> where B: SerializeWith {
 #[test]
 fn test_serialize_with_struct() {
     let a = 1;
-    assert_ser_tokens(
-        &SerializeWithStruct {
-            a: &a,
-            b: 2,
-        },
-        &[
-            Token::StructStart("SerializeWithStruct", Some(2)),
+    assert_ser_tokens(&SerializeWithStruct {
+                          a: &a,
+                          b: 2,
+                      },
+                      &[Token::StructStart("SerializeWithStruct", Some(2)),
 
-            Token::StructSep,
-            Token::Str("a"),
-            Token::I8(1),
+                        Token::StructSep,
+                        Token::Str("a"),
+                        Token::I8(1),
 
-            Token::StructSep,
-            Token::Str("b"),
-            Token::Bool(false),
+                        Token::StructSep,
+                        Token::Str("b"),
+                        Token::Bool(false),
 
-            Token::StructEnd,
-        ]
-    );
+                        Token::StructEnd]);
 
-    assert_ser_tokens(
-        &SerializeWithStruct {
-            a: &a,
-            b: 123,
-        },
-        &[
-            Token::StructStart("SerializeWithStruct", Some(2)),
+    assert_ser_tokens(&SerializeWithStruct {
+                          a: &a,
+                          b: 123,
+                      },
+                      &[Token::StructStart("SerializeWithStruct", Some(2)),
 
-            Token::StructSep,
-            Token::Str("a"),
-            Token::I8(1),
+                        Token::StructSep,
+                        Token::Str("a"),
+                        Token::I8(1),
 
-            Token::StructSep,
-            Token::Str("b"),
-            Token::Bool(true),
+                        Token::StructSep,
+                        Token::Str("b"),
+                        Token::Bool(true),
 
-            Token::StructEnd,
-        ]
-    );
+                        Token::StructEnd]);
 }
 
 #[derive(Debug, PartialEq, Serialize)]
-enum SerializeWithEnum<'a, B> where B: SerializeWith {
+enum SerializeWithEnum<'a, B>
+    where B: SerializeWith,
+{
     Struct {
         a: &'a i8,
         #[serde(serialize_with="SerializeWith::serialize_with")]
         b: B,
-    }
+    },
 }
 
 #[test]
 fn test_serialize_with_enum() {
     let a = 1;
-    assert_ser_tokens(
-        &SerializeWithEnum::Struct {
-            a: &a,
-            b: 2,
-        },
-        &[
-            Token::EnumMapStart("SerializeWithEnum", "Struct", Some(2)),
+    assert_ser_tokens(&SerializeWithEnum::Struct {
+                          a: &a,
+                          b: 2,
+                      },
+                      &[Token::EnumMapStart("SerializeWithEnum", "Struct", Some(2)),
 
-            Token::EnumMapSep,
-            Token::Str("a"),
-            Token::I8(1),
+                        Token::EnumMapSep,
+                        Token::Str("a"),
+                        Token::I8(1),
 
-            Token::EnumMapSep,
-            Token::Str("b"),
-            Token::Bool(false),
+                        Token::EnumMapSep,
+                        Token::Str("b"),
+                        Token::Bool(false),
 
-            Token::EnumMapEnd,
-        ]
-    );
+                        Token::EnumMapEnd]);
 
-    assert_ser_tokens(
-        &SerializeWithEnum::Struct {
-            a: &a,
-            b: 123,
-        },
-        &[
-            Token::EnumMapStart("SerializeWithEnum", "Struct", Some(2)),
+    assert_ser_tokens(&SerializeWithEnum::Struct {
+                          a: &a,
+                          b: 123,
+                      },
+                      &[Token::EnumMapStart("SerializeWithEnum", "Struct", Some(2)),
 
-            Token::EnumMapSep,
-            Token::Str("a"),
-            Token::I8(1),
+                        Token::EnumMapSep,
+                        Token::Str("a"),
+                        Token::I8(1),
 
-            Token::EnumMapSep,
-            Token::Str("b"),
-            Token::Bool(true),
+                        Token::EnumMapSep,
+                        Token::Str("b"),
+                        Token::Bool(true),
 
-            Token::EnumMapEnd,
-        ]
-    );
+                        Token::EnumMapEnd]);
 }
 
 #[derive(Debug, PartialEq, Deserialize)]
-struct DeserializeWithStruct<B> where B: DeserializeWith {
+struct DeserializeWithStruct<B>
+    where B: DeserializeWith,
+{
     a: i8,
     #[serde(deserialize_with="DeserializeWith::deserialize_with")]
     b: B,
@@ -800,177 +747,151 @@ struct DeserializeWithStruct<B> where B: DeserializeWith {
 
 #[test]
 fn test_deserialize_with_struct() {
-    assert_de_tokens(
-        &DeserializeWithStruct {
-            a: 1,
-            b: 2,
-        },
-        &[
-            Token::StructStart("DeserializeWithStruct", Some(2)),
+    assert_de_tokens(&DeserializeWithStruct {
+                         a: 1,
+                         b: 2,
+                     },
+                     &[Token::StructStart("DeserializeWithStruct", Some(2)),
 
-            Token::StructSep,
-            Token::Str("a"),
-            Token::I8(1),
+                       Token::StructSep,
+                       Token::Str("a"),
+                       Token::I8(1),
 
-            Token::StructSep,
-            Token::Str("b"),
-            Token::Bool(false),
+                       Token::StructSep,
+                       Token::Str("b"),
+                       Token::Bool(false),
 
-            Token::StructEnd,
-        ]
-    );
+                       Token::StructEnd]);
 
-    assert_de_tokens(
-        &DeserializeWithStruct {
-            a: 1,
-            b: 123,
-        },
-        &[
-            Token::StructStart("DeserializeWithStruct", Some(2)),
+    assert_de_tokens(&DeserializeWithStruct {
+                         a: 1,
+                         b: 123,
+                     },
+                     &[Token::StructStart("DeserializeWithStruct", Some(2)),
 
-            Token::StructSep,
-            Token::Str("a"),
-            Token::I8(1),
+                       Token::StructSep,
+                       Token::Str("a"),
+                       Token::I8(1),
 
-            Token::StructSep,
-            Token::Str("b"),
-            Token::Bool(true),
+                       Token::StructSep,
+                       Token::Str("b"),
+                       Token::Bool(true),
 
-            Token::StructEnd,
-        ]
-    );
+                       Token::StructEnd]);
 }
 
 #[derive(Debug, PartialEq, Deserialize)]
-enum DeserializeWithEnum<B> where B: DeserializeWith {
+enum DeserializeWithEnum<B>
+    where B: DeserializeWith,
+{
     Struct {
         a: i8,
         #[serde(deserialize_with="DeserializeWith::deserialize_with")]
         b: B,
-    }
+    },
 }
 
 #[test]
 fn test_deserialize_with_enum() {
-    assert_de_tokens(
-        &DeserializeWithEnum::Struct {
-            a: 1,
-            b: 2,
-        },
-        &[
-            Token::EnumMapStart("DeserializeWithEnum", "Struct", Some(2)),
+    assert_de_tokens(&DeserializeWithEnum::Struct {
+                         a: 1,
+                         b: 2,
+                     },
+                     &[Token::EnumMapStart("DeserializeWithEnum", "Struct", Some(2)),
 
-            Token::EnumMapSep,
-            Token::Str("a"),
-            Token::I8(1),
+                       Token::EnumMapSep,
+                       Token::Str("a"),
+                       Token::I8(1),
 
-            Token::EnumMapSep,
-            Token::Str("b"),
-            Token::Bool(false),
+                       Token::EnumMapSep,
+                       Token::Str("b"),
+                       Token::Bool(false),
 
-            Token::EnumMapEnd,
-        ]
-    );
+                       Token::EnumMapEnd]);
 
-    assert_de_tokens(
-        &DeserializeWithEnum::Struct {
-            a: 1,
-            b: 123,
-        },
-        &[
-            Token::EnumMapStart("DeserializeWithEnum", "Struct", Some(2)),
+    assert_de_tokens(&DeserializeWithEnum::Struct {
+                         a: 1,
+                         b: 123,
+                     },
+                     &[Token::EnumMapStart("DeserializeWithEnum", "Struct", Some(2)),
 
-            Token::EnumMapSep,
-            Token::Str("a"),
-            Token::I8(1),
+                       Token::EnumMapSep,
+                       Token::Str("a"),
+                       Token::I8(1),
 
-            Token::EnumMapSep,
-            Token::Str("b"),
-            Token::Bool(true),
+                       Token::EnumMapSep,
+                       Token::Str("b"),
+                       Token::Bool(true),
 
-            Token::EnumMapEnd,
-        ]
-    );
+                       Token::EnumMapEnd]);
 }
 
 #[test]
 fn test_missing_renamed_field_struct() {
-    assert_de_tokens_error::<RenameStruct>(
-        &[
-            Token::StructStart("Superhero", Some(2)),
+    assert_de_tokens_error::<RenameStruct>(&[Token::StructStart("Superhero", Some(2)),
 
-            Token::StructSep,
-            Token::Str("a1"),
-            Token::I32(1),
+                                             Token::StructSep,
+                                             Token::Str("a1"),
+                                             Token::I32(1),
 
-            Token::StructEnd,
-        ],
-        Error::MissingField("a3"),
-    );
+                                             Token::StructEnd],
+                                           Error::MissingField("a3"));
 
-    assert_de_tokens_error::<RenameStructSerializeDeserialize>(
-        &[
-            Token::StructStart("SuperheroDe", Some(2)),
+    assert_de_tokens_error::<RenameStructSerializeDeserialize>(&[Token::StructStart("SuperheroDe",
+                                                                                    Some(2)),
 
-            Token::StructSep,
-            Token::Str("a1"),
-            Token::I32(1),
+                                                                 Token::StructSep,
+                                                                 Token::Str("a1"),
+                                                                 Token::I32(1),
 
-            Token::StructEnd,
-        ],
-        Error::MissingField("a5"),
-    );
+                                                                 Token::StructEnd],
+                                                               Error::MissingField("a5"));
 }
 
 #[test]
 fn test_missing_renamed_field_enum() {
-    assert_de_tokens_error::<RenameEnum>(
-        &[
-            Token::EnumMapStart("Superhero", "barry_allan", Some(1)),
+    assert_de_tokens_error::<RenameEnum>(&[Token::EnumMapStart("Superhero",
+                                                               "barry_allan",
+                                                               Some(1)),
 
-            Token::EnumMapEnd,
-        ],
-        Error::MissingField("b"),
-    );
+                                           Token::EnumMapEnd],
+                                         Error::MissingField("b"));
 
-    assert_de_tokens_error::<RenameEnumSerializeDeserialize<i8>>(
-        &[
-            Token::EnumMapStart("SuperheroDe", "jason_todd", Some(2)),
+    assert_de_tokens_error::<RenameEnumSerializeDeserialize<i8>>(&[Token::EnumMapStart("SuperheroDe",
+                                                                                       "jason_todd",
+                                                                                       Some(2)),
 
-            Token::EnumMapSep,
-            Token::Str("a"),
-            Token::I8(0),
+                                                                   Token::EnumMapSep,
+                                                                   Token::Str("a"),
+                                                                   Token::I8(0),
 
-            Token::EnumMapEnd,
-        ],
-        Error::MissingField("d"),
-    );
+                                                                   Token::EnumMapEnd],
+                                                                 Error::MissingField("d"));
 }
 
 #[derive(Debug, PartialEq, Deserialize)]
 enum InvalidLengthEnum {
     A(i32, i32, i32),
-    B(#[serde(skip_deserializing)] i32, i32, i32),
+    B(#[serde(skip_deserializing)]
+      i32,
+      i32,
+      i32),
 }
 
 #[test]
 fn test_invalid_length_enum() {
-    assert_de_tokens_error::<InvalidLengthEnum>(
-        &[
-            Token::EnumSeqStart("InvalidLengthEnum", "A", Some(3)),
-                Token::EnumSeqSep,
-                Token::I32(1),
-            Token::EnumSeqEnd,
-        ],
-        Error::InvalidLength(1),
-    );
-    assert_de_tokens_error::<InvalidLengthEnum>(
-        &[
-            Token::EnumSeqStart("InvalidLengthEnum", "B", Some(3)),
-                Token::EnumSeqSep,
-                Token::I32(1),
-            Token::EnumSeqEnd,
-        ],
-        Error::InvalidLength(1),
-    );
+    assert_de_tokens_error::<InvalidLengthEnum>(&[Token::EnumSeqStart("InvalidLengthEnum",
+                                                                      "A",
+                                                                      Some(3)),
+                                                  Token::EnumSeqSep,
+                                                  Token::I32(1),
+                                                  Token::EnumSeqEnd],
+                                                Error::InvalidLength(1));
+    assert_de_tokens_error::<InvalidLengthEnum>(&[Token::EnumSeqStart("InvalidLengthEnum",
+                                                                      "B",
+                                                                      Some(3)),
+                                                  Token::EnumSeqSep,
+                                                  Token::I32(1),
+                                                  Token::EnumSeqEnd],
+                                                Error::InvalidLength(1));
 }

--- a/testing/tests/test_bytes.rs
+++ b/testing/tests/test_bytes.rs
@@ -5,19 +5,25 @@ extern crate serde;
 use self::serde::Serialize;
 use self::serde::bytes::{ByteBuf, Bytes};
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 #[derive(Debug, PartialEq)]
 struct Error;
 
 impl serde::ser::Error for Error {
-    fn custom<T: Into<String>>(_: T) -> Error { Error }
+    fn custom<T: Into<String>>(_: T) -> Error {
+        Error
+    }
 }
 
 impl serde::de::Error for Error {
-    fn custom<T: Into<String>>(_: T) -> Error { Error }
+    fn custom<T: Into<String>>(_: T) -> Error {
+        Error
+    }
 
-    fn end_of_stream() -> Error { Error }
+    fn end_of_stream() -> Error {
+        Error
+    }
 }
 
 impl fmt::Display for Error {
@@ -36,7 +42,7 @@ impl error::Error for Error {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 struct BytesSerializer {
     bytes: Vec<u8>,
@@ -102,7 +108,7 @@ impl serde::Serializer for BytesSerializer {
     }
 
     fn serialize_seq_elt<T>(&mut self, _value: T) -> Result<(), Error>
-        where T: serde::Serialize
+        where T: serde::Serialize,
     {
         Err(Error)
     }
@@ -126,7 +132,7 @@ impl serde::Serializer for BytesSerializer {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 struct BytesDeserializer {
     bytes: Option<Vec<u8>>,
@@ -156,7 +162,7 @@ impl serde::Deserializer for BytesDeserializer {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 #[test]
 fn test_bytes_ser_bytes() {
@@ -171,7 +177,7 @@ fn test_bytes_ser_bytes() {
     bytes.serialize(&mut ser).unwrap();
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 
 #[test]
 fn test_byte_buf_de_bytes() {

--- a/testing/tests/test_de.rs
+++ b/testing/tests/test_de.rs
@@ -9,14 +9,9 @@ extern crate fnv;
 use self::fnv::FnvHasher;
 
 extern crate serde_test;
-use self::serde_test::{
-    Error,
-    Token,
-    assert_de_tokens,
-    assert_de_tokens_error,
-};
+use self::serde_test::{Error, Token, assert_de_tokens, assert_de_tokens_error};
 
-//////////////////////////////////////////////////////////////////////////
+/// ///////////////////////////////////////////////////////////////////////
 
 #[derive(Copy, Clone, PartialEq, Debug, Deserialize)]
 struct UnitStruct;
@@ -37,10 +32,14 @@ enum Enum {
     Unit,
     Simple(i32),
     Seq(i32, i32, i32),
-    Map { a: i32, b: i32, c: i32 }
+    Map {
+        a: i32,
+        b: i32,
+        c: i32,
+    },
 }
 
-//////////////////////////////////////////////////////////////////////////
+/// ///////////////////////////////////////////////////////////////////////
 
 macro_rules! declare_test {
     ($name:ident { $($value:expr => $tokens:expr,)+ }) => {
@@ -81,42 +80,43 @@ fn assert_de_tokens_ignore(ignorable_tokens: &[Token<'static>]) {
     struct IgnoreBase {
         a: i32,
     }
- 
-    let expected = IgnoreBase{a: 1};
- 
+
+    let expected = IgnoreBase {
+        a: 1,
+    };
+
     // Embed the tokens to be ignored in the normal token
     // stream for an IgnoreBase type
-    let concated_tokens : Vec<Token<'static>> = vec![
-            Token::MapStart(Some(2)),
-                Token::MapSep,
-                Token::Str("a"),
-                Token::I32(1),
- 
-                Token::MapSep,
-                Token::Str("ignored")
-        ]
+    let concated_tokens: Vec<Token<'static>> = vec![Token::MapStart(Some(2)),
+                                                    Token::MapSep,
+                                                    Token::Str("a"),
+                                                    Token::I32(1),
+
+                                                    Token::MapSep,
+                                                    Token::Str("ignored")]
         .into_iter()
         .chain(ignorable_tokens.to_vec().into_iter())
         .chain(vec![
             Token::MapEnd,
-        ].into_iter())
+        ]
+            .into_iter())
         .collect();
- 
+
     let mut de = serde_test::Deserializer::new(concated_tokens.into_iter());
     let v: Result<IgnoreBase, Error> = Deserialize::deserialize(&mut de);
- 
+
     // We run this test on every token stream for convenience, but
     // some token streams don't make sense embedded as a map value,
     // so we ignore those. SyntaxError is the real sign of trouble.
     if let Err(Error::UnexpectedToken(_)) = v {
         return;
     }
- 
+
     assert_eq!(v.as_ref(), Ok(&expected));
     assert_eq!(de.next_token(), None);
 }
 
-//////////////////////////////////////////////////////////////////////////
+/// ///////////////////////////////////////////////////////////////////////
 
 declare_tests! {
     test_bool {
@@ -767,10 +767,8 @@ declare_tests! {
 #[cfg(feature = "nightly")]
 #[test]
 fn test_net_ipaddr() {
-    assert_de_tokens(
-        "1.2.3.4".parse::<net::IpAddr>().unwrap(),
-        &[Token::Str("1.2.3.4")],
-    );
+    assert_de_tokens("1.2.3.4".parse::<net::IpAddr>().unwrap(),
+                     &[Token::Str("1.2.3.4")]);
 }
 
 declare_error_tests! {

--- a/testing/tests/test_gen.rs
+++ b/testing/tests/test_gen.rs
@@ -6,7 +6,7 @@ extern crate serde;
 use self::serde::ser::{Serialize, Serializer};
 use self::serde::de::{Deserialize, Deserializer};
 
-//////////////////////////////////////////////////////////////////////////
+/// ///////////////////////////////////////////////////////////////////////
 
 #[derive(Serialize, Deserialize)]
 struct With<T> {
@@ -42,37 +42,36 @@ struct NoBounds<T> {
 #[derive(Serialize, Deserialize)]
 enum EnumWith<T> {
     Unit,
-    Newtype(
-        #[serde(serialize_with="ser_x", deserialize_with="de_x")]
-        X),
-    Tuple(
-        T,
-        #[serde(serialize_with="ser_x", deserialize_with="de_x")]
-        X),
+    Newtype(#[serde(serialize_with="ser_x", deserialize_with="de_x")]
+            X),
+    Tuple(T,
+          #[serde(serialize_with="ser_x", deserialize_with="de_x")]
+          X),
     Struct {
         t: T,
         #[serde(serialize_with="ser_x", deserialize_with="de_x")]
-        x: X },
+        x: X,
+    },
 }
 
 #[derive(Serialize)]
-struct MultipleRef<'a, 'b, 'c, T> where T: 'c, 'c: 'b, 'b: 'a {
+struct MultipleRef<'a, 'b, 'c, T>
+    where T: 'c,
+          'c: 'b,
+          'b: 'a,
+{
     t: T,
     rrrt: &'a &'b &'c T,
 }
 
 #[derive(Serialize, Deserialize)]
-struct Newtype(
-    #[serde(serialize_with="ser_x", deserialize_with="de_x")]
-    X
-);
+struct Newtype(#[serde(serialize_with="ser_x", deserialize_with="de_x")]
+               X);
 
 #[derive(Serialize, Deserialize)]
-struct Tuple<T>(
-    T,
-    #[serde(serialize_with="ser_x", deserialize_with="de_x")]
-    X,
-);
+struct Tuple<T>(T,
+                #[serde(serialize_with="ser_x", deserialize_with="de_x")]
+                X);
 
 #[derive(Serialize, Deserialize)]
 enum TreeNode<D> {
@@ -117,7 +116,7 @@ struct WithTraits2<D, E> {
     e: E,
 }
 
-//////////////////////////////////////////////////////////////////////////
+/// ///////////////////////////////////////////////////////////////////////
 
 trait SerializeWith {
     fn serialize_with<S: Serializer>(_: &Self, _: &mut S) -> Result<(), S::Error>;
@@ -129,6 +128,9 @@ trait DeserializeWith: Sized {
 
 // Implements neither Serialize nor Deserialize
 struct X;
-fn ser_x<S: Serializer>(_: &X, _: &mut S) -> Result<(), S::Error> { panic!() }
-fn de_x<D: Deserializer>(_: &mut D) -> Result<X, D::Error> { panic!() }
-
+fn ser_x<S: Serializer>(_: &X, _: &mut S) -> Result<(), S::Error> {
+    panic!()
+}
+fn de_x<D: Deserializer>(_: &mut D) -> Result<X, D::Error> {
+    panic!()
+}

--- a/testing/tests/test_macros.rs
+++ b/testing/tests/test_macros.rs
@@ -1,10 +1,5 @@
 extern crate serde_test;
-use self::serde_test::{
-    Token,
-    assert_tokens,
-    assert_ser_tokens,
-    assert_de_tokens,
-};
+use self::serde_test::{Token, assert_de_tokens, assert_ser_tokens, assert_tokens};
 
 use std::marker::PhantomData;
 
@@ -39,82 +34,68 @@ struct DeNamedMap<A, B, C> {
 }
 
 #[derive(Debug, PartialEq, Serialize)]
-enum SerEnum<'a, B: 'a, C: /* Trait + */ 'a, D> where D: /* Trait + */ 'a {
+enum SerEnum<'a, B: 'a, C: 'a, D>
+    where D: 'a,
+{
     Unit,
-    Seq(
-        i8,
+    Seq(i8,
         B,
         &'a C,
-        //C::Type,
-        &'a mut D,
-        //<D as Trait>::Type,
-    ),
+        // C::Type,
+        &'a mut D /* <D as Trait>::Type, */),
     Map {
         a: i8,
         b: B,
         c: &'a C,
-        //d: C::Type,
-        e: &'a mut D,
-        //f: <D as Trait>::Type,
+        // d: C::Type,
+        e: &'a mut D, // f: <D as Trait>::Type,
     },
 
     // Make sure we can support more than one variant.
     _Unit2,
-    _Seq2(
-        i8,
-        B,
-        &'a C,
-        //C::Type,
-        &'a mut D,
-        //<D as Trait>::Type,
-    ),
+    _Seq2(i8,
+          B,
+          &'a C,
+          // C::Type,
+          &'a mut D /* <D as Trait>::Type, */),
     _Map2 {
         a: i8,
         b: B,
         c: &'a C,
-        //d: C::Type,
-        e: &'a mut D,
-        //f: <D as Trait>::Type,
+        // d: C::Type,
+        e: &'a mut D, // f: <D as Trait>::Type,
     },
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
-enum DeEnum<B, C: /* Trait */, D> /* where D: Trait */ {
+enum DeEnum<B, C /* : /* Trait */, D> {
     Unit,
-    Seq(
-        i8,
+    Seq(i8,
         B,
         C,
-        //C::Type,
-        D,
-        //<D as Trait>::Type,
-    ),
+        // C::Type,
+        D /* <D as Trait>::Type, */),
     Map {
         a: i8,
         b: B,
         c: C,
-        //d: C::Type,
-        e: D,
-        //f: <D as Trait>::Type,
+        // d: C::Type,
+        e: D, // f: <D as Trait>::Type,
     },
 
     // Make sure we can support more than one variant.
     _Unit2,
-    _Seq2(
-        i8,
-        B,
-        C,
-        //C::Type,
-        D,
-        //<D as Trait>::Type,
-    ),
+    _Seq2(i8,
+          B,
+          C,
+          // C::Type,
+          D /* <D as Trait>::Type, */),
     _Map2 {
         a: i8,
         b: B,
         c: C,
-        //d: C::Type,
-        e: D,
-        //f: <D as Trait>::Type,
+        // d: C::Type,
+        e: D, // f: <D as Trait>::Type,
     },
 }
 
@@ -122,8 +103,12 @@ enum DeEnum<B, C: /* Trait */, D> /* where D: Trait */ {
 enum Lifetimes<'a> {
     LifetimeSeq(&'a i32),
     NoLifetimeSeq(i32),
-    LifetimeMap { a: &'a i32 },
-    NoLifetimeMap { a: i32 },
+    LifetimeMap {
+        a: &'a i32,
+    },
+    NoLifetimeMap {
+        a: i32,
+    },
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -142,7 +127,10 @@ pub enum GenericEnum<T, U> {
     Unit,
     NewType(T),
     Seq(T, U),
-    Map { x: T, y: U },
+    Map {
+        x: T,
+        y: U,
+    },
 }
 
 trait AssociatedType {
@@ -154,16 +142,13 @@ impl AssociatedType for i32 {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
-struct DefaultTyParam<T: AssociatedType<X=i32> = i32> {
-    phantom: PhantomData<T>
+struct DefaultTyParam<T: AssociatedType<X = i32> = i32> {
+    phantom: PhantomData<T>,
 }
 
 #[test]
 fn test_named_unit() {
-    assert_tokens(
-        &NamedUnit,
-        &[Token::UnitStruct("NamedUnit")]
-    );
+    assert_tokens(&NamedUnit, &[Token::UnitStruct("NamedUnit")]);
 }
 
 #[test]
@@ -171,59 +156,47 @@ fn test_ser_named_tuple() {
     let a = 5;
     let mut b = 6;
     let c = 7;
-    assert_ser_tokens(
-        &SerNamedTuple(&a, &mut b, c),
-        &[
-            Token::TupleStructStart("SerNamedTuple", Some(3)),
-            Token::TupleStructSep,
-            Token::I32(5),
+    assert_ser_tokens(&SerNamedTuple(&a, &mut b, c),
+                      &[Token::TupleStructStart("SerNamedTuple", Some(3)),
+                        Token::TupleStructSep,
+                        Token::I32(5),
 
-            Token::TupleStructSep,
-            Token::I32(6),
+                        Token::TupleStructSep,
+                        Token::I32(6),
 
-            Token::TupleStructSep,
-            Token::I32(7),
+                        Token::TupleStructSep,
+                        Token::I32(7),
 
-            Token::TupleStructEnd,
-        ],
-    );
+                        Token::TupleStructEnd]);
 }
 
 #[test]
 fn test_de_named_tuple() {
-    assert_de_tokens(
-        &DeNamedTuple(5, 6, 7),
-        &[
-            Token::SeqStart(Some(3)),
-            Token::SeqSep,
-            Token::I32(5),
+    assert_de_tokens(&DeNamedTuple(5, 6, 7),
+                     &[Token::SeqStart(Some(3)),
+                       Token::SeqSep,
+                       Token::I32(5),
 
-            Token::SeqSep,
-            Token::I32(6),
+                       Token::SeqSep,
+                       Token::I32(6),
 
-            Token::SeqSep,
-            Token::I32(7),
+                       Token::SeqSep,
+                       Token::I32(7),
 
-            Token::SeqEnd,
-        ]
-    );
+                       Token::SeqEnd]);
 
-    assert_de_tokens(
-        &DeNamedTuple(5, 6, 7),
-        &[
-            Token::TupleStructStart("DeNamedTuple", Some(3)),
-            Token::TupleStructSep,
-            Token::I32(5),
+    assert_de_tokens(&DeNamedTuple(5, 6, 7),
+                     &[Token::TupleStructStart("DeNamedTuple", Some(3)),
+                       Token::TupleStructSep,
+                       Token::I32(5),
 
-            Token::TupleStructSep,
-            Token::I32(6),
+                       Token::TupleStructSep,
+                       Token::I32(6),
 
-            Token::TupleStructSep,
-            Token::I32(7),
+                       Token::TupleStructSep,
+                       Token::I32(7),
 
-            Token::TupleStructEnd,
-        ]
-    );
+                       Token::TupleStructEnd]);
 }
 
 #[test]
@@ -232,68 +205,56 @@ fn test_ser_named_map() {
     let mut b = 6;
     let c = 7;
 
-    assert_ser_tokens(
-        &SerNamedMap {
-            a: &a,
-            b: &mut b,
-            c: c,
-        },
-        &[
-            Token::StructStart("SerNamedMap", Some(3)),
+    assert_ser_tokens(&SerNamedMap {
+                          a: &a,
+                          b: &mut b,
+                          c: c,
+                      },
+                      &[Token::StructStart("SerNamedMap", Some(3)),
 
-            Token::StructSep,
-            Token::Str("a"),
-            Token::I32(5),
+                        Token::StructSep,
+                        Token::Str("a"),
+                        Token::I32(5),
 
-            Token::StructSep,
-            Token::Str("b"),
-            Token::I32(6),
+                        Token::StructSep,
+                        Token::Str("b"),
+                        Token::I32(6),
 
-            Token::StructSep,
-            Token::Str("c"),
-            Token::I32(7),
+                        Token::StructSep,
+                        Token::Str("c"),
+                        Token::I32(7),
 
-            Token::StructEnd,
-        ]
-    );
+                        Token::StructEnd]);
 }
 
 #[test]
 fn test_de_named_map() {
-    assert_de_tokens(
-        &DeNamedMap {
-            a: 5,
-            b: 6,
-            c: 7,
-        },
-        &[
-            Token::StructStart("DeNamedMap", Some(3)),
+    assert_de_tokens(&DeNamedMap {
+                         a: 5,
+                         b: 6,
+                         c: 7,
+                     },
+                     &[Token::StructStart("DeNamedMap", Some(3)),
 
-            Token::StructSep,
-            Token::Str("a"),
-            Token::I32(5),
+                       Token::StructSep,
+                       Token::Str("a"),
+                       Token::I32(5),
 
-            Token::StructSep,
-            Token::Str("b"),
-            Token::I32(6),
+                       Token::StructSep,
+                       Token::Str("b"),
+                       Token::I32(6),
 
-            Token::StructSep,
-            Token::Str("c"),
-            Token::I32(7),
+                       Token::StructSep,
+                       Token::Str("c"),
+                       Token::I32(7),
 
-            Token::StructEnd,
-        ]
-    );
+                       Token::StructEnd]);
 }
 
 #[test]
 fn test_ser_enum_unit() {
-    assert_ser_tokens(
-        &SerEnum::Unit::<u32, u32, u32>,
-        &[
-            Token::EnumUnit("SerEnum", "Unit"),
-        ]
-    );
+    assert_ser_tokens(&SerEnum::Unit::<u32, u32, u32>,
+                      &[Token::EnumUnit("SerEnum", "Unit")]);
 }
 
 #[test]
@@ -301,37 +262,30 @@ fn test_ser_enum_seq() {
     let a = 1;
     let b = 2;
     let c = 3;
-    //let d = 4;
+    // let d = 4;
     let mut e = 5;
-    //let f = 6;
+    // let f = 6;
 
-    assert_ser_tokens(
-        &SerEnum::Seq(
-            a,
-            b,
-            &c,
-            //d,
-            &mut e,
-            //f,
-        ),
-        &[
-            Token::EnumSeqStart("SerEnum", "Seq", Some(4)),
+    assert_ser_tokens(&SerEnum::Seq(a,
+                                    b,
+                                    &c,
+                                    // d,
+                                    &mut e /* f, */),
+                      &[Token::EnumSeqStart("SerEnum", "Seq", Some(4)),
 
-            Token::EnumSeqSep,
-            Token::I8(1),
+                        Token::EnumSeqSep,
+                        Token::I8(1),
 
-            Token::EnumSeqSep,
-            Token::I32(2),
+                        Token::EnumSeqSep,
+                        Token::I32(2),
 
-            Token::EnumSeqSep,
-            Token::I32(3),
+                        Token::EnumSeqSep,
+                        Token::I32(3),
 
-            Token::EnumSeqSep,
-            Token::I32(5),
+                        Token::EnumSeqSep,
+                        Token::I32(5),
 
-            Token::EnumSeqEnd,
-        ],
-    );
+                        Token::EnumSeqEnd]);
 }
 
 #[test]
@@ -339,51 +293,42 @@ fn test_ser_enum_map() {
     let a = 1;
     let b = 2;
     let c = 3;
-    //let d = 4;
+    // let d = 4;
     let mut e = 5;
-    //let f = 6;
+    // let f = 6;
 
-    assert_ser_tokens(
-        &SerEnum::Map {
-            a: a,
-            b: b,
-            c: &c,
-            //d: d,
-            e: &mut e,
-            //f: f,
-        },
-        &[
-            Token::EnumMapStart("SerEnum", "Map", Some(4)),
+    assert_ser_tokens(&SerEnum::Map {
+                          a: a,
+                          b: b,
+                          c: &c,
+                          // d: d,
+                          e: &mut e, // f: f,
+                      },
+                      &[Token::EnumMapStart("SerEnum", "Map", Some(4)),
 
-            Token::EnumMapSep,
-            Token::Str("a"),
-            Token::I8(1),
+                        Token::EnumMapSep,
+                        Token::Str("a"),
+                        Token::I8(1),
 
-            Token::EnumMapSep,
-            Token::Str("b"),
-            Token::I32(2),
+                        Token::EnumMapSep,
+                        Token::Str("b"),
+                        Token::I32(2),
 
-            Token::EnumMapSep,
-            Token::Str("c"),
-            Token::I32(3),
+                        Token::EnumMapSep,
+                        Token::Str("c"),
+                        Token::I32(3),
 
-            Token::EnumMapSep,
-            Token::Str("e"),
-            Token::I32(5),
+                        Token::EnumMapSep,
+                        Token::Str("e"),
+                        Token::I32(5),
 
-            Token::EnumMapEnd,
-        ],
-    );
+                        Token::EnumMapEnd]);
 }
 
 #[test]
 fn test_de_enum_unit() {
-    assert_tokens(
-        &DeEnum::Unit::<u32, u32, u32>,
-        &[
-            Token::EnumUnit("DeEnum", "Unit"),
-        ],
-    );
+    assert_tokens(&DeEnum::Unit::<u32, u32, u32>,
+                  &[Token::EnumUnit("DeEnum", "Unit")]);
 }
 
 #[test]
@@ -391,37 +336,30 @@ fn test_de_enum_seq() {
     let a = 1;
     let b = 2;
     let c = 3;
-    //let d = 4;
+    // let d = 4;
     let e = 5;
-    //let f = 6;
+    // let f = 6;
 
-    assert_tokens(
-        &DeEnum::Seq(
-            a,
-            b,
-            c,
-            //d,
-            e,
-            //f,
-        ),
-        &[
-            Token::EnumSeqStart("DeEnum", "Seq", Some(4)),
+    assert_tokens(&DeEnum::Seq(a,
+                               b,
+                               c,
+                               // d,
+                               e /* f, */),
+                  &[Token::EnumSeqStart("DeEnum", "Seq", Some(4)),
 
-            Token::EnumSeqSep,
-            Token::I8(1),
+                    Token::EnumSeqSep,
+                    Token::I8(1),
 
-            Token::EnumSeqSep,
-            Token::I32(2),
+                    Token::EnumSeqSep,
+                    Token::I32(2),
 
-            Token::EnumSeqSep,
-            Token::I32(3),
+                    Token::EnumSeqSep,
+                    Token::I32(3),
 
-            Token::EnumSeqSep,
-            Token::I32(5),
+                    Token::EnumSeqSep,
+                    Token::I32(5),
 
-            Token::EnumSeqEnd,
-        ],
-    );
+                    Token::EnumSeqEnd]);
 }
 
 #[test]
@@ -429,206 +367,160 @@ fn test_de_enum_map() {
     let a = 1;
     let b = 2;
     let c = 3;
-    //let d = 4;
+    // let d = 4;
     let e = 5;
-    //let f = 6;
+    // let f = 6;
 
-    assert_tokens(
-        &DeEnum::Map {
-            a: a,
-            b: b,
-            c: c,
-            //d: d,
-            e: e,
-            //f: f,
-        },
-        &[
-            Token::EnumMapStart("DeEnum", "Map", Some(4)),
+    assert_tokens(&DeEnum::Map {
+                      a: a,
+                      b: b,
+                      c: c,
+                      // d: d,
+                      e: e, // f: f,
+                  },
+                  &[Token::EnumMapStart("DeEnum", "Map", Some(4)),
 
-            Token::EnumMapSep,
-            Token::Str("a"),
-            Token::I8(1),
+                    Token::EnumMapSep,
+                    Token::Str("a"),
+                    Token::I8(1),
 
-            Token::EnumMapSep,
-            Token::Str("b"),
-            Token::I32(2),
+                    Token::EnumMapSep,
+                    Token::Str("b"),
+                    Token::I32(2),
 
-            Token::EnumMapSep,
-            Token::Str("c"),
-            Token::I32(3),
+                    Token::EnumMapSep,
+                    Token::Str("c"),
+                    Token::I32(3),
 
-            Token::EnumMapSep,
-            Token::Str("e"),
-            Token::I32(5),
+                    Token::EnumMapSep,
+                    Token::Str("e"),
+                    Token::I32(5),
 
-            Token::EnumMapEnd,
-        ],
-    );
+                    Token::EnumMapEnd]);
 }
 
 #[test]
 fn test_lifetimes() {
     let value = 5;
 
-    assert_ser_tokens(
-        &Lifetimes::LifetimeSeq(&value),
-        &[
-            Token::EnumNewType("Lifetimes", "LifetimeSeq"),
-            Token::I32(5),
-        ]
-    );
+    assert_ser_tokens(&Lifetimes::LifetimeSeq(&value),
+                      &[Token::EnumNewType("Lifetimes", "LifetimeSeq"), Token::I32(5)]);
 
-    assert_ser_tokens(
-        &Lifetimes::NoLifetimeSeq(5),
-        &[
-            Token::EnumNewType("Lifetimes", "NoLifetimeSeq"),
-            Token::I32(5),
-        ]
-    );
+    assert_ser_tokens(&Lifetimes::NoLifetimeSeq(5),
+                      &[Token::EnumNewType("Lifetimes", "NoLifetimeSeq"), Token::I32(5)]);
 
-    assert_ser_tokens(
-        &Lifetimes::LifetimeMap { a: &value },
-        &[
-            Token::EnumMapStart("Lifetimes", "LifetimeMap", Some(1)),
+    assert_ser_tokens(&Lifetimes::LifetimeMap {
+                          a: &value,
+                      },
+                      &[Token::EnumMapStart("Lifetimes", "LifetimeMap", Some(1)),
 
-            Token::EnumMapSep,
-            Token::Str("a"),
-            Token::I32(5),
+                        Token::EnumMapSep,
+                        Token::Str("a"),
+                        Token::I32(5),
 
-            Token::EnumMapEnd,
-        ]
-    );
+                        Token::EnumMapEnd]);
 
-    assert_ser_tokens(
-        &Lifetimes::NoLifetimeMap { a: 5 },
-        &[
-            Token::EnumMapStart("Lifetimes", "NoLifetimeMap", Some(1)),
+    assert_ser_tokens(&Lifetimes::NoLifetimeMap {
+                          a: 5,
+                      },
+                      &[Token::EnumMapStart("Lifetimes", "NoLifetimeMap", Some(1)),
 
-            Token::EnumMapSep,
-            Token::Str("a"),
-            Token::I32(5),
+                        Token::EnumMapSep,
+                        Token::Str("a"),
+                        Token::I32(5),
 
-            Token::EnumMapEnd,
-        ]
-    );
+                        Token::EnumMapEnd]);
 }
 
 #[test]
 fn test_generic_struct() {
-    assert_tokens(
-        &GenericStruct { x: 5u32 },
-        &[
-            Token::StructStart("GenericStruct", Some(1)),
+    assert_tokens(&GenericStruct {
+                      x: 5u32,
+                  },
+                  &[Token::StructStart("GenericStruct", Some(1)),
 
-            Token::StructSep,
-            Token::Str("x"),
-            Token::U32(5),
+                    Token::StructSep,
+                    Token::Str("x"),
+                    Token::U32(5),
 
-            Token::StructEnd,
-        ]
-    );
+                    Token::StructEnd]);
 }
 
 #[test]
 fn test_generic_newtype_struct() {
-    assert_tokens(
-        &GenericNewTypeStruct(5u32),
-        &[
-            Token::StructNewType("GenericNewTypeStruct"),
-            Token::U32(5),
-        ]
-    );
+    assert_tokens(&GenericNewTypeStruct(5u32),
+                  &[Token::StructNewType("GenericNewTypeStruct"), Token::U32(5)]);
 }
 
 #[test]
 fn test_generic_tuple_struct() {
-    assert_tokens(
-        &GenericTupleStruct(5u32, 6u32),
-        &[
-            Token::TupleStructStart("GenericTupleStruct", Some(2)),
+    assert_tokens(&GenericTupleStruct(5u32, 6u32),
+                  &[Token::TupleStructStart("GenericTupleStruct", Some(2)),
 
-            Token::TupleStructSep,
-            Token::U32(5),
+                    Token::TupleStructSep,
+                    Token::U32(5),
 
-            Token::TupleStructSep,
-            Token::U32(6),
+                    Token::TupleStructSep,
+                    Token::U32(6),
 
-            Token::TupleStructEnd,
-        ]
-    );
+                    Token::TupleStructEnd]);
 }
 
 #[test]
 fn test_generic_enum_unit() {
-    assert_tokens(
-        &GenericEnum::Unit::<u32, u32>,
-        &[
-            Token::EnumUnit("GenericEnum", "Unit"),
-        ]
-    );
+    assert_tokens(&GenericEnum::Unit::<u32, u32>,
+                  &[Token::EnumUnit("GenericEnum", "Unit")]);
 }
 
 #[test]
 fn test_generic_enum_newtype() {
-    assert_tokens(
-        &GenericEnum::NewType::<u32, u32>(5),
-        &[
-            Token::EnumNewType("GenericEnum", "NewType"),
-            Token::U32(5),
-        ]
-    );
+    assert_tokens(&GenericEnum::NewType::<u32, u32>(5),
+                  &[Token::EnumNewType("GenericEnum", "NewType"), Token::U32(5)]);
 }
 
 #[test]
 fn test_generic_enum_seq() {
-    assert_tokens(
-        &GenericEnum::Seq::<u32, u32>(5, 6),
-        &[
-            Token::EnumSeqStart("GenericEnum", "Seq", Some(2)),
+    assert_tokens(&GenericEnum::Seq::<u32, u32>(5, 6),
+                  &[Token::EnumSeqStart("GenericEnum", "Seq", Some(2)),
 
-            Token::EnumSeqSep,
-            Token::U32(5),
+                    Token::EnumSeqSep,
+                    Token::U32(5),
 
-            Token::EnumSeqSep,
-            Token::U32(6),
+                    Token::EnumSeqSep,
+                    Token::U32(6),
 
-            Token::EnumSeqEnd,
-        ]
-    );
+                    Token::EnumSeqEnd]);
 }
 
 #[test]
 fn test_generic_enum_map() {
-    assert_tokens(
-        &GenericEnum::Map::<u32, u32> { x: 5, y: 6 },
-        &[
-            Token::EnumMapStart("GenericEnum", "Map", Some(2)),
+    assert_tokens(&GenericEnum::Map::<u32, u32> {
+                      x: 5,
+                      y: 6,
+                  },
+                  &[Token::EnumMapStart("GenericEnum", "Map", Some(2)),
 
-            Token::EnumMapSep,
-            Token::Str("x"),
-            Token::U32(5),
+                    Token::EnumMapSep,
+                    Token::Str("x"),
+                    Token::U32(5),
 
-            Token::EnumMapSep,
-            Token::Str("y"),
-            Token::U32(6),
+                    Token::EnumMapSep,
+                    Token::Str("y"),
+                    Token::U32(6),
 
-            Token::EnumMapEnd,
-        ]
-    );
+                    Token::EnumMapEnd]);
 }
 
 #[test]
 fn test_default_ty_param() {
-    assert_tokens(
-        &DefaultTyParam::<i32> { phantom: PhantomData },
-        &[
-            Token::StructStart("DefaultTyParam", Some(1)),
+    assert_tokens(&DefaultTyParam::<i32> {
+                      phantom: PhantomData,
+                  },
+                  &[Token::StructStart("DefaultTyParam", Some(1)),
 
-            Token::StructSep,
-            Token::Str("phantom"),
-            Token::UnitStruct("PhantomData"),
+                    Token::StructSep,
+                    Token::Str("phantom"),
+                    Token::UnitStruct("PhantomData"),
 
-            Token::StructEnd,
-        ]
-    );
+                    Token::StructEnd]);
 }

--- a/testing/tests/test_ser.rs
+++ b/testing/tests/test_ser.rs
@@ -4,17 +4,12 @@ use std::path::{Path, PathBuf};
 use std::str;
 
 extern crate serde_test;
-use self::serde_test::{
-    Error,
-    Token,
-    assert_ser_tokens,
-    assert_ser_tokens_error,
-};
+use self::serde_test::{Error, Token, assert_ser_tokens, assert_ser_tokens_error};
 
 extern crate fnv;
 use self::fnv::FnvHasher;
 
-//////////////////////////////////////////////////////////////////////////
+/// ///////////////////////////////////////////////////////////////////////
 
 #[derive(Serialize)]
 struct UnitStruct;
@@ -34,10 +29,13 @@ enum Enum {
     Unit,
     One(i32),
     Seq(i32, i32),
-    Map { a: i32, b: i32 },
+    Map {
+        a: i32,
+        b: i32,
+    },
 }
 
-//////////////////////////////////////////////////////////////////////////
+/// ///////////////////////////////////////////////////////////////////////
 
 declare_ser_tests! {
     test_unit {
@@ -350,27 +348,23 @@ declare_ser_tests! {
 #[cfg(feature = "nightly")]
 #[test]
 fn test_net_ipaddr() {
-    assert_ser_tokens(
-        "1.2.3.4".parse::<net::IpAddr>().unwrap(),
-        &[Token::Str("1.2.3.4")],
-    );
+    assert_ser_tokens("1.2.3.4".parse::<net::IpAddr>().unwrap(),
+                      &[Token::Str("1.2.3.4")]);
 }
 
 #[test]
 fn test_cannot_serialize_paths() {
-    let path = unsafe {
-        str::from_utf8_unchecked(b"Hello \xF0\x90\x80World")
-    };
-    assert_ser_tokens_error(
-        &Path::new(path),
-        &[],
-        Error::InvalidValue("Path contains invalid UTF-8 characters".to_owned()));
+    let path = unsafe { str::from_utf8_unchecked(b"Hello \xF0\x90\x80World") };
+    assert_ser_tokens_error(&Path::new(path),
+                            &[],
+                            Error::InvalidValue("Path contains invalid UTF-8 characters"
+                                .to_owned()));
 
     let mut path_buf = PathBuf::new();
     path_buf.push(path);
 
-    assert_ser_tokens_error(
-        &path_buf,
-        &[],
-        Error::InvalidValue("Path contains invalid UTF-8 characters".to_owned()));
+    assert_ser_tokens_error(&path_buf,
+                            &[],
+                            Error::InvalidValue("Path contains invalid UTF-8 characters"
+                                .to_owned()));
 }


### PR DESCRIPTION
Just to see what this would look like. Let's wait for #437 to merge before moving forward with this so that we avoid merge conflicts. This PR is much easier to rebase.

I have not read through this carefully but I am making a PR so we can discuss the formatting and file rustfmt issues as necessary. I already filed https://github.com/rust-lang-nursery/rustfmt/issues/1094.

One thing that got much worse is nested aster builders. Before:

```rust
    let wrapper_ty = builder.path()
        .segment("__SerializeWith")
            .with_generics(wrapper_generics.clone())
            .build()
        .build();
```

After:

```rust
    let wrapper_ty = builder.path()
        .segment("__SerializeWith")
        .with_generics(wrapper_generics.clone())
        .build()
        .build();
```

Ref #438.