### PR TITLE
Update to rustc 1.16.0-nightly (4ecc85beb 2016-12-28)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: rust
 rust:
-- 1.11.0
 - 1.12.0
+- 1.13.0
 - stable
 - beta
 - nightly

--- a/serde_codegen/Cargo.toml
+++ b/serde_codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_codegen"
-version = "0.8.21"
+version = "0.8.22"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Macros to auto-generate implementations for the serde framework"
@@ -21,9 +21,9 @@ with-syntex = [
 with-syn = []
 
 [dependencies]
-clippy = { version = "^0.*", optional = true }
+clippy = { version = "0.*", optional = true }
 quote = "0.3.8"
 serde_codegen_internals = { version = "=0.11.3", default-features = false, path = "../serde_codegen_internals" }
 syn = { version = "0.10", features = ["aster", "visit"] }
-syntex = { version = "^0.52.0", optional = true }
-syntex_syntax = { version = "^0.52.0", optional = true }
+syntex = { version = "0.53.0", optional = true }
+syntex_syntax = { version = "0.53.0", optional = true }

--- a/serde_codegen/src/lib.rs
+++ b/serde_codegen/src/lib.rs
@@ -116,7 +116,7 @@ macro_rules! shim {
 
             use syntax::{attr, ast, visit};
             struct MarkSerdeAttributesUsed;
-            impl visit::Visitor for MarkSerdeAttributesUsed {
+            impl<'a> visit::Visitor<'a> for MarkSerdeAttributesUsed {
                 fn visit_attribute(&mut self, attr: &ast::Attribute) {
                     if attr.value.name == "serde" {
                         if let ast::MetaItemKind::List(..) = attr.value.node {


### PR DESCRIPTION
Along the way, this also stops building on 1.11, and enables the benchmarks when using syntex.

Blocked on https://github.com/serde-rs/syntex/pull/108 and https://github.com/serde-rs/aster/pull/127 (and a quasi version bump).