### PR TITLE
Implement deserialize_enum for U32Deserializer

### DIFF
--- a/test_suite/tests/test_value.rs
+++ b/test_suite/tests/test_value.rs
@@ -1,0 +1,19 @@
+#[macro_use]
+extern crate serde_derive;
+
+extern crate serde;
+use serde::Deserialize;
+use serde::de::value::{self, ValueDeserializer};
+
+#[test]
+fn test_u32_to_enum() {
+    #[derive(Deserialize, Debug, PartialEq)]
+    enum E {
+        A,
+        B,
+    }
+
+    let deserializer = ValueDeserializer::<value::Error>::into_deserializer(1u32);
+    let e: E = E::deserialize(deserializer).unwrap();
+    assert_eq!(E::B, e);
+}


### PR DESCRIPTION
In serde_derive the visitors we generate for unit variants are able to deserialize from u32, so this should be supported for u32's value deserializer as well.