### PR TITLE
Remove `if !false { ... }` from generated serialization code

### DIFF
--- a/serde_codegen/src/ser.rs
+++ b/serde_codegen/src/ser.rs
@@ -539,12 +539,12 @@ fn serialize_tuple_struct_visitor(
                     &structure_ty, generics, &field.ty, path, field_expr);
             }
 
-            let ser = quote_stmt!(cx,
+            let ser = quote_expr!(cx,
                 try!(_serializer.$func(&mut state, $field_expr));
-            ).unwrap();
+            );
 
             match skip {
-                None => ser,
+                None => quote_stmt!(cx, $ser).unwrap(),
                 Some(skip) => quote_stmt!(cx, if !$skip { $ser }).unwrap(),
             }
         })
@@ -580,12 +580,12 @@ fn serialize_struct_visitor(
                     &structure_ty, generics, &field.ty, path, field_expr)
             }
 
-            let ser = quote_stmt!(cx,
+            let ser = quote_expr!(cx,
                 try!(_serializer.$func(&mut state, $key_expr, $field_expr));
-            ).unwrap();
+            );
 
             match skip {
-                None => ser,
+                None => quote_stmt!(cx, $ser).unwrap(),
                 Some(skip) => quote_stmt!(cx, if !$skip { $ser }).unwrap(),
             }
         })


### PR DESCRIPTION
I don't think this negatively affects maintainability of the code in serde_codegen and I think there is some value in keeping our generated code relatively clear so that people can use it as a template when implementing Serialize manually with minor modifications.