### PR TITLE
Implement Serialize/Deserialize for OsStr/OsString

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+environment:
+  matrix:
+    - APPVEYOR_RUST_CHANNEL: stable
+    - APPVEYOR_RUST_CHANNEL: nightly
+
+install:
+  # Install rust, x86_64-pc-windows-msvc host
+  - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+  - rustup-init.exe -y --default-host x86_64-pc-windows-msvc --default-toolchain %APPVEYOR_RUST_CHANNEL%
+  - set PATH=C:\msys64\usr\bin;%PATH%;C:\Users\appveyor\.cargo\bin
+  - rustc -vV
+  - cargo -vV
+
+build: false
+
+test_script:
+  - sh -c 'PATH=`rustc --print sysroot`/bin:$PATH ./travis.sh'

--- a/test_suite/no_std/src/main.rs
+++ b/test_suite/no_std/src/main.rs
@@ -1,7 +1,8 @@
-#![feature(lang_items, start, libc)]
+#![feature(lang_items, start, libc, compiler_builtins_lib)]
 #![no_std]
 
 extern crate libc;
+extern crate compiler_builtins;
 
 #[start]
 fn start(_argc: isize, _argv: *const *const u8) -> isize {

--- a/test_suite/tests/test_de.rs
+++ b/test_suite/tests/test_de.rs
@@ -8,7 +8,7 @@ use std::net;
 use std::path::PathBuf;
 use std::time::Duration;
 use std::default::Default;
-use std::ffi::CString;
+use std::ffi::{CString, OsString};
 
 #[cfg(feature = "unstable")]
 use std::ffi::CStr;
@@ -911,6 +911,56 @@ declare_tests! {
             Token::Bytes(b"abc"),
         ],
     }
+}
+
+#[cfg(unix)]
+#[test]
+fn test_osstring() {
+    use std::os::unix::ffi::OsStringExt;
+
+    let value = OsString::from_vec(vec![1, 2, 3]);
+    let tokens = [
+        Token::EnumStart("OsString"),
+        Token::Str("Unix"),
+        Token::SeqStart(Some(2)),
+            Token::SeqSep,
+            Token::U8(1),
+
+            Token::SeqSep,
+            Token::U8(2),
+
+            Token::SeqSep,
+            Token::U8(3),
+        Token::SeqEnd,
+    ];
+
+    assert_de_tokens(&value, &tokens);
+    assert_de_tokens_ignore(&tokens);
+}
+
+#[cfg(windows)]
+#[test]
+fn test_osstring() {
+    use std::os::windows::ffi::OsStringExt;
+
+    let value = OsString::from_wide(&[1, 2, 3]);
+    let tokens = [
+        Token::EnumStart("OsString"),
+        Token::Str("Windows"),
+        Token::SeqStart(Some(2)),
+            Token::SeqSep,
+            Token::U16(1),
+
+            Token::SeqSep,
+            Token::U16(2),
+
+            Token::SeqSep,
+            Token::U16(3),
+        Token::SeqEnd,
+    ];
+
+    assert_de_tokens(&value, &tokens);
+    assert_de_tokens_ignore(&tokens);
 }
 
 #[cfg(feature = "unstable")]

--- a/test_suite/tests/test_ser.rs
+++ b/test_suite/tests/test_ser.rs
@@ -422,6 +422,7 @@ fn test_net_ipaddr() {
 }
 
 #[test]
+#[cfg(unix)]
 fn test_cannot_serialize_paths() {
     let path = unsafe {
         str::from_utf8_unchecked(b"Hello \xF0\x90\x80World")

--- a/travis.sh
+++ b/travis.sh
@@ -10,6 +10,11 @@ channel() {
             pwd
             (set -x; cargo "$@")
         fi
+    elif [ -n "${APPVEYOR}" ]; then
+        if [ "${APPVEYOR_RUST_CHANNEL}" = "${CHANNEL}" ]; then
+            pwd
+            (set -x; cargo "$@")
+        fi
     else
         pwd
         (set -x; cargo "+${CHANNEL}" "$@")


### PR DESCRIPTION
This commit implements the two serde traits for the libstd `OsStr` and
`OsString` types. This came up as a use case during implementing sccache where
we're basically just doing IPC to communicate paths around. Additionally the
`Path` and `PathBuf` implementations have been updated to delegate to the os
string ones.

These types are platform-specific, however, so the serialization/deserialization
isn't trivial. Currently this "fakes" a newtype variant for Unix/Windows to
prevent cross-platform serialization/deserialization. This means if you're doing
IPC within the same OS (e.g. Windows to Windows) then serialization should be
infallible. If you're doing IPC across platforms (e.g.  Unix to Windows) then
using `OsString` is guaranteed to fail as bytes from one OS won't deserialize on
the other (even if they're unicode).

Closes #823