### PR TITLE
make `ser::iterator` more general by taking `IntoIterator`

### DIFF
--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -226,7 +226,7 @@ array_impls!(32);
 
 #[cfg(feature = "unstable")]
 impl<'a, I> Serialize for Iterator<I>
-    where I: iter::Iterator, <I as iter::Iterator>::Item: Serialize
+    where I: IntoIterator, <I as IntoIterator>::Item: Serialize
 {
     #[inline]
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
@@ -234,7 +234,7 @@ impl<'a, I> Serialize for Iterator<I>
     {
         // FIXME: use specialization to prevent invalidating the object in case of clonable iterators?
         let iter = match self.0.borrow_mut().take() {
-            Some(iter) => iter,
+            Some(iter) => iter.into_iter(),
             None => return Err(S::Error::custom("Iterator used twice")),
         };
         let size = match iter.size_hint() {

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -431,8 +431,8 @@ pub struct Iterator<I>(RefCell<Option<I>>)
 /// serialize the given iterator as a sequence
 #[cfg(feature = "unstable")]
 pub fn iterator<I>(iter: I) -> Iterator<I>
-    where <I as iter::Iterator>::Item: Serialize,
-          I: iter::Iterator
+    where <I as iter::IntoIterator>::Item: Serialize,
+          I: iter::IntoIterator
 {
-    Iterator(RefCell::new(Some(iter)))
+    Iterator(RefCell::new(Some(iter.into_iter())))
 }

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -22,8 +22,6 @@ use collections::String;
 use core::marker::PhantomData;
 #[cfg(feature = "unstable")]
 use core::cell::RefCell;
-#[cfg(feature = "unstable")]
-use core::iter;
 
 pub mod impls;
 
@@ -424,15 +422,15 @@ pub trait Serializer {
 /// every time you want to serialize an iterator.
 #[cfg(feature = "unstable")]
 pub struct Iterator<I>(RefCell<Option<I>>)
-    where <I as iter::Iterator>::Item: Serialize,
-          I: iter::Iterator;
+    where <I as IntoIterator>::Item: Serialize,
+          I: IntoIterator;
 
 /// Creates a temporary type that can be passed to any function expecting a `Serialize` and will
 /// serialize the given iterator as a sequence
 #[cfg(feature = "unstable")]
 pub fn iterator<I>(iter: I) -> Iterator<I>
-    where <I as iter::IntoIterator>::Item: Serialize,
-          I: iter::IntoIterator
+    where <I as IntoIterator>::Item: Serialize,
+          I: IntoIterator
 {
     Iterator(RefCell::new(Some(iter.into_iter())))
 }

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -432,5 +432,5 @@ pub fn iterator<I>(iter: I) -> Iterator<I>
     where <I as IntoIterator>::Item: Serialize,
           I: IntoIterator
 {
-    Iterator(RefCell::new(Some(iter.into_iter())))
+    Iterator(RefCell::new(Some(iter)))
 }


### PR DESCRIPTION
When I left the comment in the issue I noticed that the code wasn't as general as it could be. Alternatively the `IntoIterator` could be forwarded all the way into the `Serialize` function, as to not call `into_iter` before it is needed. Any preferences?