### PR TITLE
WIP: Initial work on supporting #758

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -502,6 +502,9 @@ fn deserialize_item_enum(type_ident: &syn::Ident,
                                                item_attrs,
                                                tag)
         }
+        attr::EnumTag::Adjacent(ref tag, ref content) => {
+            panic!("FIXME: unimplemented")
+        }
         attr::EnumTag::None => {
             deserialize_untagged_enum(type_ident, impl_generics, ty, variants, item_attrs)
         }


### PR DESCRIPTION
I've been working on #758 but got stuck partway through the implementation, so I'm uploading what I've got for the moment. **Do not pull this, it's a work in progress and won't build anyway.**

See the comments in `serialize_internally_content_tagged_variant` for where I'm stuck. The basic issue is that I want to take a enum tuple variant like:

```
#[serde(tag = "t", content = "c")]
enum A {
  B(C, D)
}
```

And split out something like:

```
{"t": "B", "c": ["value_of_C", "value_of_D"]}
```

I know how to spit out the `"t": "B"` via `serialize_field`, and the interior of `["value_of_C", "value_of_D"]` via serialize_tuple_variant`. But I can't figure out a way to spit out a `"c":` to prefix the internal content with, because it seems that all the methods for serializing fields expect to do the field name and value in one shot, and expect the value to be a valid type. In this case, we're kind of faking the type of the interior field because of course no such type actually exists.

I'd appreciate any advice on how to approach this.