### PR TITLE
use a thread in the build script of serde_codegen to allow env vars to control the stack size

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,7 +1,0 @@
-paths = [
-  "serde",
-  "serde_codegen",
-  "serde_codegen_internals",
-  "serde_macros",
-  "serde_test",
-]

--- a/serde_codegen/Cargo.toml
+++ b/serde_codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_codegen"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Macros to auto-generate implementations for the serde framework"

--- a/serde_codegen/Cargo.toml
+++ b/serde_codegen/Cargo.toml
@@ -32,6 +32,6 @@ aster = { version = "^0.22.0", default-features = false }
 clippy = { version = "^0.*", optional = true }
 quasi = { version = "^0.16.0", default-features = false }
 quasi_macros = { version = "^0.16.0", optional = true }
-serde_codegen_internals = { version = "=0.5.0", default-features = false }
+serde_codegen_internals = { version = "=0.5.0", default-features = false, path = "../serde_codegen_internals" }
 syntex = { version = "^0.39.0", optional = true }
 syntex_syntax = { version = "^0.39.0", optional = true }

--- a/serde_codegen/build.rs
+++ b/serde_codegen/build.rs
@@ -4,14 +4,17 @@ mod inner {
 
     use std::env;
     use std::path::Path;
+    use std::thread::spawn;
 
     pub fn main() {
-        let out_dir = env::var_os("OUT_DIR").unwrap();
+        // put everything into a thread, so users can use `RUST_MIN_STACK` to increase the amount of stack
+        spawn(|| {
+            let out_dir = env::var_os("OUT_DIR").unwrap();
 
-        let src = Path::new("src/lib.rs.in");
-        let dst = Path::new(&out_dir).join("lib.rs");
-
-        quasi_codegen::expand(&src, &dst).unwrap();
+            let src = Path::new("src/lib.rs.in");
+            let dst = Path::new(&out_dir).join("lib.rs");
+            quasi_codegen::expand(&src, &dst).unwrap();
+        }).join().unwrap()
     }
 }
 

--- a/serde_macros/Cargo.toml
+++ b/serde_macros/Cargo.toml
@@ -28,7 +28,7 @@ skeptic = { version = "^0.6.0", optional = true }
 
 [dependencies]
 clippy = { version = "^0.*", optional = true }
-serde_codegen = { version = "=0.8.1", default-features = false, features = ["unstable"] }
+serde_codegen = { version = "=0.8.1", default-features = false, features = ["unstable"], path = "../serde_codegen" }
 skeptic = { version = "^0.6.0", optional = true }
 serde_json = { version = "0.8.0", optional = true }
 
@@ -37,8 +37,8 @@ clippy = "^0.*"
 compiletest_rs = "^0.2.0"
 fnv = "1.0"
 rustc-serialize = "^0.3.16"
-serde = "0.8.0"
-serde_test = "0.8.0"
+serde = { version = "0.8.0", path = "../serde" }
+serde_test = { version = "0.8.0", path = "../serde_test" }
 
 [[test]]
 name = "test"

--- a/serde_macros/Cargo.toml
+++ b/serde_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_macros"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Macros to auto-generate implementations for the serde framework"
@@ -28,7 +28,7 @@ skeptic = { version = "^0.6.0", optional = true }
 
 [dependencies]
 clippy = { version = "^0.*", optional = true }
-serde_codegen = { version = "=0.8.0", default-features = false, features = ["unstable"] }
+serde_codegen = { version = "=0.8.1", default-features = false, features = ["unstable"] }
 skeptic = { version = "^0.6.0", optional = true }
 serde_json = { version = "0.8.0", optional = true }
 

--- a/serde_test/Cargo.toml
+++ b/serde_test/Cargo.toml
@@ -11,4 +11,4 @@ keywords = ["serde", "serialization"]
 include = ["Cargo.toml", "src/**/*.rs"]
 
 [dependencies]
-serde = "0.8.0"
+serde = { version = "0.8.0", path = "../serde" }


### PR DESCRIPTION
cc #486