### PR TITLE
Enforce correct use of Deserialize trait

### DIFF
--- a/serde/src/bytes.rs
+++ b/serde/src/bytes.rs
@@ -182,14 +182,14 @@ mod bytebuf {
         type Value = ByteBuf;
 
         #[inline]
-        fn visit_unit<E>(&mut self) -> Result<ByteBuf, E>
+        fn visit_unit<E>(self) -> Result<ByteBuf, E>
             where E: de::Error,
         {
             Ok(ByteBuf::new())
         }
 
         #[inline]
-        fn visit_seq<V>(&mut self, mut visitor: V) -> Result<ByteBuf, V::Error>
+        fn visit_seq<V>(self, mut visitor: V) -> Result<ByteBuf, V::Error>
             where V: de::SeqVisitor,
         {
             let (len, _) = visitor.size_hint();
@@ -203,26 +203,26 @@ mod bytebuf {
         }
 
         #[inline]
-        fn visit_bytes<E>(&mut self, v: &[u8]) -> Result<ByteBuf, E>
+        fn visit_bytes<E>(self, v: &[u8]) -> Result<ByteBuf, E>
             where E: de::Error,
         {
             Ok(ByteBuf::from(v))
         }
 
         #[inline]
-        fn visit_byte_buf<E>(&mut self, v: Vec<u8>) -> Result<ByteBuf, E>
+        fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<ByteBuf, E>
             where E: de::Error,
         {
             Ok(ByteBuf::from(v))
         }
 
-        fn visit_str<E>(&mut self, v: &str) -> Result<ByteBuf, E>
+        fn visit_str<E>(self, v: &str) -> Result<ByteBuf, E>
             where E: de::Error,
         {
             Ok(ByteBuf::from(v))
         }
 
-        fn visit_string<E>(&mut self, v: String) -> Result<ByteBuf, E>
+        fn visit_string<E>(self, v: String) -> Result<ByteBuf, E>
             where E: de::Error,
         {
             Ok(ByteBuf::from(v))
@@ -231,7 +231,7 @@ mod bytebuf {
 
     impl de::Deserialize for ByteBuf {
         #[inline]
-        fn deserialize<D>(deserializer: &mut D) -> Result<ByteBuf, D::Error>
+        fn deserialize<D>(deserializer: D) -> Result<ByteBuf, D::Error>
             where D: de::Deserializer
         {
             deserializer.deserialize_bytes(ByteBufVisitor)

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -222,7 +222,7 @@ impl fmt::Display for Type {
 /// `Deserialize` represents a type that can be deserialized.
 pub trait Deserialize: Sized {
     /// Deserialize this value given this `Deserializer`.
-    fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where D: Deserializer;
 }
 
@@ -245,100 +245,100 @@ pub trait Deserializer {
     type Error: Error;
 
     /// This method walks a visitor through a value as it is being deserialized.
-    fn deserialize<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor;
 
     /// This method hints that the `Deserialize` type is expecting a `bool` value.
-    fn deserialize_bool<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor;
 
     /// This method hints that the `Deserialize` type is expecting an `usize` value.
     /// A reasonable default is to forward to `deserialize_u64`.
-    fn deserialize_usize<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_usize<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor;
 
     /// This method hints that the `Deserialize` type is expecting an `u8` value.
     /// A reasonable default is to forward to `deserialize_u64`.
-    fn deserialize_u8<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor;
 
     /// This method hints that the `Deserialize` type is expecting an `u16` value.
     /// A reasonable default is to forward to `deserialize_u64`.
-    fn deserialize_u16<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor;
 
     /// This method hints that the `Deserialize` type is expecting an `u32` value.
     /// A reasonable default is to forward to `deserialize_u64`.
-    fn deserialize_u32<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor;
 
     /// This method hints that the `Deserialize` type is expecting an `u64` value.
-    fn deserialize_u64<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor;
 
     /// This method hints that the `Deserialize` type is expecting an `isize` value.
     /// A reasonable default is to forward to `deserialize_i64`.
-    fn deserialize_isize<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_isize<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor;
 
     /// This method hints that the `Deserialize` type is expecting an `i8` value.
     /// A reasonable default is to forward to `deserialize_i64`.
-    fn deserialize_i8<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor;
 
     /// This method hints that the `Deserialize` type is expecting an `i16` value.
     /// A reasonable default is to forward to `deserialize_i64`.
-    fn deserialize_i16<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor;
 
     /// This method hints that the `Deserialize` type is expecting an `i32` value.
     /// A reasonable default is to forward to `deserialize_i64`.
-    fn deserialize_i32<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor;
 
     /// This method hints that the `Deserialize` type is expecting an `i64` value.
-    fn deserialize_i64<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor;
 
     /// This method hints that the `Deserialize` type is expecting a `f32` value.
     /// A reasonable default is to forward to `deserialize_f64`.
-    fn deserialize_f32<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor;
 
     /// This method hints that the `Deserialize` type is expecting a `f64` value.
-    fn deserialize_f64<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor;
 
     /// This method hints that the `Deserialize` type is expecting a `char` value.
-    fn deserialize_char<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor;
 
     /// This method hints that the `Deserialize` type is expecting a `&str` value.
-    fn deserialize_str<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor;
 
     /// This method hints that the `Deserialize` type is expecting a `String` value.
-    fn deserialize_string<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor;
 
     /// This method hints that the `Deserialize` type is expecting an `unit` value.
-    fn deserialize_unit<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor;
 
     /// This method hints that the `Deserialize` type is expecting an `Option` value. This allows
     /// deserializers that encode an optional value as a nullable value to convert the null value
     /// into a `None`, and a regular value as `Some(value)`.
-    fn deserialize_option<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor;
 
     /// This method hints that the `Deserialize` type is expecting a sequence value. This allows
     /// deserializers to parse sequences that aren't tagged as sequences.
-    fn deserialize_seq<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor;
 
     /// This method hints that the `Deserialize` type is expecting a fixed size array. This allows
     /// deserializers to parse arrays that aren't tagged as arrays.
-    fn deserialize_seq_fixed_size<V>(&mut self,
+    fn deserialize_seq_fixed_size<V>(self,
                                      len: usize,
                                      visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor;
@@ -346,17 +346,17 @@ pub trait Deserializer {
     /// This method hints that the `Deserialize` type is expecting a `Vec<u8>`. This allows
     /// deserializers that provide a custom byte vector serialization to properly deserialize the
     /// type.
-    fn deserialize_bytes<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor;
 
     /// This method hints that the `Deserialize` type is expecting a map of values. This allows
     /// deserializers to parse sequences that aren't tagged as maps.
-    fn deserialize_map<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor;
 
     /// This method hints that the `Deserialize` type is expecting a unit struct. This allows
     /// deserializers to a unit struct that aren't tagged as a unit struct.
-    fn deserialize_unit_struct<V>(&mut self,
+    fn deserialize_unit_struct<V>(self,
                                   name: &'static str,
                                   visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor;
@@ -364,14 +364,14 @@ pub trait Deserializer {
     /// This method hints that the `Deserialize` type is expecting a newtype struct. This allows
     /// deserializers to a newtype struct that aren't tagged as a newtype struct.
     /// A reasonable default is to simply deserialize the expected value directly.
-    fn deserialize_newtype_struct<V>(&mut self,
+    fn deserialize_newtype_struct<V>(self,
                                      name: &'static str,
                                      visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor;
 
     /// This method hints that the `Deserialize` type is expecting a tuple struct. This allows
     /// deserializers to parse sequences that aren't tagged as sequences.
-    fn deserialize_tuple_struct<V>(&mut self,
+    fn deserialize_tuple_struct<V>(self,
                                    name: &'static str,
                                    len: usize,
                                    visitor: V) -> Result<V::Value, Self::Error>
@@ -379,7 +379,7 @@ pub trait Deserializer {
 
     /// This method hints that the `Deserialize` type is expecting a struct. This allows
     /// deserializers to parse sequences that aren't tagged as maps.
-    fn deserialize_struct<V>(&mut self,
+    fn deserialize_struct<V>(self,
                              name: &'static str,
                              fields: &'static [&'static str],
                              visitor: V) -> Result<V::Value, Self::Error>
@@ -388,18 +388,18 @@ pub trait Deserializer {
     /// This method hints that the `Deserialize` type is expecting some sort of struct field
     /// name.  This allows deserializers to choose between &str, usize, or &[u8] to properly
     /// deserialize a struct field.
-    fn deserialize_struct_field<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_struct_field<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor;
 
     /// This method hints that the `Deserialize` type is expecting a tuple value. This allows
     /// deserializers that provide a custom tuple serialization to properly deserialize the type.
-    fn deserialize_tuple<V>(&mut self, len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_tuple<V>(self, len: usize, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor;
 
     /// This method hints that the `Deserialize` type is expecting an enum value. This allows
     /// deserializers that provide a custom enumeration serialization to properly deserialize the
     /// type.
-    fn deserialize_enum<V>(&mut self,
+    fn deserialize_enum<V>(self,
                            name: &'static str,
                            variants: &'static [&'static str],
                            visitor: V) -> Result<V::Value, Self::Error>
@@ -407,19 +407,19 @@ pub trait Deserializer {
 
     /// This method hints that the `Deserialize` type needs to deserialize a value whose type
     /// doesn't matter because it is ignored.
-    fn deserialize_ignored_any<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 
 /// This trait represents a visitor that walks through a deserializer.
-pub trait Visitor {
+pub trait Visitor: Sized {
     /// The value produced by this visitor.
     type Value;
 
     /// `visit_bool` deserializes a `bool` into a `Value`.
-    fn visit_bool<E>(&mut self, v: bool) -> Result<Self::Value, E>
+    fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
         where E: Error,
     {
         let _ = v;
@@ -427,35 +427,35 @@ pub trait Visitor {
     }
 
     /// `visit_isize` deserializes a `isize` into a `Value`.
-    fn visit_isize<E>(&mut self, v: isize) -> Result<Self::Value, E>
+    fn visit_isize<E>(self, v: isize) -> Result<Self::Value, E>
         where E: Error,
     {
         self.visit_i64(v as i64)
     }
 
     /// `visit_i8` deserializes a `i8` into a `Value`.
-    fn visit_i8<E>(&mut self, v: i8) -> Result<Self::Value, E>
+    fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E>
         where E: Error,
     {
         self.visit_i64(v as i64)
     }
 
     /// `visit_i16` deserializes a `i16` into a `Value`.
-    fn visit_i16<E>(&mut self, v: i16) -> Result<Self::Value, E>
+    fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E>
         where E: Error,
     {
         self.visit_i64(v as i64)
     }
 
     /// `visit_i32` deserializes a `i32` into a `Value`.
-    fn visit_i32<E>(&mut self, v: i32) -> Result<Self::Value, E>
+    fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
         where E: Error,
     {
         self.visit_i64(v as i64)
     }
 
     /// `visit_i64` deserializes a `i64` into a `Value`.
-    fn visit_i64<E>(&mut self, v: i64) -> Result<Self::Value, E>
+    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
         where E: Error,
     {
         let _ = v;
@@ -463,35 +463,35 @@ pub trait Visitor {
     }
 
     /// `visit_usize` deserializes a `usize` into a `Value`.
-    fn visit_usize<E>(&mut self, v: usize) -> Result<Self::Value, E>
+    fn visit_usize<E>(self, v: usize) -> Result<Self::Value, E>
         where E: Error,
     {
         self.visit_u64(v as u64)
     }
 
     /// `visit_u8` deserializes a `u8` into a `Value`.
-    fn visit_u8<E>(&mut self, v: u8) -> Result<Self::Value, E>
+    fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
         where E: Error,
     {
         self.visit_u64(v as u64)
     }
 
     /// `visit_u16` deserializes a `u16` into a `Value`.
-    fn visit_u16<E>(&mut self, v: u16) -> Result<Self::Value, E>
+    fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E>
         where E: Error,
     {
         self.visit_u64(v as u64)
     }
 
     /// `visit_u32` deserializes a `u32` into a `Value`.
-    fn visit_u32<E>(&mut self, v: u32) -> Result<Self::Value, E>
+    fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
         where E: Error,
     {
         self.visit_u64(v as u64)
     }
 
     /// `visit_u64` deserializes a `u64` into a `Value`.
-    fn visit_u64<E>(&mut self, v: u64) -> Result<Self::Value, E>
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
         where E: Error,
     {
         let _ = v;
@@ -499,14 +499,14 @@ pub trait Visitor {
     }
 
     /// `visit_f32` deserializes a `f32` into a `Value`.
-    fn visit_f32<E>(&mut self, v: f32) -> Result<Self::Value, E>
+    fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E>
         where E: Error,
     {
         self.visit_f64(v as f64)
     }
 
     /// `visit_f64` deserializes a `f64` into a `Value`.
-    fn visit_f64<E>(&mut self, v: f64) -> Result<Self::Value, E>
+    fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
         where E: Error,
     {
         let _ = v;
@@ -515,14 +515,14 @@ pub trait Visitor {
 
     /// `visit_char` deserializes a `char` into a `Value`.
     #[inline]
-    fn visit_char<E>(&mut self, v: char) -> Result<Self::Value, E>
+    fn visit_char<E>(self, v: char) -> Result<Self::Value, E>
         where E: Error,
     {
         self.visit_str(::utils::encode_utf8(v).as_str())
     }
 
     /// `visit_str` deserializes a `&str` into a `Value`.
-    fn visit_str<E>(&mut self, v: &str) -> Result<Self::Value, E>
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
         where E: Error,
     {
         let _ = v;
@@ -534,14 +534,14 @@ pub trait Visitor {
     /// to the `visit_str` method.
     #[inline]
     #[cfg(any(feature = "std", feature = "collections"))]
-    fn visit_string<E>(&mut self, v: String) -> Result<Self::Value, E>
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
         where E: Error,
     {
         self.visit_str(&v)
     }
 
     /// `visit_unit` deserializes a `()` into a `Value`.
-    fn visit_unit<E>(&mut self) -> Result<Self::Value, E>
+    fn visit_unit<E>(self) -> Result<Self::Value, E>
         where E: Error,
     {
         Err(Error::invalid_type(Type::Unit))
@@ -549,7 +549,7 @@ pub trait Visitor {
 
     /// `visit_unit_struct` deserializes a unit struct into a `Value`.
     #[inline]
-    fn visit_unit_struct<E>(&mut self, name: &'static str) -> Result<Self::Value, E>
+    fn visit_unit_struct<E>(self, name: &'static str) -> Result<Self::Value, E>
         where E: Error,
     {
         let _ = name;
@@ -557,14 +557,14 @@ pub trait Visitor {
     }
 
     /// `visit_none` deserializes a none value into a `Value`.
-    fn visit_none<E>(&mut self) -> Result<Self::Value, E>
+    fn visit_none<E>(self) -> Result<Self::Value, E>
         where E: Error,
     {
         Err(Error::invalid_type(Type::Option))
     }
 
     /// `visit_some` deserializes a value into a `Value`.
-    fn visit_some<D>(&mut self, deserializer: &mut D) -> Result<Self::Value, D::Error>
+    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
         where D: Deserializer,
     {
         let _ = deserializer;
@@ -572,7 +572,7 @@ pub trait Visitor {
     }
 
     /// `visit_newtype_struct` deserializes a value into a `Value`.
-    fn visit_newtype_struct<D>(&mut self, deserializer: &mut D) -> Result<Self::Value, D::Error>
+    fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
         where D: Deserializer,
     {
         let _ = deserializer;
@@ -580,7 +580,7 @@ pub trait Visitor {
     }
 
     /// `visit_seq` deserializes a `SeqVisitor` into a `Value`.
-    fn visit_seq<V>(&mut self, visitor: V) -> Result<Self::Value, V::Error>
+    fn visit_seq<V>(self, visitor: V) -> Result<Self::Value, V::Error>
         where V: SeqVisitor,
     {
         let _ = visitor;
@@ -588,23 +588,23 @@ pub trait Visitor {
     }
 
     /// `visit_map` deserializes a `MapVisitor` into a `Value`.
-    fn visit_map<V>(&mut self, visitor: V) -> Result<Self::Value, V::Error>
+    fn visit_map<V>(self, visitor: V) -> Result<Self::Value, V::Error>
         where V: MapVisitor,
     {
         let _ = visitor;
         Err(Error::invalid_type(Type::Map))
     }
 
-    /// `visit_enum` deserializes a `VariantVisitor` into a `Value`.
-    fn visit_enum<V>(&mut self, visitor: V) -> Result<Self::Value, V::Error>
-        where V: VariantVisitor,
+    /// `visit_enum` deserializes a `EnumVisitor` into a `Value`.
+    fn visit_enum<V>(self, visitor: V) -> Result<Self::Value, V::Error>
+        where V: EnumVisitor,
     {
         let _ = visitor;
         Err(Error::invalid_type(Type::Enum))
     }
 
     /// `visit_bytes` deserializes a `&[u8]` into a `Value`.
-    fn visit_bytes<E>(&mut self, v: &[u8]) -> Result<Self::Value, E>
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
         where E: Error,
     {
         let _ = v;
@@ -613,7 +613,7 @@ pub trait Visitor {
 
     /// `visit_byte_buf` deserializes a `Vec<u8>` into a `Value`.
     #[cfg(any(feature = "std", feature = "collections"))]
-    fn visit_byte_buf<E>(&mut self, v: Vec<u8>) -> Result<Self::Value, E>
+    fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
         where E: Error,
     {
         self.visit_bytes(&v)
@@ -746,28 +746,40 @@ impl<'a, V_> MapVisitor for &'a mut V_ where V_: MapVisitor {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-/// `VariantVisitor` is a visitor that is created by the `Deserializer` and passed to the
-/// `Deserialize` in order to deserialize a specific enum variant.
+/// `EnumVisitor` is a visitor that is created by the `Deserializer` and passed
+/// to the `Deserialize` in order to identify which variant of an enum to
+/// deserialize.
+pub trait EnumVisitor {
+    /// The error type that can be returned if some error occurs during deserialization.
+    type Error: Error;
+    /// The `Visitor` that will be used to deserialize the content of the enum
+    /// variant.
+    type Variant: VariantVisitor<Error=Self::Error>;
+
+    /// `visit_variant` is called to identify which variant to deserialize.
+    fn visit_variant<V>(self) -> Result<(V, Self::Variant), Self::Error>
+        where V: Deserialize;
+}
+
+/// `VariantVisitor` is a visitor that is created by the `Deserializer` and
+/// passed to the `Deserialize` to deserialize the content of a particular enum
+/// variant.
 pub trait VariantVisitor {
     /// The error type that can be returned if some error occurs during deserialization.
     type Error: Error;
 
-    /// `visit_variant` is called to identify which variant to deserialize.
-    fn visit_variant<V>(&mut self) -> Result<V, Self::Error>
-        where V: Deserialize;
-
     /// `visit_unit` is called when deserializing a variant with no values.
-    fn visit_unit(&mut self) -> Result<(), Self::Error>;
+    fn visit_unit(self) -> Result<(), Self::Error>;
 
     /// `visit_newtype` is called when deserializing a variant with a single value.
     /// A good default is often to use the `visit_tuple` method to deserialize a `(value,)`.
-    fn visit_newtype<T>(&mut self) -> Result<T, Self::Error>
+    fn visit_newtype<T>(self) -> Result<T, Self::Error>
         where T: Deserialize;
 
     /// `visit_tuple` is called when deserializing a tuple-like variant.
     /// If no tuple variants are expected, yield a
     /// `Err(serde::de::Error::invalid_type(serde::de::Type::TupleVariant))`
-    fn visit_tuple<V>(&mut self,
+    fn visit_tuple<V>(self,
                       len: usize,
                       visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor;
@@ -775,44 +787,8 @@ pub trait VariantVisitor {
     /// `visit_struct` is called when deserializing a struct-like variant.
     /// If no struct variants are expected, yield a
     /// `Err(serde::de::Error::invalid_type(serde::de::Type::StructVariant))`
-    fn visit_struct<V>(&mut self,
+    fn visit_struct<V>(self,
                        fields: &'static [&'static str],
                        visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor;
-}
-
-impl<'a, T> VariantVisitor for &'a mut T where T: VariantVisitor {
-    type Error = T::Error;
-
-    fn visit_variant<V>(&mut self) -> Result<V, T::Error>
-        where V: Deserialize
-    {
-        (**self).visit_variant()
-    }
-
-    fn visit_unit(&mut self) -> Result<(), T::Error> {
-        (**self).visit_unit()
-    }
-
-    fn visit_newtype<D>(&mut self) -> Result<D, T::Error>
-        where D: Deserialize,
-    {
-        (**self).visit_newtype()
-    }
-
-    fn visit_tuple<V>(&mut self,
-                      len: usize,
-                      visitor: V) -> Result<V::Value, T::Error>
-        where V: Visitor,
-    {
-        (**self).visit_tuple(len, visitor)
-    }
-
-    fn visit_struct<V>(&mut self,
-                       fields: &'static [&'static str],
-                       visitor: V) -> Result<V::Value, T::Error>
-        where V: Visitor,
-    {
-        (**self).visit_struct(fields, visitor)
-    }
 }

--- a/serde/src/de/value.rs
+++ b/serde/src/de/value.rs
@@ -978,7 +978,8 @@ impl<E> de::Deserializer for ByteBufDeserializer<E>
 
 #[cfg(any(feature = "std", feature = "collections"))]
 mod private {
-    use super::*;
+    use de;
+    use core::marker::PhantomData;
 
     pub struct UnitOnly<E>(PhantomData<E>);
 

--- a/serde/src/de/value.rs
+++ b/serde/src/de/value.rs
@@ -976,7 +976,6 @@ impl<E> de::Deserializer for ByteBufDeserializer<E>
 
 ///////////////////////////////////////////////////////////////////////////////
 
-#[cfg(any(feature = "std", feature = "collections"))]
 mod private {
     use de;
     use core::marker::PhantomData;

--- a/serde/src/macros.rs
+++ b/serde/src/macros.rs
@@ -4,7 +4,7 @@
 macro_rules! forward_to_deserialize_method {
     ($func:ident($($arg:ty),*)) => {
         #[inline]
-        fn $func<__V>(&mut self, $(_: $arg,)* visitor: __V) -> ::std::result::Result<__V::Value, Self::Error>
+        fn $func<__V>(self, $(_: $arg,)* visitor: __V) -> ::std::result::Result<__V::Value, Self::Error>
             where __V: $crate::de::Visitor
         {
             self.deserialize(visitor)
@@ -18,7 +18,7 @@ macro_rules! forward_to_deserialize_method {
 macro_rules! forward_to_deserialize_method {
     ($func:ident($($arg:ty),*)) => {
         #[inline]
-        fn $func<__V>(&mut self, $(_: $arg,)* visitor: __V) -> ::core::result::Result<__V::Value, Self::Error>
+        fn $func<__V>(self, $(_: $arg,)* visitor: __V) -> ::core::result::Result<__V::Value, Self::Error>
             where __V: $crate::de::Visitor
         {
             self.deserialize(visitor)
@@ -128,7 +128,7 @@ macro_rules! forward_to_deserialize_helper {
 ///
 /// ```rust,ignore
 /// impl Deserializer for MyDeserializer {
-///     fn deserialize<V>(&mut self, visitor: V) -> Result<V::Value, Self::Error>
+///     fn deserialize<V>(self, visitor: V) -> Result<V::Value, Self::Error>
 ///         where V: Visitor
 ///     {
 ///         /* ... */

--- a/serde_test/src/de.rs
+++ b/serde_test/src/de.rs
@@ -3,11 +3,13 @@ use std::iter;
 use serde::de::{
     self,
     Deserialize,
+    EnumVisitor,
     MapVisitor,
     SeqVisitor,
     VariantVisitor,
     Visitor,
 };
+use serde::de::value::ValueDeserializer;
 
 use error::Error;
 use token::Token;
@@ -44,7 +46,7 @@ impl<I> Deserializer<I>
         }
     }
 
-    fn visit_seq<V>(&mut self, len: Option<usize>, mut visitor: V) -> Result<V::Value, Error>
+    fn visit_seq<V>(&mut self, len: Option<usize>, visitor: V) -> Result<V::Value, Error>
         where V: Visitor,
     {
         let value = try!(visitor.visit_seq(DeserializerSeqVisitor {
@@ -55,7 +57,7 @@ impl<I> Deserializer<I>
         Ok(value)
     }
 
-    fn visit_array<V>(&mut self, len: usize, mut visitor: V) -> Result<V::Value, Error>
+    fn visit_array<V>(&mut self, len: usize, visitor: V) -> Result<V::Value, Error>
         where V: Visitor,
     {
         let value = try!(visitor.visit_seq(DeserializerArrayVisitor {
@@ -66,7 +68,7 @@ impl<I> Deserializer<I>
         Ok(value)
     }
 
-    fn visit_tuple<V>(&mut self, len: usize, mut visitor: V) -> Result<V::Value, Error>
+    fn visit_tuple<V>(&mut self, len: usize, visitor: V) -> Result<V::Value, Error>
         where V: Visitor,
     {
         let value = try!(visitor.visit_seq(DeserializerTupleVisitor {
@@ -77,7 +79,7 @@ impl<I> Deserializer<I>
         Ok(value)
     }
 
-    fn visit_tuple_struct<V>(&mut self, len: usize, mut visitor: V) -> Result<V::Value, Error>
+    fn visit_tuple_struct<V>(&mut self, len: usize, visitor: V) -> Result<V::Value, Error>
         where V: Visitor,
     {
         let value = try!(visitor.visit_seq(DeserializerTupleStructVisitor {
@@ -88,7 +90,7 @@ impl<I> Deserializer<I>
         Ok(value)
     }
 
-    fn visit_variant_seq<V>(&mut self, len: Option<usize>, mut visitor: V) -> Result<V::Value, Error>
+    fn visit_variant_seq<V>(&mut self, len: Option<usize>, visitor: V) -> Result<V::Value, Error>
         where V: Visitor,
     {
         let value = try!(visitor.visit_seq(DeserializerVariantSeqVisitor {
@@ -99,7 +101,7 @@ impl<I> Deserializer<I>
         Ok(value)
     }
 
-    fn visit_map<V>(&mut self, len: Option<usize>, mut visitor: V) -> Result<V::Value, Error>
+    fn visit_map<V>(&mut self, len: Option<usize>, visitor: V) -> Result<V::Value, Error>
         where V: Visitor,
     {
         let value = try!(visitor.visit_map(DeserializerMapVisitor {
@@ -110,7 +112,7 @@ impl<I> Deserializer<I>
         Ok(value)
     }
 
-    fn visit_struct<V>(&mut self, fields: &'static [&'static str], mut visitor: V) -> Result<V::Value, Error>
+    fn visit_struct<V>(&mut self, fields: &'static [&'static str], visitor: V) -> Result<V::Value, Error>
         where V: Visitor,
     {
         let value = try!(visitor.visit_map(DeserializerStructVisitor {
@@ -121,7 +123,7 @@ impl<I> Deserializer<I>
         Ok(value)
     }
 
-    fn visit_variant_map<V>(&mut self, len: Option<usize>, mut visitor: V) -> Result<V::Value, Error>
+    fn visit_variant_map<V>(&mut self, len: Option<usize>, visitor: V) -> Result<V::Value, Error>
         where V: Visitor,
     {
         let value = try!(visitor.visit_map(DeserializerVariantMapVisitor {
@@ -133,101 +135,101 @@ impl<I> Deserializer<I>
     }
 }
 
-impl<I> de::Deserializer for Deserializer<I>
+impl<'a, I> de::Deserializer for &'a mut Deserializer<I>
     where I: Iterator<Item=Token<'static>>,
 {
     type Error = Error;
 
-    fn deserialize_seq<__V>(&mut self, visitor: __V) -> Result<__V::Value, Self::Error>
+    fn deserialize_seq<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
         where __V: de::Visitor {
         self.deserialize(visitor)
     }
-    fn deserialize_struct_field<__V>(&mut self, visitor: __V) -> Result<__V::Value, Self::Error>
+    fn deserialize_struct_field<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
         where __V: de::Visitor {
         self.deserialize(visitor)
     }
-    fn deserialize_map<__V>(&mut self, visitor: __V) -> Result<__V::Value, Self::Error>
+    fn deserialize_map<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
         where __V: de::Visitor {
         self.deserialize(visitor)
     }
-    fn deserialize_unit<__V>(&mut self, visitor: __V) -> Result<__V::Value, Self::Error>
+    fn deserialize_unit<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
         where __V: de::Visitor {
         self.deserialize(visitor)
     }
-    fn deserialize_bytes<__V>(&mut self, visitor: __V) -> Result<__V::Value, Self::Error>
+    fn deserialize_bytes<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
         where __V: de::Visitor {
         self.deserialize(visitor)
     }
-    fn deserialize_ignored_any<__V>(&mut self, visitor: __V) -> Result<__V::Value, Self::Error>
+    fn deserialize_ignored_any<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
         where __V: de::Visitor {
         self.deserialize(visitor)
     }
-    fn deserialize_string<__V>(&mut self, visitor: __V) -> Result<__V::Value, Self::Error>
+    fn deserialize_string<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
         where __V: de::Visitor {
         self.deserialize(visitor)
     }
-    fn deserialize_str<__V>(&mut self, visitor: __V) -> Result<__V::Value, Self::Error>
+    fn deserialize_str<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
         where __V: de::Visitor {
         self.deserialize(visitor)
     }
-    fn deserialize_char<__V>(&mut self, visitor: __V) -> Result<__V::Value, Self::Error>
+    fn deserialize_char<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
         where __V: de::Visitor {
         self.deserialize(visitor)
     }
-    fn deserialize_i64<__V>(&mut self, visitor: __V) -> Result<__V::Value, Self::Error>
+    fn deserialize_i64<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
         where __V: de::Visitor {
         self.deserialize(visitor)
     }
-    fn deserialize_i32<__V>(&mut self, visitor: __V) -> Result<__V::Value, Self::Error>
+    fn deserialize_i32<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
         where __V: de::Visitor {
         self.deserialize(visitor)
     }
-    fn deserialize_i16<__V>(&mut self, visitor: __V) -> Result<__V::Value, Self::Error>
+    fn deserialize_i16<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
         where __V: de::Visitor {
         self.deserialize(visitor)
     }
-    fn deserialize_i8<__V>(&mut self, visitor: __V) -> Result<__V::Value, Self::Error>
+    fn deserialize_i8<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
         where __V: de::Visitor {
         self.deserialize(visitor)
     }
-    fn deserialize_u64<__V>(&mut self, visitor: __V) -> Result<__V::Value, Self::Error>
+    fn deserialize_u64<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
         where __V: de::Visitor {
         self.deserialize(visitor)
     }
-    fn deserialize_u32<__V>(&mut self, visitor: __V) -> Result<__V::Value, Self::Error>
+    fn deserialize_u32<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
         where __V: de::Visitor {
         self.deserialize(visitor)
     }
-    fn deserialize_u16<__V>(&mut self, visitor: __V) -> Result<__V::Value, Self::Error>
+    fn deserialize_u16<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
         where __V: de::Visitor {
         self.deserialize(visitor)
     }
-    fn deserialize_u8<__V>(&mut self, visitor: __V) -> Result<__V::Value, Self::Error>
+    fn deserialize_u8<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
         where __V: de::Visitor {
         self.deserialize(visitor)
     }
-    fn deserialize_f32<__V>(&mut self, visitor: __V) -> Result<__V::Value, Self::Error>
+    fn deserialize_f32<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
         where __V: de::Visitor {
         self.deserialize(visitor)
     }
-    fn deserialize_f64<__V>(&mut self, visitor: __V) -> Result<__V::Value, Self::Error>
+    fn deserialize_f64<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
         where __V: de::Visitor {
         self.deserialize(visitor)
     }
-    fn deserialize_bool<__V>(&mut self, visitor: __V) -> Result<__V::Value, Self::Error>
+    fn deserialize_bool<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
         where __V: de::Visitor {
         self.deserialize(visitor)
     }
-    fn deserialize_usize<__V>(&mut self, visitor: __V) -> Result<__V::Value, Self::Error>
+    fn deserialize_usize<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
         where __V: de::Visitor {
         self.deserialize(visitor)
     }
-    fn deserialize_isize<__V>(&mut self, visitor: __V) -> Result<__V::Value, Self::Error>
+    fn deserialize_isize<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
         where __V: de::Visitor {
         self.deserialize(visitor)
     }
 
-    fn deserialize<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
+    fn deserialize<V>(self, visitor: V) -> Result<V::Value, Error>
         where V: Visitor,
     {
         match self.tokens.next() {
@@ -271,7 +273,7 @@ impl<I> de::Deserializer for Deserializer<I>
 
     /// Hook into `Option` deserializing so we can treat `Unit` as a
     /// `None`, or a regular value as `Some(value)`.
-    fn deserialize_option<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Error>
         where V: Visitor,
     {
         match self.tokens.peek() {
@@ -292,17 +294,17 @@ impl<I> de::Deserializer for Deserializer<I>
         }
     }
 
-    fn deserialize_enum<V>(&mut self,
+    fn deserialize_enum<V>(self,
                      name: &str,
                      _variants: &'static [&'static str],
-                     mut visitor: V) -> Result<V::Value, Error>
+                     visitor: V) -> Result<V::Value, Error>
         where V: Visitor,
     {
         match self.tokens.peek() {
             Some(&Token::EnumStart(n)) if name == n => {
                 self.tokens.next();
 
-                visitor.visit_enum(DeserializerVariantVisitor {
+                visitor.visit_enum(DeserializerEnumVisitor {
                     de: self,
                 })
             }
@@ -310,7 +312,7 @@ impl<I> de::Deserializer for Deserializer<I>
             | Some(&Token::EnumNewType(n, _))
             | Some(&Token::EnumSeqStart(n, _, _))
             | Some(&Token::EnumMapStart(n, _, _)) if name == n => {
-                visitor.visit_enum(DeserializerVariantVisitor {
+                visitor.visit_enum(DeserializerEnumVisitor {
                     de: self,
                 })
             }
@@ -322,7 +324,7 @@ impl<I> de::Deserializer for Deserializer<I>
         }
     }
 
-    fn deserialize_unit_struct<V>(&mut self, name: &str, mut visitor: V) -> Result<V::Value, Error>
+    fn deserialize_unit_struct<V>(self, name: &str, visitor: V) -> Result<V::Value, Error>
         where V: Visitor,
     {
         match self.tokens.peek() {
@@ -339,9 +341,9 @@ impl<I> de::Deserializer for Deserializer<I>
         }
     }
 
-    fn deserialize_newtype_struct<V>(&mut self,
+    fn deserialize_newtype_struct<V>(self,
                                      name: &str,
-                                     mut visitor: V) -> Result<V::Value, Error>
+                                     visitor: V) -> Result<V::Value, Error>
         where V: Visitor,
     {
         match self.tokens.peek() {
@@ -358,7 +360,7 @@ impl<I> de::Deserializer for Deserializer<I>
         }
     }
 
-    fn deserialize_seq_fixed_size<V>(&mut self,
+    fn deserialize_seq_fixed_size<V>(self,
                                        len: usize,
                                        visitor: V) -> Result<V::Value, Error>
         where V: Visitor,
@@ -373,9 +375,9 @@ impl<I> de::Deserializer for Deserializer<I>
         }
     }
 
-    fn deserialize_tuple<V>(&mut self,
+    fn deserialize_tuple<V>(self,
                             len: usize,
-                            mut visitor: V) -> Result<V::Value, Error>
+                            visitor: V) -> Result<V::Value, Error>
         where V: Visitor,
     {
         match self.tokens.peek() {
@@ -408,10 +410,10 @@ impl<I> de::Deserializer for Deserializer<I>
         }
     }
 
-    fn deserialize_tuple_struct<V>(&mut self,
+    fn deserialize_tuple_struct<V>(self,
                                    name: &str,
                                    len: usize,
-                                   mut visitor: V) -> Result<V::Value, Error>
+                                   visitor: V) -> Result<V::Value, Error>
         where V: Visitor,
     {
         match self.tokens.peek() {
@@ -452,7 +454,7 @@ impl<I> de::Deserializer for Deserializer<I>
         }
     }
 
-    fn deserialize_struct<V>(&mut self,
+    fn deserialize_struct<V>(self,
                              name: &str,
                              fields: &'static [&'static str],
                              visitor: V) -> Result<V::Value, Error>
@@ -496,7 +498,7 @@ impl<'a, I> SeqVisitor for DeserializerSeqVisitor<'a, I>
             Some(&Token::SeqSep) => {
                 self.de.tokens.next();
                 self.len = self.len.map(|len| len - 1);
-                Ok(Some(try!(Deserialize::deserialize(self.de))))
+                Deserialize::deserialize(&mut *self.de).map(Some)
             }
             Some(&Token::SeqEnd) => Ok(None),
             Some(_) => {
@@ -532,7 +534,7 @@ impl<'a, I> SeqVisitor for DeserializerArrayVisitor<'a, I>
             Some(&Token::SeqSep) => {
                 self.de.tokens.next();
                 self.len -= 1;
-                Ok(Some(try!(Deserialize::deserialize(self.de))))
+                Deserialize::deserialize(&mut *self.de).map(Some)
             }
             Some(&Token::SeqEnd) => Ok(None),
             Some(_) => {
@@ -567,7 +569,7 @@ impl<'a, I> SeqVisitor for DeserializerTupleVisitor<'a, I>
             Some(&Token::TupleSep) => {
                 self.de.tokens.next();
                 self.len -= 1;
-                Ok(Some(try!(Deserialize::deserialize(self.de))))
+                Deserialize::deserialize(&mut *self.de).map(Some)
             }
             Some(&Token::TupleEnd) => Ok(None),
             Some(_) => {
@@ -602,7 +604,7 @@ impl<'a, I> SeqVisitor for DeserializerTupleStructVisitor<'a, I>
             Some(&Token::TupleStructSep) => {
                 self.de.tokens.next();
                 self.len -= 1;
-                Ok(Some(try!(Deserialize::deserialize(self.de))))
+                Deserialize::deserialize(&mut *self.de).map(Some)
             }
             Some(&Token::TupleStructEnd) => Ok(None),
             Some(_) => {
@@ -637,7 +639,7 @@ impl<'a, I> SeqVisitor for DeserializerVariantSeqVisitor<'a, I>
             Some(&Token::EnumSeqSep) => {
                 self.de.tokens.next();
                 self.len = self.len.map(|len| len - 1);
-                Ok(Some(try!(Deserialize::deserialize(self.de))))
+                Deserialize::deserialize(&mut *self.de).map(Some)
             }
             Some(&Token::EnumSeqEnd) => Ok(None),
             Some(_) => {
@@ -673,7 +675,7 @@ impl<'a, I> MapVisitor for DeserializerMapVisitor<'a, I>
             Some(&Token::MapSep) => {
                 self.de.tokens.next();
                 self.len = self.len.map(|len| if len > 0 { len - 1} else { 0 });
-                Ok(Some(try!(Deserialize::deserialize(self.de))))
+                Deserialize::deserialize(&mut *self.de).map(Some)
             }
             Some(&Token::MapEnd) => Ok(None),
             Some(_) => {
@@ -687,7 +689,7 @@ impl<'a, I> MapVisitor for DeserializerMapVisitor<'a, I>
     fn visit_value<V>(&mut self) -> Result<V, Error>
         where V: Deserialize,
     {
-        Ok(try!(Deserialize::deserialize(self.de)))
+        Deserialize::deserialize(&mut *self.de)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -715,7 +717,7 @@ impl<'a, I> MapVisitor for DeserializerStructVisitor<'a, I>
             Some(&Token::StructSep) => {
                 self.de.tokens.next();
                 self.len = self.len.saturating_sub(1);
-                Ok(Some(try!(Deserialize::deserialize(self.de))))
+                Deserialize::deserialize(&mut *self.de).map(Some)
             }
             Some(&Token::StructEnd) => Ok(None),
             Some(_) => {
@@ -729,7 +731,7 @@ impl<'a, I> MapVisitor for DeserializerStructVisitor<'a, I>
     fn visit_value<V>(&mut self) -> Result<V, Error>
         where V: Deserialize,
     {
-        Ok(try!(Deserialize::deserialize(self.de)))
+        Deserialize::deserialize(&mut *self.de)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -739,16 +741,17 @@ impl<'a, I> MapVisitor for DeserializerStructVisitor<'a, I>
 
 //////////////////////////////////////////////////////////////////////////
 
-struct DeserializerVariantVisitor<'a, I: 'a> where I: Iterator<Item=Token<'static>> {
+struct DeserializerEnumVisitor<'a, I: 'a> where I: Iterator<Item=Token<'static>> {
     de: &'a mut Deserializer<I>,
 }
 
-impl<'a, I> VariantVisitor for DeserializerVariantVisitor<'a, I>
+impl<'a, I> EnumVisitor for DeserializerEnumVisitor<'a, I>
     where I: Iterator<Item=Token<'static>>,
 {
     type Error = Error;
+    type Variant = Self;
 
-    fn visit_variant<V>(&mut self) -> Result<V, Error>
+    fn visit_variant<V>(self) -> Result<(V, Self), Error>
         where V: Deserialize,
     {
         match self.de.tokens.peek() {
@@ -756,18 +759,25 @@ impl<'a, I> VariantVisitor for DeserializerVariantVisitor<'a, I>
             | Some(&Token::EnumNewType(_, v))
             | Some(&Token::EnumSeqStart(_, v, _))
             | Some(&Token::EnumMapStart(_, v, _)) => {
-                let mut de = de::value::ValueDeserializer::<Error>::into_deserializer(v);
-                let value = try!(Deserialize::deserialize(&mut de));
-                Ok(value)
+                let de = v.into_deserializer();
+                let value = try!(Deserialize::deserialize(de));
+                Ok((value, self))
             }
             Some(_) => {
-                Deserialize::deserialize(self.de)
+                let value = try!(Deserialize::deserialize(&mut *self.de));
+                Ok((value, self))
             }
             None => Err(Error::EndOfStream),
         }
     }
+}
 
-    fn visit_unit(&mut self) -> Result<(), Error> {
+impl<'a, I> VariantVisitor for DeserializerEnumVisitor<'a, I>
+    where I: Iterator<Item=Token<'static>>
+{
+    type Error = Error;
+
+    fn visit_unit(self) -> Result<(), Error> {
         match self.de.tokens.peek() {
             Some(&Token::EnumUnit(_, _)) => {
                 self.de.tokens.next();
@@ -780,7 +790,7 @@ impl<'a, I> VariantVisitor for DeserializerVariantVisitor<'a, I>
         }
     }
 
-    fn visit_newtype<T>(&mut self) -> Result<T, Self::Error>
+    fn visit_newtype<T>(self) -> Result<T, Self::Error>
         where T: Deserialize,
     {
         match self.de.tokens.peek() {
@@ -795,7 +805,7 @@ impl<'a, I> VariantVisitor for DeserializerVariantVisitor<'a, I>
         }
     }
 
-    fn visit_tuple<V>(&mut self,
+    fn visit_tuple<V>(self,
                       len: usize,
                       visitor: V) -> Result<V::Value, Error>
         where V: Visitor,
@@ -826,7 +836,7 @@ impl<'a, I> VariantVisitor for DeserializerVariantVisitor<'a, I>
         }
     }
 
-    fn visit_struct<V>(&mut self,
+    fn visit_struct<V>(self,
                        fields: &'static [&'static str],
                        visitor: V) -> Result<V::Value, Error>
         where V: Visitor,
@@ -877,7 +887,7 @@ impl<'a, I> MapVisitor for DeserializerVariantMapVisitor<'a, I>
             Some(&Token::EnumMapSep) => {
                 self.de.tokens.next();
                 self.len = self.len.map(|len| if len > 0 { len - 1} else { 0 });
-                Ok(Some(try!(Deserialize::deserialize(self.de))))
+                Deserialize::deserialize(&mut *self.de).map(Some)
             }
             Some(&Token::EnumMapEnd) => Ok(None),
             Some(_) => {
@@ -891,7 +901,7 @@ impl<'a, I> MapVisitor for DeserializerVariantMapVisitor<'a, I>
     fn visit_value<V>(&mut self) -> Result<V, Error>
         where V: Deserialize,
     {
-        Ok(try!(Deserialize::deserialize(self.de)))
+        Deserialize::deserialize(&mut *self.de)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/testing/tests/test_annotations.rs
+++ b/testing/tests/test_annotations.rs
@@ -25,7 +25,7 @@ trait SerializeWith: Sized {
 }
 
 trait DeserializeWith: Sized {
-    fn deserialize_with<D>(de: &mut D) -> Result<Self, D::Error>
+    fn deserialize_with<D>(de: D) -> Result<Self, D::Error>
         where D: Deserializer;
 }
 
@@ -50,7 +50,7 @@ impl SerializeWith for i32 {
 }
 
 impl DeserializeWith for i32 {
-    fn deserialize_with<D>(de: &mut D) -> Result<Self, D::Error>
+    fn deserialize_with<D>(de: D) -> Result<Self, D::Error>
         where D: Deserializer
     {
         if try!(Deserialize::deserialize(de)) {
@@ -239,7 +239,7 @@ impl Default for NotDeserializeStruct {
 }
 
 impl DeserializeWith for NotDeserializeStruct {
-    fn deserialize_with<D>(_: &mut D) -> Result<Self, D::Error>
+    fn deserialize_with<D>(_: D) -> Result<Self, D::Error>
         where D: Deserializer
     {
         panic!()

--- a/testing/tests/test_gen.rs
+++ b/testing/tests/test_gen.rs
@@ -299,7 +299,7 @@ trait SerializeWith {
 }
 
 trait DeserializeWith: Sized {
-    fn deserialize_with<D: Deserializer>(_: &mut D) -> StdResult<Self, D::Error>;
+    fn deserialize_with<D: Deserializer>(_: D) -> StdResult<Self, D::Error>;
 }
 
 // Implements neither Serialize nor Deserialize
@@ -309,7 +309,7 @@ fn ser_x<S: Serializer>(_: &X, _: &mut S) -> StdResult<(), S::Error> {
     unimplemented!()
 }
 
-fn de_x<D: Deserializer>(_: &mut D) -> StdResult<X, D::Error> {
+fn de_x<D: Deserializer>(_: D) -> StdResult<X, D::Error> {
     unimplemented!()
 }
 
@@ -320,7 +320,7 @@ impl SerializeWith for X {
 }
 
 impl DeserializeWith for X {
-    fn deserialize_with<D: Deserializer>(_: &mut D) -> StdResult<Self, D::Error> {
+    fn deserialize_with<D: Deserializer>(_: D) -> StdResult<Self, D::Error> {
         unimplemented!()
     }
 }


### PR DESCRIPTION
This ensures Deserialize::deserialize calls Deserializer::deserialize_\* at most once.

Half of #651.