### PR TITLE
fix various serde(rename) bugs

### DIFF
--- a/serde_codegen/src/de.rs
+++ b/serde_codegen/src/de.rs
@@ -503,7 +503,7 @@ fn deserialize_item_enum(
         true,
     );
 
-    let variant_names = variants.iter().map(|variant| variant.ident.to_string());
+    let variant_names = variants.iter().map(|variant| variant.attrs.name().deserialize_name());
 
     let variants_stmt = quote! {
         const VARIANTS: &'static [&'static str] = &[ #(#variant_names),* ];

--- a/serde_codegen/src/de.rs
+++ b/serde_codegen/src/de.rs
@@ -714,7 +714,7 @@ fn deserialize_struct_visitor(
     fields: &[Field],
     item_attrs: &attr::Item,
 ) -> (Tokens, Tokens, Tokens) {
-    let field_exprs = fields.iter()
+    let field_exprs: Vec<_> = fields.iter()
         .map(|field| field.attrs.name().deserialize_name())
         .collect();
     let field_names = field_exprs.clone();

--- a/serde_codegen/src/de.rs
+++ b/serde_codegen/src/de.rs
@@ -717,6 +717,7 @@ fn deserialize_struct_visitor(
     let field_exprs = fields.iter()
         .map(|field| field.attrs.name().deserialize_name())
         .collect();
+    let field_names = field_exprs.clone();
 
     let field_visitor = deserialize_field_visitor(
         field_exprs,
@@ -731,10 +732,6 @@ fn deserialize_struct_visitor(
         fields,
         item_attrs,
     );
-
-    let field_names = fields.iter().map(|field| {
-        field.ident.clone().expect("struct contains unnamed field").to_string()
-    });
 
     let fields_stmt = quote! {
         const FIELDS: &'static [&'static str] = &[ #(#field_names),* ];


### PR DESCRIPTION
fixes #559 

writing tests for this is hard, because we never have a string available, just a generic `K: Deserialize`, we could create a custom Deserializer that allows exactly one string deserialization and it has to match a given string. It's somewhat roundabout, but that's the best I can think of.