### PR TITLE
Fix internally tagged enums by implementing ContentDeserializer::deserialize_enum

### DIFF
--- a/serde/src/de/content.rs
+++ b/serde/src/de/content.rs
@@ -759,7 +759,7 @@ impl<E> de::VariantVisitor for VariantDeserializer<E> where E: de::Error {
 }
 
 struct SeqDeserializer<E> where E: de::Error {
-    iter: ::std::vec::IntoIter<Content>,
+    iter: <Vec<Content> as IntoIterator>::IntoIter,
     err: PhantomData<E>,
 }
 

--- a/serde/src/de/content.rs
+++ b/serde/src/de/content.rs
@@ -75,9 +75,7 @@ impl Content {
             Content::Char(c) => Unexpected::Char(c),
             Content::String(ref s) => Unexpected::Str(s),
             Content::Bytes(ref b) => Unexpected::Bytes(b),
-            // @TODO: Are these mappings correct?
-            Content::None => Unexpected::Option,
-            Content::Some(_) => Unexpected::Option,
+            Content::None | Content::Some(_) => Unexpected::Option,
             Content::Unit => Unexpected::Unit,
             Content::Newtype(_) => Unexpected::NewtypeStruct,
             Content::Seq(_) => Unexpected::Seq,


### PR DESCRIPTION
These commits are to fix #775 for internally tagged enums. My testcases pass with this implementation but I'm not sure about the code correctness. Is there a particular test file I should add to?

Untagged enums need a similar fix.