### PR TITLE
Allow the use of `IpAddr` implementations on stable

### DIFF
--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -809,7 +809,7 @@ map_impl!(
 
 ///////////////////////////////////////////////////////////////////////////////
 
-#[cfg(all(feature = "unstable", feature = "std"))]
+#[cfg(feature = "std")]
 impl Deserialize for net::IpAddr {
     fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
         where D: Deserializer,

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -640,15 +640,12 @@ impl Serialize for Duration {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-#[cfg(all(feature = "std", feature = "unstable"))]
+#[cfg(feature = "std")]
 impl Serialize for net::IpAddr {
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: Serializer,
     {
-        match *self {
-            net::IpAddr::V4(ref addr) => addr.serialize(serializer),
-            net::IpAddr::V6(ref addr) => addr.serialize(serializer),
-        }
+        self.to_string().serialize(serializer)
     }
 }
 


### PR DESCRIPTION
Also use the same strategy for serialization as for deserialization of
`IpAddr`.

Fixes #551.