### PR TITLE
Stop exporting serde::de::Error as serde::Error

### DIFF
--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -38,7 +38,7 @@ mod core {
 }
 
 pub use ser::{Serialize, Serializer};
-pub use de::{Deserialize, Deserializer, Error};
+pub use de::{Deserialize, Deserializer};
 
 #[cfg(not(feature = "std"))]
 macro_rules! format {


### PR DESCRIPTION
Fixes #669.

This dates back about 2 years to 3fac47e01cbb10c2b6c519f354e9ce1f3792e567, when `serde::de::Error` was the only Error and `serde::ser::Error` did not exist.

Now `serde::Error` is just confusing.