### PR TITLE
Inline <PhantomData<T> as DeserializeSeed>::deserialize

### DIFF
--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -367,6 +367,7 @@ impl<T> DeserializeSeed for PhantomData<T>
 {
     type Value = T;
 
+    #[inline]
     fn deserialize<D>(self, deserializer: D) -> Result<T, D::Error>
         where D: Deserializer
     {


### PR DESCRIPTION
This fixes a 2-5% performance regression in deserialization due to the DeserializeSeed change. https://github.com/serde-rs/serde/issues/650#issuecomment-273939785