### PR TITLE
Generate docs from 'docs' branch instead of master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
 - (cd examples/serde-syntex-example && travis-cargo --only nightly run -- --no-default-features --features unstable)
 - (cd serde && travis-cargo --only stable doc)
 after_success:
-- (cd serde && travis-cargo --only stable doc-upload)
+- (cd serde && travis-cargo --only stable doc-upload --branch docs)
 - (cd testing && travis-cargo --only stable coveralls --no-sudo)
 env:
   global:


### PR DESCRIPTION
Fixes #461. This is a little more flexible because we can push out documentation improvements before a release if necessary. We will need to manually bump the "docs" branch as part of the release process.