### PR TITLE
Treat skipped fields as unknown

### DIFF
--- a/serde_codegen/src/de.rs
+++ b/serde_codegen/src/de.rs
@@ -702,20 +702,11 @@ fn deserialize_struct_visitor(
     fields: &[Field],
     item_attrs: &attr::Item,
 ) -> (Tokens, Tokens, Tokens) {
-<<<<<<< HEAD
     let field_names_idents = fields.iter()
         .enumerate()
         .filter(|&(_, field)| !field.attrs.skip_deserializing())
         .map(|(i, field)| (field.attrs.name().deserialize_name(), field_i(i)))
-||||||| merged common ancestors
-    let field_exprs = fields.iter()
-        .map(|field| field.attrs.name().deserialize_name())
-=======
-    let field_exprs: Vec<_> = fields.iter()
-        .map(|field| field.attrs.name().deserialize_name())
->>>>>>> origin/master
         .collect();
-    let field_names = field_exprs.clone();
 
     let field_visitor = deserialize_field_visitor(
         field_names_idents,
@@ -731,6 +722,7 @@ fn deserialize_struct_visitor(
         item_attrs,
     );
 
+    let field_names = fields.iter().map(|field| field.attrs.name().deserialize_name());
     let fields_stmt = quote! {
         const FIELDS: &'static [&'static str] = &[ #(#field_names),* ];
     };

--- a/serde_codegen/src/de.rs
+++ b/serde_codegen/src/de.rs
@@ -480,14 +480,14 @@ fn deserialize_item_enum(
 
     let type_name = item_attrs.name().deserialize_name();
 
-    let variant_names = variants.iter()
+    let variant_names_idents = variants.iter()
         .enumerate()
         .filter(|&(_, variant)| !variant.attrs.skip_deserializing())
         .map(|(i, variant)| (variant.attrs.name().deserialize_name(), field_i(i)))
         .collect();
 
     let variant_visitor = deserialize_field_visitor(
-        variant_names,
+        variant_names_idents,
         item_attrs,
         true,
     );
@@ -700,14 +700,14 @@ fn deserialize_struct_visitor(
     fields: &[Field],
     item_attrs: &attr::Item,
 ) -> (Tokens, Tokens, Tokens) {
-    let field_names = fields.iter()
+    let field_names_idents = fields.iter()
         .enumerate()
         .filter(|&(_, field)| !field.attrs.skip_deserializing())
         .map(|(i, field)| (field.attrs.name().deserialize_name(), field_i(i)))
         .collect();
 
     let field_visitor = deserialize_field_visitor(
-        field_names,
+        field_names_idents,
         item_attrs,
         false,
     );

--- a/testing/tests/test_de.rs
+++ b/testing/tests/test_de.rs
@@ -64,6 +64,13 @@ enum Enum {
     Map { a: i32, b: i32, c: i32 },
 }
 
+#[derive(PartialEq, Debug, Deserialize)]
+enum EnumSkipAll {
+    #[allow(dead_code)]
+    #[serde(skip_deserializing)]
+    Skipped,
+}
+
 //////////////////////////////////////////////////////////////////////////
 
 macro_rules! declare_test {
@@ -869,6 +876,12 @@ declare_error_tests! {
     test_enum_skipped_variant<Enum> {
         &[
             Token::EnumUnit("Enum", "Skipped"),
+        ],
+        Error::UnknownVariant("Skipped".to_owned()),
+    }
+    test_enum_skip_all<EnumSkipAll> {
+        &[
+            Token::EnumUnit("EnumSkipAll", "Skipped"),
         ],
         Error::UnknownVariant("Skipped".to_owned()),
     }

--- a/testing/tests/test_de.rs
+++ b/testing/tests/test_de.rs
@@ -41,6 +41,19 @@ struct StructDenyUnknown {
 }
 
 #[derive(PartialEq, Debug, Deserialize)]
+struct StructSkipAll {
+    #[serde(skip_deserializing)]
+    a: i32,
+}
+
+#[derive(PartialEq, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StructSkipAllDenyUnknown {
+    #[serde(skip_deserializing)]
+    a: i32,
+}
+
+#[derive(PartialEq, Debug, Deserialize)]
 enum Enum {
     #[allow(dead_code)]
     #[serde(skip_deserializing)]
@@ -689,6 +702,29 @@ declare_tests! {
             Token::StructEnd,
         ],
     }
+    test_struct_skip_all {
+        StructSkipAll { a: 0 } => &[
+            Token::StructStart("StructSkipAll", 0),
+            Token::StructEnd,
+        ],
+        StructSkipAll { a: 0 } => &[
+            Token::StructStart("StructSkipAll", 1),
+                Token::StructSep,
+                Token::Str("a"),
+                Token::I32(1),
+
+                Token::StructSep,
+                Token::Str("b"),
+                Token::I32(2),
+            Token::StructEnd,
+        ],
+    }
+    test_struct_skip_all_deny_unknown {
+        StructSkipAllDenyUnknown { a: 0 } => &[
+            Token::StructStart("StructSkipAllDenyUnknown", 0),
+            Token::StructEnd,
+        ],
+    }
     test_enum_unit {
         Enum::Unit => &[
             Token::EnumUnit("Enum", "Unit"),
@@ -815,6 +851,14 @@ declare_error_tests! {
                 Token::Str("b"),
         ],
         Error::UnknownField("b".to_owned()),
+    }
+    test_skip_all_deny_unknown<StructSkipAllDenyUnknown> {
+        &[
+            Token::StructStart("StructSkipAllDenyUnknown", 1),
+                Token::StructSep,
+                Token::Str("a"),
+        ],
+        Error::UnknownField("a".to_owned()),
     }
     test_unknown_variant<Enum> {
         &[

--- a/testing/tests/test_de.rs
+++ b/testing/tests/test_de.rs
@@ -33,6 +33,14 @@ struct Struct {
 }
 
 #[derive(PartialEq, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StructDenyUnknown {
+    a: i32,
+    #[serde(skip_deserializing)]
+    b: i32,
+}
+
+#[derive(PartialEq, Debug, Deserialize)]
 enum Enum {
     Unit,
     Simple(i32),
@@ -788,6 +796,26 @@ fn test_net_ipaddr() {
 }
 
 declare_error_tests! {
+    test_unknown_field<StructDenyUnknown> {
+        &[
+            Token::StructStart("StructDenyUnknown", 2),
+                Token::StructSep,
+                Token::Str("a"),
+                Token::I32(0),
+
+                Token::StructSep,
+                Token::Str("d"),
+        ],
+        Error::UnknownField("d".to_owned()),
+    }
+    test_skipped_field_is_unknown<StructDenyUnknown> {
+        &[
+            Token::StructStart("StructDenyUnknown", 2),
+                Token::StructSep,
+                Token::Str("b"),
+        ],
+        Error::UnknownField("b".to_owned()),
+    }
     test_unknown_variant<Enum> {
         &[
             Token::EnumUnit("Enum", "Foo"),

--- a/testing/tests/test_de.rs
+++ b/testing/tests/test_de.rs
@@ -42,13 +42,13 @@ struct StructDenyUnknown {
 
 #[derive(PartialEq, Debug, Deserialize)]
 enum Enum {
+    #[allow(dead_code)]
+    #[serde(skip_deserializing)]
+    Skipped,
     Unit,
     Simple(i32),
     Seq(i32, i32, i32),
     Map { a: i32, b: i32, c: i32 },
-    #[allow(dead_code)]
-    #[serde(skip_deserializing)]
-    Skipped,
 }
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes #444.

Previously, skipped fields were included in the __Field enum. Now they are not, so the variants of the __Field enum may be non-consecutive like __field0, __field2 if the second field is skipped. Skipped fields will error with Error::unknown_field if using deny_unknown_fields and will go through the usual __Field::__ignore variant otherwise.