### PR TITLE
Untagged and internally tagged enums

### DIFF
--- a/serde/src/de/content.rs
+++ b/serde/src/de/content.rs
@@ -537,11 +537,17 @@ impl<E> Deserializer for Content<E>
             Content::Newtype(v) => visitor.visit_newtype_struct(*v),
             Content::Seq(v) => {
                 let seq = v.into_iter();
-                visitor.visit_seq(de::value::SeqDeserializer::new(seq))
+                let mut seq_visitor = de::value::SeqDeserializer::new(seq);
+                let value = try!(visitor.visit_seq(&mut seq_visitor));
+                try!(seq_visitor.end());
+                Ok(value)
             },
             Content::Map(v) => {
                 let map = v.into_iter();
-                visitor.visit_map(de::value::MapDeserializer::new(map))
+                let mut map_visitor = de::value::MapDeserializer::new(map);
+                let value = try!(visitor.visit_map(&mut map_visitor));
+                try!(map_visitor.end());
+                Ok(value)
             },
             Content::Bytes(v) => visitor.visit_byte_buf(v),
         }
@@ -611,11 +617,17 @@ impl<'a, E> Deserializer for &'a Content<E>
             Content::Newtype(ref v) => visitor.visit_newtype_struct(&**v),
             Content::Seq(ref v) => {
                 let seq = v.into_iter();
-                visitor.visit_seq(de::value::SeqDeserializer::new(seq))
+                let mut seq_visitor = de::value::SeqDeserializer::new(seq);
+                let value = try!(visitor.visit_seq(&mut seq_visitor));
+                try!(seq_visitor.end());
+                Ok(value)
             },
             Content::Map(ref v) => {
                 let map = v.into_iter().map(|&(ref k, ref v)| (k, v));
-                visitor.visit_map(de::value::MapDeserializer::new(map))
+                let mut map_visitor = de::value::MapDeserializer::new(map);
+                let value = try!(visitor.visit_map(&mut map_visitor));
+                try!(map_visitor.end());
+                Ok(value)
             },
             Content::Bytes(ref v) => visitor.visit_bytes(v),
         }

--- a/serde/src/de/content.rs
+++ b/serde/src/de/content.rs
@@ -1,5 +1,11 @@
-use std::fmt;
-use std::marker::PhantomData;
+use core::fmt;
+use core::marker::PhantomData;
+
+#[cfg(all(not(feature = "std"), feature = "collections"))]
+use collections::{String, Vec};
+
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+use alloc::boxed::Box;
 
 use de::{
     self,

--- a/serde/src/de/content.rs
+++ b/serde/src/de/content.rs
@@ -1,3 +1,15 @@
+// This module is doc(hidden) and nothing here should be used outside of
+// generated code.
+//
+// We will iterate on the implementation for a few releases and only have to
+// worry about backward compatibility for the `untagged` and `tag` attributes
+// rather than for this entire mechanism.
+//
+// This issue is tracking making some of this stuff public:
+// https://github.com/serde-rs/serde/issues/741
+
+#![doc(hidden)]
+
 use core::fmt;
 use core::marker::PhantomData;
 
@@ -22,7 +34,6 @@ use de::{
 /// deserializing untagged enums and internally tagged enums.
 ///
 /// Not public API. Use serde-value instead.
-#[allow(missing_docs)]
 #[derive(Debug)]
 pub enum Content<E> {
     // Don't mind the PhantomData, just need to use E somewhere.

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -115,6 +115,7 @@ mod from_primitive;
 // Helpers used by generated code. Not public API.
 #[doc(hidden)]
 pub mod private;
+#[cfg(any(feature = "std", feature = "collections"))]
 mod content;
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -115,6 +115,7 @@ mod from_primitive;
 // Helpers used by generated code. Not public API.
 #[doc(hidden)]
 pub mod private;
+mod content;
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/serde/src/de/private.rs
+++ b/serde/src/de/private.rs
@@ -2,6 +2,13 @@ use core::marker::PhantomData;
 
 use de::{Deserialize, Deserializer, Error, Visitor};
 
+pub use de::content::{
+    Content,
+    TaggedContentVisitor,
+    InternallyTaggedUnitVisitor,
+    UntaggedUnitVisitor,
+};
+
 /// If the missing field is of type `Option<T>` then treat is as `None`,
 /// otherwise it is an error.
 pub fn missing_field<V, E>(field: &'static str) -> Result<V, E>

--- a/serde/src/de/private.rs
+++ b/serde/src/de/private.rs
@@ -2,6 +2,7 @@ use core::marker::PhantomData;
 
 use de::{Deserialize, Deserializer, Error, Visitor};
 
+#[cfg(any(feature = "std", feature = "collections"))]
 pub use de::content::{
     Content,
     TaggedContentVisitor,

--- a/serde/src/de/value.rs
+++ b/serde/src/de/value.rs
@@ -428,7 +428,9 @@ impl<I, E> SeqDeserializer<I, E>
         }
     }
 
-    fn end(&mut self) -> Result<(), E> {
+    /// Check for remaining elements after passing a `SeqDeserializer` to
+    /// `Visitor::visit_seq`.
+    pub fn end(mut self) -> Result<(), E> {
         let mut remaining = 0;
         while self.iter.next().is_some() {
             remaining += 1;
@@ -610,17 +612,9 @@ impl<I, E> MapDeserializer<I, E>
         }
     }
 
-    fn next_pair(&mut self) -> Option<(<I::Item as private::Pair>::First, <I::Item as private::Pair>::Second)> {
-        match self.iter.next() {
-            Some(kv) => {
-                self.count += 1;
-                Some(private::Pair::split(kv))
-            }
-            None => None,
-        }
-    }
-
-    fn end(&mut self) -> Result<(), E> {
+    /// Check for remaining elements after passing a `MapDeserializer` to
+    /// `Visitor::visit_map`.
+    pub fn end(mut self) -> Result<(), E> {
         let mut remaining = 0;
         while self.iter.next().is_some() {
             remaining += 1;
@@ -631,6 +625,16 @@ impl<I, E> MapDeserializer<I, E>
             // First argument is the number of elements in the data, second
             // argument is the number of elements expected by the Deserialize.
             Err(de::Error::invalid_length(self.count + remaining, &ExpectedInMap(self.count)))
+        }
+    }
+
+    fn next_pair(&mut self) -> Option<(<I::Item as private::Pair>::First, <I::Item as private::Pair>::Second)> {
+        match self.iter.next() {
+            Some(kv) => {
+                self.count += 1;
+                Some(private::Pair::split(kv))
+            }
+            None => None,
         }
     }
 }

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -106,6 +106,10 @@ use core::fmt::Display;
 mod impls;
 mod impossible;
 
+// Helpers used by generated code. Not public API.
+#[doc(hidden)]
+pub mod private;
+
 pub use self::impossible::Impossible;
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/serde/src/ser/private.rs
+++ b/serde/src/ser/private.rs
@@ -1,0 +1,235 @@
+use std::fmt::{self, Display};
+
+use ser::{self, Serialize, Serializer, SerializeMap, SerializeStruct};
+
+/// Not public API.
+pub fn serialize_tagged_newtype<S, T>(
+    serializer: S,
+    type_ident: &'static str,
+    variant_ident: &'static str,
+    tag: &'static str,
+    variant_name: &'static str,
+    value: T,
+) -> Result<S::Ok, S::Error>
+    where S: Serializer,
+          T: Serialize
+{
+    value.serialize(TaggedSerializer {
+        type_ident: type_ident,
+        variant_ident: variant_ident,
+        tag: tag,
+        variant_name: variant_name,
+        delegate: serializer,
+    })
+}
+
+struct TaggedSerializer<S> {
+    type_ident: &'static str,
+    variant_ident: &'static str,
+    tag: &'static str,
+    variant_name: &'static str,
+    delegate: S,
+}
+
+enum Unsupported {
+    Boolean,
+    Integer,
+    Float,
+    Char,
+    String,
+    ByteArray,
+    Optional,
+    Unit,
+    UnitStruct,
+    Sequence,
+    Tuple,
+    TupleStruct,
+    Enum,
+}
+
+impl Display for Unsupported {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Unsupported::Boolean => formatter.write_str("a boolean"),
+            Unsupported::Integer => formatter.write_str("an integer"),
+            Unsupported::Float => formatter.write_str("a float"),
+            Unsupported::Char => formatter.write_str("a char"),
+            Unsupported::String => formatter.write_str("a string"),
+            Unsupported::ByteArray => formatter.write_str("a byte array"),
+            Unsupported::Optional => formatter.write_str("an optional"),
+            Unsupported::Unit => formatter.write_str("unit"),
+            Unsupported::UnitStruct => formatter.write_str("a unit struct"),
+            Unsupported::Sequence => formatter.write_str("a sequence"),
+            Unsupported::Tuple => formatter.write_str("a tuple"),
+            Unsupported::TupleStruct => formatter.write_str("a tuple struct"),
+            Unsupported::Enum => formatter.write_str("an enum"),
+        }
+    }
+}
+
+struct Error {
+    type_ident: &'static str,
+    variant_ident: &'static str,
+    ty: Unsupported,
+}
+
+impl Display for Error {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter,
+               "cannot serialize tagged newtype variant {}::{} containing {}",
+               self.type_ident, self.variant_ident, self.ty)
+    }
+}
+
+impl<S> TaggedSerializer<S>
+    where S: Serializer
+{
+    fn bad_type(self, what: Unsupported) -> S::Error {
+        ser::Error::custom(Error {
+            type_ident: self.type_ident,
+            variant_ident: self.variant_ident,
+            ty: what,
+        })
+    }
+}
+
+impl<S> Serializer for TaggedSerializer<S>
+    where S: Serializer
+{
+    type Ok = S::Ok;
+    type Error = S::Error;
+
+    type SerializeSeq = S::SerializeSeq;
+    type SerializeTuple = S::SerializeTuple;
+    type SerializeTupleStruct = S::SerializeTupleStruct;
+    type SerializeTupleVariant = S::SerializeTupleVariant;
+    type SerializeMap = S::SerializeMap;
+    type SerializeStruct = S::SerializeStruct;
+    type SerializeStructVariant = S::SerializeStructVariant;
+
+    fn serialize_bool(self, _: bool) -> Result<Self::Ok, Self::Error> {
+        Err(self.bad_type(Unsupported::Boolean))
+    }
+
+    fn serialize_i8(self, _: i8) -> Result<Self::Ok, Self::Error> {
+        Err(self.bad_type(Unsupported::Integer))
+    }
+
+    fn serialize_i16(self, _: i16) -> Result<Self::Ok, Self::Error> {
+        Err(self.bad_type(Unsupported::Integer))
+    }
+
+    fn serialize_i32(self, _: i32) -> Result<Self::Ok, Self::Error> {
+        Err(self.bad_type(Unsupported::Integer))
+    }
+
+    fn serialize_i64(self, _: i64) -> Result<Self::Ok, Self::Error> {
+        Err(self.bad_type(Unsupported::Integer))
+    }
+
+    fn serialize_u8(self, _: u8) -> Result<Self::Ok, Self::Error> {
+        Err(self.bad_type(Unsupported::Integer))
+    }
+
+    fn serialize_u16(self, _: u16) -> Result<Self::Ok, Self::Error> {
+        Err(self.bad_type(Unsupported::Integer))
+    }
+
+    fn serialize_u32(self, _: u32) -> Result<Self::Ok, Self::Error> {
+        Err(self.bad_type(Unsupported::Integer))
+    }
+
+    fn serialize_u64(self, _: u64) -> Result<Self::Ok, Self::Error> {
+        Err(self.bad_type(Unsupported::Integer))
+    }
+
+    fn serialize_f32(self, _: f32) -> Result<Self::Ok, Self::Error> {
+        Err(self.bad_type(Unsupported::Float))
+    }
+
+    fn serialize_f64(self, _: f64) -> Result<Self::Ok, Self::Error> {
+        Err(self.bad_type(Unsupported::Float))
+    }
+
+    fn serialize_char(self, _: char) -> Result<Self::Ok, Self::Error> {
+        Err(self.bad_type(Unsupported::Char))
+    }
+
+    fn serialize_str(self, _: &str) -> Result<Self::Ok, Self::Error> {
+        Err(self.bad_type(Unsupported::String))
+    }
+
+    fn serialize_bytes(self, _: &[u8]) -> Result<Self::Ok, Self::Error> {
+        Err(self.bad_type(Unsupported::ByteArray))
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Err(self.bad_type(Unsupported::Optional))
+    }
+
+    fn serialize_some<T: ?Sized>(self, _: &T) -> Result<Self::Ok, Self::Error>
+        where T: Serialize
+    {
+        Err(self.bad_type(Unsupported::Optional))
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Err(self.bad_type(Unsupported::Unit))
+    }
+
+    fn serialize_unit_struct(self, _: &'static str) -> Result<Self::Ok, Self::Error> {
+        Err(self.bad_type(Unsupported::UnitStruct))
+    }
+
+    fn serialize_unit_variant(self, _: &'static str, _: usize, _: &'static str) -> Result<Self::Ok, Self::Error> {
+        Err(self.bad_type(Unsupported::Enum))
+    }
+
+    fn serialize_newtype_struct<T: ?Sized>(self, _: &'static str, value: &T) -> Result<Self::Ok, Self::Error>
+        where T: Serialize
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_newtype_variant<T: ?Sized>(self, _: &'static str, _: usize, _: &'static str, _: &T) -> Result<Self::Ok, Self::Error>
+        where T: Serialize
+    {
+        Err(self.bad_type(Unsupported::Enum))
+    }
+
+    fn serialize_seq(self, _: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Err(self.bad_type(Unsupported::Sequence))
+    }
+
+    fn serialize_seq_fixed_size(self, _: usize) -> Result<Self::SerializeSeq, Self::Error> {
+        Err(self.bad_type(Unsupported::Sequence))
+    }
+
+    fn serialize_tuple(self, _: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Err(self.bad_type(Unsupported::Tuple))
+    }
+
+    fn serialize_tuple_struct(self, _: &'static str, _: usize) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Err(self.bad_type(Unsupported::TupleStruct))
+    }
+
+    fn serialize_tuple_variant(self, _: &'static str, _: usize, _: &'static str, _: usize) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Err(self.bad_type(Unsupported::Enum))
+    }
+
+    fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        let mut map = try!(self.delegate.serialize_map(len.map(|len| len + 1)));
+        try!(map.serialize_entry(self.tag, self.variant_name));
+        Ok(map)
+    }
+
+    fn serialize_struct(self, name: &'static str, len: usize) -> Result<Self::SerializeStruct, Self::Error> {
+        let mut state = try!(self.delegate.serialize_struct(name, len + 1));
+        try!(state.serialize_field(self.tag, self.variant_name));
+        Ok(state)
+    }
+
+    fn serialize_struct_variant(self, _: &'static str, _: usize, _: &'static str, _: usize) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Err(self.bad_type(Unsupported::Enum))
+    }
+}

--- a/serde/src/ser/private.rs
+++ b/serde/src/ser/private.rs
@@ -1,4 +1,4 @@
-use std::fmt::{self, Display};
+use core::fmt::{self, Display};
 
 use ser::{self, Serialize, Serializer, SerializeMap, SerializeStruct};
 

--- a/serde_test/src/de.rs
+++ b/serde_test/src/de.rs
@@ -47,91 +47,29 @@ impl<I> Deserializer<I>
         }
     }
 
-    fn visit_seq<V>(&mut self, len: Option<usize>, visitor: V) -> Result<V::Value, Error>
+    fn visit_seq<V>(&mut self, len: Option<usize>, sep: Token<'static>, end: Token<'static>, visitor: V) -> Result<V::Value, Error>
         where V: Visitor,
     {
         let value = try!(visitor.visit_seq(DeserializerSeqVisitor {
             de: self,
             len: len,
+            sep: sep,
+            end: end.clone(),
         }));
-        try!(self.expect_token(Token::SeqEnd));
+        try!(self.expect_token(end));
         Ok(value)
     }
 
-    fn visit_array<V>(&mut self, len: usize, visitor: V) -> Result<V::Value, Error>
-        where V: Visitor,
-    {
-        let value = try!(visitor.visit_seq(DeserializerArrayVisitor {
-            de: self,
-            len: len,
-        }));
-        try!(self.expect_token(Token::SeqEnd));
-        Ok(value)
-    }
-
-    fn visit_tuple<V>(&mut self, len: usize, visitor: V) -> Result<V::Value, Error>
-        where V: Visitor,
-    {
-        let value = try!(visitor.visit_seq(DeserializerTupleVisitor {
-            de: self,
-            len: len,
-        }));
-        try!(self.expect_token(Token::TupleEnd));
-        Ok(value)
-    }
-
-    fn visit_tuple_struct<V>(&mut self, len: usize, visitor: V) -> Result<V::Value, Error>
-        where V: Visitor,
-    {
-        let value = try!(visitor.visit_seq(DeserializerTupleStructVisitor {
-            de: self,
-            len: len,
-        }));
-        try!(self.expect_token(Token::TupleStructEnd));
-        Ok(value)
-    }
-
-    fn visit_variant_seq<V>(&mut self, len: Option<usize>, visitor: V) -> Result<V::Value, Error>
-        where V: Visitor,
-    {
-        let value = try!(visitor.visit_seq(DeserializerVariantSeqVisitor {
-            de: self,
-            len: len,
-        }));
-        try!(self.expect_token(Token::EnumSeqEnd));
-        Ok(value)
-    }
-
-    fn visit_map<V>(&mut self, len: Option<usize>, visitor: V) -> Result<V::Value, Error>
+    fn visit_map<V>(&mut self, len: Option<usize>, sep: Token<'static>, end: Token<'static>, visitor: V) -> Result<V::Value, Error>
         where V: Visitor,
     {
         let value = try!(visitor.visit_map(DeserializerMapVisitor {
             de: self,
             len: len,
+            sep: sep,
+            end: end.clone(),
         }));
-        try!(self.expect_token(Token::MapEnd));
-        Ok(value)
-    }
-
-    fn visit_struct<V>(&mut self, fields: &'static [&'static str], visitor: V) -> Result<V::Value, Error>
-        where V: Visitor,
-    {
-        let value = try!(visitor.visit_map(DeserializerStructVisitor {
-            de: self,
-            len: fields.len(),
-        }));
-        try!(self.expect_token(Token::StructEnd));
-        Ok(value)
-    }
-
-    fn visit_variant_map<V>(&mut self, len: Option<usize>, visitor: V) -> Result<V::Value, Error>
-        where V: Visitor,
-    {
-        let value = try!(visitor.visit_map(DeserializerVariantMapVisitor {
-            de: self,
-            len: len,
-        }));
-        try!(self.expect_token(Token::EnumMapEnd));
+        try!(self.expect_token(end));
         Ok(value)
     }
 }
@@ -141,89 +79,9 @@ impl<'a, I> de::Deserializer for &'a mut Deserializer<I>
 {
     type Error = Error;
 
-    fn deserialize_seq<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
-        where __V: de::Visitor {
-        self.deserialize(visitor)
-    }
-    fn deserialize_struct_field<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
-        where __V: de::Visitor {
-        self.deserialize(visitor)
-    }
-    fn deserialize_map<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
-        where __V: de::Visitor {
-        self.deserialize(visitor)
-    }
-    fn deserialize_unit<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
-        where __V: de::Visitor {
-        self.deserialize(visitor)
-    }
-    fn deserialize_bytes<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
-        where __V: de::Visitor {
-        self.deserialize(visitor)
-    }
-    fn deserialize_byte_buf<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
-        where __V: de::Visitor {
-        self.deserialize(visitor)
-    }
-    fn deserialize_ignored_any<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
-        where __V: de::Visitor {
-        self.deserialize(visitor)
-    }
-    fn deserialize_string<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
-        where __V: de::Visitor {
-        self.deserialize(visitor)
-    }
-    fn deserialize_str<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
-        where __V: de::Visitor {
-        self.deserialize(visitor)
-    }
-    fn deserialize_char<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
-        where __V: de::Visitor {
-        self.deserialize(visitor)
-    }
-    fn deserialize_i64<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
-        where __V: de::Visitor {
-        self.deserialize(visitor)
-    }
-    fn deserialize_i32<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
-        where __V: de::Visitor {
-        self.deserialize(visitor)
-    }
-    fn deserialize_i16<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
-        where __V: de::Visitor {
-        self.deserialize(visitor)
-    }
-    fn deserialize_i8<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
-        where __V: de::Visitor {
-        self.deserialize(visitor)
-    }
-    fn deserialize_u64<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
-        where __V: de::Visitor {
-        self.deserialize(visitor)
-    }
-    fn deserialize_u32<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
-        where __V: de::Visitor {
-        self.deserialize(visitor)
-    }
-    fn deserialize_u16<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
-        where __V: de::Visitor {
-        self.deserialize(visitor)
-    }
-    fn deserialize_u8<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
-        where __V: de::Visitor {
-        self.deserialize(visitor)
-    }
-    fn deserialize_f32<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
-        where __V: de::Visitor {
-        self.deserialize(visitor)
-    }
-    fn deserialize_f64<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
-        where __V: de::Visitor {
-        self.deserialize(visitor)
-    }
-    fn deserialize_bool<__V>(self, visitor: __V) -> Result<__V::Value, Self::Error>
-        where __V: de::Visitor {
-        self.deserialize(visitor)
+    forward_to_deserialize! {
+        bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string unit
+        seq bytes byte_buf map struct_field ignored_any
     }
 
     fn deserialize<V>(self, visitor: V) -> Result<V::Value, Error>
@@ -251,16 +109,22 @@ impl<'a, I> de::Deserializer for &'a mut Deserializer<I>
             Some(Token::Unit) => visitor.visit_unit(),
             Some(Token::UnitStruct(_name)) => visitor.visit_unit(),
             Some(Token::SeqStart(len)) => {
-                self.visit_seq(len, visitor)
+                self.visit_seq(len, Token::SeqSep, Token::SeqEnd, visitor)
             }
-            Some(Token::SeqArrayStart(len))| Some(Token::TupleStructStart(_, len)) => {
-                self.visit_seq(Some(len), visitor)
+            Some(Token::SeqArrayStart(len)) => {
+                self.visit_seq(Some(len), Token::SeqSep, Token::SeqEnd, visitor)
+            }
+            Some(Token::TupleStart(len)) => {
+                self.visit_seq(Some(len), Token::TupleSep, Token::TupleEnd, visitor)
+            }
+            Some(Token::TupleStructStart(_, len)) => {
+                self.visit_seq(Some(len), Token::TupleStructSep, Token::TupleStructEnd, visitor)
             }
             Some(Token::MapStart(len)) => {
-                self.visit_map(len, visitor)
+                self.visit_map(len, Token::MapSep, Token::MapEnd, visitor)
             }
             Some(Token::StructStart(_, len)) => {
-                self.visit_map(Some(len), visitor)
+                self.visit_map(Some(len), Token::StructSep, Token::StructEnd, visitor)
             }
             Some(token) => Err(Error::UnexpectedToken(token)),
             None => Err(Error::EndOfTokens),
@@ -360,7 +224,7 @@ impl<'a, I> de::Deserializer for &'a mut Deserializer<I>
         match self.tokens.peek() {
             Some(&Token::SeqArrayStart(_)) => {
                 self.tokens.next();
-                self.visit_array(len, visitor)
+                self.visit_seq(Some(len), Token::SeqSep, Token::SeqEnd, visitor)
             }
             Some(_) => self.deserialize(visitor),
             None => Err(Error::EndOfTokens),
@@ -379,19 +243,19 @@ impl<'a, I> de::Deserializer for &'a mut Deserializer<I>
             }
             Some(&Token::SeqStart(_)) => {
                 self.tokens.next();
-                self.visit_seq(Some(len), visitor)
+                self.visit_seq(Some(len), Token::SeqSep, Token::SeqEnd, visitor)
             }
             Some(&Token::SeqArrayStart(_)) => {
                 self.tokens.next();
-                self.visit_array(len, visitor)
+                self.visit_seq(Some(len), Token::SeqSep, Token::SeqEnd, visitor)
             }
             Some(&Token::TupleStart(_)) => {
                 self.tokens.next();
-                self.visit_tuple(len, visitor)
+                self.visit_seq(Some(len), Token::TupleSep, Token::TupleEnd, visitor)
             }
             Some(&Token::TupleStructStart(_, _)) => {
                 self.tokens.next();
-                self.visit_tuple_struct(len, visitor)
+                self.visit_seq(Some(len), Token::TupleStructSep, Token::TupleStructEnd, visitor)
             }
             Some(_) => self.deserialize(visitor),
             None => Err(Error::EndOfTokens),
@@ -419,20 +283,20 @@ impl<'a, I> de::Deserializer for &'a mut Deserializer<I>
             }
             Some(&Token::SeqStart(_)) => {
                 self.tokens.next();
-                self.visit_seq(Some(len), visitor)
+                self.visit_seq(Some(len), Token::SeqSep, Token::SeqEnd, visitor)
             }
             Some(&Token::SeqArrayStart(_)) => {
                 self.tokens.next();
-                self.visit_array(len, visitor)
+                self.visit_seq(Some(len), Token::SeqSep, Token::SeqEnd, visitor)
             }
             Some(&Token::TupleStart(_)) => {
                 self.tokens.next();
-                self.visit_tuple(len, visitor)
+                self.visit_seq(Some(len), Token::TupleSep, Token::TupleEnd, visitor)
             }
             Some(&Token::TupleStructStart(n, _)) => {
                 self.tokens.next();
                 if name == n {
-                    self.visit_tuple_struct(len, visitor)
+                    self.visit_seq(Some(len), Token::TupleStructSep, Token::TupleStructEnd, visitor)
                 } else {
                     Err(Error::InvalidName(n))
                 }
@@ -452,14 +316,14 @@ impl<'a, I> de::Deserializer for &'a mut Deserializer<I>
             Some(&Token::StructStart(n, _)) => {
                 self.tokens.next();
                 if name == n {
-                    self.visit_struct(fields, visitor)
+                    self.visit_map(Some(fields.len()), Token::StructSep, Token::StructEnd, visitor)
                 } else {
                     Err(Error::InvalidName(n))
                 }
             }
             Some(&Token::MapStart(_)) => {
                 self.tokens.next();
-                self.visit_map(Some(fields.len()), visitor)
+                self.visit_map(Some(fields.len()), Token::MapSep, Token::MapEnd, visitor)
             }
             Some(_) => self.deserialize(visitor),
             None => Err(Error::EndOfTokens),
@@ -472,6 +336,8 @@ impl<'a, I> de::Deserializer for &'a mut Deserializer<I>
 struct DeserializerSeqVisitor<'a, I: 'a> where I: Iterator<Item=Token<'static>> {
     de: &'a mut Deserializer<I>,
     len: Option<usize>,
+    sep: Token<'static>,
+    end: Token<'static>,
 }
 
 impl<'a, I> SeqVisitor for DeserializerSeqVisitor<'a, I>
@@ -482,158 +348,15 @@ impl<'a, I> SeqVisitor for DeserializerSeqVisitor<'a, I>
     fn visit_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Error>
         where T: DeserializeSeed,
     {
-        match self.de.tokens.peek() {
-            Some(&Token::SeqSep) => {
-                self.de.tokens.next();
-                self.len = self.len.map(|len| len - 1);
-                seed.deserialize(&mut *self.de).map(Some)
-            }
-            Some(&Token::SeqEnd) => Ok(None),
-            Some(_) => {
-                let token = self.de.tokens.next().unwrap();
-                Err(Error::UnexpectedToken(token))
-            }
-            None => Err(Error::EndOfTokens),
+        if self.de.tokens.peek() == Some(&self.end) {
+            return Ok(None);
         }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.len.unwrap_or(0);
-        (len, self.len)
-    }
-}
-
-//////////////////////////////////////////////////////////////////////////
-
-struct DeserializerArrayVisitor<'a, I: 'a> where I: Iterator<Item=Token<'static>> {
-    de: &'a mut Deserializer<I>,
-    len: usize,
-}
-
-impl<'a, I> SeqVisitor for DeserializerArrayVisitor<'a, I>
-    where I: Iterator<Item=Token<'static>>,
-{
-    type Error = Error;
-
-    fn visit_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Error>
-        where T: DeserializeSeed,
-    {
-        match self.de.tokens.peek() {
-            Some(&Token::SeqSep) => {
-                self.de.tokens.next();
-                self.len -= 1;
+        match self.de.tokens.next() {
+            Some(ref token) if *token == self.sep => {
+                self.len = self.len.map(|len| len.saturating_sub(1));
                 seed.deserialize(&mut *self.de).map(Some)
             }
-            Some(&Token::SeqEnd) => Ok(None),
-            Some(_) => {
-                let token = self.de.tokens.next().unwrap();
-                Err(Error::UnexpectedToken(token))
-            }
-            None => Err(Error::EndOfTokens),
-        }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.len, Some(self.len))
-    }
-}
-
-//////////////////////////////////////////////////////////////////////////
-
-struct DeserializerTupleVisitor<'a, I: 'a> where I: Iterator<Item=Token<'static>> {
-    de: &'a mut Deserializer<I>,
-    len: usize,
-}
-
-impl<'a, I> SeqVisitor for DeserializerTupleVisitor<'a, I>
-    where I: Iterator<Item=Token<'static>>,
-{
-    type Error = Error;
-
-    fn visit_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Error>
-        where T: DeserializeSeed,
-    {
-        match self.de.tokens.peek() {
-            Some(&Token::TupleSep) => {
-                self.de.tokens.next();
-                self.len -= 1;
-                seed.deserialize(&mut *self.de).map(Some)
-            }
-            Some(&Token::TupleEnd) => Ok(None),
-            Some(_) => {
-                let token = self.de.tokens.next().unwrap();
-                Err(Error::UnexpectedToken(token))
-            }
-            None => Err(Error::EndOfTokens),
-        }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.len, Some(self.len))
-    }
-}
-
-//////////////////////////////////////////////////////////////////////////
-
-struct DeserializerTupleStructVisitor<'a, I: 'a> where I: Iterator<Item=Token<'static>> {
-    de: &'a mut Deserializer<I>,
-    len: usize,
-}
-
-impl<'a, I> SeqVisitor for DeserializerTupleStructVisitor<'a, I>
-    where I: Iterator<Item=Token<'static>>,
-{
-    type Error = Error;
-
-    fn visit_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Error>
-        where T: DeserializeSeed,
-    {
-        match self.de.tokens.peek() {
-            Some(&Token::TupleStructSep) => {
-                self.de.tokens.next();
-                self.len -= 1;
-                seed.deserialize(&mut *self.de).map(Some)
-            }
-            Some(&Token::TupleStructEnd) => Ok(None),
-            Some(_) => {
-                let token = self.de.tokens.next().unwrap();
-                Err(Error::UnexpectedToken(token))
-            }
-            None => Err(Error::EndOfTokens),
-        }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.len, Some(self.len))
-    }
-}
-
-//////////////////////////////////////////////////////////////////////////
-
-struct DeserializerVariantSeqVisitor<'a, I: 'a> where I: Iterator<Item=Token<'static>> {
-    de: &'a mut Deserializer<I>,
-    len: Option<usize>,
-}
-
-impl<'a, I> SeqVisitor for DeserializerVariantSeqVisitor<'a, I>
-    where I: Iterator<Item=Token<'static>>,
-{
-    type Error = Error;
-
-    fn visit_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Error>
-        where T: DeserializeSeed,
-    {
-        match self.de.tokens.peek() {
-            Some(&Token::EnumSeqSep) => {
-                self.de.tokens.next();
-                self.len = self.len.map(|len| len - 1);
-                seed.deserialize(&mut *self.de).map(Some)
-            }
-            Some(&Token::EnumSeqEnd) => Ok(None),
-            Some(_) => {
-                let token = self.de.tokens.next().unwrap();
-                Err(Error::UnexpectedToken(token))
-            }
+            Some(other) => Err(Error::UnexpectedToken(other)),
             None => Err(Error::EndOfTokens),
         }
     }
@@ -649,6 +372,8 @@ impl<'a, I> SeqVisitor for DeserializerVariantSeqVisitor<'a, I>
 struct DeserializerMapVisitor<'a, I: 'a> where I: Iterator<Item=Token<'static>> {
     de: &'a mut Deserializer<I>,
     len: Option<usize>,
+    sep: Token<'static>,
+    end: Token<'static>,
 }
 
 impl<'a, I> MapVisitor for DeserializerMapVisitor<'a, I>
@@ -659,17 +384,15 @@ impl<'a, I> MapVisitor for DeserializerMapVisitor<'a, I>
     fn visit_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Error>
         where K: DeserializeSeed,
     {
-        match self.de.tokens.peek() {
-            Some(&Token::MapSep) => {
-                self.de.tokens.next();
-                self.len = self.len.map(|len| if len > 0 { len - 1} else { 0 });
+        if self.de.tokens.peek() == Some(&self.end) {
+            return Ok(None);
+        }
+        match self.de.tokens.next() {
+            Some(ref token) if *token == self.sep => {
+                self.len = self.len.map(|len| len.saturating_sub(1));
                 seed.deserialize(&mut *self.de).map(Some)
             }
-            Some(&Token::MapEnd) => Ok(None),
-            Some(_) => {
-                let token = self.de.tokens.next().unwrap();
-                Err(Error::UnexpectedToken(token))
-            }
+            Some(other) => Err(Error::UnexpectedToken(other)),
             None => Err(Error::EndOfTokens),
         }
     }
@@ -683,47 +406,6 @@ impl<'a, I> MapVisitor for DeserializerMapVisitor<'a, I>
     fn size_hint(&self) -> (usize, Option<usize>) {
         let len = self.len.unwrap_or(0);
         (len, self.len)
-    }
-}
-
-//////////////////////////////////////////////////////////////////////////
-
-struct DeserializerStructVisitor<'a, I: 'a> where I: Iterator<Item=Token<'static>> {
-    de: &'a mut Deserializer<I>,
-    len: usize,
-}
-
-impl<'a, I> MapVisitor for DeserializerStructVisitor<'a, I>
-    where I: Iterator<Item=Token<'static>>,
-{
-    type Error = Error;
-
-    fn visit_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Error>
-        where K: DeserializeSeed,
-    {
-        match self.de.tokens.peek() {
-            Some(&Token::StructSep) => {
-                self.de.tokens.next();
-                self.len = self.len.saturating_sub(1);
-                seed.deserialize(&mut *self.de).map(Some)
-            }
-            Some(&Token::StructEnd) => Ok(None),
-            Some(_) => {
-                let token = self.de.tokens.next().unwrap();
-                Err(Error::UnexpectedToken(token))
-            }
-            None => Err(Error::EndOfTokens),
-        }
-    }
-
-    fn visit_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Error>
-        where V: DeserializeSeed,
-    {
-        seed.deserialize(&mut *self.de)
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.len, Some(self.len))
     }
 }
 
@@ -803,7 +485,7 @@ impl<'a, I> VariantVisitor for DeserializerEnumVisitor<'a, I>
                 let token = self.de.tokens.next().unwrap();
 
                 if len == enum_len {
-                    self.de.visit_variant_seq(Some(len), visitor)
+                    self.de.visit_seq(Some(len), Token::EnumSeqSep, Token::EnumSeqEnd, visitor)
                 } else {
                     Err(Error::UnexpectedToken(token))
                 }
@@ -812,7 +494,7 @@ impl<'a, I> VariantVisitor for DeserializerEnumVisitor<'a, I>
                 let token = self.de.tokens.next().unwrap();
 
                 if len == enum_len {
-                    self.de.visit_seq(Some(len), visitor)
+                    self.de.visit_seq(Some(len), Token::SeqSep, Token::SeqEnd, visitor)
                 } else {
                     Err(Error::UnexpectedToken(token))
                 }
@@ -834,7 +516,7 @@ impl<'a, I> VariantVisitor for DeserializerEnumVisitor<'a, I>
                 let token = self.de.tokens.next().unwrap();
 
                 if fields.len() == enum_len {
-                    self.de.visit_variant_map(Some(fields.len()), visitor)
+                    self.de.visit_map(Some(fields.len()), Token::EnumMapSep, Token::EnumMapEnd, visitor)
                 } else {
                     Err(Error::UnexpectedToken(token))
                 }
@@ -843,7 +525,7 @@ impl<'a, I> VariantVisitor for DeserializerEnumVisitor<'a, I>
                 let token = self.de.tokens.next().unwrap();
 
                 if fields.len() == enum_len {
-                    self.de.visit_map(Some(fields.len()), visitor)
+                    self.de.visit_map(Some(fields.len()), Token::MapSep, Token::MapEnd, visitor)
                 } else {
                     Err(Error::UnexpectedToken(token))
                 }
@@ -853,47 +535,5 @@ impl<'a, I> VariantVisitor for DeserializerEnumVisitor<'a, I>
             }
             None => Err(Error::EndOfTokens),
         }
-    }
-}
-
-//////////////////////////////////////////////////////////////////////////
-
-struct DeserializerVariantMapVisitor<'a, I: 'a> where I: Iterator<Item=Token<'static>> {
-    de: &'a mut Deserializer<I>,
-    len: Option<usize>,
-}
-
-impl<'a, I> MapVisitor for DeserializerVariantMapVisitor<'a, I>
-    where I: Iterator<Item=Token<'static>>,
-{
-    type Error = Error;
-
-    fn visit_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Error>
-        where K: DeserializeSeed,
-    {
-        match self.de.tokens.peek() {
-            Some(&Token::EnumMapSep) => {
-                self.de.tokens.next();
-                self.len = self.len.map(|len| if len > 0 { len - 1} else { 0 });
-                seed.deserialize(&mut *self.de).map(Some)
-            }
-            Some(&Token::EnumMapEnd) => Ok(None),
-            Some(_) => {
-                let token = self.de.tokens.next().unwrap();
-                Err(Error::UnexpectedToken(token))
-            }
-            None => Err(Error::EndOfTokens),
-        }
-    }
-
-    fn visit_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Error>
-        where V: DeserializeSeed,
-    {
-        seed.deserialize(&mut *self.de)
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.len.unwrap_or(0);
-        (len, self.len)
     }
 }

--- a/serde_test/src/lib.rs
+++ b/serde_test/src/lib.rs
@@ -1,3 +1,4 @@
+#[macro_use]
 extern crate serde;
 
 mod assert;

--- a/test_suite/tests/compile-fail/enum-representation/internal-tuple-variant.rs
+++ b/test_suite/tests/compile-fail/enum-representation/internal-tuple-variant.rs
@@ -1,0 +1,10 @@
+#[macro_use]
+extern crate serde_derive;
+
+#[derive(Serialize)] //~ ERROR: custom derive attribute panicked
+#[serde(tag = "type")] //~^ HELP: #[serde(tag = "...")] cannot be used with tuple variants
+enum E {
+    Tuple(u8, u8),
+}
+
+fn main() {}

--- a/test_suite/tests/compile-fail/enum-representation/internally-tagged-struct.rs
+++ b/test_suite/tests/compile-fail/enum-representation/internally-tagged-struct.rs
@@ -1,0 +1,8 @@
+#[macro_use]
+extern crate serde_derive;
+
+#[derive(Serialize)] //~ ERROR: custom derive attribute panicked
+#[serde(tag = "type")] //~^ HELP: #[serde(tag = "...")] can only be used on enums
+struct S;
+
+fn main() {}

--- a/test_suite/tests/compile-fail/enum-representation/untagged-and-internal.rs
+++ b/test_suite/tests/compile-fail/enum-representation/untagged-and-internal.rs
@@ -1,0 +1,12 @@
+#[macro_use]
+extern crate serde_derive;
+
+#[derive(Serialize)] //~ ERROR: custom derive attribute panicked
+#[serde(untagged)]
+#[serde(tag = "type")] //~^^ HELP: enum cannot be both untagged and internally tagged
+enum E {
+    A(u8),
+    B(String),
+}
+
+fn main() {}

--- a/test_suite/tests/compile-fail/enum-representation/untagged-struct.rs
+++ b/test_suite/tests/compile-fail/enum-representation/untagged-struct.rs
@@ -1,0 +1,8 @@
+#[macro_use]
+extern crate serde_derive;
+
+#[derive(Serialize)] //~ ERROR: custom derive attribute panicked
+#[serde(untagged)] //~^ HELP: #[serde(untagged)] can only be used on enums
+struct S;
+
+fn main() {}

--- a/test_suite/tests/test_de.rs
+++ b/test_suite/tests/test_de.rs
@@ -225,7 +225,7 @@ declare_tests! {
         ],
         () => &[
             Token::TupleStructStart("Anything", 0),
-            Token::SeqEnd,
+            Token::TupleStructEnd,
         ],
     }
     test_unit_struct {
@@ -330,7 +330,7 @@ declare_tests! {
         ],
         BTreeSet::<isize>::new() => &[
             Token::TupleStructStart("Anything", 0),
-            Token::SeqEnd,
+            Token::TupleStructEnd,
         ],
     }
     test_hashset {
@@ -358,7 +358,7 @@ declare_tests! {
         ],
         HashSet::<isize>::new() => &[
             Token::TupleStructStart("Anything", 0),
-            Token::SeqEnd,
+            Token::TupleStructEnd,
         ],
         hashset![FnvHasher @ 1, 2, 3] => &[
             Token::SeqStart(Some(3)),
@@ -408,7 +408,7 @@ declare_tests! {
         ],
         Vec::<isize>::new() => &[
             Token::TupleStructStart("Anything", 0),
-            Token::SeqEnd,
+            Token::TupleStructEnd,
         ],
     }
     test_array {
@@ -472,7 +472,7 @@ declare_tests! {
         ],
         [0; 0] => &[
             Token::TupleStructStart("Anything", 0),
-            Token::SeqEnd,
+            Token::TupleStructEnd,
         ],
     }
     test_tuple {
@@ -564,7 +564,7 @@ declare_tests! {
         ],
         BTreeMap::<isize, isize>::new() => &[
             Token::StructStart("Anything", 0),
-            Token::MapEnd,
+            Token::StructEnd,
         ],
     }
     test_hashmap {
@@ -618,7 +618,7 @@ declare_tests! {
         ],
         HashMap::<isize, isize>::new() => &[
             Token::StructStart("Anything", 0),
-            Token::MapEnd,
+            Token::StructEnd,
         ],
         hashmap![FnvHasher @ 1 => 2, 3 => 4] => &[
             Token::MapStart(Some(2)),

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -725,6 +725,24 @@ fn test_untagged_enum() {
         ],
         Error::Message("data did not match any variant of untagged enum Untagged".to_owned()),
     );
+
+    assert_de_tokens_error::<Untagged>(
+        &[
+            Token::TupleStart(3),
+
+            Token::TupleSep,
+            Token::U8(1),
+
+            Token::TupleSep,
+            Token::U8(2),
+
+            Token::TupleSep,
+            Token::U8(3),
+
+            Token::TupleEnd,
+        ],
+        Error::Message("data did not match any variant of untagged enum Untagged".to_owned()),
+    );
 }
 
 #[test]

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -1,11 +1,14 @@
 extern crate serde_test;
 use self::serde_test::{
+    Error,
     Token,
     assert_tokens,
     assert_ser_tokens,
     assert_de_tokens,
+    assert_de_tokens_error,
 };
 
+use std::collections::BTreeMap;
 use std::marker::PhantomData;
 
 // That tests that the derived Serialize implementation doesn't trigger
@@ -623,5 +626,240 @@ fn test_enum_state_field() {
 
             Token::EnumMapEnd,
         ]
+    );
+}
+
+#[test]
+fn test_untagged_enum() {
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    #[serde(untagged)]
+    enum Untagged {
+        A {
+            a: u8,
+        },
+        B {
+            b: u8,
+        },
+        C,
+        D(u8),
+        E(String),
+        F(u8, u8),
+    }
+
+    assert_tokens(
+        &Untagged::A { a: 1 },
+        &[
+            Token::StructStart("Untagged", 1),
+
+            Token::StructSep,
+            Token::Str("a"),
+            Token::U8(1),
+
+            Token::StructEnd,
+        ]
+    );
+
+    assert_tokens(
+        &Untagged::B { b: 2 },
+        &[
+            Token::StructStart("Untagged", 1),
+
+            Token::StructSep,
+            Token::Str("b"),
+            Token::U8(2),
+
+            Token::StructEnd,
+        ]
+    );
+
+    assert_tokens(
+        &Untagged::C,
+        &[
+            Token::Unit,
+        ]
+    );
+
+    assert_tokens(
+        &Untagged::D(4),
+        &[
+            Token::U8(4),
+        ]
+    );
+    assert_tokens(
+        &Untagged::E("e".to_owned()),
+        &[
+            Token::Str("e"),
+        ]
+    );
+
+    assert_tokens(
+        &Untagged::F(1, 2),
+        &[
+            Token::TupleStart(2),
+
+            Token::TupleSep,
+            Token::U8(1),
+
+            Token::TupleSep,
+            Token::U8(2),
+
+            Token::TupleEnd,
+        ]
+    );
+
+    assert_de_tokens_error::<Untagged>(
+        &[
+            Token::Option(false),
+        ],
+        Error::Message("data did not match any variant of untagged enum Untagged".to_owned()),
+    );
+
+    assert_de_tokens_error::<Untagged>(
+        &[
+            Token::TupleStart(1),
+
+            Token::TupleSep,
+            Token::U8(1),
+
+            Token::TupleEnd,
+        ],
+        Error::Message("data did not match any variant of untagged enum Untagged".to_owned()),
+    );
+}
+
+#[test]
+fn test_internally_tagged_enum() {
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct Newtype(BTreeMap<String, String>);
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct Struct {
+        f: u8,
+    }
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    #[serde(tag = "type")]
+    enum InternallyTagged {
+        A {
+            a: u8,
+        },
+        B {
+            b: u8,
+        },
+        C,
+        D(BTreeMap<String, String>),
+        E(Newtype),
+        F(Struct),
+    }
+
+    assert_tokens(
+        &InternallyTagged::A { a: 1 },
+        &[
+            Token::StructStart("InternallyTagged", 2),
+
+            Token::StructSep,
+            Token::Str("type"),
+            Token::Str("A"),
+
+            Token::StructSep,
+            Token::Str("a"),
+            Token::U8(1),
+
+            Token::StructEnd,
+        ]
+    );
+
+    assert_tokens(
+        &InternallyTagged::B { b: 2 },
+        &[
+            Token::StructStart("InternallyTagged", 2),
+
+            Token::StructSep,
+            Token::Str("type"),
+            Token::Str("B"),
+
+            Token::StructSep,
+            Token::Str("b"),
+            Token::U8(2),
+
+            Token::StructEnd,
+        ]
+    );
+
+    assert_tokens(
+        &InternallyTagged::C,
+        &[
+            Token::StructStart("InternallyTagged", 1),
+
+            Token::StructSep,
+            Token::Str("type"),
+            Token::Str("C"),
+
+            Token::StructEnd,
+        ]
+    );
+
+    assert_tokens(
+        &InternallyTagged::D(BTreeMap::new()),
+        &[
+            Token::MapStart(Some(1)),
+
+            Token::MapSep,
+            Token::Str("type"),
+            Token::Str("D"),
+
+            Token::MapEnd,
+        ]
+    );
+
+    assert_tokens(
+        &InternallyTagged::E(Newtype(BTreeMap::new())),
+        &[
+            Token::MapStart(Some(1)),
+
+            Token::MapSep,
+            Token::Str("type"),
+            Token::Str("E"),
+
+            Token::MapEnd,
+        ]
+    );
+
+    assert_tokens(
+        &InternallyTagged::F(Struct { f: 6 }),
+        &[
+            Token::StructStart("Struct", 2),
+
+            Token::StructSep,
+            Token::Str("type"),
+            Token::Str("F"),
+
+            Token::StructSep,
+            Token::Str("f"),
+            Token::U8(6),
+
+            Token::StructEnd,
+        ]
+    );
+
+    assert_de_tokens_error::<InternallyTagged>(
+        &[
+            Token::MapStart(Some(0)),
+            Token::MapEnd,
+        ],
+        Error::Message("missing field `type`".to_owned()),
+    );
+
+    assert_de_tokens_error::<InternallyTagged>(
+        &[
+            Token::MapStart(Some(1)),
+
+            Token::MapSep,
+            Token::Str("type"),
+            Token::Str("Z"),
+
+            Token::MapEnd,
+        ],
+        Error::Message("unknown variant `Z`, expected one of `A`, `B`, `C`, `D`, `E`, `F`".to_owned()),
     );
 }


### PR DESCRIPTION
Fixes #415 and fixes https://github.com/serde-rs/json/issues/67.

The attribute for untagged enums is:

```rust
#[derive(Serialize, Deserialize)]
#[serde(untagged)]
enum E {
    /* variants */
}
```

During serialization, the variant is serialized as though it were not part of an enum. Struct variants are serialized as structs, tuple variants are serialized as tuples, unit variants are serialized as unit, and newtype variants are serialized as the value.

During deserialization, we buffer the content of the Deserializer and try it against each variant in order, returning the first one that deserializes successfully from that content.

The attribute for internally tagged enums is:

```rust
#[derive(Serialize, Deserialize)]
#[serde(tag = "type")]
enum E {
    /* variants */
}
```

The enum must contain only unit, newtype and struct variants. Tuple variants are not supported. During serialization unit variants are serialized as structs with a single field: `{"type": "T"}`, struct variants are serialized with `"type": "T"` inserted as the first field, and newtype variants must contain either a struct or a map and are serialized with `"type": "T"` inserted as the first field.

During deserialization, we buffer the content of the Deserializer, pull out the tag, and deserialize the rest of the content against the correct variant.

The use case from #415 looks like:

```rust
#[derive(Serialize, Deserialize, Debug)]
#[serde(tag = "type")]
enum Motion {
    Column { content: i32 },
    Line { content: i32 },
}

#[derive(Serialize, Deserialize, Debug)]
#[serde(tag = "type")]
enum Command {
    Move { content: Motion },
    Delete { content: Motion },
    Input { content: String },
}
```

And the use case from https://github.com/serde-rs/json/issues/67 looks like:

```rust
#[derive(Serialize, Deserialize, Debug)]
#[serde(tag = "type")]
enum Message {
    #[serde(rename = "ok")]
    Ok { response: Response },
    #[serde(rename = "error")]
    Error { message: String },
}
```

cc @sfackler who asked about this in IRC and @alexcrichton who is removing this functionality from toml.