### PR TITLE
Add Deserialize impl for CStr

### DIFF
--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -27,6 +27,8 @@ use std::path;
 use core::str;
 #[cfg(feature = "std")]
 use std::ffi::CString;
+#[cfg(all(feature = "std", feature="unstable"))]
+use std::ffi::CStr;
 
 #[cfg(feature = "std")]
 use std::rc::Rc;
@@ -299,6 +301,16 @@ impl Deserialize for String {
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+
+#[cfg(all(feature = "std", feature="unstable"))]
+impl Deserialize for Box<CStr> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: Deserializer
+    {
+        let s = try!(CString::deserialize(deserializer));
+        Ok(s.into_boxed_c_str())
+    }
+}
 
 #[cfg(feature = "std")]
 impl Deserialize for CString {

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -61,7 +61,7 @@
 
 #![doc(html_root_url="https://docs.serde.rs")]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(feature = "unstable", feature(inclusive_range, nonzero, specialization, zero_one))]
+#![cfg_attr(feature = "unstable", feature(inclusive_range, nonzero, specialization, zero_one, into_boxed_c_str))]
 #![cfg_attr(feature = "alloc", feature(alloc))]
 #![cfg_attr(feature = "collections", feature(collections))]
 #![cfg_attr(feature = "cargo-clippy", allow(linkedlist, type_complexity, doc_markdown))]

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 publish = false
 
 [features]
-unstable-testing = ["compiletest_rs"]
+unstable = ["serde/unstable", "compiletest_rs"]
 
 [dev-dependencies]
 fnv = "1.0"

--- a/test_suite/tests/compiletest.rs
+++ b/test_suite/tests/compiletest.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "unstable-testing")]
+#![cfg(feature = "unstable")]
 
 extern crate compiletest_rs as compiletest;
 

--- a/test_suite/tests/test_de.rs
+++ b/test_suite/tests/test_de.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(feature = "unstable", feature(into_boxed_c_str))]
+
 #[macro_use]
 extern crate serde_derive;
 
@@ -900,7 +902,7 @@ fn test_cstr() {
 #[test]
 fn test_net_ipaddr() {
     assert_de_tokens(
-        "1.2.3.4".parse::<net::IpAddr>().unwrap(),
+        &"1.2.3.4".parse::<net::IpAddr>().unwrap(),
         &[Token::Str("1.2.3.4")],
     );
 }

--- a/test_suite/tests/test_de.rs
+++ b/test_suite/tests/test_de.rs
@@ -8,6 +8,9 @@ use std::time::Duration;
 use std::default::Default;
 use std::ffi::CString;
 
+#[cfg(feature = "unstable")]
+use std::ffi::CStr;
+
 extern crate serde;
 use serde::Deserialize;
 
@@ -888,10 +891,39 @@ declare_tests! {
 
 #[cfg(feature = "unstable")]
 #[test]
+fn test_cstr() {
+    assert_de_tokens::<Box<CStr>>(&CString::new("abc").unwrap().into_boxed_c_str(),
+                                  &[Token::Bytes(b"abc")]);
+}
+
+#[cfg(feature = "unstable")]
+#[test]
 fn test_net_ipaddr() {
     assert_de_tokens(
         "1.2.3.4".parse::<net::IpAddr>().unwrap(),
         &[Token::Str("1.2.3.4")],
+    );
+}
+
+#[cfg(feature = "unstable")]
+#[test]
+fn test_cstr_internal_null() {
+    assert_de_tokens_error::<Box<CStr>>(
+        &[
+            Token::Bytes(b"a\0c"),
+        ],
+        Error::Message("nul byte found in provided data at position: 1".into())
+    );
+}
+
+#[cfg(feature = "unstable")]
+#[test]
+fn test_cstr_internal_null_end() {
+    assert_de_tokens_error::<Box<CStr>>(
+        &[
+            Token::Bytes(b"ac\0"),
+        ],
+        Error::Message("nul byte found in provided data at position: 2".into())
     );
 }
 

--- a/test_suite/tests/test_gen.rs
+++ b/test_suite/tests/test_gen.rs
@@ -2,7 +2,7 @@
 // successfully when there are a variety of generics and non-(de)serializable
 // types involved.
 
-#![cfg_attr(feature = "unstable-testing", feature(non_ascii_idents))]
+#![cfg_attr(feature = "unstable", feature(non_ascii_idents))]
 
 #[macro_use]
 extern crate serde_derive;
@@ -220,8 +220,8 @@ fn test_gen() {
     }
     assert::<EmptyEnumVariant>();
 
-    #[cfg(feature = "unstable-testing")]
-    #[cfg_attr(feature = "unstable-testing", derive(Serialize, Deserialize))]
+    #[cfg(feature = "unstable")]
+    #[derive(Serialize, Deserialize)]
     struct NonAsciiIdents {
         σ: f64
     }
@@ -246,12 +246,12 @@ fn test_gen() {
         f: u8,
     }
 
-    #[cfg(feature = "unstable-testing")]
-    #[cfg_attr(feature = "unstable-testing", derive(Serialize, Deserialize))]
+    #[cfg(feature = "unstable")]
+    #[derive(Serialize, Deserialize)]
     struct EmptyTuple();
 
-    #[cfg(feature = "unstable-testing")]
-    #[cfg_attr(feature = "unstable-testing", derive(Serialize, Deserialize))]
+    #[cfg(feature = "unstable")]
+    #[derive(Serialize, Deserialize)]
     #[serde(deny_unknown_fields)]
     struct EmptyTupleDenyUnknown();
 
@@ -276,8 +276,8 @@ fn test_gen() {
         Variant,
     }
 
-    #[cfg(feature = "unstable-testing")]
-    #[cfg_attr(feature = "unstable-testing", derive(Serialize, Deserialize))]
+    #[cfg(feature = "unstable")]
+    #[derive(Serialize, Deserialize)]
     enum EmptyVariants {
         Braced {},
         Tuple(),
@@ -288,8 +288,8 @@ fn test_gen() {
         TupleSkip(#[serde(skip_deserializing)] u8),
     }
 
-    #[cfg(feature = "unstable-testing")]
-    #[cfg_attr(feature = "unstable-testing", derive(Serialize, Deserialize))]
+    #[cfg(feature = "unstable")]
+    #[derive(Serialize, Deserialize)]
     #[serde(deny_unknown_fields)]
     enum EmptyVariantsDenyUnknown {
         Braced {},

--- a/test_suite/tests/test_ser.rs
+++ b/test_suite/tests/test_ser.rs
@@ -21,9 +21,6 @@ use self::serde_test::{
 extern crate fnv;
 use self::fnv::FnvHasher;
 
-#[cfg(feature = "unstable")]
-use serde::ser::iterator;
-
 #[macro_use]
 mod macros;
 
@@ -402,54 +399,11 @@ declare_tests! {
     }
 }
 
-
-#[cfg(feature = "unstable")]
-#[test]
-fn test_iterator() {
-    assert_ser_tokens(iterator([0; 0].iter()), &[
-        Token::SeqStart(Some(0)),
-        Token::SeqEnd,
-    ]);
-    assert_ser_tokens(iterator([1, 2, 3].iter()), &[
-        Token::SeqStart(Some(3)),
-            Token::SeqSep,
-            Token::I32(1),
-
-            Token::SeqSep,
-            Token::I32(2),
-
-            Token::SeqSep,
-            Token::I32(3),
-        Token::SeqEnd,
-    ]);
-    assert_ser_tokens(iterator([1, 2, 3].iter().map(|x| x * 2)), &[
-        Token::SeqStart(Some(3)),
-            Token::SeqSep,
-            Token::I32(2),
-
-            Token::SeqSep,
-            Token::I32(4),
-
-            Token::SeqSep,
-            Token::I32(6),
-        Token::SeqEnd,
-    ]);
-    assert_ser_tokens(iterator([1, 2, 3].iter().filter(|&x| x % 2 != 0)), &[
-        Token::SeqStart(None),
-            Token::SeqSep,
-            Token::I32(1),
-
-            Token::SeqSep,
-            Token::I32(3),
-        Token::SeqEnd,
-    ]);
-}
-
 #[cfg(feature = "unstable")]
 #[test]
 fn test_net_ipaddr() {
     assert_ser_tokens(
-        "1.2.3.4".parse::<net::IpAddr>().unwrap(),
+        &"1.2.3.4".parse::<net::IpAddr>().unwrap(),
         &[Token::Str("1.2.3.4")],
     );
 }

--- a/travis.sh
+++ b/travis.sh
@@ -30,7 +30,7 @@ if [ -n "${CLIPPY}" ]; then
     cargo clippy --features unstable-testing -- -Dclippy
 
     cd "$DIR/test_suite"
-    cargo clippy --features unstable-testing -- -Dclippy
+    cargo clippy --features unstable -- -Dclippy
 
     cd "$DIR/test_suite/no_std"
     cargo clippy -- -Dclippy
@@ -46,7 +46,7 @@ else
     cd "$DIR/test_suite/deps"
     channel build
     cd "$DIR/test_suite"
-    channel test --features unstable-testing
+    channel test --features unstable
     cd "$DIR/test_suite/no_std"
     channel build
 


### PR DESCRIPTION
Fixes #810.

I've scoped the `impl` under `feature="unstable"` for now (don't know what the policy for that feature is), but this should possibly not be merged until https://github.com/rust-lang/rust/issues/40380 lands and fully stabilizes [`CString::into_boxed_c_str`](https://doc.rust-lang.org/nightly/std/ffi/struct.CString.html#method.into_boxed_c_str). At that point, `feature="unstable"` should obviously be removed.