### PR TITLE
Bump quasi and aster

### DIFF
--- a/serde_codegen/Cargo.toml
+++ b/serde_codegen/Cargo.toml
@@ -25,14 +25,14 @@ with-syntex = [
 ]
 
 [build-dependencies]
-quasi_codegen = { version = "^0.20.0", optional = true }
+quasi_codegen = { version = "^0.21.0", optional = true }
 syntex = { version = "^0.44.0", optional = true }
 
 [dependencies]
-aster = { version = "^0.27.0", default-features = false }
+aster = { version = "^0.29.0", default-features = false }
 clippy = { version = "^0.*", optional = true }
-quasi = { version = "^0.20.0", default-features = false }
-quasi_macros = { version = "^0.20.0", optional = true }
+quasi = { version = "^0.21.0", default-features = false }
+quasi_macros = { version = "^0.21.0", optional = true }
 serde_codegen_internals = { version = "=0.8.9", default-features = false, path = "../serde_codegen_internals" }
 syntex = { version = "^0.44.0", optional = true }
 syntex_syntax = { version = "^0.44.0", optional = true }


### PR DESCRIPTION
#558 was failing because it bumped aster without bumping quasi, and quasi continued to pull in the old aster. cc @erickt 