### PR TITLE
Use the live serde_derive for serde doc tests

### DIFF
--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -29,7 +29,7 @@ unstable-testing = ["unstable", "std"]
 playground = ["serde_derive"]
 
 [dependencies]
-serde_derive = { version = "0.9", optional = true }
+serde_derive = { version = "0.9", optional = true, path = "../serde_derive" }
 
 [dev-dependencies]
-serde_derive = "0.9"
+serde_derive = { version = "0.9", path = "../serde_derive" }


### PR DESCRIPTION
This is required for #826 as both are updated to Deserialize<'de> together.