### PR TITLE
No longer need `e!`

### DIFF
--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -313,11 +313,6 @@ impl Serialize for () {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-// FIXME(rust #19630) Remove this work-around
-macro_rules! e {
-    ($e:expr) => { $e }
-}
-
 macro_rules! tuple_impls {
     ($(
         $TupleVisitor:ident ($len:expr, $($T:ident),+) {
@@ -334,7 +329,7 @@ macro_rules! tuple_impls {
                 {
                     let mut state = try!(serializer.serialize_tuple($len));
                     $(
-                        try!(serializer.serialize_tuple_elt(&mut state, &e!(self.$idx)));
+                        try!(serializer.serialize_tuple_elt(&mut state, &self.$idx));
                     )+
                     serializer.serialize_tuple_end(state)
                 }


### PR DESCRIPTION
This compiles all the way back to Rust 1.7.0, and 1.6.0 fails for other reasons so I think we are clear here. The referenced issue https://github.com/rust-lang/rust/issues/19630 is still open so they must have fixed it some other way.