### PR TITLE
Disable clippy until Manishearth/rust-clippy#1174 is fixed

### DIFF
--- a/serde_codegen/Cargo.toml
+++ b/serde_codegen/Cargo.toml
@@ -13,7 +13,7 @@ include = ["Cargo.toml", "build.rs", "src/**/*.rs", "src/lib.rs.in"]
 [features]
 default = ["with-syntex"]
 unstable = ["quasi_macros"]
-unstable-testing = ["clippy"]
+unstable-testing = []
 with-syntex = [
     "quasi/with-syntex",
     "quasi_codegen",

--- a/serde_macros/Cargo.toml
+++ b/serde_macros/Cargo.toml
@@ -16,7 +16,6 @@ plugin = true
 
 [features]
 unstable-testing = [
-    "clippy",
     "skeptic",
     "serde_json",
     "serde/unstable-testing",


### PR DESCRIPTION
I don't like that Clippy is delaying us from [supporting nightly](https://github.com/serde-rs/serde/pull/498).