### PR TITLE
Expose number of variants when serializing enum

### DIFF
--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -74,6 +74,7 @@ use super::{
     SerializeStruct,
     SerializeTuple,
     Serializer,
+    SerializeEnum,
 };
 
 #[cfg(feature = "unstable")]
@@ -654,6 +655,8 @@ impl<'a, T: ?Sized> Serialize for Cow<'a, T>
 
 ///////////////////////////////////////////////////////////////////////////////
 
+const RESULT_VARIANTS: &'static [&'static str] = &["Ok", "Err"];
+
 impl<T, E> Serialize for Result<T, E>
     where T: Serialize,
           E: Serialize
@@ -663,10 +666,18 @@ impl<T, E> Serialize for Result<T, E>
     {
         match *self {
             Result::Ok(ref value) => {
-                serializer.serialize_newtype_variant("Result", 0, "Ok", value)
+                let ser = try!(serializer.serialize_enum(
+                    "Result",
+                    RESULT_VARIANTS,
+                ));
+                ser.serialize_newtype_variant(0, value)
             }
             Result::Err(ref value) => {
-                serializer.serialize_newtype_variant("Result", 1, "Err", value)
+                let ser = try!(serializer.serialize_enum(
+                    "Result",
+                    RESULT_VARIANTS,
+                ));
+                ser.serialize_newtype_variant(1, value)
             }
         }
     }

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -664,21 +664,13 @@ impl<T, E> Serialize for Result<T, E>
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where S: Serializer
     {
+        let ser = try!(serializer.serialize_enum(
+            "Result",
+            RESULT_VARIANTS,
+        ));
         match *self {
-            Result::Ok(ref value) => {
-                let ser = try!(serializer.serialize_enum(
-                    "Result",
-                    RESULT_VARIANTS,
-                ));
-                ser.serialize_newtype_variant(0, value)
-            }
-            Result::Err(ref value) => {
-                let ser = try!(serializer.serialize_enum(
-                    "Result",
-                    RESULT_VARIANTS,
-                ));
-                ser.serialize_newtype_variant(1, value)
-            }
+            Result::Ok(ref value) => ser.serialize_newtype_variant(0, value),
+            Result::Err(ref value) => ser.serialize_newtype_variant(1, value),
         }
     }
 }

--- a/serde_codegen/src/de.rs
+++ b/serde_codegen/src/de.rs
@@ -501,7 +501,11 @@ fn deserialize_item_enum(
         true,
     );
 
-    let variant_names = variants.iter().map(|variant| variant.attrs.name().deserialize_name());
+    let variant_names = variants.iter().filter_map(|variant| if variant.attrs.skip_deserializing() {
+        None
+    } else {
+        Some(variant.attrs.name().deserialize_name())
+    });
 
     let variants_stmt = quote! {
         const VARIANTS: &'static [&'static str] = &[ #(#variant_names),* ];

--- a/serde_test/src/error.rs
+++ b/serde_test/src/error.rs
@@ -15,6 +15,7 @@ pub enum Error {
     InvalidType(de::Type),
     InvalidLength(usize),
     UnknownVariant(String),
+    UnknownDiscriminant(usize),
     UnknownField(String),
     MissingField(&'static str),
     DuplicateField(&'static str),

--- a/serde_test/src/token.rs
+++ b/serde_test/src/token.rs
@@ -26,9 +26,9 @@ pub enum Token<'a> {
 
     StructNewType(&'a str),
 
-    EnumStart(&'a str),
-    EnumUnit(&'a str, &'a str),
-    EnumNewType(&'a str, &'a str),
+    EnumStart(&'a str, &'a [&'a str]),
+    EnumUnit(usize),
+    EnumNewType(usize),
 
     SeqStart(Option<usize>),
     SeqArrayStart(usize),
@@ -51,11 +51,11 @@ pub enum Token<'a> {
     StructSep,
     StructEnd,
 
-    EnumSeqStart(&'a str, &'a str, usize),
+    EnumSeqStart(usize, usize),
     EnumSeqSep,
     EnumSeqEnd,
 
-    EnumMapStart(&'a str, &'a str, usize),
+    EnumMapStart(usize, usize),
     EnumMapSep,
     EnumMapEnd,
 }

--- a/testing/tests/test_annotations.rs
+++ b/testing/tests/test_annotations.rs
@@ -140,12 +140,15 @@ enum DefaultEnum<A, B, C, D, E>
     }
 }
 
+const STRUCT: &'static[&'static str] = &["Struct"];
+
 #[test]
 fn test_default_enum() {
     assert_de_tokens(
         &DefaultEnum::Struct { a1: 1, a2: 2, a3: 3, a4: 0, a5: 123 },
         &[
-            Token::EnumMapStart("DefaultEnum", "Struct", 5),
+            Token::EnumStart("DefaultEnum", STRUCT),
+            Token::EnumMapStart(0, 5),
 
             Token::EnumMapSep,
             Token::Str("a1"),
@@ -174,7 +177,8 @@ fn test_default_enum() {
     assert_de_tokens(
         &DefaultEnum::Struct { a1: 1, a2: 0, a3: 123, a4: 0, a5: 123 },
         &[
-            Token::EnumMapStart("DefaultEnum", "Struct", 5),
+            Token::EnumStart("DefaultEnum", STRUCT),
+            Token::EnumMapStart(0, 5),
 
             Token::EnumMapSep,
             Token::Str("a1"),
@@ -445,19 +449,25 @@ enum RenameEnumSerializeDeserialize<A> {
     },
 }
 
+const SUPERHEROS: &'static [&'static str] = &["bruce_wayne", "clark_kent", "diana_prince", "barry_allan"];
+const ROBIN: &'static [&'static str] = &["dick_grayson"];
+const ROBIN2: &'static [&'static str] = &["jason_todd"];
+
 #[test]
 fn test_rename_enum() {
     assert_tokens(
         &RenameEnum::Batman,
         &[
-            Token::EnumUnit("Superhero", "bruce_wayne"),
+            Token::EnumStart("Superhero", SUPERHEROS),
+            Token::EnumUnit(0),
         ]
     );
 
     assert_tokens(
         &RenameEnum::Superman(0),
         &[
-            Token::EnumNewType("Superhero", "clark_kent"),
+            Token::EnumStart("Superhero", SUPERHEROS),
+            Token::EnumNewType(1),
             Token::I8(0),
         ]
     );
@@ -465,7 +475,8 @@ fn test_rename_enum() {
     assert_tokens(
         &RenameEnum::WonderWoman(0, 1),
         &[
-            Token::EnumSeqStart("Superhero", "diana_prince", 2),
+            Token::EnumStart("Superhero", SUPERHEROS),
+            Token::EnumSeqStart(2, 2),
 
             Token::EnumSeqSep,
             Token::I8(0),
@@ -480,7 +491,8 @@ fn test_rename_enum() {
     assert_tokens(
         &RenameEnum::Flash { a: 1 },
         &[
-            Token::EnumMapStart("Superhero", "barry_allan", 1),
+            Token::EnumStart("Superhero", SUPERHEROS),
+            Token::EnumMapStart(3, 1),
 
             Token::EnumMapSep,
             Token::Str("b"),
@@ -496,7 +508,8 @@ fn test_rename_enum() {
             b: String::new(),
         },
         &[
-            Token::EnumMapStart("SuperheroSer", "dick_grayson", 2),
+            Token::EnumStart("SuperheroSer", ROBIN),
+            Token::EnumMapStart(0, 2),
 
             Token::EnumMapSep,
             Token::Str("a"),
@@ -516,7 +529,8 @@ fn test_rename_enum() {
             b: String::new(),
         },
         &[
-            Token::EnumMapStart("SuperheroDe", "jason_todd", 2),
+            Token::EnumStart("SuperheroDe", ROBIN2),
+            Token::EnumMapStart(0, 2),
 
             Token::EnumMapSep,
             Token::Str("a"),
@@ -603,7 +617,8 @@ fn test_skip_serializing_enum() {
             c: 3,
         },
         &[
-            Token::EnumMapStart("SkipSerializingEnum", "Struct", 2),
+            Token::EnumStart("SkipSerializingEnum", &["Struct"]),
+            Token::EnumMapStart(0, 2),
 
             Token::EnumMapSep,
             Token::Str("a"),
@@ -624,7 +639,8 @@ fn test_skip_serializing_enum() {
             c: 123,
         },
         &[
-            Token::EnumMapStart("SkipSerializingEnum", "Struct", 1),
+            Token::EnumStart("SkipSerializingEnum", &["Struct"]),
+            Token::EnumMapStart(0, 1),
 
             Token::EnumMapSep,
             Token::Str("a"),
@@ -756,7 +772,8 @@ fn test_serialize_with_enum() {
             b: 2,
         },
         &[
-            Token::EnumMapStart("SerializeWithEnum", "Struct", 2),
+            Token::EnumStart("SerializeWithEnum", &["Struct"]),
+            Token::EnumMapStart(0, 2),
 
             Token::EnumMapSep,
             Token::Str("a"),
@@ -776,7 +793,8 @@ fn test_serialize_with_enum() {
             b: 123,
         },
         &[
-            Token::EnumMapStart("SerializeWithEnum", "Struct", 2),
+            Token::EnumStart("SerializeWithEnum", &["Struct"]),
+            Token::EnumMapStart(0, 2),
 
             Token::EnumMapSep,
             Token::Str("a"),
@@ -858,7 +876,8 @@ fn test_deserialize_with_enum() {
             b: 2,
         },
         &[
-            Token::EnumMapStart("DeserializeWithEnum", "Struct", 2),
+            Token::EnumStart("DeserializeWithEnum", STRUCT),
+            Token::EnumMapStart(0, 2),
 
             Token::EnumMapSep,
             Token::Str("a"),
@@ -878,7 +897,8 @@ fn test_deserialize_with_enum() {
             b: 123,
         },
         &[
-            Token::EnumMapStart("DeserializeWithEnum", "Struct", 2),
+            Token::EnumStart("DeserializeWithEnum", STRUCT),
+            Token::EnumMapStart(0, 2),
 
             Token::EnumMapSep,
             Token::Str("a"),
@@ -926,7 +946,8 @@ fn test_missing_renamed_field_struct() {
 fn test_missing_renamed_field_enum() {
     assert_de_tokens_error::<RenameEnum>(
         &[
-            Token::EnumMapStart("Superhero", "barry_allan", 1),
+            Token::EnumStart("Superhero", SUPERHEROS),
+            Token::EnumMapStart(3, 1),
 
             Token::EnumMapEnd,
         ],
@@ -935,7 +956,8 @@ fn test_missing_renamed_field_enum() {
 
     assert_de_tokens_error::<RenameEnumSerializeDeserialize<i8>>(
         &[
-            Token::EnumMapStart("SuperheroDe", "jason_todd", 2),
+            Token::EnumStart("SuperheroDe", ROBIN2),
+            Token::EnumMapStart(0, 2),
 
             Token::EnumMapSep,
             Token::Str("a"),
@@ -953,11 +975,14 @@ enum InvalidLengthEnum {
     B(#[serde(skip_deserializing)] i32, i32, i32),
 }
 
+const INVALID_LEN_ENUM: &'static [&'static str] = &["A", "B"];
+
 #[test]
 fn test_invalid_length_enum() {
     assert_de_tokens_error::<InvalidLengthEnum>(
         &[
-            Token::EnumSeqStart("InvalidLengthEnum", "A", 3),
+            Token::EnumStart("InvalidLengthEnum", INVALID_LEN_ENUM),
+            Token::EnumSeqStart(0, 3),
                 Token::EnumSeqSep,
                 Token::I32(1),
             Token::EnumSeqEnd,
@@ -966,7 +991,8 @@ fn test_invalid_length_enum() {
     );
     assert_de_tokens_error::<InvalidLengthEnum>(
         &[
-            Token::EnumSeqStart("InvalidLengthEnum", "B", 3),
+            Token::EnumStart("InvalidLengthEnum", INVALID_LEN_ENUM),
+            Token::EnumSeqStart(1, 3),
                 Token::EnumSeqSep,
                 Token::I32(1),
             Token::EnumSeqEnd,

--- a/testing/tests/test_macros.rs
+++ b/testing/tests/test_macros.rs
@@ -275,7 +275,8 @@ fn test_ser_enum_unit() {
     assert_ser_tokens(
         &SerEnum::Unit::<u32, u32, u32>,
         &[
-            Token::EnumUnit("SerEnum", "Unit"),
+            Token::EnumStart("SerEnum", &["Unit", "Seq", "Map", "_Unit2", "_Seq2", "_Map2"]),
+            Token::EnumUnit(0),
         ]
     );
 }
@@ -295,7 +296,8 @@ fn test_ser_enum_seq() {
             &mut d,
         ),
         &[
-            Token::EnumSeqStart("SerEnum", "Seq", 4),
+            Token::EnumStart("SerEnum", &["Unit", "Seq", "Map", "_Unit2", "_Seq2", "_Map2"]),
+            Token::EnumSeqStart(1, 4),
 
             Token::EnumSeqSep,
             Token::I8(1),
@@ -329,7 +331,8 @@ fn test_ser_enum_map() {
             d: &mut d,
         },
         &[
-            Token::EnumMapStart("SerEnum", "Map", 4),
+            Token::EnumStart("SerEnum", &["Unit", "Seq", "Map", "_Unit2", "_Seq2", "_Map2"]),
+            Token::EnumMapStart(2, 4),
 
             Token::EnumMapSep,
             Token::Str("a"),
@@ -352,12 +355,15 @@ fn test_ser_enum_map() {
     );
 }
 
+const DEENUM: &'static[&'static str] = &["Unit", "Seq", "Map", "_Unit2", "_Seq2", "_Map2"];
+
 #[test]
 fn test_de_enum_unit() {
     assert_tokens(
         &DeEnum::Unit::<u32, u32, u32>,
         &[
-            Token::EnumUnit("DeEnum", "Unit"),
+            Token::EnumStart("DeEnum", DEENUM),
+            Token::EnumUnit(0),
         ],
     );
 }
@@ -377,7 +383,8 @@ fn test_de_enum_seq() {
             d,
         ),
         &[
-            Token::EnumSeqStart("DeEnum", "Seq", 4),
+            Token::EnumStart("DeEnum", DEENUM),
+            Token::EnumSeqStart(1, 4),
 
             Token::EnumSeqSep,
             Token::I8(1),
@@ -411,7 +418,8 @@ fn test_de_enum_map() {
             d: d,
         },
         &[
-            Token::EnumMapStart("DeEnum", "Map", 4),
+            Token::EnumStart("DeEnum", DEENUM),
+            Token::EnumMapStart(2, 4),
 
             Token::EnumMapSep,
             Token::Str("a"),
@@ -434,6 +442,8 @@ fn test_de_enum_map() {
     );
 }
 
+const LIFETIMES: &'static[&'static str] = &["LifetimeSeq", "NoLifetimeSeq", "LifetimeMap", "NoLifetimeMap"];
+
 #[test]
 fn test_lifetimes() {
     let value = 5;
@@ -441,7 +451,8 @@ fn test_lifetimes() {
     assert_ser_tokens(
         &Lifetimes::LifetimeSeq(&value),
         &[
-            Token::EnumNewType("Lifetimes", "LifetimeSeq"),
+            Token::EnumStart("Lifetimes", LIFETIMES),
+            Token::EnumNewType(0),
             Token::I32(5),
         ]
     );
@@ -449,7 +460,8 @@ fn test_lifetimes() {
     assert_ser_tokens(
         &Lifetimes::NoLifetimeSeq(5),
         &[
-            Token::EnumNewType("Lifetimes", "NoLifetimeSeq"),
+            Token::EnumStart("Lifetimes", LIFETIMES),
+            Token::EnumNewType(1),
             Token::I32(5),
         ]
     );
@@ -457,7 +469,8 @@ fn test_lifetimes() {
     assert_ser_tokens(
         &Lifetimes::LifetimeMap { a: &value },
         &[
-            Token::EnumMapStart("Lifetimes", "LifetimeMap", 1),
+            Token::EnumStart("Lifetimes", LIFETIMES),
+            Token::EnumMapStart(2, 1),
 
             Token::EnumMapSep,
             Token::Str("a"),
@@ -470,7 +483,8 @@ fn test_lifetimes() {
     assert_ser_tokens(
         &Lifetimes::NoLifetimeMap { a: 5 },
         &[
-            Token::EnumMapStart("Lifetimes", "NoLifetimeMap", 1),
+            Token::EnumStart("Lifetimes", LIFETIMES),
+            Token::EnumMapStart(3, 1),
 
             Token::EnumMapSep,
             Token::Str("a"),
@@ -526,12 +540,15 @@ fn test_generic_tuple_struct() {
     );
 }
 
+const GENERIC: &'static [&'static str] = &["Unit", "NewType", "Seq", "Map"];
+
 #[test]
 fn test_generic_enum_unit() {
     assert_tokens(
         &GenericEnum::Unit::<u32, u32>,
         &[
-            Token::EnumUnit("GenericEnum", "Unit"),
+            Token::EnumStart("GenericEnum", GENERIC),
+            Token::EnumUnit(0),
         ]
     );
 }
@@ -541,7 +558,8 @@ fn test_generic_enum_newtype() {
     assert_tokens(
         &GenericEnum::NewType::<u32, u32>(5),
         &[
-            Token::EnumNewType("GenericEnum", "NewType"),
+            Token::EnumStart("GenericEnum", GENERIC),
+            Token::EnumNewType(1),
             Token::U32(5),
         ]
     );
@@ -552,7 +570,8 @@ fn test_generic_enum_seq() {
     assert_tokens(
         &GenericEnum::Seq::<u32, u32>(5, 6),
         &[
-            Token::EnumSeqStart("GenericEnum", "Seq", 2),
+            Token::EnumStart("GenericEnum", GENERIC),
+            Token::EnumSeqStart(2, 2),
 
             Token::EnumSeqSep,
             Token::U32(5),
@@ -570,7 +589,8 @@ fn test_generic_enum_map() {
     assert_tokens(
         &GenericEnum::Map::<u32, u32> { x: 5, y: 6 },
         &[
-            Token::EnumMapStart("GenericEnum", "Map", 2),
+            Token::EnumStart("GenericEnum", GENERIC),
+            Token::EnumMapStart(3, 2),
 
             Token::EnumMapSep,
             Token::Str("x"),
@@ -608,10 +628,13 @@ fn test_enum_state_field() {
         Key { key: char, state: bool },
     }
 
+    const SOME: &'static [&'static str] = &["Key"];
+
     assert_tokens(
         &SomeEnum::Key { key: 'a', state: true },
         &[
-            Token::EnumMapStart("SomeEnum", "Key", 2),
+            Token::EnumStart("SomeEnum", SOME),
+            Token::EnumMapStart(0, 2),
 
             Token::EnumMapSep,
             Token::Str("key"),

--- a/testing/tests/test_ser.rs
+++ b/testing/tests/test_ser.rs
@@ -93,11 +93,13 @@ declare_ser_tests! {
     }
     test_result {
         Ok::<i32, i32>(0) => &[
-            Token::EnumNewType("Result", "Ok"),
+            Token::EnumStart("Result", &["Ok", "Err"]),
+            Token::EnumNewType(0),
             Token::I32(0),
         ],
         Err::<i32, i32>(1) => &[
-            Token::EnumNewType("Result", "Err"),
+            Token::EnumStart("Result", &["Ok", "Err"]),
+            Token::EnumNewType(1),
             Token::I32(1),
         ],
     }
@@ -298,10 +300,18 @@ declare_ser_tests! {
         ],
     }
     test_enum {
-        Enum::Unit => &[Token::EnumUnit("Enum", "Unit")],
-        Enum::One(42) => &[Token::EnumNewType("Enum", "One"), Token::I32(42)],
+        Enum::Unit => &[
+            Token::EnumStart("Enum", &["Unit", "One", "Seq", "Map"]),
+            Token::EnumUnit(0)
+        ],
+        Enum::One(42) => &[
+            Token::EnumStart("Enum", &["Unit", "One", "Seq", "Map"]),
+            Token::EnumNewType(1),
+            Token::I32(42),
+        ],
         Enum::Seq(1, 2) => &[
-            Token::EnumSeqStart("Enum", "Seq", 2),
+            Token::EnumStart("Enum", &["Unit", "One", "Seq", "Map"]),
+            Token::EnumSeqStart(2, 2),
                 Token::EnumSeqSep,
                 Token::I32(1),
 
@@ -310,7 +320,8 @@ declare_ser_tests! {
             Token::EnumSeqEnd,
         ],
         Enum::Map { a: 1, b: 2 } => &[
-            Token::EnumMapStart("Enum", "Map", 2),
+            Token::EnumStart("Enum", &["Unit", "One", "Seq", "Map"]),
+            Token::EnumMapStart(3, 2),
                 Token::EnumMapSep,
                 Token::Str("a"),
                 Token::I32(1),
@@ -447,18 +458,18 @@ fn test_cannot_serialize_paths() {
 fn test_enum_skipped() {
     assert_ser_tokens_error(
         &Enum::SkippedUnit,
-        &[],
+        &[Token::EnumStart("Enum", &["Unit", "One", "Seq", "Map"])],
         Error::InvalidValue("The enum variant Enum::SkippedUnit cannot be serialized".to_owned()));
     assert_ser_tokens_error(
         &Enum::SkippedOne(42),
-        &[],
+        &[Token::EnumStart("Enum", &["Unit", "One", "Seq", "Map"])],
         Error::InvalidValue("The enum variant Enum::SkippedOne cannot be serialized".to_owned()));
     assert_ser_tokens_error(
         &Enum::SkippedSeq(1, 2),
-        &[],
+        &[Token::EnumStart("Enum", &["Unit", "One", "Seq", "Map"])],
         Error::InvalidValue("The enum variant Enum::SkippedSeq cannot be serialized".to_owned()));
     assert_ser_tokens_error(
         &Enum::SkippedMap { _a: 1, _b: 2 },
-        &[],
+        &[Token::EnumStart("Enum", &["Unit", "One", "Seq", "Map"])],
         Error::InvalidValue("The enum variant Enum::SkippedMap cannot be serialized".to_owned()));
 }


### PR DESCRIPTION
fixes #663 

drive-by fix for deserializing enums with skipped variants