### PR TITLE
Implemented skip_deserializing for enum

### DIFF
--- a/serde_codegen/src/de.rs
+++ b/serde_codegen/src/de.rs
@@ -496,6 +496,7 @@ fn deserialize_item_enum(
 
     let variant_visitor = deserialize_field_visitor(
         variants.iter()
+            .filter(|variant| !variant.attrs.skip_deserializing())
             .map(|variant| variant.attrs.name().deserialize_name())
             .collect(),
         item_attrs,
@@ -518,7 +519,7 @@ fn deserialize_item_enum(
 
     // Match arms to extract a variant from a string
     let mut variant_arms = vec![];
-    for (i, variant) in variants.iter().enumerate() {
+    for (i, variant) in variants.iter().filter(|variant| !variant.attrs.skip_deserializing()).enumerate() {
         let variant_name = aster::id(format!("__field{}", i));
         let variant_name = quote!(__Field::#variant_name);
 

--- a/testing/tests/test_de.rs
+++ b/testing/tests/test_de.rs
@@ -37,7 +37,9 @@ enum Enum {
     Unit,
     Simple(i32),
     Seq(i32, i32, i32),
-    Map { a: i32, b: i32, c: i32 }
+    Map { a: i32, b: i32, c: i32 },
+    #[serde(skip_deserializing)]
+    Skipped,
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -804,6 +806,12 @@ declare_error_tests! {
             Token::EnumUnit("Enum", "Foo"),
         ],
         Error::UnknownVariant("Foo".to_owned()),
+    }
+    test_enum_skipped_variant<Enum> {
+        &[
+            Token::EnumUnit("Enum", "Skipped"),
+        ],
+        Error::UnknownVariant("Skipped".to_owned()),
     }
     test_struct_seq_too_long<Struct> {
         &[


### PR DESCRIPTION
This partially fixes https://github.com/serde-rs/serde/issues/638

I guess this patch is too naive, there are probably some case I missed. I'd like to get some feedback on this.