### PR TITLE
Errors redesign

### DIFF
--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde"
-version = "0.9.0-rc1"
+version = "0.9.0-rc2"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "A generic serialization/deserialization framework"

--- a/serde/src/bytes.rs
+++ b/serde/src/bytes.rs
@@ -181,6 +181,10 @@ mod bytebuf {
     impl de::Visitor for ByteBufVisitor {
         type Value = ByteBuf;
 
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("byte array")
+        }
+
         #[inline]
         fn visit_unit<E>(self) -> Result<ByteBuf, E>
             where E: de::Error,

--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -295,7 +295,7 @@ impl Visitor for StringVisitor {
     {
         match str::from_utf8(v) {
             Ok(s) => Ok(s.to_owned()),
-            Err(_) => Err(Error::invalid_value(Unexpected::Bytes, &self)),
+            Err(_) => Err(Error::invalid_value(Unexpected::Bytes(v), &self)),
         }
     }
 
@@ -304,7 +304,7 @@ impl Visitor for StringVisitor {
     {
         match String::from_utf8(v) {
             Ok(s) => Ok(s),
-            Err(_) => Err(Error::invalid_value(Unexpected::Bytes, &self)),
+            Err(e) => Err(Error::invalid_value(Unexpected::Bytes(&e.into_bytes()), &self)),
         }
     }
 }
@@ -1180,7 +1180,7 @@ impl<T, E> Deserialize for Result<T, E> where T: Deserialize, E: Deserialize {
                             _ => {
                                 match str::from_utf8(value) {
                                     Ok(value) => Err(Error::unknown_variant(value, VARIANTS)),
-                                    Err(_) => Err(Error::invalid_value(Unexpected::Bytes, &self)),
+                                    Err(_) => Err(Error::invalid_value(Unexpected::Bytes(value), &self)),
                                 }
                             }
                         }

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -237,6 +237,9 @@ pub enum Unexpected<'a> {
     /// The input contained a `&str` or `String` that was not expected.
     Str(&'a str),
 
+    /// The input contained a `&[u8]` or `Vec<u8>` that was not expected.
+    Bytes(&'a [u8]),
+
     /// The input contained a unit `()` that was not expected.
     Unit,
 
@@ -266,9 +269,6 @@ pub enum Unexpected<'a> {
 
     /// The input contained a struct variant that was not expected.
     StructVariant,
-
-    /// The input contained a `&[u8]` or `Vec<u8>` that was not expected.
-    Bytes,
 }
 
 impl<'a> fmt::Display for Unexpected<'a> {
@@ -281,6 +281,7 @@ impl<'a> fmt::Display for Unexpected<'a> {
             Float(f) => write!(formatter, "floating point `{}`", f),
             Char(c) => write!(formatter, "character `{}`", c),
             Str(s) => write!(formatter, "string {:?}", s),
+            Bytes(_) => write!(formatter, "byte array"),
             Unit => write!(formatter, "unit value"),
             Option => write!(formatter, "Option value"),
             NewtypeStruct => write!(formatter, "newtype struct"),
@@ -291,7 +292,6 @@ impl<'a> fmt::Display for Unexpected<'a> {
             NewtypeVariant => write!(formatter, "newtype variant"),
             TupleVariant => write!(formatter, "tuple variant"),
             StructVariant => write!(formatter, "struct variant"),
-            Bytes => write!(formatter, "byte array"),
         }
     }
 }
@@ -942,7 +942,7 @@ pub trait Visitor: Sized {
         where E: Error,
     {
         let _ = v;
-        Err(Error::invalid_type(Unexpected::Bytes, &self))
+        Err(Error::invalid_type(Unexpected::Bytes(v), &self))
     }
 
     /// `visit_byte_buf` deserializes a `Vec<u8>` into a `Value`.

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -269,6 +269,13 @@ pub enum Unexpected<'a> {
 
     /// The input contained a struct variant that was not expected.
     StructVariant,
+
+    /// A message stating what uncategorized thing the input contained that was
+    /// not expected.
+    ///
+    /// The message should be a noun or noun phrase, not capitalized and without
+    /// a period. An example message is "unoriginal superhero".
+    Other(&'a str),
 }
 
 impl<'a> fmt::Display for Unexpected<'a> {
@@ -292,6 +299,7 @@ impl<'a> fmt::Display for Unexpected<'a> {
             NewtypeVariant => write!(formatter, "newtype variant"),
             TupleVariant => write!(formatter, "tuple variant"),
             StructVariant => write!(formatter, "struct variant"),
+            Other(other) => formatter.write_str(other),
         }
     }
 }

--- a/serde/src/de/value.rs
+++ b/serde/src/de/value.rs
@@ -28,6 +28,10 @@ use collections::{
 };
 #[cfg(all(feature = "collections", not(feature = "std")))]
 use collections::borrow::Cow;
+#[cfg(all(feature = "collections", not(feature = "std")))]
+use collections::boxed::Box;
+#[cfg(all(feature = "collections", not(feature = "std")))]
+use collections::string::ToString;
 
 #[cfg(all(feature = "unstable", feature = "collections"))]
 use collections::borrow::ToOwned;

--- a/serde/src/error.rs
+++ b/serde/src/error.rs
@@ -1,5 +1,4 @@
 //! A stand-in for `std::error`
-use core::any::TypeId;
 use core::fmt::{Debug, Display};
 
 /// A stand-in for `std::error::Error`, which requires no allocation.
@@ -13,10 +12,4 @@ pub trait Error: Debug + Display {
 
     /// The lower-level cause of this error, if any.
     fn cause(&self) -> Option<&Error> { None }
-
-    /// Get the `TypeId` of `self`
-    #[doc(hidden)]
-    fn type_id(&self) -> TypeId where Self: 'static {
-        TypeId::of::<Self>()
-    }
 }

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -40,11 +40,6 @@ mod core {
 pub use ser::{Serialize, Serializer};
 pub use de::{Deserialize, Deserializer};
 
-#[cfg(not(feature = "std"))]
-macro_rules! format {
-    ($s:expr, $($rest:tt)*) => ($s)
-}
-
 #[macro_use]
 mod macros;
 

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -772,7 +772,7 @@ impl Serialize for path::Path {
     {
         match self.to_str() {
             Some(s) => s.serialize(serializer),
-            None => Err(Error::invalid_value("Path contains invalid UTF-8 characters")),
+            None => Err(Error::custom("Path contains invalid UTF-8 characters")),
         }
     }
 }

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -23,6 +23,8 @@ use core::marker::PhantomData;
 #[cfg(feature = "unstable")]
 use core::cell::RefCell;
 
+use core::fmt::Display;
+
 pub mod impls;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -31,17 +33,7 @@ pub mod impls;
 /// `Serializer` error.
 pub trait Error: Sized + error::Error {
     /// Raised when there is a general error when serializing a type.
-    #[cfg(any(feature = "std", feature = "collections"))]
-    fn custom<T: Into<String>>(msg: T) -> Self;
-
-    /// Raised when there is a general error when serializing a type.
-    #[cfg(all(not(feature = "std"), not(feature = "collections")))]
-    fn custom<T: Into<&'static str>>(msg: T) -> Self;
-
-    /// Raised when a `Serialize` was passed an incorrect value.
-    fn invalid_value(msg: &str) -> Self {
-        Error::custom(format!("invalid value: {}", msg))
-    }
+    fn custom<T: Display>(msg: T) -> Self;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/serde_codegen/Cargo.toml
+++ b/serde_codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_codegen"
-version = "0.9.0-rc1"
+version = "0.9.0-rc2"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Macros to auto-generate implementations for the serde framework"

--- a/serde_codegen/src/ser.rs
+++ b/serde_codegen/src/ser.rs
@@ -257,10 +257,10 @@ fn serialize_variant(
     let variant_name = variant.attrs.name().serialize_name();
 
     if variant.attrs.skip_serializing() {
-        let skipped_msg = format!("The enum variant {}::{} cannot be serialized",
+        let skipped_msg = format!("the enum variant {}::{} cannot be serialized",
                                 type_ident, variant_ident);
         let skipped_err = quote! {
-            Err(_serde::ser::Error::invalid_value(#skipped_msg))
+            Err(_serde::ser::Error::custom(#skipped_msg))
         };
         let fields_pat = match variant.style {
             Style::Unit => quote!(),

--- a/serde_derive/Cargo.toml
+++ b/serde_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_derive"
-version = "0.9.0-rc1"
+version = "0.9.0-rc2"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Macros 1.1 implementation of #[derive(Serialize, Deserialize)]"
@@ -15,7 +15,7 @@ name = "serde_derive"
 proc-macro = true
 
 [dependencies.serde_codegen]
-version = "=0.9.0-rc1"
+version = "=0.9.0-rc2"
 path = "../serde_codegen"
 default-features = false
 features = ["with-syn"]
@@ -23,5 +23,5 @@ features = ["with-syn"]
 [dev-dependencies]
 compiletest_rs = "^0.2.0"
 fnv = "1.0"
-serde = { version = "0.9.0-rc1", path = "../serde" }
-serde_test = { version = "0.9.0-rc1", path = "../serde_test" }
+serde = { version = "0.9.0-rc2", path = "../serde" }
+serde_test = { version = "0.9.0-rc2", path = "../serde_test" }

--- a/serde_test/Cargo.toml
+++ b/serde_test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_test"
-version = "0.9.0-rc1"
+version = "0.9.0-rc2"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Token De/Serializer for testing De/Serialize implementations"
@@ -12,4 +12,4 @@ keywords = ["serde", "serialization"]
 include = ["Cargo.toml", "src/**/*.rs"]
 
 [dependencies]
-serde = { version = "0.9.0-rc1", path = "../serde" }
+serde = { version = "0.9.0-rc2", path = "../serde" }

--- a/serde_test/src/de.rs
+++ b/serde_test/src/de.rs
@@ -43,7 +43,7 @@ impl<I> Deserializer<I>
                     Err(Error::UnexpectedToken(token))
                 }
             }
-            None => Err(Error::EndOfStream),
+            None => Err(Error::EndOfTokens),
         }
     }
 
@@ -259,7 +259,7 @@ impl<'a, I> de::Deserializer for &'a mut Deserializer<I>
             Some(Token::Option(false)) => visitor.visit_none(),
             Some(Token::Option(true)) => visitor.visit_some(self),
             Some(Token::Unit) => visitor.visit_unit(),
-            Some(Token::UnitStruct(name)) => visitor.visit_unit_struct(name),
+            Some(Token::UnitStruct(_name)) => visitor.visit_unit(),
             Some(Token::SeqStart(len)) => {
                 self.visit_seq(len, visitor)
             }
@@ -273,7 +273,7 @@ impl<'a, I> de::Deserializer for &'a mut Deserializer<I>
                 self.visit_map(Some(len), visitor)
             }
             Some(token) => Err(Error::UnexpectedToken(token)),
-            None => Err(Error::EndOfStream),
+            None => Err(Error::EndOfTokens),
         }
     }
 
@@ -296,7 +296,7 @@ impl<'a, I> de::Deserializer for &'a mut Deserializer<I>
                 visitor.visit_none()
             }
             Some(_) => visitor.visit_some(self),
-            None => Err(Error::EndOfStream),
+            None => Err(Error::EndOfTokens),
         }
     }
 
@@ -326,7 +326,7 @@ impl<'a, I> de::Deserializer for &'a mut Deserializer<I>
                 let token = self.tokens.next().unwrap();
                 Err(Error::UnexpectedToken(token))
             }
-            None => { return Err(Error::EndOfStream); }
+            None => { return Err(Error::EndOfTokens); }
         }
     }
 
@@ -343,7 +343,7 @@ impl<'a, I> de::Deserializer for &'a mut Deserializer<I>
                 }
             }
             Some(_) => self.deserialize(visitor),
-            None => Err(Error::EndOfStream),
+            None => Err(Error::EndOfTokens),
         }
     }
 
@@ -362,7 +362,7 @@ impl<'a, I> de::Deserializer for &'a mut Deserializer<I>
                 }
             }
             Some(_) => self.deserialize(visitor),
-            None => Err(Error::EndOfStream),
+            None => Err(Error::EndOfTokens),
         }
     }
 
@@ -377,7 +377,7 @@ impl<'a, I> de::Deserializer for &'a mut Deserializer<I>
                 self.visit_array(len, visitor)
             }
             Some(_) => self.deserialize(visitor),
-            None => Err(Error::EndOfStream),
+            None => Err(Error::EndOfTokens),
         }
     }
 
@@ -412,7 +412,7 @@ impl<'a, I> de::Deserializer for &'a mut Deserializer<I>
                 self.visit_tuple_struct(len, visitor)
             }
             Some(_) => self.deserialize(visitor),
-            None => Err(Error::EndOfStream),
+            None => Err(Error::EndOfTokens),
         }
     }
 
@@ -456,7 +456,7 @@ impl<'a, I> de::Deserializer for &'a mut Deserializer<I>
                 }
             }
             Some(_) => self.deserialize(visitor),
-            None => Err(Error::EndOfStream),
+            None => Err(Error::EndOfTokens),
         }
     }
 
@@ -480,7 +480,7 @@ impl<'a, I> de::Deserializer for &'a mut Deserializer<I>
                 self.visit_map(Some(fields.len()), visitor)
             }
             Some(_) => self.deserialize(visitor),
-            None => Err(Error::EndOfStream),
+            None => Err(Error::EndOfTokens),
         }
     }
 }
@@ -511,7 +511,7 @@ impl<'a, I> SeqVisitor for DeserializerSeqVisitor<'a, I>
                 let token = self.de.tokens.next().unwrap();
                 Err(Error::UnexpectedToken(token))
             }
-            None => Err(Error::EndOfStream),
+            None => Err(Error::EndOfTokens),
         }
     }
 
@@ -547,7 +547,7 @@ impl<'a, I> SeqVisitor for DeserializerArrayVisitor<'a, I>
                 let token = self.de.tokens.next().unwrap();
                 Err(Error::UnexpectedToken(token))
             }
-            None => Err(Error::EndOfStream),
+            None => Err(Error::EndOfTokens),
         }
     }
 
@@ -582,7 +582,7 @@ impl<'a, I> SeqVisitor for DeserializerTupleVisitor<'a, I>
                 let token = self.de.tokens.next().unwrap();
                 Err(Error::UnexpectedToken(token))
             }
-            None => Err(Error::EndOfStream),
+            None => Err(Error::EndOfTokens),
         }
     }
 
@@ -617,7 +617,7 @@ impl<'a, I> SeqVisitor for DeserializerTupleStructVisitor<'a, I>
                 let token = self.de.tokens.next().unwrap();
                 Err(Error::UnexpectedToken(token))
             }
-            None => Err(Error::EndOfStream),
+            None => Err(Error::EndOfTokens),
         }
     }
 
@@ -652,7 +652,7 @@ impl<'a, I> SeqVisitor for DeserializerVariantSeqVisitor<'a, I>
                 let token = self.de.tokens.next().unwrap();
                 Err(Error::UnexpectedToken(token))
             }
-            None => Err(Error::EndOfStream),
+            None => Err(Error::EndOfTokens),
         }
     }
 
@@ -688,7 +688,7 @@ impl<'a, I> MapVisitor for DeserializerMapVisitor<'a, I>
                 let token = self.de.tokens.next().unwrap();
                 Err(Error::UnexpectedToken(token))
             }
-            None => Err(Error::EndOfStream),
+            None => Err(Error::EndOfTokens),
         }
     }
 
@@ -730,7 +730,7 @@ impl<'a, I> MapVisitor for DeserializerStructVisitor<'a, I>
                 let token = self.de.tokens.next().unwrap();
                 Err(Error::UnexpectedToken(token))
             }
-            None => Err(Error::EndOfStream),
+            None => Err(Error::EndOfTokens),
         }
     }
 
@@ -773,7 +773,7 @@ impl<'a, I> EnumVisitor for DeserializerEnumVisitor<'a, I>
                 let value = try!(seed.deserialize(&mut *self.de));
                 Ok((value, self))
             }
-            None => Err(Error::EndOfStream),
+            None => Err(Error::EndOfTokens),
         }
     }
 }
@@ -792,7 +792,7 @@ impl<'a, I> VariantVisitor for DeserializerEnumVisitor<'a, I>
             Some(_) => {
                 Deserialize::deserialize(self.de)
             }
-            None => Err(Error::EndOfStream),
+            None => Err(Error::EndOfTokens),
         }
     }
 
@@ -807,7 +807,7 @@ impl<'a, I> VariantVisitor for DeserializerEnumVisitor<'a, I>
             Some(_) => {
                 seed.deserialize(self.de)
             }
-            None => Err(Error::EndOfStream),
+            None => Err(Error::EndOfTokens),
         }
     }
 
@@ -838,7 +838,7 @@ impl<'a, I> VariantVisitor for DeserializerEnumVisitor<'a, I>
             Some(_) => {
                 de::Deserializer::deserialize(self.de, visitor)
             }
-            None => Err(Error::EndOfStream),
+            None => Err(Error::EndOfTokens),
         }
     }
 
@@ -869,7 +869,7 @@ impl<'a, I> VariantVisitor for DeserializerEnumVisitor<'a, I>
             Some(_) => {
                 de::Deserializer::deserialize(self.de, visitor)
             }
-            None => Err(Error::EndOfStream),
+            None => Err(Error::EndOfTokens),
         }
     }
 }
@@ -900,7 +900,7 @@ impl<'a, I> MapVisitor for DeserializerVariantMapVisitor<'a, I>
                 let token = self.de.tokens.next().unwrap();
                 Err(Error::UnexpectedToken(token))
             }
-            None => Err(Error::EndOfStream),
+            None => Err(Error::EndOfTokens),
         }
     }
 

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_testing"
-version = "0.9.0-rc1"
+version = "0.9.0-rc2"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "A generic serialization/deserialization framework"

--- a/testing/tests/test_annotations.rs
+++ b/testing/tests/test_annotations.rs
@@ -343,7 +343,7 @@ fn test_ignore_unknown() {
             Token::StructSep,
             Token::Str("whoops"),
         ],
-        Error::UnknownField("whoops".to_owned())
+        Error::Message("unknown field `whoops`, expected `a1`".to_owned())
     );
 }
 
@@ -905,7 +905,7 @@ fn test_missing_renamed_field_struct() {
 
             Token::StructEnd,
         ],
-        Error::MissingField("a3"),
+        Error::Message("missing field `a3`".to_owned()),
     );
 
     assert_de_tokens_error::<RenameStructSerializeDeserialize>(
@@ -918,7 +918,7 @@ fn test_missing_renamed_field_struct() {
 
             Token::StructEnd,
         ],
-        Error::MissingField("a5"),
+        Error::Message("missing field `a5`".to_owned()),
     );
 }
 
@@ -930,7 +930,7 @@ fn test_missing_renamed_field_enum() {
 
             Token::EnumMapEnd,
         ],
-        Error::MissingField("b"),
+        Error::Message("missing field `b`".to_owned()),
     );
 
     assert_de_tokens_error::<RenameEnumSerializeDeserialize<i8>>(
@@ -943,7 +943,7 @@ fn test_missing_renamed_field_enum() {
 
             Token::EnumMapEnd,
         ],
-        Error::MissingField("d"),
+        Error::Message("missing field `d`".to_owned()),
     );
 }
 
@@ -962,7 +962,7 @@ fn test_invalid_length_enum() {
                 Token::I32(1),
             Token::EnumSeqEnd,
         ],
-        Error::InvalidLength(1),
+        Error::Message("invalid length 1, expected tuple of 3 elements".to_owned()),
     );
     assert_de_tokens_error::<InvalidLengthEnum>(
         &[
@@ -971,6 +971,6 @@ fn test_invalid_length_enum() {
                 Token::I32(1),
             Token::EnumSeqEnd,
         ],
-        Error::InvalidLength(1),
+        Error::Message("invalid length 1, expected tuple of 2 elements".to_owned()),
     );
 }

--- a/testing/tests/test_de.rs
+++ b/testing/tests/test_de.rs
@@ -3,7 +3,7 @@ use std::net;
 use std::path::PathBuf;
 use std::time::Duration;
 
-use serde::de::{Deserialize, Type};
+use serde::Deserialize;
 
 extern crate fnv;
 use self::fnv::FnvHasher;
@@ -849,7 +849,7 @@ declare_error_tests! {
                 Token::StructSep,
                 Token::Str("d"),
         ],
-        Error::UnknownField("d".to_owned()),
+        Error::Message("unknown field `d`, expected `a` or `b`".to_owned()),
     }
     test_skipped_field_is_unknown<StructDenyUnknown> {
         &[
@@ -857,7 +857,7 @@ declare_error_tests! {
                 Token::StructSep,
                 Token::Str("b"),
         ],
-        Error::UnknownField("b".to_owned()),
+        Error::Message("unknown field `b`, expected `a` or `b`".to_owned()),
     }
     test_skip_all_deny_unknown<StructSkipAllDenyUnknown> {
         &[
@@ -865,25 +865,25 @@ declare_error_tests! {
                 Token::StructSep,
                 Token::Str("a"),
         ],
-        Error::UnknownField("a".to_owned()),
+        Error::Message("unknown field `a`, expected `a`".to_owned()),
     }
     test_unknown_variant<Enum> {
         &[
             Token::EnumUnit("Enum", "Foo"),
         ],
-        Error::UnknownVariant("Foo".to_owned()),
+        Error::Message("unknown variant `Foo`, expected one of `Skipped`, `Unit`, `Simple`, `Seq`, `Map`".to_owned()),
     }
     test_enum_skipped_variant<Enum> {
         &[
             Token::EnumUnit("Enum", "Skipped"),
         ],
-        Error::UnknownVariant("Skipped".to_owned()),
+        Error::Message("unknown variant `Skipped`, expected one of `Skipped`, `Unit`, `Simple`, `Seq`, `Map`".to_owned()),
     }
     test_enum_skip_all<EnumSkipAll> {
         &[
             Token::EnumUnit("EnumSkipAll", "Skipped"),
         ],
-        Error::UnknownVariant("Skipped".to_owned()),
+        Error::Message("unknown variant `Skipped`, expected `Skipped`".to_owned()),
     }
     test_struct_seq_too_long<Struct> {
         &[
@@ -904,7 +904,7 @@ declare_error_tests! {
                 Token::MapSep,
                 Token::Str("a"),
         ],
-        Error::DuplicateField("a"),
+        Error::Message("duplicate field `a`".to_owned()),
     }
     test_duplicate_field_enum<Enum> {
         &[
@@ -916,7 +916,7 @@ declare_error_tests! {
                 Token::EnumMapSep,
                 Token::Str("a"),
         ],
-        Error::DuplicateField("a"),
+        Error::Message("duplicate field `a`".to_owned()),
     }
     test_enum_unit_usize<Enum> {
         &[
@@ -924,7 +924,7 @@ declare_error_tests! {
             Token::Usize(0),
             Token::Unit,
         ],
-        Error::InvalidType(Type::U64),
+        Error::Message("invalid type: integer `0`, expected field name".into()),
     }
     test_enum_unit_bytes<Enum> {
         &[
@@ -932,6 +932,6 @@ declare_error_tests! {
             Token::Bytes(b"Unit"),
             Token::Unit,
         ],
-        Error::InvalidType(Type::Bytes),
+        Error::Message("invalid type: byte array, expected field name".into()),
     }
 }

--- a/testing/tests/test_ser.rs
+++ b/testing/tests/test_ser.rs
@@ -432,7 +432,7 @@ fn test_cannot_serialize_paths() {
     assert_ser_tokens_error(
         &Path::new(path),
         &[],
-        Error::InvalidValue("Path contains invalid UTF-8 characters".to_owned()));
+        Error::Message("Path contains invalid UTF-8 characters".to_owned()));
 
     let mut path_buf = PathBuf::new();
     path_buf.push(path);
@@ -440,7 +440,7 @@ fn test_cannot_serialize_paths() {
     assert_ser_tokens_error(
         &path_buf,
         &[],
-        Error::InvalidValue("Path contains invalid UTF-8 characters".to_owned()));
+        Error::Message("Path contains invalid UTF-8 characters".to_owned()));
 }
 
 #[test]
@@ -448,17 +448,17 @@ fn test_enum_skipped() {
     assert_ser_tokens_error(
         &Enum::SkippedUnit,
         &[],
-        Error::InvalidValue("The enum variant Enum::SkippedUnit cannot be serialized".to_owned()));
+        Error::Message("the enum variant Enum::SkippedUnit cannot be serialized".to_owned()));
     assert_ser_tokens_error(
         &Enum::SkippedOne(42),
         &[],
-        Error::InvalidValue("The enum variant Enum::SkippedOne cannot be serialized".to_owned()));
+        Error::Message("the enum variant Enum::SkippedOne cannot be serialized".to_owned()));
     assert_ser_tokens_error(
         &Enum::SkippedSeq(1, 2),
         &[],
-        Error::InvalidValue("The enum variant Enum::SkippedSeq cannot be serialized".to_owned()));
+        Error::Message("the enum variant Enum::SkippedSeq cannot be serialized".to_owned()));
     assert_ser_tokens_error(
         &Enum::SkippedMap { _a: 1, _b: 2 },
         &[],
-        Error::InvalidValue("The enum variant Enum::SkippedMap cannot be serialized".to_owned()));
+        Error::Message("the enum variant Enum::SkippedMap cannot be serialized".to_owned()));
 }


### PR DESCRIPTION
Fixes #528 and fixes #675 and fixes #709 and fixes #702..

Essentially we rely on every Visitor to tell us what type of data it is expecting. See the doc comments in serde/src/de/mod.rs.

In general my goal is to centralize error message building in Serde rather than leaving it to each individual format to reimplement lousy messages. This is a step in that direction and I have a design for https://github.com/serde-rs/json/issues/173 which I will implement in another PR.