### PR TITLE
Remove the EnumSet impls

### DIFF
--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -28,8 +28,6 @@ use std::collections::{
 };
 
 #[cfg(feature = "collections")]
-use collections::enum_set::{CLike, EnumSet};
-#[cfg(feature = "collections")]
 use collections::borrow::ToOwned;
 
 use core::fmt;
@@ -480,15 +478,6 @@ seq_impl!(
     BTreeSet::new(),
     BTreeSet::new(),
     BTreeSet::insert);
-
-#[cfg(feature = "collections")]
-seq_impl!(
-    EnumSet<T>,
-    EnumSetVisitor<T: Deserialize + CLike>,
-    visitor,
-    EnumSet::new(),
-    EnumSet::new(),
-    EnumSet::insert);
 
 #[cfg(any(feature = "std", feature = "collections"))]
 seq_impl!(

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -63,7 +63,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "unstable", feature(nonzero, inclusive_range, zero_one))]
 #![cfg_attr(feature = "alloc", feature(alloc))]
-#![cfg_attr(feature = "collections", feature(collections, enumset))]
+#![cfg_attr(feature = "collections", feature(collections))]
 #![cfg_attr(feature = "cargo-clippy", allow(linkedlist, type_complexity, doc_markdown))]
 #![deny(missing_docs)]
 

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -25,8 +25,6 @@ use collections::{
 };
 
 #[cfg(feature = "collections")]
-use collections::enum_set::{CLike, EnumSet};
-#[cfg(feature = "collections")]
 use collections::borrow::ToOwned;
 
 #[cfg(feature = "std")]
@@ -274,13 +272,6 @@ impl<T> Serialize for BinaryHeap<T>
 #[cfg(any(feature = "std", feature = "collections"))]
 impl<T> Serialize for BTreeSet<T>
     where T: Serialize + Ord,
-{
-    serialize_seq!();
-}
-
-#[cfg(feature = "collections")]
-impl<T> Serialize for EnumSet<T>
-    where T: Serialize + CLike
 {
     serialize_seq!();
 }


### PR DESCRIPTION
In the most recent nightly this gives a strongly worded warning:

> **warning:** use of deprecated item: long since replaced