### PR TITLE
impls for null-terminated FFI string types

### DIFF
--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -55,6 +55,7 @@ use de::{Deserialize, Deserializer, EnumVisitor, Error, MapVisitor, SeqVisitor, 
          VariantVisitor, Visitor};
 use de::from_primitive::FromPrimitive;
 
+#[cfg(feature = "std")]
 use bytes::ByteBuf;
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -298,19 +298,6 @@ impl Deserialize for String {
 ///////////////////////////////////////////////////////////////////////////////
 
 #[cfg(feature = "std")]
-impl Deserialize for Box<CStr> {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: Deserializer
-    {
-        use std::mem;
-        let s = try!(CString::deserialize(deserializer));
-        let slice = s.into_bytes_with_nul().into_boxed_slice();
-        Ok(unsafe { mem::transmute::<Box<[u8]>, Box<CStr>>(slice) })
-    }
-}
-
-
-#[cfg(feature = "std")]
 impl Deserialize for CString {
     fn deserialize<D>(deserializer: D) -> Result<CString, D::Error>
         where D: Deserializer

--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -26,7 +26,7 @@ use std::net;
 use std::path;
 use core::str;
 #[cfg(feature = "std")]
-use std::ffi::{CStr, CString};
+use std::ffi::CString;
 
 #[cfg(feature = "std")]
 use std::rc::Rc;
@@ -54,6 +54,8 @@ use core::num::Zero;
 use de::{Deserialize, Deserializer, EnumVisitor, Error, MapVisitor, SeqVisitor, Unexpected,
          VariantVisitor, Visitor};
 use de::from_primitive::FromPrimitive;
+
+use super::super::bytes::ByteBuf;
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -302,7 +304,7 @@ impl Deserialize for CString {
     fn deserialize<D>(deserializer: D) -> Result<CString, D::Error>
         where D: Deserializer
     {
-        let v: Vec<u8> = try!(Deserialize::deserialize(deserializer));
+        let v: Vec<u8> = try!(ByteBuf::deserialize(deserializer)).into();
         CString::new(v)
             .map_err(|e| Error::custom(format!("unexpected NULL at byte {}", e.nul_position())))
     }

--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -315,8 +315,7 @@ impl Deserialize for CString {
     fn deserialize<D>(deserializer: D) -> Result<CString, D::Error>
         where D: Deserializer
     {
-        let mut v: Vec<u8> = try!(Deserialize::deserialize(deserializer));
-        v.pop(); // cut trailing NULL, because CString::new adds it
+        let v: Vec<u8> = try!(Deserialize::deserialize(deserializer));
         CString::new(v)
             .map_err(|e| Error::custom(format!("unexpected NULL at byte {}", e.nul_position())))
     }

--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -55,7 +55,7 @@ use de::{Deserialize, Deserializer, EnumVisitor, Error, MapVisitor, SeqVisitor, 
          VariantVisitor, Visitor};
 use de::from_primitive::FromPrimitive;
 
-use super::super::bytes::ByteBuf;
+use bytes::ByteBuf;
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -106,7 +106,7 @@ impl Serialize for CStr {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where S: Serializer
     {
-        self.to_bytes().serialize(serializer)
+        serializer.serialize_bytes(self.to_bytes())
     }
 }
 
@@ -116,7 +116,7 @@ impl Serialize for CString {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where S: Serializer
     {
-        self.to_bytes().serialize(serializer)
+        serializer.serialize_bytes(self.to_bytes())
     }
 }
 

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -106,7 +106,7 @@ impl Serialize for CStr {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where S: Serializer
     {
-        (self.to_bytes_with_nul()).serialize(serializer)
+        self.to_bytes().serialize(serializer)
     }
 }
 
@@ -116,7 +116,7 @@ impl Serialize for CString {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where S: Serializer
     {
-        (self.to_bytes_with_nul()).serialize(serializer)
+        self.to_bytes().serialize(serializer)
     }
 }
 

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -22,6 +22,8 @@ use core::ops;
 #[cfg(feature = "std")]
 use std::path;
 #[cfg(feature = "std")]
+use std::ffi::{CString, CStr};
+#[cfg(feature = "std")]
 use std::rc::Rc;
 #[cfg(all(feature = "alloc", not(feature = "std")))]
 use alloc::rc::Rc;
@@ -93,6 +95,28 @@ impl Serialize for String {
         where S: Serializer
     {
         (&self[..]).serialize(serializer)
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+#[cfg(feature = "std")]
+impl Serialize for CStr {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: Serializer
+    {
+        (self.to_bytes_with_nul()).serialize(serializer)
+    }
+}
+
+#[cfg(feature = "std")]
+impl Serialize for CString {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: Serializer
+    {
+        (self.to_bytes_with_nul()).serialize(serializer)
     }
 }
 

--- a/test_suite/tests/test_de.rs
+++ b/test_suite/tests/test_de.rs
@@ -6,6 +6,7 @@ use std::net;
 use std::path::PathBuf;
 use std::time::Duration;
 use std::default::Default;
+use std::ffi::CString;
 
 extern crate serde;
 use serde::Deserialize;
@@ -878,6 +879,11 @@ declare_tests! {
             Token::String("/usr/local/lib".to_owned()),
         ],
     }
+    test_cstring {
+        CString::new("abc").unwrap() => &[
+            Token::Bytes(b"abc"),
+        ],
+    }
 }
 
 #[cfg(feature = "unstable")]
@@ -994,5 +1000,17 @@ declare_error_tests! {
             Token::SeqEnd,
         ],
         Error::Message("invalid length 1, expected an array of length 3".into()),
+    }
+    test_cstring_internal_null<CString> {
+        &[
+            Token::Bytes(b"a\0c"),
+        ],
+        Error::Message("unexpected NULL at byte 1".into()),
+    }
+    test_cstring_internal_null_end<CString> {
+        &[
+            Token::Bytes(b"ac\0"),
+        ],
+        Error::Message("unexpected NULL at byte 2".into()),
     }
 }

--- a/test_suite/tests/test_ser.rs
+++ b/test_suite/tests/test_ser.rs
@@ -6,6 +6,7 @@ use std::net;
 use std::path::{Path, PathBuf};
 use std::str;
 use std::time::Duration;
+use std::ffi::CString;
 
 extern crate serde;
 
@@ -387,6 +388,16 @@ declare_tests! {
     test_path_buf {
         PathBuf::from("/usr/local/lib") => &[
             Token::Str("/usr/local/lib"),
+        ],
+    }
+    test_cstring {
+        CString::new("abc").unwrap() => &[
+            Token::Bytes(b"abc"),
+        ],
+    }
+    test_cstr {
+        (&*CString::new("abc").unwrap()) => &[
+            Token::Bytes(b"abc"),
         ],
     }
 }


### PR DESCRIPTION
From #800: `serde` currently ships with an `impl` of `Serialize` and `Deserialize` for [`str`](https://github.com/serde-rs/serde/blob/master/serde/src/ser/impls.rs#L80) and [`String`](https://github.com/serde-rs/serde/blob/master/serde/src/ser/impls.rs#L90), but not for the null-terminated C-like string types [`ffi::CStr`](https://doc.rust-lang.org/std/ffi/struct.CStr.html) and [`ffi::CString`](https://doc.rust-lang.org/std/ffi/struct.CString.html). Under the hood, these string implementations are very similar, and providing serialization implementations for the latter two shouldn't be too hard.

This patch adds serialization and deserialization of those types through null-terminated `[u8]`s. I'm guessing I should also implement tests for this, but didn't find where those should go. Feedback welcome!