### PR TITLE
Allow running travis build locally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,5 @@ matrix:
   include:
     - rust: nightly
       env: CLIPPY=true
-  allow_failures:
-    - rust: nightly
-      env: CLIPPY=true
-  fast_finish: true
 
 script: ./travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,4 @@ matrix:
       env: CLIPPY=true
   fast_finish: true
 
-before_script:
-  - pip install 'travis-cargo<0.2' --user
-  - export PATH=$HOME/.local/bin:$PATH
-
 script: ./travis.sh
-
-env:
-  global:
-    - TRAVIS_CARGO_NIGHTLY_FEATURE=""

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ matrix:
   include:
     - rust: nightly
       env: CLIPPY=true
+  allow_failures:
+    - rust: nightly
+      env: CLIPPY=true
+  fast_finish: true
 
 before_script:
   - pip install 'travis-cargo<0.2' --user

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
   - pip install 'travis-cargo<0.2' --user
   - export PATH=$HOME/.local/bin:$PATH
 
-script: sh travis.sh
+script: ./travis.sh
 
 env:
   global:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,9 @@
+[workspace]
+members = [
+    "serde",
+    "serde_codegen_internals",
+    "serde_derive",
+    "serde_test",
+    "test_suite",
+    "test_suite/no_std",
+]

--- a/test_suite/deps/Cargo.toml
+++ b/test_suite/deps/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.0.0"
 authors = ["David Tolnay <dtolnay@gmail.com>"]
 publish = false
 
+[workspace]
+
 [dependencies]
 serde = { path = "../../serde" }
 serde_derive = { path = "../../serde_derive" }

--- a/travis.sh
+++ b/travis.sh
@@ -19,7 +19,7 @@ channel() {
 if [ -n "${CLIPPY}" ]; then
     if [ -n "${TRAVIS}" ]; then
         # cached installation will not work on a later nightly
-        cargo install clippy --force
+        cargo install clippy --debug --force
     fi
 
     cd "$DIR/serde"

--- a/travis.sh
+++ b/travis.sh
@@ -1,24 +1,70 @@
 #!/bin/bash
-set -ev
-if [ "${CLIPPY}" = "true" ]; then
-    if cargo install clippy -f; then
-        (cd serde && cargo clippy --features unstable-testing -- -Dclippy)
-        (cd serde_derive && cargo clippy --features unstable-testing -- -Dclippy)
-        (cd test_suite && cargo clippy --features unstable-testing -- -Dclippy)
-        (cd test_suite/deps && cargo clippy -- -Dclippy)
-        (cd test_suite/no_std && cargo clippy -- -Dclippy)
+
+set -e
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+channel() {
+    if [ -n "${TRAVIS}" ]; then
+        if [ "${TRAVIS_RUST_VERSION}" = "${CHANNEL}" ]; then
+            pwd
+            (set -x; cargo "$@")
+        fi
     else
-        echo "could not compile clippy, ignoring clippy tests"
+        pwd
+        (set -x; cargo "+${CHANNEL}" "$@")
     fi
+}
+
+if [ -n "${CLIPPY}" ]; then
+    if [ -n "${TRAVIS}" ]; then
+        # cached installation will not work on a later nightly
+        cargo install clippy --force
+    fi
+
+    cd "$DIR/serde"
+    cargo clippy --features unstable-testing -- -Dclippy
+
+    cd "$DIR/serde_derive"
+    cargo clippy --features unstable-testing -- -Dclippy
+
+    cd "$DIR/test_suite"
+    cargo clippy --features unstable-testing -- -Dclippy
+
+    cd "$DIR/test_suite/no_std"
+    cargo clippy -- -Dclippy
 else
-    (cd serde && travis-cargo build)
-    (cd serde && travis-cargo --only beta test)
-    (cd serde && travis-cargo --only nightly test -- --features unstable-testing)
-    (cd serde && travis-cargo build -- --no-default-features)
-    (cd serde && travis-cargo --only nightly build -- --no-default-features --features alloc)
-    (cd serde && travis-cargo --only nightly build -- --no-default-features --features collections)
-    (cd test_suite && travis-cargo --only beta test)
-    (cd test_suite/deps && travis-cargo --only nightly build)
-    (cd test_suite travis-cargo --only nightly test -- --features unstable-testing)
-    (cd test_suite/no_std && travis-cargo --only nightly build)
+    CHANNEL=nightly
+    cargo clean
+    cd "$DIR/serde"
+    channel build
+    channel build --no-default-features
+    channel build --no-default-features --features alloc
+    channel build --no-default-features --features collections
+    channel test --features unstable-testing
+    cd "$DIR/test_suite/deps"
+    channel build
+    cd "$DIR/test_suite"
+    channel test --features unstable-testing
+    cd "$DIR/test_suite/no_std"
+    channel build
+
+    CHANNEL=beta
+    cargo clean
+    cd "$DIR/serde"
+    channel build
+    cd "$DIR/test_suite"
+    channel test
+
+    CHANNEL=stable
+    cargo clean
+    cd "$DIR/serde"
+    channel build
+    channel build --no-default-features
+
+    CHANNEL=1.13.0
+    cargo clean
+    cd "$DIR/serde"
+    channel build
+    channel build --no-default-features
 fi

--- a/travis.sh
+++ b/travis.sh
@@ -17,9 +17,10 @@ channel() {
 }
 
 if [ -n "${CLIPPY}" ]; then
-    if [ -n "${TRAVIS}" ]; then
-        # cached installation will not work on a later nightly
-        cargo install clippy --debug --force
+    # cached installation will not work on a later nightly
+    if [ -n "${TRAVIS}" ] && ! cargo install clippy --debug --force; then
+        echo "COULD NOT COMPILE CLIPPY, IGNORING CLIPPY TESTS"
+        exit
     fi
 
     cd "$DIR/serde"


### PR DESCRIPTION
This lets me run `./travis.sh` locally and it completes all of the builds against all of the trains in 2 minutes 25 seconds on my machine, which is faster than waiting for Travis.