### PR TITLE
Result needs to be fully qualified

### DIFF
--- a/serde_codegen/src/ser.rs
+++ b/serde_codegen/src/ser.rs
@@ -636,7 +636,7 @@ fn wrap_serialize_with(
         }
 
         impl $wrapper_generics _serde::ser::Serialize for $wrapper_ty $where_clause {
-            fn serialize<__S>(&self, __s: &mut __S) -> Result<(), __S::Error>
+            fn serialize<__S>(&self, __s: &mut __S) -> ::std::result::Result<(), __S::Error>
                 where __S: _serde::ser::Serializer
             {
                 $path(self.value, __s)

--- a/testing/tests/test_gen.rs
+++ b/testing/tests/test_gen.rs
@@ -9,6 +9,11 @@ use self::serde::de::{Deserialize, Deserializer};
 use std::borrow::Cow;
 use std::marker::PhantomData;
 
+// Try to trip up the generated code if it fails to use fully qualified paths.
+#[allow(dead_code)]
+struct Result;
+use std::result::Result as StdResult;
+
 //////////////////////////////////////////////////////////////////////////
 
 #[test]
@@ -205,32 +210,32 @@ fn assert<T: Serialize + Deserialize>() {}
 fn assert_ser<T: Serialize>() {}
 
 trait SerializeWith {
-    fn serialize_with<S: Serializer>(_: &Self, _: &mut S) -> Result<(), S::Error>;
+    fn serialize_with<S: Serializer>(_: &Self, _: &mut S) -> StdResult<(), S::Error>;
 }
 
 trait DeserializeWith: Sized {
-    fn deserialize_with<D: Deserializer>(_: &mut D) -> Result<Self, D::Error>;
+    fn deserialize_with<D: Deserializer>(_: &mut D) -> StdResult<Self, D::Error>;
 }
 
 // Implements neither Serialize nor Deserialize
 struct X;
 
-fn ser_x<S: Serializer>(_: &X, _: &mut S) -> Result<(), S::Error> {
+fn ser_x<S: Serializer>(_: &X, _: &mut S) -> StdResult<(), S::Error> {
     unimplemented!()
 }
 
-fn de_x<D: Deserializer>(_: &mut D) -> Result<X, D::Error> {
+fn de_x<D: Deserializer>(_: &mut D) -> StdResult<X, D::Error> {
     unimplemented!()
 }
 
 impl SerializeWith for X {
-    fn serialize_with<S: Serializer>(_: &Self, _: &mut S) -> Result<(), S::Error> {
+    fn serialize_with<S: Serializer>(_: &Self, _: &mut S) -> StdResult<(), S::Error> {
         unimplemented!()
     }
 }
 
 impl DeserializeWith for X {
-    fn deserialize_with<D: Deserializer>(_: &mut D) -> Result<Self, D::Error> {
+    fn deserialize_with<D: Deserializer>(_: &mut D) -> StdResult<Self, D::Error> {
         unimplemented!()
     }
 }


### PR DESCRIPTION
Without this:

```
error[E0244]: wrong number of type arguments
  --> src/api/accounts.rs:19:10
   |
19 | #[derive(Serialize, Deserialize, Debug)]
   |          ^^^^^^^^^^ expected 1 type arguments, found 2
```