### PR TITLE
Split serialize_map_elt

### DIFF
--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -522,7 +522,8 @@ macro_rules! serialize_map {
         {
             let mut state = try!(serializer.serialize_map(Some(self.len())));
             for (k, v) in self {
-                try!(serializer.serialize_map_elt(&mut state, k, v));
+                try!(serializer.serialize_map_key(&mut state, k));
+                try!(serializer.serialize_map_value(&mut state, v));
             }
             serializer.serialize_map_end(state)
         }

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -334,18 +334,25 @@ pub trait Serializer {
     ) -> Result<(), Self::Error>;
 
     /// Begins to serialize a map. This call must be followed by zero or more
-    /// calls to `serialize_map_elt`, then a call to `serialize_map_end`.
+    /// calls to `serialize_map_key` and `serialize_map_value`, then a call to
+    /// `serialize_map_end`.
     fn serialize_map(
         &mut self,
         len: Option<usize>,
     ) -> Result<Self::MapState, Self::Error>;
 
-    /// Serialize a map element. Must have previously called `serialize_map`.
-    fn serialize_map_elt<K: Serialize, V: Serialize>(
+    /// Serialize a map key. Must have previously called `serialize_map`.
+    fn serialize_map_key<T: Serialize>(
         &mut self,
         state: &mut Self::MapState,
-        key: K,
-        value: V,
+        key: T
+    ) -> Result<(), Self::Error>;
+
+    /// Serialize a map value. Must have previously called `serialize_map`.
+    fn serialize_map_value<T: Serialize>(
+        &mut self,
+        state: &mut Self::MapState,
+        value: T
     ) -> Result<(), Self::Error>;
 
     /// Finishes serializing a map.

--- a/serde_test/src/ser.rs
+++ b/serde_test/src/ser.rs
@@ -259,9 +259,12 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
         Ok(())
     }
 
-    fn serialize_map_elt<K, V>(&mut self, _: &mut (), key: K, value: V) -> Result<(), Self::Error> where K: Serialize, V: Serialize {
+    fn serialize_map_key<T>(&mut self, _: &mut (), key: T) -> Result<(), Self::Error> where T: Serialize {
         assert_eq!(self.tokens.next(), Some(&Token::MapSep));
-        try!(key.serialize(self));
+        key.serialize(self)
+    }
+
+    fn serialize_map_value<T>(&mut self, _: &mut (), value: T) -> Result<(), Self::Error> where T: Serialize {
         value.serialize(self)
     }
 

--- a/testing/tests/test_bytes.rs
+++ b/testing/tests/test_bytes.rs
@@ -229,9 +229,14 @@ impl Serializer for BytesSerializer {
         Err(Error)
     }
 
-    fn serialize_map_elt<K, V>(&mut self, _: &mut (), _key: K, _value: V) -> Result<(), Error>
-        where K: Serialize,
-              V: Serialize,
+    fn serialize_map_key<T>(&mut self, _: &mut (), _key: T) -> Result<(), Error>
+        where T: Serialize
+    {
+        Err(Error)
+    }
+
+    fn serialize_map_value<T>(&mut self, _: &mut (), _value: T) -> Result<(), Error>
+        where T: Serialize
     {
         Err(Error)
     }


### PR DESCRIPTION
Like what's been done on the deserialization side with MapVisitor, this
allows some weirder uses of Serde to handle the key and value in
separate steps.

r? @dtolnay