### PR TITLE
Macro attributes to specify From and Into trait types for structs and enums

### DIFF
--- a/serde/src/export.rs
+++ b/serde/src/export.rs
@@ -7,7 +7,7 @@ use std::borrow::Cow;
 use collections::borrow::Cow;
 
 pub use core::default::Default;
-pub use core::fmt;
+pub use core::{fmt, clone, convert};
 pub use core::marker::PhantomData;
 pub use core::option::Option::{self, None, Some};
 pub use core::result::Result::{self, Ok, Err};

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -79,7 +79,8 @@ extern crate core as actual_core;
 #[cfg(feature = "std")]
 mod core {
     pub use std::{ops, hash, fmt, cmp, marker, mem, i8, i16, i32, i64, u8, u16, u32, u64, isize,
-                  usize, f32, f64, char, str, num, slice, iter, cell, default, result, option};
+                  usize, f32, f64, char, str, num, slice, iter, cell, default, result, option,
+                  clone, convert};
     #[cfg(feature = "unstable")]
     pub use actual_core::nonzero;
 }

--- a/serde_codegen_internals/src/attr.rs
+++ b/serde_codegen_internals/src/attr.rs
@@ -149,7 +149,6 @@ impl Item {
         let mut content = Attr::none(cx, "content");
         let mut from_type = Attr::none(cx, "from");
         let mut into_type = Attr::none(cx, "into");
-        let mut as_type = Attr::none(cx, "into_as");
 
         for meta_items in item.attrs.iter().filter_map(get_serde_meta_items) {
             for meta_item in meta_items {
@@ -275,7 +274,7 @@ impl Item {
                         }
                     }
 
-                    // Parse `#[serde(types(from = "type", into = "type", as = "type"))]
+                    // Parse `#[serde(from = "type", into = "type")]
                     MetaItem(NameValue(ref name, ref lit)) if name == "from" => {
                         if let Ok(from_ty) = get_type(cx, name.as_ref(), lit) {
                             from_type.set_opt(Some(from_ty));
@@ -284,11 +283,6 @@ impl Item {
                     MetaItem(NameValue(ref name, ref lit)) if name == "into" => {
                         if let Ok(into_ty) = get_type(cx, name.as_ref(), lit) {
                             into_type.set_opt(Some(into_ty));
-                        }
-                    }
-                    MetaItem(NameValue(ref name, ref lit)) if name == "as" => {
-                        if let Ok(as_ty) = get_type(cx, name.as_ref(), lit) {
-                            as_type.set_opt(Some(as_ty));
                         }
                     }
 

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -86,11 +86,7 @@ fn requires_default(attrs: &attr::Field) -> bool {
 
 fn deserialize_body(item: &Item, generics: &syn::Generics) -> Fragment {
     if let Some(fr_ty) = item.attrs.from_type() {
-        if let Some(fr_as_ty) = item.attrs.from_as_type() {
-            deserialize_from_as(fr_ty, fr_as_ty)
-        } else {
-            deserialize_from(fr_ty)
-        }
+        deserialize_from(fr_ty)
     } else {
         match item.body {
             Body::Enum(ref variants) => {
@@ -125,23 +121,13 @@ fn deserialize_body(item: &Item, generics: &syn::Generics) -> Fragment {
 }
 
 fn deserialize_from(from_type: &syn::Ty) -> Fragment {
-    quote_block!({
+    quote_block! {
         let de_val = <#from_type as _serde::Deserialize>::deserialize(deserializer);
         match de_val {
-            Ok(from_in) => Ok(_serde::export::convert::From::from(from_in)),
-            Err(e) => Err(e)
+            _serde::export::Result::Ok(from_in) => _serde::export::Result::Ok(_serde::export::convert::From::from(from_in)),
+            _serde::export::Result::Err(e) => _serde::export::Result::Err(e)
         }
-    })
-}
-
-fn deserialize_from_as(from_type: &syn::Ty, from_as_type: &syn::Ty) -> Fragment {
-    quote_block!({
-        let de_val = <#from_type as _serde::Deserialize>::deserialize(deserializer);
-        match de_val {
-            Ok(from_in) => Ok(_serde::export::convert::From::from(from_in as #from_as_type)),
-            Err(e) => Err(e)
-        }
-    })
+    }
 }
 
 fn deserialize_unit_struct(ident: &syn::Ident, item_attrs: &attr::Item) -> Fragment {

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -62,11 +62,7 @@ fn needs_serialize_bound(attrs: &attr::Field) -> bool {
 
 fn serialize_body(item: &Item, generics: &syn::Generics) -> Fragment {
     if let Some(in_ty) = item.attrs.into_type() {
-        if let Some(in_as_ty) = item.attrs.into_as_type() {
-            serialize_into_as(in_ty, in_as_ty)
-        } else {
-            serialize_into(in_ty)
-        }
+        serialize_into(in_ty)
     } else {
         match item.body {
             Body::Enum(ref variants) => {
@@ -94,16 +90,8 @@ fn serialize_body(item: &Item, generics: &syn::Generics) -> Fragment {
 
 fn serialize_into(into_type: &syn::Ty) -> Fragment {
     quote_block! {
-        let cloned_val: #into_type = _serde::export::clone::Clone::clone(self).into();
-        cloned_val.serialize(_serializer)
-    }
-}
-
-fn serialize_into_as(into_type: &syn::Ty, into_as_type: &syn::Ty) -> Fragment {
-    quote_block! {
-        let cloned_val: #into_type = _serde::export::clone::Clone::clone(self).into();
-        let cloned_val_as = cloned_val as #into_as_type;
-        cloned_val_as.serialize(_serializer)
+        let cloned_val: #into_type = _serde::export::convert::Into::into(_serde::export::clone::Clone::clone(self));
+        _serde::Serialize::serialize(&cloned_val, _serializer)
     }
 }
 

--- a/test_suite/tests/compile-fail/type-attribute/type_attribute_fail_from.rs
+++ b/test_suite/tests/compile-fail/type-attribute/type_attribute_fail_from.rs
@@ -1,0 +1,11 @@
+#[macro_use]
+extern crate serde_derive;
+
+#[derive(Deserialize)] //~ ERROR: proc-macro derive panicked
+#[serde(from="")]
+enum TestOne {
+    Testing,
+    One,
+    Two,
+    Three,
+}

--- a/test_suite/tests/compile-fail/type-attribute/type_attribute_fail_into.rs
+++ b/test_suite/tests/compile-fail/type-attribute/type_attribute_fail_into.rs
@@ -1,0 +1,11 @@
+#[macro_use]
+extern crate serde_derive;
+
+#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+#[serde(into="")]
+enum TestOne {
+    Testing,
+    One,
+    Two,
+    Three,
+}

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -978,6 +978,34 @@ fn test_invalid_length_enum() {
     );
 }
 
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+#[serde(into="EnumToU32", from="EnumToU32")]
+struct StructFromEnum(Option<u32>);
+
+impl Into<EnumToU32> for StructFromEnum {
+    fn into(self) -> EnumToU32 {
+        match self {
+            StructFromEnum(v) => v.into()
+        }
+    }
+}
+
+impl From<EnumToU32> for StructFromEnum {
+    fn from(v: EnumToU32) -> Self {
+        StructFromEnum(v.into())
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+#[serde(into="Option<u32>", from="Option<u32>")]
+enum EnumToU32 {
+    One,
+    Two,
+    Three,
+    Four,
+    Nothing
+}
+
 impl Into<Option<u32>> for EnumToU32 {
     fn into(self) -> Option<u32> {
         match self {
@@ -1000,34 +1028,6 @@ impl From<Option<u32>> for EnumToU32 {
             _ => EnumToU32::Nothing
         }
     }
-}
-
-impl Into<EnumToU32> for StructFromEnum {
-    fn into(self) -> EnumToU32 {
-        match self {
-            StructFromEnum(v) => v.into()
-        }
-    }
-}
-
-impl From<EnumToU32> for StructFromEnum {
-    fn from(v: EnumToU32) -> Self {
-        StructFromEnum(v.into())
-    }
-}
-
-#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(into="EnumToU32", from="EnumToU32")]
-struct StructFromEnum(Option<u32>);
-
-#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(into="Option<u32>", from="Option<u32>")]
-enum EnumToU32 {
-    One,
-    Two,
-    Three,
-    Four,
-    Nothing
 }
 
 #[test]

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -977,3 +977,83 @@ fn test_invalid_length_enum() {
         Error::Message("invalid length 1, expected tuple of 2 elements".to_owned()),
     );
 }
+
+impl Into<Option<u32>> for EnumToU32 {
+    fn into(self) -> Option<u32> {
+        match self {
+            EnumToU32::One => Some(1),
+            EnumToU32::Two => Some(2),
+            EnumToU32::Three => Some(3),
+            EnumToU32::Four => Some(4),
+            EnumToU32::Nothing => None
+        }
+    }
+}
+
+impl From<Option<u32>> for EnumToU32 {
+    fn from(v: Option<u32>) -> Self {
+        match v {
+            Some(1) => EnumToU32::One,
+            Some(2) => EnumToU32::Two,
+            Some(3) => EnumToU32::Three,
+            Some(4) => EnumToU32::Four,
+            _ => EnumToU32::Nothing
+        }
+    }
+}
+
+impl Into<EnumToU32> for StructFromEnum {
+    fn into(self) -> EnumToU32 {
+        match self {
+            StructFromEnum(v) => v.into()
+        }
+    }
+}
+
+impl From<EnumToU32> for StructFromEnum {
+    fn from(v: EnumToU32) -> Self {
+        StructFromEnum(v.into())
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+#[serde(types(into="EnumToU32", from="EnumToU32"))]
+struct StructFromEnum(Option<u32>);
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+#[serde(types(into="Option<u32>", from="Option<u32>"))]
+enum EnumToU32 {
+    One,
+    Two,
+    Three,
+    Four,
+    Nothing
+}
+
+#[test]
+fn test_from_into_traits() {
+    assert_ser_tokens::<EnumToU32>(&EnumToU32::One,
+        &[Token::Option(true),
+          Token::U32(1)
+        ] 
+    );
+    assert_ser_tokens::<EnumToU32>(&EnumToU32::Nothing,
+        &[Token::Option(false)] 
+    );
+    assert_de_tokens::<EnumToU32>(&EnumToU32::Two,
+        &[Token::Option(true),
+          Token::U32(2)
+        ]
+    );
+    assert_ser_tokens::<StructFromEnum>(&StructFromEnum(Some(5)),
+        &[Token::Option(false)]
+    );
+    assert_ser_tokens::<StructFromEnum>(&StructFromEnum(None),
+        &[Token::Option(false)]
+    );
+    assert_de_tokens::<StructFromEnum>(&StructFromEnum(Some(2)),
+        &[Token::Option(true),
+          Token::U32(2)
+        ]
+    );
+}

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -1017,11 +1017,11 @@ impl From<EnumToU32> for StructFromEnum {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(types(into="EnumToU32", from="EnumToU32"))]
+#[serde(into="EnumToU32", from="EnumToU32")]
 struct StructFromEnum(Option<u32>);
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(types(into="Option<u32>", from="Option<u32>"))]
+#[serde(into="Option<u32>", from="Option<u32>")]
 enum EnumToU32 {
     One,
     Two,


### PR DESCRIPTION
I have implemented `#[serde(types(from="type", into="type", from_as="type", into_as="type))]` to allow more complicated serialization and deserialization. The `from` type specifies the type from which the result will be converted after being passed through `Derializer`. The `into` type specifies the type that the value will be converted to before being passed through `Serializer`. `from_as` and `into_as` provide an additional safe cast as necessary between the `Serializer`/`Deserializer` and the `From`/`Into` traits.