### PR TITLE
Allow strings in place of other types for map keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: rust
+cache: cargo
 rust:
 - 1.11.0
 - 1.12.0

--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -743,7 +743,13 @@ macro_rules! map_impl {
             {
                 let mut values = $with_capacity;
 
-                while let Some((key, value)) = try!($visitor.visit()) {
+                while let Some((key, value)) = try!(
+                    $visitor.visit()
+                    .or_else(
+                        $visitor.visit()
+                        .and_then(|(k,v)|(k.parse(),v))
+                    )
+                ) {
                     values.insert(key, value);
                 }
 


### PR DESCRIPTION
Just works for types implementing FromStr.

See serde-rs/json#177