### PR TITLE
Serializeable objects

### DIFF
--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde"
-version = "0.8.16"
+version = "0.9.0"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "A generic serialization/deserialization framework"

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -37,7 +37,7 @@ mod core {
     pub use self::core::nonzero;
 }
 
-pub use ser::{Serialize, Serializer};
+pub use ser::{Serialize, Serializer, SerializeTo};
 pub use de::{Deserialize, Deserializer, Error};
 
 #[cfg(not(feature = "std"))]

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -727,7 +727,7 @@ impl<T> Serialize for NonZero<T> where T: Serialize + Zeroable {
 
 
 ///////////////////////////////////////////////////////////////////////////////
-impl<S, T> SerializeTo<S> for T where S: Serializer, T: Serialize {
+impl<S, T: ?Sized> SerializeTo<S> for T where S: Serializer, T: Serialize {
     fn serialize_to(&self, serializer: &mut S) -> Result<(), S::Error> {
         self.serialize(serializer)
     }

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -69,6 +69,7 @@ use core::nonzero::{NonZero, Zeroable};
 use super::{
     Error,
     Serialize,
+    SerializeTo,
     Serializer,
 };
 
@@ -721,5 +722,13 @@ impl Serialize for path::PathBuf {
 impl<T> Serialize for NonZero<T> where T: Serialize + Zeroable {
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error> where S: Serializer {
         (**self).serialize(serializer)
+    }
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+impl<S, T> SerializeTo<S> for T where S: Serializer, T: Serialize {
+    fn serialize_to(&self, serializer: &mut S) -> Result<(), S::Error> {
+        self.serialize(serializer)
     }
 }

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -3,12 +3,6 @@
 //! Implement the `Serialize` trait for the type of objects you want to serialize. Call methods of
 //! the `serializer` object. For which methods to call and how to do so, look at the documentation
 //! of the `Serializer` trait.
-//!
-//! # For Serialization Format Developers
-//! Implement the `Serializer` trait for a structure that contains fields that enable it to write
-//! the serialization result to your target. When a method's argument is an object of type
-//! `Serialize`, you can either forward the serializer object (`self`) or create a new one,
-//! depending on the quirks of your format.
 
 #[cfg(feature = "std")]
 use std::error;
@@ -75,15 +69,6 @@ pub trait SerializeTo<S: Serializer + ?Sized> {
 /// Make sure that you always use the same state object and only the state object that was returned
 /// by the `serialize_T` method. Finally, when your object is done, call the `serialize_T_end`
 /// method and pass the state object by value
-///
-/// # For Serialization Format Developers
-/// If your format has different situations where it accepts different types, create a
-/// `Serializer` for each situation. You can create the sub-`Serializer` in one of the aggregate
-/// `serialize_T` methods and return it as a state object. Remember to also set the corresponding
-/// associated type `TState`. In the `serialize_T_elt` methods you will be given a mutable
-/// reference to that state. You do not need to do any additional checks for the correctness of the
-/// state object, as it is expected that the user will not modify it. Due to the generic nature
-/// of the `Serialize` impls, modifying the object is impossible on stable Rust.
 pub trait Serializer {
     /// The error type that can be returned if some error occurs during serialization.
     type Error: Error;

--- a/serde_codegen/Cargo.toml
+++ b/serde_codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_codegen"
-version = "0.8.16"
+version = "0.9.0"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Macros to auto-generate implementations for the serde framework"

--- a/serde_derive/Cargo.toml
+++ b/serde_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_derive"
-version = "0.8.16"
+version = "0.9.0"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Macros 1.1 implementation of #[derive(Serialize, Deserialize)]"

--- a/serde_test/Cargo.toml
+++ b/serde_test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_test"
-version = "0.8.16"
+version = "0.9.0"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Token De/Serializer for testing De/Serialize implementations"
@@ -12,4 +12,4 @@ keywords = ["serde", "serialization"]
 include = ["Cargo.toml", "src/**/*.rs"]
 
 [dependencies]
-serde = { version = "0.8.16", path = "../serde" }
+serde = { version = "0.9.0", path = "../serde" }

--- a/serde_test/src/ser.rs
+++ b/serde_test/src/ser.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use serde::ser::{
     self,
-    Serialize,
+    SerializeTo,
 };
 
 use error::Error;
@@ -52,10 +52,10 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
                                 _variant_index: usize,
                                 variant: &str,
                                 value: T) -> Result<(), Error>
-        where T: Serialize,
+        where T: SerializeTo<Self>,
     {
         assert_eq!(self.tokens.next(), Some(&Token::EnumNewType(name, variant)));
-        value.serialize(self)
+        value.serialize_to(self)
     }
 
     fn serialize_unit_struct(&mut self, name: &str) -> Result<(), Error> {
@@ -153,10 +153,10 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
     }
 
     fn serialize_some<V>(&mut self, value: V) -> Result<(), Error>
-        where V: Serialize,
+        where V: SerializeTo<Self>,
     {
         assert_eq!(self.tokens.next(), Some(&Token::Option(true)));
-        value.serialize(self)
+        value.serialize_to(self)
     }
 
     fn serialize_seq<'b>(&'b mut self, len: Option<usize>) -> Result<(), Error>
@@ -166,10 +166,10 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
     }
 
     fn serialize_seq_elt<T>(&mut self, _: &mut (), value: T) -> Result<(), Error>
-        where T: Serialize
+        where T: SerializeTo<Self>,
     {
         assert_eq!(self.tokens.next(), Some(&Token::SeqSep));
-        value.serialize(self)
+        value.serialize_to(self)
     }
 
     fn serialize_seq_end(&mut self, _: ()) -> Result<(), Error> {
@@ -190,10 +190,10 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
     }
 
     fn serialize_tuple_elt<T>(&mut self, _: &mut (), value: T) -> Result<(), Error>
-        where T: Serialize
+        where T: SerializeTo<Self>
     {
         assert_eq!(self.tokens.next(), Some(&Token::TupleSep));
-        value.serialize(self)
+        value.serialize_to(self)
     }
 
     fn serialize_tuple_end(&mut self, _: ()) -> Result<(), Error> {
@@ -204,10 +204,10 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
     fn serialize_newtype_struct<T>(&mut self,
                                    name: &'static str,
                                    value: T) -> Result<(), Error>
-        where T: Serialize,
+        where T: SerializeTo<Self>,
     {
         assert_eq!(self.tokens.next(), Some(&Token::StructNewType(name)));
-        value.serialize(self)
+        value.serialize_to(self)
     }
 
     fn serialize_tuple_struct(&mut self, name: &'static str, len: usize) -> Result<(), Error>
@@ -218,10 +218,10 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
     }
 
     fn serialize_tuple_struct_elt<T>(&mut self, _: &mut (), value: T) -> Result<(), Error>
-        where T: Serialize
+        where T: SerializeTo<Self>,
     {
         assert_eq!(self.tokens.next(), Some(&Token::TupleStructSep));
-        value.serialize(self)
+        value.serialize_to(self)
     }
 
     fn serialize_tuple_struct_end(&mut self, _: ()) -> Result<(), Error> {
@@ -241,10 +241,10 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
     }
 
     fn serialize_tuple_variant_elt<T>(&mut self, _: &mut (), value: T) -> Result<(), Error>
-        where T: Serialize
+        where T: SerializeTo<Self>,
     {
         assert_eq!(self.tokens.next(), Some(&Token::EnumSeqSep));
-        value.serialize(self)
+        value.serialize_to(self)
     }
 
     fn serialize_tuple_variant_end(&mut self, _: ()) -> Result<(), Error> {
@@ -259,13 +259,17 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
         Ok(())
     }
 
-    fn serialize_map_key<T>(&mut self, _: &mut (), key: T) -> Result<(), Self::Error> where T: Serialize {
+    fn serialize_map_key<T>(&mut self, _: &mut (), key: T) -> Result<(), Self::Error>
+        where T: SerializeTo<Self>,
+    {
         assert_eq!(self.tokens.next(), Some(&Token::MapSep));
-        key.serialize(self)
+        key.serialize_to(self)
     }
 
-    fn serialize_map_value<T>(&mut self, _: &mut (), value: T) -> Result<(), Self::Error> where T: Serialize {
-        value.serialize(self)
+    fn serialize_map_value<T>(&mut self, _: &mut (), value: T) -> Result<(), Self::Error>
+        where T: SerializeTo<Self>,
+    {
+        value.serialize_to(self)
     }
 
     fn serialize_map_end(&mut self, _: ()) -> Result<(), Self::Error> {
@@ -280,10 +284,12 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
         Ok(())
     }
 
-    fn serialize_struct_elt<V>(&mut self, _: &mut (), key: &'static str, value: V) -> Result<(), Self::Error> where V: Serialize {
+    fn serialize_struct_elt<V>(&mut self, _: &mut (), key: &'static str, value: V) -> Result<(), Self::Error>
+        where V: SerializeTo<Self>,
+    {
         assert_eq!(self.tokens.next(), Some(&Token::StructSep));
-        try!(key.serialize(self));
-        value.serialize(self)
+        try!(key.serialize_to(self));
+        value.serialize_to(self)
     }
 
     fn serialize_struct_end(&mut self, _: ()) -> Result<(), Self::Error> {
@@ -302,10 +308,12 @@ impl<'a, I> ser::Serializer for Serializer<'a, I>
         Ok(())
     }
 
-    fn serialize_struct_variant_elt<V>(&mut self, _: &mut (), key: &'static str, value: V) -> Result<(), Self::Error> where V: Serialize {
+    fn serialize_struct_variant_elt<V>(&mut self, _: &mut (), key: &'static str, value: V) -> Result<(), Self::Error>
+        where V: SerializeTo<Self>,
+    {
         assert_eq!(self.tokens.next(), Some(&Token::EnumMapSep));
-        try!(key.serialize(self));
-        value.serialize(self)
+        try!(key.serialize_to(self));
+        value.serialize_to(self)
     }
 
     fn serialize_struct_variant_end(&mut self, _: ()) -> Result<(), Self::Error> {

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_testing"
-version = "0.8.16"
+version = "0.9.0"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "A generic serialization/deserialization framework"

--- a/testing/tests/test_bytes.rs
+++ b/testing/tests/test_bytes.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::error;
 
-use serde::{Serialize, Serializer, Deserialize, Deserializer};
+use serde::{Serialize, SerializeTo, Serializer, Deserialize, Deserializer};
 use serde::bytes::{ByteBuf, Bytes};
 use serde::ser;
 use serde::de;
@@ -138,19 +138,19 @@ impl Serializer for BytesSerializer {
     }
 
     fn serialize_some<V>(&mut self, _value: V) -> Result<(), Error>
-        where V: Serialize,
+        where V: SerializeTo<Self>,
     {
         Err(Error)
     }
 
     fn serialize_newtype_struct<V>(&mut self, _: &'static str, _value: V) -> Result<(), Error>
-        where V: Serialize,
+        where V: SerializeTo<Self>,
     {
         Err(Error)
     }
 
     fn serialize_newtype_variant<V>(&mut self, _: &'static str, _: usize, _: &'static str, _value: V) -> Result<(), Error>
-        where V: Serialize,
+        where V: SerializeTo<Self>,
     {
         Err(Error)
     }
@@ -166,7 +166,7 @@ impl Serializer for BytesSerializer {
     }
 
     fn serialize_seq_elt<T>(&mut self, _: &mut (), _value: T) -> Result<(), Error>
-        where T: Serialize
+        where T: SerializeTo<Self>,
     {
         Err(Error)
     }
@@ -182,7 +182,7 @@ impl Serializer for BytesSerializer {
     }
 
     fn serialize_tuple_elt<T>(&mut self, _: &mut (), _value: T) -> Result<(), Error>
-        where T: Serialize
+        where T: SerializeTo<Self>,
     {
         Err(Error)
     }
@@ -198,7 +198,7 @@ impl Serializer for BytesSerializer {
     }
 
     fn serialize_tuple_struct_elt<T>(&mut self, _: &mut (), _value: T) -> Result<(), Error>
-        where T: Serialize
+        where T: SerializeTo<Self>,
     {
         Err(Error)
     }
@@ -214,7 +214,7 @@ impl Serializer for BytesSerializer {
     }
 
     fn serialize_tuple_variant_elt<T>(&mut self, _: &mut (), _value: T) -> Result<(), Error>
-        where T: Serialize
+        where T: SerializeTo<Self>,
     {
         Err(Error)
     }
@@ -230,13 +230,13 @@ impl Serializer for BytesSerializer {
     }
 
     fn serialize_map_key<T>(&mut self, _: &mut (), _key: T) -> Result<(), Error>
-        where T: Serialize
+        where T: SerializeTo<Self>,
     {
         Err(Error)
     }
 
     fn serialize_map_value<T>(&mut self, _: &mut (), _value: T) -> Result<(), Error>
-        where T: Serialize
+        where T: SerializeTo<Self>,
     {
         Err(Error)
     }
@@ -252,7 +252,7 @@ impl Serializer for BytesSerializer {
     }
 
     fn serialize_struct_elt<V>(&mut self, _: &mut (), _key: &'static str, _value: V) -> Result<(), Error>
-        where V: Serialize,
+        where V: SerializeTo<Self>,
     {
         Err(Error)
     }
@@ -268,7 +268,7 @@ impl Serializer for BytesSerializer {
     }
 
     fn serialize_struct_variant_elt<V>(&mut self, _: &mut (), _key: &'static str, _value: V) -> Result<(), Error>
-        where V: Serialize,
+        where V: SerializeTo<Self>,
     {
         Err(Error)
     }


### PR DESCRIPTION
This PR introduces a `SerializeTo` trait, which is similar to `Serialize`, except that it is object-safe. The `Serializer` trait now takes `SerializeTo<Self>` as a bound anywhere it used to use `Serialize`, and a blanket impl of `SerializeTo<S: Serializer>` is provided for all types which implement `Serialize`. This enables the construction of serializeable trait objects.

**This is a breaking a change.**

Most serializers will probably be able to transform to using this API trivially. However, some serializers take advantage of the current definition in a way which is not compatible with the new definition in this PR. In particular, the feature by which serializers can restrict the values serializable in a certain position by delegating to a separate serializer is no longer supported.

I have adapted the json crate (which currently uses this feature) to the new version in a separate PR. See that PR for background on the rest of this PR comment. [json#164](https://github.com/serde-rs/json/pull/164)

There are some serious trade offs here:
1. This allows trait objects to be serialized - for example, supporting the serialization of heterogeneous trait collections, as some schemas require.
2. This is a breaking change.
3. The fix to the JSON serializer requires specialization. This is an unstable feature.
4. The fix to the JSON serializer _changes which values can be serialized by keys in a JSON object_ (in my opinion, this is an improvement, but your mileage may vary). This is discussed at greater length on the other PR.

I think, because this would make the JSON serializer unstable, it would make sense not to accept this PR until specialization is stabilized.
