### PR TITLE
Add a 'de lifetime to the deserialize traits

### DIFF
--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -29,7 +29,7 @@ unstable-testing = ["unstable", "std"]
 playground = ["serde_derive"]
 
 [dependencies]
-serde_derive = { version = "0.9", optional = true }
+serde_derive = { version = "0.9", optional = true, path = "../serde_derive" }
 
 [dev-dependencies]
-serde_derive = "0.9"
+serde_derive = { version = "0.9", path = "../serde_derive" }

--- a/serde/src/bytes.rs
+++ b/serde/src/bytes.rs
@@ -237,7 +237,7 @@ mod bytebuf {
     /// This type implements the `serde::de::Visitor` trait for a `ByteBuf`.
     pub struct ByteBufVisitor;
 
-    impl de::Visitor for ByteBufVisitor {
+    impl<'de> de::Visitor<'de> for ByteBufVisitor {
         type Value = ByteBuf;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -253,7 +253,7 @@ mod bytebuf {
 
         #[inline]
         fn visit_seq<V>(self, mut visitor: V) -> Result<ByteBuf, V::Error>
-            where V: de::SeqVisitor
+            where V: de::SeqVisitor<'de>
         {
             let len = cmp::min(visitor.size_hint().0, 4096);
             let mut values = Vec::with_capacity(len);
@@ -292,10 +292,10 @@ mod bytebuf {
         }
     }
 
-    impl de::Deserialize for ByteBuf {
+    impl<'de> de::Deserialize<'de> for ByteBuf {
         #[inline]
         fn deserialize<D>(deserializer: D) -> Result<ByteBuf, D::Error>
-            where D: de::Deserializer
+            where D: de::Deserializer<'de>
         {
             deserializer.deserialize_byte_buf(ByteBufVisitor)
         }

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -405,8 +405,8 @@ pub trait Expected {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result;
 }
 
-impl<T> Expected for T
-    where T: Visitor
+impl<'de, T> Expected for T
+    where T: Visitor<'de>
 {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         self.expecting(formatter)
@@ -451,15 +451,35 @@ impl<'a> Display for Expected + 'a {
 /// [de]: https://docs.serde.rs/serde/de/index.html
 /// [codegen]: https://serde.rs/codegen.html
 /// [impl-deserialize]: https://serde.rs/impl-deserialize.html
-pub trait Deserialize: Sized {
+pub trait Deserialize<'de>: Sized {
     /// Deserialize this value from the given Serde deserializer.
     ///
     /// See the [Implementing `Deserialize`][impl-deserialize] section of the
     /// manual for more information about how to implement this method.
     ///
     /// [impl-deserialize]: https://serde.rs/impl-deserialize.html
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer;
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: Deserializer<'de>;
 }
+
+/// A data structure that can be deserialized without borrowing any data from
+/// the deserializer.
+///
+/// This is primarily useful for trait bounds on functions. For example a
+/// `from_str` function may be able to deserialize a data structure that borrows
+/// from the input string, but a `from_reader` function may only deserialize
+/// owned data.
+///
+/// ```rust,ignore
+/// pub fn from_str<'a, T>(s: &'a str) -> Result<T>
+///     where T: Deserialize<'a>;
+///
+/// pub fn from_reader<R, T>(rdr: R) -> Result<T>
+///     where R: Read,
+///           T: DeserializeOwned;
+/// ```
+pub trait DeserializeOwned: for<'de> Deserialize<'de> {}
+impl<T> DeserializeOwned for T where T: for<'de> Deserialize<'de> {}
 
 /// `DeserializeSeed` is the stateful form of the `Deserialize` trait. If you
 /// ever find yourself looking for a way to pass data into a `Deserialize` impl,
@@ -600,23 +620,24 @@ pub trait Deserialize: Sized {
 /// # let _ = flattened;
 /// # Ok(()) }
 /// ```
-pub trait DeserializeSeed: Sized {
+pub trait DeserializeSeed<'de>: Sized {
     /// The type produced by using this seed.
     type Value;
 
     /// Equivalent to the more common `Deserialize::deserialize` method, except
     /// with some initial piece of data (the seed) passed in.
-    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error> where D: Deserializer;
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+        where D: Deserializer<'de>;
 }
 
-impl<T> DeserializeSeed for PhantomData<T>
-    where T: Deserialize
+impl<'de, T> DeserializeSeed<'de> for PhantomData<T>
+    where T: Deserialize<'de>
 {
     type Value = T;
 
     #[inline]
     fn deserialize<D>(self, deserializer: D) -> Result<T, D::Error>
-        where D: Deserializer
+        where D: Deserializer<'de>
     {
         T::deserialize(deserializer)
     }
@@ -705,7 +726,7 @@ impl<T> DeserializeSeed for PhantomData<T>
 /// what type is in the input. Know that relying on `Deserializer::deserialize`
 /// means your data type will be able to deserialize from self-describing
 /// formats only, ruling out Bincode and many others.
-pub trait Deserializer: Sized {
+pub trait Deserializer<'de>: Sized {
     /// The error type that can be returned if some error occurs during
     /// deserialization.
     type Error: Error;
@@ -719,43 +740,43 @@ pub trait Deserializer: Sized {
     /// `Deserializer::deserialize` means your data type will be able to
     /// deserialize from self-describing formats only, ruling out Bincode and
     /// many others.
-    fn deserialize<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor;
+    fn deserialize<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type is expecting a `bool` value.
-    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor;
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type is expecting a `u8` value.
-    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor;
+    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type is expecting a `u16` value.
-    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor;
+    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type is expecting a `u32` value.
-    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor;
+    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type is expecting a `u64` value.
-    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor;
+    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type is expecting an `i8` value.
-    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor;
+    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type is expecting an `i16` value.
-    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor;
+    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type is expecting an `i32` value.
-    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor;
+    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type is expecting an `i64` value.
-    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor;
+    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type is expecting a `f32` value.
-    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor;
+    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type is expecting a `f64` value.
-    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor;
+    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type is expecting a `char` value.
-    fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor;
+    fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type is expecting a string value and does
     /// not benefit from taking ownership of buffered data owned by the
@@ -764,7 +785,7 @@ pub trait Deserializer: Sized {
     /// If the `Visitor` would benefit from taking ownership of `String` data,
     /// indiciate this to the `Deserializer` by using `deserialize_string`
     /// instead.
-    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor;
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type is expecting a string value and would
     /// benefit from taking ownership of buffered data owned by the
@@ -773,7 +794,7 @@ pub trait Deserializer: Sized {
     /// If the `Visitor` would not benefit from taking ownership of `String`
     /// data, indicate that to the `Deserializer` by using `deserialize_str`
     /// instead.
-    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor;
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type is expecting a byte array and does not
     /// benefit from taking ownership of buffered data owned by the
@@ -782,7 +803,7 @@ pub trait Deserializer: Sized {
     /// If the `Visitor` would benefit from taking ownership of `Vec<u8>` data,
     /// indicate this to the `Deserializer` by using `deserialize_byte_buf`
     /// instead.
-    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor;
+    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type is expecting a byte array and would
     /// benefit from taking ownership of buffered data owned by the
@@ -791,17 +812,17 @@ pub trait Deserializer: Sized {
     /// If the `Visitor` would not benefit from taking ownership of `Vec<u8>`
     /// data, indicate that to the `Deserializer` by using `deserialize_bytes`
     /// instead.
-    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor;
+    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type is expecting an optional value.
     ///
     /// This allows deserializers that encode an optional value as a nullable
     /// value to convert the null value into `None` and a regular value into
     /// `Some(value)`.
-    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor;
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type is expecting a unit value.
-    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor;
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type is expecting a unit struct with a
     /// particular name.
@@ -809,7 +830,7 @@ pub trait Deserializer: Sized {
                                   name: &'static str,
                                   visitor: V)
                                   -> Result<V::Value, Self::Error>
-        where V: Visitor;
+        where V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type is expecting a newtype struct with a
     /// particular name.
@@ -817,10 +838,10 @@ pub trait Deserializer: Sized {
                                      name: &'static str,
                                      visitor: V)
                                      -> Result<V::Value, Self::Error>
-        where V: Visitor;
+        where V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type is expecting a sequence of values.
-    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor;
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type is expecting a sequence of values and
     /// knows how many values there are without looking at the serialized data.
@@ -828,12 +849,12 @@ pub trait Deserializer: Sized {
                                      len: usize,
                                      visitor: V)
                                      -> Result<V::Value, Self::Error>
-        where V: Visitor;
+        where V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type is expecting a tuple value with a
     /// particular number of elements.
     fn deserialize_tuple<V>(self, len: usize, visitor: V) -> Result<V::Value, Self::Error>
-        where V: Visitor;
+        where V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type is expecting a tuple struct with a
     /// particular name and number of fields.
@@ -842,10 +863,10 @@ pub trait Deserializer: Sized {
                                    len: usize,
                                    visitor: V)
                                    -> Result<V::Value, Self::Error>
-        where V: Visitor;
+        where V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type is expecting a map of key-value pairs.
-    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor;
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error> where V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type is expecting a struct with a particular
     /// name and fields.
@@ -854,12 +875,12 @@ pub trait Deserializer: Sized {
                              fields: &'static [&'static str],
                              visitor: V)
                              -> Result<V::Value, Self::Error>
-        where V: Visitor;
+        where V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type is expecting the name of a struct
     /// field.
     fn deserialize_struct_field<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-        where V: Visitor;
+        where V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type is expecting an enum value with a
     /// particular name and possible variants.
@@ -868,14 +889,14 @@ pub trait Deserializer: Sized {
                            variants: &'static [&'static str],
                            visitor: V)
                            -> Result<V::Value, Self::Error>
-        where V: Visitor;
+        where V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type needs to deserialize a value whose type
     /// doesn't matter because it is ignored.
     ///
     /// Deserializers for non-self-describing formats may not support this mode.
     fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-        where V: Visitor;
+        where V: Visitor<'de>;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -910,7 +931,7 @@ pub trait Deserializer: Sized {
 ///     }
 /// }
 /// ```
-pub trait Visitor: Sized {
+pub trait Visitor<'de>: Sized {
     /// The value produced by this visitor.
     type Value;
 
@@ -1035,6 +1056,21 @@ pub trait Visitor: Sized {
         Err(Error::invalid_type(Unexpected::Str(v), &self))
     }
 
+    /// Deserialize a `&str` that is borrowed from the input data.
+    ///
+    /// This enables zero-copy deserialization of strings in some formats. For
+    /// example JSON input containing the JSON string `"borrowed"` can be
+    /// deserialized with zero copying into a `&'a str` as long as the input
+    /// data outlives `'a`.
+    ///
+    /// The default implementation forwards to `visit_str`.
+    #[inline]
+    fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+        where E: Error
+    {
+        self.visit_str(v)
+    }
+
     /// Deserialize a `String` into a `Value`.
     ///
     /// This method allows the `Visitor` to avoid a copy by taking ownership of
@@ -1073,7 +1109,7 @@ pub trait Visitor: Sized {
 
     /// Deserialize a present optional `Value`.
     fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-        where D: Deserializer
+        where D: Deserializer<'de>
     {
         let _ = deserializer;
         Err(Error::invalid_type(Unexpected::Option, &self))
@@ -1081,7 +1117,7 @@ pub trait Visitor: Sized {
 
     /// Deserialize `Value` as a newtype struct.
     fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-        where D: Deserializer
+        where D: Deserializer<'de>
     {
         let _ = deserializer;
         Err(Error::invalid_type(Unexpected::NewtypeStruct, &self))
@@ -1089,7 +1125,7 @@ pub trait Visitor: Sized {
 
     /// Deserialize `Value` as a sequence of elements.
     fn visit_seq<V>(self, visitor: V) -> Result<Self::Value, V::Error>
-        where V: SeqVisitor
+        where V: SeqVisitor<'de>
     {
         let _ = visitor;
         Err(Error::invalid_type(Unexpected::Seq, &self))
@@ -1097,7 +1133,7 @@ pub trait Visitor: Sized {
 
     /// Deserialize `Value` as a key-value map.
     fn visit_map<V>(self, visitor: V) -> Result<Self::Value, V::Error>
-        where V: MapVisitor
+        where V: MapVisitor<'de>
     {
         let _ = visitor;
         Err(Error::invalid_type(Unexpected::Map, &self))
@@ -1105,7 +1141,7 @@ pub trait Visitor: Sized {
 
     /// Deserialize `Value` as an enum.
     fn visit_enum<V>(self, visitor: V) -> Result<Self::Value, V::Error>
-        where V: EnumVisitor
+        where V: EnumVisitor<'de>
     {
         let _ = visitor;
         Err(Error::invalid_type(Unexpected::Enum, &self))
@@ -1126,6 +1162,20 @@ pub trait Visitor: Sized {
     {
         let _ = v;
         Err(Error::invalid_type(Unexpected::Bytes(v), &self))
+    }
+
+    /// Deserialize a `&[u8]` that is borrowed from the input data.
+    ///
+    /// This enables zero-copy deserialization of bytes in some formats. For
+    /// example Bincode data containing bytes can be deserialized with zero
+    /// copying into a `&'a [u8]` as long as the input data outlives `'a`.
+    ///
+    /// The default implementation forwards to `visit_bytes`.
+    #[inline]
+    fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
+        where E: Error
+    {
+        self.visit_bytes(v)
     }
 
     /// Deserialize a `Vec<u8>` into a `Value`.
@@ -1157,7 +1207,7 @@ pub trait Visitor: Sized {
 ///
 /// This is a trait that a `Deserializer` passes to a `Visitor` implementation,
 /// which deserializes each item in a sequence.
-pub trait SeqVisitor {
+pub trait SeqVisitor<'de> {
     /// The error type that can be returned if some error occurs during
     /// deserialization.
     type Error: Error;
@@ -1168,7 +1218,7 @@ pub trait SeqVisitor {
     /// `Deserialize` implementations should typically use `SeqVisitor::visit`
     /// instead.
     fn visit_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
-        where T: DeserializeSeed;
+        where T: DeserializeSeed<'de>;
 
     /// This returns `Ok(Some(value))` for the next value in the sequence, or
     /// `Ok(None)` if there are no more remaining items.
@@ -1177,7 +1227,7 @@ pub trait SeqVisitor {
     /// `SeqVisitor` implementations should not override the default behavior.
     #[inline]
     fn visit<T>(&mut self) -> Result<Option<T>, Self::Error>
-        where T: Deserialize
+        where T: Deserialize<'de>
     {
         self.visit_seed(PhantomData)
     }
@@ -1189,21 +1239,21 @@ pub trait SeqVisitor {
     }
 }
 
-impl<'a, V> SeqVisitor for &'a mut V
-    where V: SeqVisitor
+impl<'de, 'a, V> SeqVisitor<'de> for &'a mut V
+    where V: SeqVisitor<'de>
 {
     type Error = V::Error;
 
     #[inline]
     fn visit_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, V::Error>
-        where T: DeserializeSeed
+        where T: DeserializeSeed<'de>
     {
         (**self).visit_seed(seed)
     }
 
     #[inline]
     fn visit<T>(&mut self) -> Result<Option<T>, V::Error>
-        where T: Deserialize
+        where T: Deserialize<'de>
     {
         (**self).visit()
     }
@@ -1219,7 +1269,7 @@ impl<'a, V> SeqVisitor for &'a mut V
 /// `MapVisitor` visits each item in a sequence.
 ///
 /// This is a trait that a `Deserializer` passes to a `Visitor` implementation.
-pub trait MapVisitor {
+pub trait MapVisitor<'de> {
     /// The error type that can be returned if some error occurs during
     /// deserialization.
     type Error: Error;
@@ -1230,14 +1280,14 @@ pub trait MapVisitor {
     /// `Deserialize` implementations should typically use
     /// `MapVisitor::visit_key` or `MapVisitor::visit` instead.
     fn visit_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
-        where K: DeserializeSeed;
+        where K: DeserializeSeed<'de>;
 
     /// This returns a `Ok(value)` for the next value in the map.
     ///
     /// `Deserialize` implementations should typically use
     /// `MapVisitor::visit_value` instead.
     fn visit_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
-        where V: DeserializeSeed;
+        where V: DeserializeSeed<'de>;
 
     /// This returns `Ok(Some((key, value)))` for the next (key-value) pair in
     /// the map, or `Ok(None)` if there are no more remaining items.
@@ -1252,8 +1302,8 @@ pub trait MapVisitor {
                         kseed: K,
                         vseed: V)
                         -> Result<Option<(K::Value, V::Value)>, Self::Error>
-        where K: DeserializeSeed,
-              V: DeserializeSeed
+        where K: DeserializeSeed<'de>,
+              V: DeserializeSeed<'de>
     {
         match try!(self.visit_key_seed(kseed)) {
             Some(key) => {
@@ -1271,7 +1321,7 @@ pub trait MapVisitor {
     /// `MapVisitor` implementations should not override the default behavior.
     #[inline]
     fn visit_key<K>(&mut self) -> Result<Option<K>, Self::Error>
-        where K: Deserialize
+        where K: Deserialize<'de>
     {
         self.visit_key_seed(PhantomData)
     }
@@ -1282,7 +1332,7 @@ pub trait MapVisitor {
     /// `MapVisitor` implementations should not override the default behavior.
     #[inline]
     fn visit_value<V>(&mut self) -> Result<V, Self::Error>
-        where V: Deserialize
+        where V: Deserialize<'de>
     {
         self.visit_value_seed(PhantomData)
     }
@@ -1294,8 +1344,8 @@ pub trait MapVisitor {
     /// `MapVisitor` implementations should not override the default behavior.
     #[inline]
     fn visit<K, V>(&mut self) -> Result<Option<(K, V)>, Self::Error>
-        where K: Deserialize,
-              V: Deserialize
+        where K: Deserialize<'de>,
+              V: Deserialize<'de>
     {
         self.visit_seed(PhantomData, PhantomData)
     }
@@ -1307,21 +1357,21 @@ pub trait MapVisitor {
     }
 }
 
-impl<'a, V_> MapVisitor for &'a mut V_
-    where V_: MapVisitor
+impl<'de, 'a, V_> MapVisitor<'de> for &'a mut V_
+    where V_: MapVisitor<'de>
 {
     type Error = V_::Error;
 
     #[inline]
     fn visit_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
-        where K: DeserializeSeed
+        where K: DeserializeSeed<'de>
     {
         (**self).visit_key_seed(seed)
     }
 
     #[inline]
     fn visit_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
-        where V: DeserializeSeed
+        where V: DeserializeSeed<'de>
     {
         (**self).visit_value_seed(seed)
     }
@@ -1331,30 +1381,30 @@ impl<'a, V_> MapVisitor for &'a mut V_
                         kseed: K,
                         vseed: V)
                         -> Result<Option<(K::Value, V::Value)>, Self::Error>
-        where K: DeserializeSeed,
-              V: DeserializeSeed
+        where K: DeserializeSeed<'de>,
+              V: DeserializeSeed<'de>
     {
         (**self).visit_seed(kseed, vseed)
     }
 
     #[inline]
     fn visit<K, V>(&mut self) -> Result<Option<(K, V)>, V_::Error>
-        where K: Deserialize,
-              V: Deserialize
+        where K: Deserialize<'de>,
+              V: Deserialize<'de>
     {
         (**self).visit()
     }
 
     #[inline]
     fn visit_key<K>(&mut self) -> Result<Option<K>, V_::Error>
-        where K: Deserialize
+        where K: Deserialize<'de>
     {
         (**self).visit_key()
     }
 
     #[inline]
     fn visit_value<V>(&mut self) -> Result<V, V_::Error>
-        where V: Deserialize
+        where V: Deserialize<'de>
     {
         (**self).visit_value()
     }
@@ -1370,20 +1420,20 @@ impl<'a, V_> MapVisitor for &'a mut V_
 /// `EnumVisitor` is a visitor that is created by the `Deserializer` and passed
 /// to the `Deserialize` in order to identify which variant of an enum to
 /// deserialize.
-pub trait EnumVisitor: Sized {
+pub trait EnumVisitor<'de>: Sized {
     /// The error type that can be returned if some error occurs during
     /// deserialization.
     type Error: Error;
     /// The `Visitor` that will be used to deserialize the content of the enum
     /// variant.
-    type Variant: VariantVisitor<Error = Self::Error>;
+    type Variant: VariantVisitor<'de, Error = Self::Error>;
 
     /// `visit_variant` is called to identify which variant to deserialize.
     ///
     /// `Deserialize` implementations should typically use
     /// `EnumVisitor::visit_variant` instead.
     fn visit_variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
-        where V: DeserializeSeed;
+        where V: DeserializeSeed<'de>;
 
     /// `visit_variant` is called to identify which variant to deserialize.
     ///
@@ -1391,7 +1441,7 @@ pub trait EnumVisitor: Sized {
     /// `EnumVisitor` implementations should not override the default behavior.
     #[inline]
     fn visit_variant<V>(self) -> Result<(V, Self::Variant), Self::Error>
-        where V: Deserialize
+        where V: Deserialize<'de>
     {
         self.visit_variant_seed(PhantomData)
     }
@@ -1400,7 +1450,7 @@ pub trait EnumVisitor: Sized {
 /// `VariantVisitor` is a visitor that is created by the `Deserializer` and
 /// passed to the `Deserialize` to deserialize the content of a particular enum
 /// variant.
-pub trait VariantVisitor: Sized {
+pub trait VariantVisitor<'de>: Sized {
     /// The error type that can be returned if some error occurs during
     /// deserialization. Must match the error type of our `EnumVisitor`.
     type Error: Error;
@@ -1437,7 +1487,7 @@ pub trait VariantVisitor: Sized {
     /// }
     /// ```
     fn visit_newtype_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
-        where T: DeserializeSeed;
+        where T: DeserializeSeed<'de>;
 
     /// Called when deserializing a variant with a single value.
     ///
@@ -1446,7 +1496,7 @@ pub trait VariantVisitor: Sized {
     /// behavior.
     #[inline]
     fn visit_newtype<T>(self) -> Result<T, Self::Error>
-        where T: Deserialize
+        where T: Deserialize<'de>
     {
         self.visit_newtype_seed(PhantomData)
     }
@@ -1470,7 +1520,7 @@ pub trait VariantVisitor: Sized {
     /// }
     /// ```
     fn visit_tuple<V>(self, len: usize, visitor: V) -> Result<V::Value, Self::Error>
-        where V: Visitor;
+        where V: Visitor<'de>;
 
     /// Called when deserializing a struct-like variant.
     ///
@@ -1494,7 +1544,7 @@ pub trait VariantVisitor: Sized {
                        fields: &'static [&'static str],
                        visitor: V)
                        -> Result<V::Value, Self::Error>
-        where V: Visitor;
+        where V: Visitor<'de>;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/serde/src/de/private.rs
+++ b/serde/src/de/private.rs
@@ -9,25 +9,25 @@ pub use de::content::{Content, ContentRefDeserializer, ContentDeserializer, Tagg
 
 /// If the missing field is of type `Option<T>` then treat is as `None`,
 /// otherwise it is an error.
-pub fn missing_field<V, E>(field: &'static str) -> Result<V, E>
-    where V: Deserialize,
+pub fn missing_field<'de, V, E>(field: &'static str) -> Result<V, E>
+    where V: Deserialize<'de>,
           E: Error
 {
     struct MissingFieldDeserializer<E>(&'static str, PhantomData<E>);
 
-    impl<E> Deserializer for MissingFieldDeserializer<E>
+    impl<'de, E> Deserializer<'de> for MissingFieldDeserializer<E>
         where E: Error
     {
         type Error = E;
 
         fn deserialize<V>(self, _visitor: V) -> Result<V::Value, E>
-            where V: Visitor
+            where V: Visitor<'de>
         {
             Err(Error::missing_field(self.0))
         }
 
         fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, E>
-            where V: Visitor
+            where V: Visitor<'de>
         {
             visitor.visit_none()
         }

--- a/serde/src/macros.rs
+++ b/serde/src/macros.rs
@@ -135,15 +135,15 @@ macro_rules! forward_to_deserialize_helper {
 /// # #[macro_use] extern crate serde;
 /// # use serde::de::{value, Deserializer, Visitor};
 /// # pub struct MyDeserializer;
-/// # impl Deserializer for MyDeserializer {
+/// # impl<'de> Deserializer<'de> for MyDeserializer {
 /// #     type Error = value::Error;
 /// #     fn deserialize<V>(self, _: V) -> Result<V::Value, Self::Error>
-/// #         where V: Visitor
+/// #         where V: Visitor<'de>
 /// #     { unimplemented!() }
 /// #
 /// #[inline]
 /// fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-///     where V: Visitor
+///     where V: Visitor<'de>
 /// {
 ///     self.deserialize(visitor)
 /// }
@@ -164,10 +164,10 @@ macro_rules! forward_to_deserialize_helper {
 /// # #[macro_use] extern crate serde;
 /// # use serde::de::{value, Deserializer, Visitor};
 /// # pub struct MyDeserializer;
-/// impl Deserializer for MyDeserializer {
+/// impl<'de> Deserializer<'de> for MyDeserializer {
 /// #   type Error = value::Error;
 ///     fn deserialize<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-///         where V: Visitor
+///         where V: Visitor<'de>
 ///     {
 ///         /* ... */
 /// #       let _ = visitor;

--- a/serde/src/macros.rs
+++ b/serde/src/macros.rs
@@ -182,6 +182,10 @@ macro_rules! forward_to_deserialize_helper {
 /// }
 /// # fn main() {}
 /// ```
+///
+/// The macro assumes the convention that your `Deserializer` lifetime parameter
+/// is called `'de`. It will not work if the `Deserializer` lifetime parameter
+/// is called something different.
 #[macro_export]
 macro_rules! forward_to_deserialize {
     ($($func:ident)*) => {

--- a/serde/src/macros.rs
+++ b/serde/src/macros.rs
@@ -5,7 +5,7 @@ macro_rules! forward_to_deserialize_method {
     ($func:ident($($arg:ty),*)) => {
         #[inline]
         fn $func<__V>(self, $(_: $arg,)* visitor: __V) -> ::std::result::Result<__V::Value, Self::Error>
-            where __V: $crate::de::Visitor
+            where __V: $crate::de::Visitor<'de>
         {
             self.deserialize(visitor)
         }
@@ -19,7 +19,7 @@ macro_rules! forward_to_deserialize_method {
     ($func:ident($($arg:ty),*)) => {
         #[inline]
         fn $func<__V>(self, $(_: $arg,)* visitor: __V) -> ::core::result::Result<__V::Value, Self::Error>
-            where __V: $crate::de::Visitor
+            where __V: $crate::de::Visitor<'de>
         {
             self.deserialize(visitor)
         }

--- a/serde_derive/src/bound.rs
+++ b/serde_derive/src/bound.rs
@@ -6,28 +6,8 @@ use internals::ast::Item;
 use internals::attr;
 
 macro_rules! path {
-    ($first:ident $(:: $rest:ident)*) => {
-        syn::Path {
-            global: false,
-            segments: vec![
-                stringify!($first).into(),
-                $(
-                    stringify!($rest).into(),
-                )*
-            ],
-        }
-    };
-
-    (::$first:ident $(:: $rest:ident)*) => {
-        syn::Path {
-            global: true,
-            segments: vec![
-                stringify!($first).into(),
-                $(
-                    stringify!($rest).into(),
-                )*
-            ],
-        }
+    ($($path:tt)+) => {
+        syn::parse_path(stringify!($($path)+)).unwrap()
     };
 }
 

--- a/serde_test/src/assert.rs
+++ b/serde_test/src/assert.rs
@@ -8,8 +8,8 @@ use token::Token;
 use std::fmt::Debug;
 
 /// Runs both `assert_ser_tokens` and `assert_de_tokens`.
-pub fn assert_tokens<T>(value: &T, tokens: &[Token<'static>])
-    where T: Serialize + Deserialize + PartialEq + Debug
+pub fn assert_tokens<'de, T>(value: &T, tokens: &[Token<'static>])
+    where T: Serialize + Deserialize<'de> + PartialEq + Debug
 {
     assert_ser_tokens(value, tokens);
     assert_de_tokens(value, tokens);
@@ -35,8 +35,8 @@ pub fn assert_ser_tokens_error<T>(value: &T, tokens: &[Token], error: Error)
 }
 
 /// Asserts that the given `tokens` deserialize into `value`.
-pub fn assert_de_tokens<T>(value: &T, tokens: &[Token<'static>])
-    where T: Deserialize + PartialEq + Debug
+pub fn assert_de_tokens<'de, T>(value: &T, tokens: &[Token<'static>])
+    where T: Deserialize<'de> + PartialEq + Debug
 {
     let mut de = Deserializer::new(tokens.to_vec().into_iter());
     let v: Result<T, Error> = Deserialize::deserialize(&mut de);
@@ -45,8 +45,8 @@ pub fn assert_de_tokens<T>(value: &T, tokens: &[Token<'static>])
 }
 
 /// Asserts that the given `tokens` yield `error` when deserializing.
-pub fn assert_de_tokens_error<T>(tokens: &[Token<'static>], error: Error)
-    where T: Deserialize + PartialEq + Debug
+pub fn assert_de_tokens_error<'de, T>(tokens: &[Token<'static>], error: Error)
+    where T: Deserialize<'de> + PartialEq + Debug
 {
     let mut de = Deserializer::new(tokens.to_vec().into_iter());
     let v: Result<T, Error> = Deserialize::deserialize(&mut de);

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -28,8 +28,8 @@ trait SerializeWith: Sized {
 }
 
 trait DeserializeWith: Sized {
-    fn deserialize_with<D>(de: D) -> Result<Self, D::Error>
-        where D: Deserializer;
+    fn deserialize_with<'de, D>(de: D) -> Result<Self, D::Error>
+        where D: Deserializer<'de>;
 }
 
 impl MyDefault for i32 {
@@ -53,8 +53,8 @@ impl SerializeWith for i32 {
 }
 
 impl DeserializeWith for i32 {
-    fn deserialize_with<D>(de: D) -> Result<Self, D::Error>
-        where D: Deserializer
+    fn deserialize_with<'de, D>(de: D) -> Result<Self, D::Error>
+        where D: Deserializer<'de>
     {
         if try!(Deserialize::deserialize(de)) {
             Ok(123)
@@ -242,8 +242,8 @@ impl Default for NotDeserializeStruct {
 }
 
 impl DeserializeWith for NotDeserializeStruct {
-    fn deserialize_with<D>(_: D) -> Result<Self, D::Error>
-        where D: Deserializer
+    fn deserialize_with<'de, D>(_: D) -> Result<Self, D::Error>
+        where D: Deserializer<'de>
     {
         panic!()
     }


### PR DESCRIPTION
This is the boring part of #492 - just plumbing `'de` through all the relevant places.

In this PR all `#[derive(Deserialize)]` generated implementations will apply to any lifetime `'de`. The remaining work for #492 is to support a `#[serde(borrow)]` attribute that constrains the lifetimes that `'de` is allowed to be.

---

The weirdest part of this PR is in serde/src/macros.rs where it assumes that the lifetime of your deserializer is called `'de`. So in particular this would not work:

```rust
impl<'x> Deserializer<'x> for MyDeserializer {
    /* ... */

    forward_to_deserialize! {
        /* ... */
    }
}
```

I think settling on a particular lifetime name as a convention is fine and we can add a feature to `forward_to_deserialize!` to select a different lifetime name in the future if necessary.

---

There is an unfortunate interaction with type checking where any handwritten Deserialize bound on a type parameter conflicts with the automatically inferred Deserialize bound.

```rust
#[derive(Deserialize)]
struct Bounds<T: DeserializeOwned> {
    /* ... */
}
```

The same error is triggered by this simplified model:

```rust
trait Deserialize<'de> {}

trait DeserializeOwned: for<'de> Deserialize<'de> {}
impl<T> DeserializeOwned for T where T: for<'de> Deserialize<'de> {}

struct Bounds<T: DeserializeOwned>(T);
impl<'de, T: DeserializeOwned> Deserialize<'de> for Bounds<T> where T: Deserialize<'de> {}
```

```
error[E0283]: type annotations required: cannot resolve `T: Deserialize<'de>`
 --> src/main.rs:7:1
  |
7 | impl<'de, T: DeserializeOwned> Deserialize<'de> for Bounds<T> where T: Deserialize<'de> {}
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: required by `Deserialize`
```