### PR TITLE
Restore visit_usize and visit_bytes for identifying variants

### DIFF
--- a/testing/tests/test_de.rs
+++ b/testing/tests/test_de.rs
@@ -774,6 +774,13 @@ declare_tests! {
             Token::EnumMapEnd,
         ],
     }
+    test_enum_unit_usize {
+        Enum::Unit => &[
+            Token::EnumStart("Enum"),
+            Token::Usize(0),
+            Token::Unit,
+        ],
+    }
     test_box {
         Box::new(0i32) => &[Token::I32(0)],
     }
@@ -918,13 +925,13 @@ declare_error_tests! {
         ],
         Error::DuplicateField("a"),
     }
-    test_enum_unit_usize<Enum> {
+    test_enum_out_of_range<Enum> {
         &[
             Token::EnumStart("Enum"),
-            Token::Usize(0),
+            Token::Usize(4),
             Token::Unit,
         ],
-        Error::InvalidType(Type::U64),
+        Error::InvalidValue("expected variant index 0 <= i < 4".to_owned()),
     }
     test_enum_unit_bytes<Enum> {
         &[

--- a/testing/tests/test_de.rs
+++ b/testing/tests/test_de.rs
@@ -3,7 +3,7 @@ use std::net;
 use std::path::PathBuf;
 use std::time::Duration;
 
-use serde::de::{Deserialize, Type};
+use serde::de::Deserialize;
 
 extern crate fnv;
 use self::fnv::FnvHasher;
@@ -781,6 +781,13 @@ declare_tests! {
             Token::Unit,
         ],
     }
+    test_enum_unit_bytes {
+        Enum::Unit => &[
+            Token::EnumStart("Enum"),
+            Token::Bytes(b"Unit"),
+            Token::Unit,
+        ],
+    }
     test_box {
         Box::new(0i32) => &[Token::I32(0)],
     }
@@ -932,13 +939,5 @@ declare_error_tests! {
             Token::Unit,
         ],
         Error::InvalidValue("expected variant index 0 <= i < 4".to_owned()),
-    }
-    test_enum_unit_bytes<Enum> {
-        &[
-            Token::EnumStart("Enum"),
-            Token::Bytes(b"Unit"),
-            Token::Unit,
-        ],
-        Error::InvalidType(Type::Bytes),
     }
 }


### PR DESCRIPTION
I removed this in #671 but it is still used by Bincode [here](https://github.com/TyOverby/bincode/blob/54205283375e6a3d79e6506225f8e15a7cab7520/src/serde/reader.rs#L519-L520).