### PR TITLE
Remove the Deserialize trait bound on Visitor::Value

### DIFF
--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -412,7 +412,7 @@ pub trait Deserializer {
 /// This trait represents a visitor that walks through a deserializer.
 pub trait Visitor {
     /// The value produced by this visitor.
-    type Value: Deserialize;
+    type Value;
 
     /// `visit_bool` deserializes a `bool` into a `Value`.
     fn visit_bool<E>(&mut self, v: bool) -> Result<Self::Value, E>

--- a/serde_test/src/de.rs
+++ b/serde_test/src/de.rs
@@ -856,7 +856,7 @@ impl<'a, I> VariantVisitor for DeserializerVariantVisitor<'a, I>
                 }
             }
             Some(_) => {
-                Deserialize::deserialize(self.de)
+                de::Deserializer::deserialize(self.de, visitor)
             }
             None => Err(Error::EndOfStream),
         }
@@ -887,7 +887,7 @@ impl<'a, I> VariantVisitor for DeserializerVariantVisitor<'a, I>
                 }
             }
             Some(_) => {
-                Deserialize::deserialize(self.de)
+                de::Deserializer::deserialize(self.de, visitor)
             }
             None => Err(Error::EndOfStream),
         }


### PR DESCRIPTION
Fixes #657. This is a breaking change but only breaks buggy code.