### PR TITLE
Use absolute paths to Ok, Err, and other types and methods

### DIFF
--- a/serde/src/export.rs
+++ b/serde/src/export.rs
@@ -9,7 +9,7 @@ use collections::borrow::Cow;
 pub use core::default::Default;
 pub use core::fmt;
 pub use core::marker::PhantomData;
-pub use core::result::Result;
+pub use core::result::Result::{self, Ok, Err};
 
 #[cfg(any(feature = "collections", feature = "std"))]
 pub fn from_utf8_lossy(bytes: &[u8]) -> Cow<str> {

--- a/serde/src/export.rs
+++ b/serde/src/export.rs
@@ -9,6 +9,7 @@ use collections::borrow::Cow;
 pub use core::default::Default;
 pub use core::fmt;
 pub use core::marker::PhantomData;
+pub use core::option::Option::{self, None, Some};
 pub use core::result::Result::{self, Ok, Err};
 
 #[cfg(any(feature = "collections", feature = "std"))]

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -79,7 +79,7 @@ extern crate core as actual_core;
 #[cfg(feature = "std")]
 mod core {
     pub use std::{ops, hash, fmt, cmp, marker, mem, i8, i16, i32, i64, u8, u16, u32, u64, isize,
-            usize, f32, f64, char, str, num, slice, iter, cell, default, result};
+            usize, f32, f64, char, str, num, slice, iter, cell, default, result, option};
     #[cfg(feature = "unstable")]
     pub use actual_core::nonzero;
 }

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -216,14 +216,14 @@ fn deserialize_unit_struct(
             fn visit_unit<__E>(self) -> _serde::export::Result<#type_ident, __E>
                 where __E: _serde::de::Error,
             {
-                Ok(#type_ident)
+                _serde::export::Ok(#type_ident)
             }
 
             #[inline]
             fn visit_seq<__V>(self, _: __V) -> _serde::export::Result<#type_ident, __V::Error>
                 where __V: _serde::de::SeqVisitor,
             {
-                Ok(#type_ident)
+                _serde::export::Ok(#type_ident)
             }
         }
 
@@ -357,7 +357,7 @@ fn deserialize_seq(
                     let #var = match #visit {
                         Some(value) => { value },
                         None => {
-                            return Err(_serde::de::Error::invalid_length(#index_in_seq, &#expecting));
+                            return _serde::export::Err(_serde::de::Error::invalid_length(#index_in_seq, &#expecting));
                         }
                     };
                 };
@@ -379,7 +379,7 @@ fn deserialize_seq(
 
     quote! {
         #(#let_values)*
-        Ok(#result)
+        _serde::export::Ok(#result)
     }
 }
 
@@ -411,7 +411,7 @@ fn deserialize_newtype_struct(
         fn visit_newtype_struct<__E>(self, __e: __E) -> _serde::export::Result<Self::Value, __E::Error>
             where __E: _serde::Deserializer,
         {
-            Ok(#type_path(#value))
+            _serde::export::Ok(#type_path(#value))
         }
     }
 }
@@ -563,8 +563,8 @@ fn deserialize_item_enum(
         // all variants have `#[serde(skip_deserializing)]`.
         quote! {
             // FIXME: Once we drop support for Rust 1.15:
-            // let Err(err) = visitor.visit_variant::<__Field>();
-            // Err(err)
+            // let _serde::export::Err(err) = visitor.visit_variant::<__Field>();
+            // _serde::export::Err(err)
             visitor.visit_variant::<__Field>().map(|(impossible, _)| match impossible {})
         }
     } else {
@@ -615,7 +615,7 @@ fn deserialize_variant(
         Style::Unit => {
             quote!({
                 try!(_serde::de::VariantVisitor::visit_unit(visitor));
-                Ok(#type_ident::#variant_ident)
+                _serde::export::Ok(#type_ident::#variant_ident)
             })
         }
         Style::Newtype => {
@@ -673,7 +673,7 @@ fn deserialize_newtype_variant(
         }
     };
     quote! {
-        Ok(#type_ident::#variant_ident(#visit)),
+        _serde::export::Ok(#type_ident::#variant_ident(#visit)),
     }
 }
 
@@ -701,9 +701,9 @@ fn deserialize_field_visitor(
             {
                 match value {
                     #(
-                        #variant_indices => Ok(__Field::#field_idents),
+                        #variant_indices => _serde::export::Ok(__Field::#field_idents),
                     )*
-                    _ => Err(_serde::de::Error::invalid_value(
+                    _ => _serde::export::Err(_serde::de::Error::invalid_value(
                                 _serde::de::Unexpected::Unsigned(value as u64),
                                 &#fallthrough_msg))
                 }
@@ -715,15 +715,15 @@ fn deserialize_field_visitor(
 
     let fallthrough_arm = if is_variant {
         quote! {
-            Err(_serde::de::Error::unknown_variant(value, VARIANTS))
+            _serde::export::Err(_serde::de::Error::unknown_variant(value, VARIANTS))
         }
     } else if item_attrs.deny_unknown_fields() {
         quote! {
-            Err(_serde::de::Error::unknown_field(value, FIELDS))
+            _serde::export::Err(_serde::de::Error::unknown_field(value, FIELDS))
         }
     } else {
         quote! {
-            Ok(__Field::__ignore)
+            _serde::export::Ok(__Field::__ignore)
         }
     };
 
@@ -765,7 +765,7 @@ fn deserialize_field_visitor(
                     {
                         match value {
                             #(
-                                #field_strs => Ok(__Field::#field_idents),
+                                #field_strs => _serde::export::Ok(__Field::#field_idents),
                             )*
                             _ => #fallthrough_arm
                         }
@@ -776,7 +776,7 @@ fn deserialize_field_visitor(
                     {
                         match value {
                             #(
-                                #field_bytes => Ok(__Field::#field_idents),
+                                #field_bytes => _serde::export::Ok(__Field::#field_idents),
                             )*
                             _ => {
                                 #bytes_to_str
@@ -878,7 +878,7 @@ fn deserialize_map(
             quote! {
                 __Field::#name => {
                     if #name.is_some() {
-                        return Err(<__V::Error as _serde::de::Error>::duplicate_field(#deser_name));
+                        return _serde::export::Err(<__V::Error as _serde::de::Error>::duplicate_field(#deser_name));
                     }
                     #name = Some(#visit);
                 }
@@ -943,7 +943,7 @@ fn deserialize_map(
 
         #(#extract_values)*
 
-        Ok(#struct_path { #(#result),* })
+        _serde::export::Ok(#struct_path { #(#result),* })
     }
 }
 
@@ -990,7 +990,7 @@ fn wrap_deserialize_with(
                     where __D: _serde::Deserializer
                 {
                     let value = try!(#deserialize_with(__d));
-                    Ok(__SerdeDeserializeWithStruct {
+                    _serde::export::Ok(__SerdeDeserializeWithStruct {
                         value: value,
                         phantom: _serde::export::PhantomData,
                     })
@@ -1021,7 +1021,7 @@ fn expr_is_missing(attrs: &attr::Field) -> Tokens {
         }
         Some(_) => {
             quote! {
-                return Err(<__V::Error as _serde::de::Error>::missing_field(#name))
+                return _serde::export::Err(<__V::Error as _serde::de::Error>::missing_field(#name))
             }
         }
     }

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -260,7 +260,7 @@ fn serialize_variant(
         let skipped_msg = format!("the enum variant {}::{} cannot be serialized",
                                 type_ident, variant_ident);
         let skipped_err = quote! {
-            Err(_serde::ser::Error::custom(#skipped_msg))
+            _serde::export::Err(_serde::ser::Error::custom(#skipped_msg))
         };
         let fields_pat = match variant.style {
             Style::Unit => quote!(),

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -125,7 +125,7 @@ fn serialize_unit_struct(item_attrs: &attr::Item) -> Tokens {
     let type_name = item_attrs.name().serialize_name();
 
     quote! {
-        _serializer.serialize_unit_struct(#type_name)
+        _serde::Serializer::serialize_unit_struct(_serializer, #type_name)
     }
 }
 
@@ -144,7 +144,7 @@ fn serialize_newtype_struct(
     }
 
     quote! {
-        _serializer.serialize_newtype_struct(#type_name, #field_expr)
+        _serde::Serializer::serialize_newtype_struct(_serializer, #type_name, #field_expr)
     }
 }
 
@@ -167,7 +167,7 @@ fn serialize_tuple_struct(
     let let_mut = mut_if(len > 0);
 
     quote! {
-        let #let_mut __serde_state = try!(_serializer.serialize_tuple_struct(#type_name, #len));
+        let #let_mut __serde_state = try!(_serde::Serializer::serialize_tuple_struct(_serializer, #type_name, #len));
         #(#serialize_stmts)*
         _serde::ser::SerializeTupleStruct::end(__serde_state)
     }
@@ -208,7 +208,7 @@ fn serialize_struct(
         .fold(quote!(0), |sum, expr| quote!(#sum + #expr));
 
     quote! {
-        let #let_mut __serde_state = try!(_serializer.serialize_struct(#type_name, #len));
+        let #let_mut __serde_state = try!(_serde::Serializer::serialize_struct(_serializer, #type_name, #len));
         #(#serialize_fields)*
         _serde::ser::SerializeStruct::end(__serde_state)
     }
@@ -380,7 +380,8 @@ fn serialize_tuple_variant(
     let let_mut = mut_if(len > 0);
 
     quote! {
-        let #let_mut __serde_state = try!(_serializer.serialize_tuple_variant(
+        let #let_mut __serde_state = try!(_serde::Serializer::serialize_tuple_variant(
+            _serializer,
             #type_name,
             #variant_index,
             #variant_name,
@@ -426,7 +427,8 @@ fn serialize_struct_variant(
         .fold(quote!(0), |sum, expr| quote!(#sum + #expr));
 
     quote! {
-        let #let_mut __serde_state = try!(_serializer.serialize_struct_variant(
+        let #let_mut __serde_state = try!(_serde::Serializer::serialize_struct_variant(
+            _serializer,
             #item_name,
             #variant_index,
             #variant_name,
@@ -537,7 +539,7 @@ fn wrap_serialize_with(
     quote!({
         struct __SerializeWith #wrapper_generics #where_clause {
             value: &'__a #field_ty,
-            phantom: ::std::marker::PhantomData<#item_ty>,
+            phantom: _serde::export::PhantomData<#item_ty>,
         }
 
         impl #wrapper_generics _serde::Serialize for #wrapper_ty #where_clause {
@@ -550,7 +552,7 @@ fn wrap_serialize_with(
 
         &__SerializeWith {
             value: #value,
-            phantom: ::std::marker::PhantomData::<#item_ty>,
+            phantom: _serde::export::PhantomData::<#item_ty>,
         }
     })
 }

--- a/test_suite/tests/test_gen.rs
+++ b/test_suite/tests/test_gen.rs
@@ -8,11 +8,15 @@ use self::serde::de::{Deserialize, Deserializer};
 
 use std::borrow::Cow;
 use std::marker::PhantomData;
+use std::result::Result as StdResult;
 
 // Try to trip up the generated code if it fails to use fully qualified paths.
 #[allow(dead_code)]
 struct Result;
-use std::result::Result as StdResult;
+#[allow(dead_code)]
+struct Ok;
+#[allow(dead_code)]
+struct Err;
 
 //////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Fixes #737.