### PR TITLE
Add deserialization helpers for map and sequence types

### DIFF
--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -462,7 +462,7 @@ pub fn deserialize_seq<D, F, G, R, V, V2>(deserializer: D, with_capacity: F, con
             Ok(values)
         }
     }
-    deserializer.deserialize_map(SeqVisitor_ {
+    deserializer.deserialize_seq(SeqVisitor_ {
         convert: convert,
         with_capacity: with_capacity,
         marker: PhantomData,

--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -396,14 +396,13 @@ impl<T> Deserialize for PhantomData<T> {
 
 macro_rules! seq_impl {
     (
-        $ty:ty,
-        < $($typaram:ident : $bound1:ident $(+ $bound2:ident)*),* >,
+        $ty:ident< $($typaram:ident : $bound1:ident $(+ $bound2:ident)*),* >,
         $with_capacity:expr
     ) => {
-        impl<$($typaram),*> Deserialize for $ty
+        impl<$($typaram),*> Deserialize for $ty<$($typaram),*>
             where $($typaram: $bound1 $(+ $bound2)*),*
         {
-            fn deserialize<D>(deserializer: D) -> Result<$ty, D::Error>
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
                 where D: Deserializer,
             {
                 deserialize_seq(deserializer, $with_capacity, |v| v)
@@ -472,38 +471,32 @@ pub fn deserialize_seq<D, F, G, R, V, V2>(deserializer: D, with_capacity: F, con
 
 #[cfg(any(feature = "std", feature = "collections"))]
 seq_impl!(
-    BinaryHeap<T>,
-    <T: Deserialize + Ord>,
+    BinaryHeap<T: Deserialize + Ord>,
     |_, _| BinaryHeap::new());
 
 #[cfg(any(feature = "std", feature = "collections"))]
 seq_impl!(
-    BTreeSet<T>,
-    <T: Deserialize + Eq + Ord>,
+    BTreeSet<T: Deserialize + Eq + Ord>,
     |_, _| BTreeSet::new());
 
 #[cfg(any(feature = "std", feature = "collections"))]
 seq_impl!(
-    LinkedList<T>,
-    <T: Deserialize>,
+    LinkedList<T: Deserialize>,
     |_, _| LinkedList::new());
 
 #[cfg(feature = "std")]
 seq_impl!(
-    HashSet<T, S>,
-    <T: Deserialize + Eq + Hash, S: BuildHasher + Default>,
+    HashSet<T: Deserialize + Eq + Hash, S: BuildHasher + Default>,
     |min, _| HashSet::with_capacity_and_hasher(min, S::default()));
 
 #[cfg(any(feature = "std", feature = "collections"))]
 seq_impl!(
-    Vec<T>,
-    <T: Deserialize>,
+    Vec<T: Deserialize>,
     |min, _| Vec::with_capacity(min));
 
 #[cfg(any(feature = "std", feature = "collections"))]
 seq_impl!(
-    VecDeque<T>,
-    <T: Deserialize>,
+    VecDeque<T: Deserialize>,
     |min, _| VecDeque::with_capacity(min));
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -700,14 +693,13 @@ tuple_impls! {
 
 macro_rules! map_impl {
     (
-        $ty:ty,
-        < $($typaram:ident : $bound1:ident $(+ $bound2:ident)*),* >,
+        $ty:ident < $($typaram:ident : $bound1:ident $(+ $bound2:ident)*),* >,
         $with_capacity:expr
     ) => {
-        impl<$($typaram),*> Deserialize for $ty
+        impl<$($typaram),*> Deserialize for $ty<$($typaram),*>
             where $($typaram: $bound1 $(+ $bound2)*),*
         {
-            fn deserialize<D>(deserializer: D) -> Result<$ty, D::Error>
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
                 where D: Deserializer,
             {
                 deserialize_map(deserializer, $with_capacity, |key, value| (key, value))
@@ -779,14 +771,12 @@ pub fn deserialize_map<D, F, G, R, K, V, K2, V2>(deserializer: D, with_capacity:
 
 #[cfg(any(feature = "std", feature = "collections"))]
 map_impl!(
-    BTreeMap<K, V>,
-    <K: Deserialize + Ord, V: Deserialize>,
+    BTreeMap<K: Deserialize + Ord, V: Deserialize>,
     |_, _| BTreeMap::new());
 
 #[cfg(feature = "std")]
 map_impl!(
-    HashMap<K, V, S>,
-    <K: Deserialize + Eq + Hash, V: Deserialize, S: BuildHasher + Default>,
+    HashMap<K: Deserialize + Eq + Hash, V: Deserialize, S: BuildHasher + Default>,
     |min, _| HashMap::with_capacity_and_hasher(min, S::default()));
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -118,7 +118,7 @@ pub mod private;
 #[cfg(any(feature = "std", feature = "collections"))]
 mod content;
 
-pub use self::impls::deserialize_map;
+pub use self::impls::{deserialize_map, deserialize_seq};
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -118,6 +118,8 @@ pub mod private;
 #[cfg(any(feature = "std", feature = "collections"))]
 mod content;
 
+pub use self::impls::deserialize_map;
+
 ///////////////////////////////////////////////////////////////////////////////
 
 /// The `Error` trait allows `Deserialize` implementations to create descriptive


### PR DESCRIPTION
The motivating case for this is that https://github.com/gluon-lang/languageserver-types has a type which contains a `HashMap<Url, SomeType>` but `Url` can't be deserialized directly with serde 0.9, it is instead provided by functions and wrappers in [a separate crate](https://github.com/servo/rust-url/tree/master/url_serde).

#553 mentions that this should perhaps be in another crate but since this PR simply reuses the normal sequence and map deserializers I'd argue it is a good idea to just provide them from `serde` directly.

 https://github.com/gluon-lang/languageserver-types/pull/7/commits/88e2565f6b1873b59dc1493c00d1c7166acbb766#diff-b4aea3e418ccdb71239b96952d9cddb6R335
#553 