### PR TITLE
Explictly discard result of visiting IgnoredAny

### DIFF
--- a/serde_codegen/src/de.rs
+++ b/serde_codegen/src/de.rs
@@ -881,7 +881,7 @@ fn deserialize_map(
         .map(|&(_, ref name)| {
             quote! {
                 __Field::#name => {
-                    try!(visitor.visit_value::<_serde::de::impls::IgnoredAny>());
+                    let _ = try!(visitor.visit_value::<_serde::de::impls::IgnoredAny>());
                 }
             }
         })
@@ -892,7 +892,7 @@ fn deserialize_map(
         None
     } else {
         Some(quote! {
-            _ => { try!(visitor.visit_value::<_serde::de::impls::IgnoredAny>()); }
+            _ => { let _ = try!(visitor.visit_value::<_serde::de::impls::IgnoredAny>()); }
         })
     };
 


### PR DESCRIPTION
Makes the code generated by `derive(Deserialize)` compile cleanly when `unused_results` lint is enabled.

I'm not familiar with the internals at all, so it's entirely possible that there are more spots that trip the lint up, this is just something that starts shouting at you pretty much immediately, with trivial code:

```
#![feature(proc_macro)]
#![warn(unused_results)]

#[macro_use]
extern crate serde_derive;

#[derive(Deserialize)]
pub struct Foo {
    pub foo: i32,
    #[serde(skip_deserializing)]
    pub bar: i32,
}
```

With 0.8.15 you get:

```
warning: unused result
 --> src\lib.rs:7:1
  |
7 | #[derive(Deserialize)]
  | ^^^^^^^^^^^^^^^^^^^^^^
  |
note: lint level defined here
 --> src\lib.rs:2:9
  |
2 | #![warn(unused_results)]
  |         ^^^^^^^^^^^^^^
  = note: this error originates in a macro outside of the current crate

warning: unused result
 --> src\lib.rs:7:1
  |
7 | #[derive(Deserialize)]
  | ^^^^^^^^^^^^^^^^^^^^^^
  |
note: lint level defined here
 --> src\lib.rs:2:9
  |
2 | #![warn(unused_results)]
  |         ^^^^^^^^^^^^^^
  = note: this error originates in a macro outside of the current crate
```