### PR TITLE
Use cargo override instead of relative paths

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,7 @@
+paths = [
+  "serde",
+  "serde_codegen",
+  "serde_codegen_internals",
+  "serde_macros",
+  "serde_test",
+]

--- a/examples/.cargo/config
+++ b/examples/.cargo/config
@@ -1,5 +1,0 @@
-paths = [
-    "../serde",
-    "../serde_codegen",
-    "../serde_macros",
-]

--- a/serde_codegen/Cargo.toml
+++ b/serde_codegen/Cargo.toml
@@ -32,6 +32,6 @@ aster = { version = "^0.21.1", default-features = false }
 clippy = { version = "^0.*", optional = true }
 quasi = { version = "^0.15.0", default-features = false }
 quasi_macros = { version = "^0.15.0", optional = true }
-serde_codegen_internals = { version = "^0.3.0", path = "../serde_codegen_internals", default-features = false }
+serde_codegen_internals = { version = "^0.3.0", default-features = false }
 syntex = { version = "^0.38.0", optional = true }
 syntex_syntax = { version = "^0.38.0", optional = true }

--- a/serde_macros/Cargo.toml
+++ b/serde_macros/Cargo.toml
@@ -18,15 +18,15 @@ nightly-testing = ["clippy", "serde/nightly-testing", "serde_codegen/nightly-tes
 
 [dependencies]
 clippy = { version = "^0.*", optional = true }
-serde_codegen = { version = "^0.7.14", path = "../serde_codegen", default-features = false, features = ["nightly"] }
+serde_codegen = { version = "^0.7.14", default-features = false, features = ["nightly"] }
 
 [dev-dependencies]
 clippy = "^0.0.78"
 compiletest_rs = "^0.2.0"
 fnv = "1.0"
 rustc-serialize = "^0.3.16"
-serde = { version = "^0.7.14", path = "../serde" }
-serde_test = { version = "^0.7.14", path = "../serde_test" }
+serde = "0.7.14"
+serde_test = "0.7.14"
 
 [[test]]
 name = "test"

--- a/serde_test/Cargo.toml
+++ b/serde_test/Cargo.toml
@@ -11,4 +11,4 @@ keywords = ["serde", "serialization"]
 include = ["Cargo.toml", "src/**/*.rs"]
 
 [dependencies]
-serde = { version = "0.7.14", path = "../serde" }
+serde = "0.7.14"

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -14,13 +14,13 @@ build = "build.rs"
 nightly-testing = ["clippy", "serde/nightly-testing", "serde_codegen/nightly-testing"]
 
 [build-dependencies]
-serde_codegen = { version = "*", path = "../serde_codegen", features = ["with-syntex"] }
+serde_codegen = { version = "*", features = ["with-syntex"] }
 
 [dev-dependencies]
 fnv = "1.0"
 rustc-serialize = "^0.3.16"
-serde = { version = "*", path = "../serde" }
-serde_test = { version = "*", path = "../serde_test" }
+serde = "*"
+serde_test = "*"
 
 [dependencies]
 clippy = { version = "^0.*", optional = true }


### PR DESCRIPTION
This makes it possible to use `cargo clone` + `cargo build`.