### PR TITLE
Use exact dependencies on other serde crates

### DIFF
--- a/serde_codegen/Cargo.toml
+++ b/serde_codegen/Cargo.toml
@@ -32,6 +32,6 @@ aster = { version = "^0.22.0", default-features = false }
 clippy = { version = "^0.*", optional = true }
 quasi = { version = "^0.16.0", default-features = false }
 quasi_macros = { version = "^0.16.0", optional = true }
-serde_codegen_internals = { version = "0.5.0", default-features = false }
+serde_codegen_internals = { version = "=0.5.0", default-features = false }
 syntex = { version = "^0.39.0", optional = true }
 syntex_syntax = { version = "^0.39.0", optional = true }

--- a/serde_macros/Cargo.toml
+++ b/serde_macros/Cargo.toml
@@ -18,15 +18,15 @@ unstable-testing = ["clippy", "serde/unstable-testing", "serde_codegen/unstable-
 
 [dependencies]
 clippy = { version = "^0.*", optional = true }
-serde_codegen = { version = "0.8.0", default-features = false, features = ["unstable"] }
+serde_codegen = { version = "=0.8.0", default-features = false, features = ["unstable"] }
 
 [dev-dependencies]
 clippy = "^0.*"
 compiletest_rs = "^0.2.0"
 fnv = "1.0"
 rustc-serialize = "^0.3.16"
-serde = "0.8.0"
-serde_test = "0.8.0"
+serde = "=0.8.0"
+serde_test = "=0.8.0"
 
 [[test]]
 name = "test"

--- a/serde_macros/Cargo.toml
+++ b/serde_macros/Cargo.toml
@@ -25,8 +25,8 @@ clippy = "^0.*"
 compiletest_rs = "^0.2.0"
 fnv = "1.0"
 rustc-serialize = "^0.3.16"
-serde = "=0.8.0"
-serde_test = "=0.8.0"
+serde = "0.8.0"
+serde_test = "0.8.0"
 
 [[test]]
 name = "test"

--- a/serde_test/Cargo.toml
+++ b/serde_test/Cargo.toml
@@ -11,4 +11,4 @@ keywords = ["serde", "serialization"]
 include = ["Cargo.toml", "src/**/*.rs"]
 
 [dependencies]
-serde = "=0.8.0"
+serde = "0.8.0"

--- a/serde_test/Cargo.toml
+++ b/serde_test/Cargo.toml
@@ -11,4 +11,4 @@ keywords = ["serde", "serialization"]
 include = ["Cargo.toml", "src/**/*.rs"]
 
 [dependencies]
-serde = "0.8.0"
+serde = "=0.8.0"


### PR DESCRIPTION
@azerupi @oli-obk @erickt do you think this would fix the problem in #470? Are there other problems it could cause?

When compiling an old serde_macros this prevents it from depending on a new serde_codegen which may be on an incompatible quasi version.