### PR TITLE
Standardize on u32 for struct field index and enum variant index

### DIFF
--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -1232,7 +1232,7 @@ impl<'de> Deserialize<'de> for Duration {
                     }
                 }
 
-                deserializer.deserialize_struct_field(FieldVisitor)
+                deserializer.deserialize_identifier(FieldVisitor)
             }
         }
 
@@ -1358,7 +1358,7 @@ impl<'de, Idx: Deserialize<'de>> Deserialize<'de> for std::ops::Range<Idx> {
                     }
                 }
 
-                deserializer.deserialize_struct_field(FieldVisitor)
+                deserializer.deserialize_identifier(FieldVisitor)
             }
         }
 

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -911,8 +911,8 @@ pub trait Deserializer<'de>: Sized {
         where V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type is expecting the name of a struct
-    /// field.
-    fn deserialize_struct_field<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    /// field or the discriminant of an enum variant.
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type is expecting an enum value with a

--- a/serde/src/de/value.rs
+++ b/serde/src/de/value.rs
@@ -108,7 +108,7 @@ impl<'de, E> de::Deserializer<'de> for UnitDeserializer<E>
     forward_to_deserialize! {
         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string unit seq
         seq_fixed_size bytes map unit_struct newtype_struct tuple_struct struct
-        struct_field tuple enum ignored_any byte_buf
+        identifier tuple enum ignored_any byte_buf
     }
 
     fn deserialize<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -155,7 +155,7 @@ macro_rules! primitive_deserializer {
             forward_to_deserialize! {
                 bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string unit
                 option seq seq_fixed_size bytes map unit_struct newtype_struct
-                tuple_struct struct struct_field tuple enum ignored_any byte_buf
+                tuple_struct struct identifier tuple enum ignored_any byte_buf
             }
 
             fn deserialize<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -208,7 +208,7 @@ impl<'de, E> de::Deserializer<'de> for U32Deserializer<E>
     forward_to_deserialize! {
         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string unit option
         seq seq_fixed_size bytes map unit_struct newtype_struct tuple_struct
-        struct struct_field tuple ignored_any byte_buf
+        struct identifier tuple ignored_any byte_buf
     }
 
     fn deserialize<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -286,7 +286,7 @@ impl<'de, 'a, E> de::Deserializer<'de> for StrDeserializer<'a, E>
     forward_to_deserialize! {
         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string unit option
         seq seq_fixed_size bytes map unit_struct newtype_struct tuple_struct
-        struct struct_field tuple ignored_any byte_buf
+        struct identifier tuple ignored_any byte_buf
     }
 }
 
@@ -351,7 +351,7 @@ impl<'de, E> de::Deserializer<'de> for StringDeserializer<E>
     forward_to_deserialize! {
         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string unit option
         seq seq_fixed_size bytes map unit_struct newtype_struct tuple_struct
-        struct struct_field tuple ignored_any byte_buf
+        struct identifier tuple ignored_any byte_buf
     }
 }
 
@@ -420,7 +420,7 @@ impl<'de, 'a, E> de::Deserializer<'de> for CowStrDeserializer<'a, E>
     forward_to_deserialize! {
         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string unit option
         seq seq_fixed_size bytes map unit_struct newtype_struct tuple_struct
-        struct struct_field tuple ignored_any byte_buf
+        struct identifier tuple ignored_any byte_buf
     }
 }
 
@@ -495,7 +495,7 @@ impl<'de, I, T, E> de::Deserializer<'de> for SeqDeserializer<I, E>
     forward_to_deserialize! {
         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string unit option
         seq seq_fixed_size bytes map unit_struct newtype_struct tuple_struct
-        struct struct_field tuple enum ignored_any byte_buf
+        struct identifier tuple enum ignored_any byte_buf
     }
 }
 
@@ -603,7 +603,7 @@ impl<'de, V_> de::Deserializer<'de> for SeqVisitorDeserializer<V_>
     forward_to_deserialize! {
         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string unit option
         seq seq_fixed_size bytes map unit_struct newtype_struct tuple_struct
-        struct struct_field tuple enum ignored_any byte_buf
+        struct identifier tuple enum ignored_any byte_buf
     }
 }
 
@@ -707,7 +707,7 @@ impl<'de, I, E> de::Deserializer<'de> for MapDeserializer<'de, I, E>
 
     forward_to_deserialize! {
         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string unit option
-        bytes map unit_struct newtype_struct tuple_struct struct struct_field
+        bytes map unit_struct newtype_struct tuple_struct struct identifier
         tuple enum ignored_any byte_buf
     }
 }
@@ -804,7 +804,7 @@ impl<'de, A, B, E> de::Deserializer<'de> for PairDeserializer<A, B, E>
 
     forward_to_deserialize! {
         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string unit option
-        bytes map unit_struct newtype_struct tuple_struct struct struct_field
+        bytes map unit_struct newtype_struct tuple_struct struct identifier
         tuple enum ignored_any byte_buf
     }
 
@@ -945,7 +945,7 @@ impl<'de, V_> de::Deserializer<'de> for MapVisitorDeserializer<V_>
     forward_to_deserialize! {
         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string unit option
         seq seq_fixed_size bytes map unit_struct newtype_struct tuple_struct
-        struct struct_field tuple enum ignored_any byte_buf
+        struct identifier tuple enum ignored_any byte_buf
     }
 }
 

--- a/serde/src/macros.rs
+++ b/serde/src/macros.rs
@@ -89,8 +89,8 @@ macro_rules! forward_to_deserialize_helper {
     (struct) => {
         forward_to_deserialize_method!{deserialize_struct(&'static str, &'static [&'static str])}
     };
-    (struct_field) => {
-        forward_to_deserialize_method!{deserialize_struct_field()}
+    (identifier) => {
+        forward_to_deserialize_method!{deserialize_identifier()}
     };
     (tuple) => {
         forward_to_deserialize_method!{deserialize_tuple(usize)}
@@ -143,7 +143,7 @@ macro_rules! forward_to_deserialize_helper {
 /// #     forward_to_deserialize! {
 /// #         u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string unit option
 /// #         seq seq_fixed_size bytes byte_buf map unit_struct newtype_struct
-/// #         tuple_struct struct struct_field tuple enum ignored_any
+/// #         tuple_struct struct identifier tuple enum ignored_any
 /// #     }
 /// # }
 /// #
@@ -176,7 +176,7 @@ macro_rules! forward_to_deserialize_helper {
 ///     forward_to_deserialize! {
 ///         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string unit option
 ///         seq seq_fixed_size bytes byte_buf map unit_struct newtype_struct
-///         tuple_struct struct struct_field tuple enum ignored_any
+///         tuple_struct struct identifier tuple enum ignored_any
 ///     }
 /// }
 /// #

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -52,7 +52,7 @@ pub fn missing_field<'de, V, E>(field: &'static str) -> Result<V, E>
         forward_to_deserialize! {
             bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string unit seq
             seq_fixed_size bytes byte_buf map unit_struct newtype_struct
-            tuple_struct struct struct_field tuple enum ignored_any
+            tuple_struct struct identifier tuple enum ignored_any
         }
     }
 
@@ -855,7 +855,7 @@ mod content {
         forward_to_deserialize! {
             bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string unit seq
             seq_fixed_size bytes byte_buf map unit_struct tuple_struct struct
-            struct_field tuple ignored_any
+            identifier tuple ignored_any
         }
     }
 
@@ -996,7 +996,7 @@ mod content {
         forward_to_deserialize! {
             bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string unit option
             seq seq_fixed_size bytes byte_buf map unit_struct newtype_struct
-            tuple_struct struct struct_field tuple enum ignored_any
+            tuple_struct struct identifier tuple enum ignored_any
         }
     }
 
@@ -1085,7 +1085,7 @@ mod content {
         forward_to_deserialize! {
             bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string unit option
             seq seq_fixed_size bytes byte_buf map unit_struct newtype_struct
-            tuple_struct struct struct_field tuple enum ignored_any
+            tuple_struct struct identifier tuple enum ignored_any
         }
     }
 
@@ -1202,7 +1202,7 @@ mod content {
         forward_to_deserialize! {
             bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string unit seq
             seq_fixed_size bytes byte_buf map unit_struct tuple_struct struct
-            struct_field tuple ignored_any
+            identifier tuple ignored_any
         }
     }
 
@@ -1341,7 +1341,7 @@ mod content {
         forward_to_deserialize! {
             bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string unit option
             seq seq_fixed_size bytes byte_buf map unit_struct newtype_struct
-            tuple_struct struct struct_field tuple enum ignored_any
+            tuple_struct struct identifier tuple enum ignored_any
         }
     }
 
@@ -1430,7 +1430,7 @@ mod content {
         forward_to_deserialize! {
             bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string unit option
             seq seq_fixed_size bytes byte_buf map unit_struct newtype_struct
-            tuple_struct struct struct_field tuple enum ignored_any
+            tuple_struct struct identifier tuple enum ignored_any
         }
     }
 

--- a/serde/src/private/macros.rs
+++ b/serde/src/private/macros.rs
@@ -66,13 +66,13 @@ macro_rules! __serialize_unimplemented_helper {
         __serialize_unimplemented_method!(serialize_unit_struct(&str) -> Ok);
     };
     (unit_variant) => {
-        __serialize_unimplemented_method!(serialize_unit_variant(&str, usize, &str) -> Ok);
+        __serialize_unimplemented_method!(serialize_unit_variant(&str, u32, &str) -> Ok);
     };
     (newtype_struct) => {
         __serialize_unimplemented_method!(serialize_newtype_struct<T>(&str, &T) -> Ok);
     };
     (newtype_variant) => {
-        __serialize_unimplemented_method!(serialize_newtype_variant<T>(&str, usize, &str, &T) -> Ok);
+        __serialize_unimplemented_method!(serialize_newtype_variant<T>(&str, u32, &str, &T) -> Ok);
     };
     (seq) => {
         type SerializeSeq = $crate::ser::Impossible<Self::Ok, Self::Error>;
@@ -91,7 +91,7 @@ macro_rules! __serialize_unimplemented_helper {
     };
     (tuple_variant) => {
         type SerializeTupleVariant = $crate::ser::Impossible<Self::Ok, Self::Error>;
-        __serialize_unimplemented_method!(serialize_tuple_variant(&str, usize, &str, usize) -> SerializeTupleVariant);
+        __serialize_unimplemented_method!(serialize_tuple_variant(&str, u32, &str, usize) -> SerializeTupleVariant);
     };
     (map) => {
         type SerializeMap = $crate::ser::Impossible<Self::Ok, Self::Error>;
@@ -103,7 +103,7 @@ macro_rules! __serialize_unimplemented_helper {
     };
     (struct_variant) => {
         type SerializeStructVariant = $crate::ser::Impossible<Self::Ok, Self::Error>;
-        __serialize_unimplemented_method!(serialize_struct_variant(&str, usize, &str, usize) -> SerializeStructVariant);
+        __serialize_unimplemented_method!(serialize_struct_variant(&str, u32, &str, usize) -> SerializeStructVariant);
     };
 }
 

--- a/serde/src/private/ser.rs
+++ b/serde/src/private/ser.rs
@@ -184,7 +184,7 @@ impl<S> Serializer for TaggedSerializer<S>
 
     fn serialize_unit_variant(self,
                               _: &'static str,
-                              _: usize,
+                              _: u32,
                               inner_variant: &'static str)
                               -> Result<Self::Ok, Self::Error> {
         let mut map = try!(self.delegate.serialize_map(Some(2)));
@@ -204,7 +204,7 @@ impl<S> Serializer for TaggedSerializer<S>
 
     fn serialize_newtype_variant<T: ?Sized>(self,
                                             _: &'static str,
-                                            _: usize,
+                                            _: u32,
                                             inner_variant: &'static str,
                                             inner_value: &T)
                                             -> Result<Self::Ok, Self::Error>
@@ -238,7 +238,7 @@ impl<S> Serializer for TaggedSerializer<S>
     #[cfg(not(any(feature = "std", feature = "collections")))]
     fn serialize_tuple_variant(self,
                                _: &'static str,
-                               _: usize,
+                               _: u32,
                                _: &'static str,
                                _: usize)
                                -> Result<Self::SerializeTupleVariant, Self::Error> {
@@ -250,7 +250,7 @@ impl<S> Serializer for TaggedSerializer<S>
     #[cfg(any(feature = "std", feature = "collections"))]
     fn serialize_tuple_variant(self,
                                _: &'static str,
-                               _: usize,
+                               _: u32,
                                inner_variant: &'static str,
                                len: usize)
                                -> Result<Self::SerializeTupleVariant, Self::Error> {
@@ -278,7 +278,7 @@ impl<S> Serializer for TaggedSerializer<S>
     #[cfg(not(any(feature = "std", feature = "collections")))]
     fn serialize_struct_variant(self,
                                 _: &'static str,
-                                _: usize,
+                                _: u32,
                                 _: &'static str,
                                 _: usize)
                                 -> Result<Self::SerializeStructVariant, Self::Error> {
@@ -290,7 +290,7 @@ impl<S> Serializer for TaggedSerializer<S>
     #[cfg(any(feature = "std", feature = "collections"))]
     fn serialize_struct_variant(self,
                                 _: &'static str,
-                                _: usize,
+                                _: u32,
                                 inner_variant: &'static str,
                                 len: usize)
                                 -> Result<Self::SerializeStructVariant, Self::Error> {
@@ -444,18 +444,18 @@ mod content {
 
         Unit,
         UnitStruct(&'static str),
-        UnitVariant(&'static str, usize, &'static str),
+        UnitVariant(&'static str, u32, &'static str),
         NewtypeStruct(&'static str, Box<Content>),
-        NewtypeVariant(&'static str, usize, &'static str, Box<Content>),
+        NewtypeVariant(&'static str, u32, &'static str, Box<Content>),
 
         Seq(Vec<Content>),
         SeqFixedSize(Vec<Content>),
         Tuple(Vec<Content>),
         TupleStruct(&'static str, Vec<Content>),
-        TupleVariant(&'static str, usize, &'static str, Vec<Content>),
+        TupleVariant(&'static str, u32, &'static str, Vec<Content>),
         Map(Vec<(Content, Content)>),
         Struct(&'static str, Vec<(&'static str, Content)>),
-        StructVariant(&'static str, usize, &'static str, Vec<(&'static str, Content)>),
+        StructVariant(&'static str, u32, &'static str, Vec<(&'static str, Content)>),
     }
 
     impl Serialize for Content {
@@ -645,7 +645,7 @@ mod content {
 
         fn serialize_unit_variant(self,
                                 name: &'static str,
-                                variant_index: usize,
+                                variant_index: u32,
                                 variant: &'static str)
                                 -> Result<Content, E> {
             Ok(Content::UnitVariant(name, variant_index, variant))
@@ -660,7 +660,7 @@ mod content {
 
         fn serialize_newtype_variant<T: ?Sized + Serialize>(self,
                                                             name: &'static str,
-                                                            variant_index: usize,
+                                                            variant_index: u32,
                                                             variant: &'static str,
                                                             value: &T)
                                                             -> Result<Content, E> {
@@ -706,7 +706,7 @@ mod content {
 
         fn serialize_tuple_variant(self,
                                 name: &'static str,
-                                variant_index: usize,
+                                variant_index: u32,
                                 variant: &'static str,
                                 len: usize)
                                 -> Result<Self::SerializeTupleVariant, E> {
@@ -737,7 +737,7 @@ mod content {
 
         fn serialize_struct_variant(self,
                                     name: &'static str,
-                                    variant_index: usize,
+                                    variant_index: u32,
                                     variant: &'static str,
                                     len: usize)
                                     -> Result<Self::SerializeStructVariant, E> {
@@ -825,7 +825,7 @@ mod content {
 
     struct SerializeTupleVariant<E> {
         name: &'static str,
-        variant_index: usize,
+        variant_index: u32,
         variant: &'static str,
         fields: Vec<Content>,
         error: PhantomData<E>,
@@ -916,7 +916,7 @@ mod content {
 
     struct SerializeStructVariant<E> {
         name: &'static str,
-        variant_index: usize,
+        variant_index: u32,
         variant: &'static str,
         fields: Vec<(&'static str, Content)>,
         error: PhantomData<E>,

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -449,7 +449,7 @@ pub trait Serializer: Sized {
     /// ```
     fn serialize_unit_variant(self,
                               name: &'static str,
-                              variant_index: usize,
+                              variant_index: u32,
                               variant: &'static str)
                               -> Result<Self::Ok, Self::Error>;
 
@@ -504,7 +504,7 @@ pub trait Serializer: Sized {
     /// ```
     fn serialize_newtype_variant<T: ?Sized + Serialize>(self,
                                                         name: &'static str,
-                                                        variant_index: usize,
+                                                        variant_index: u32,
                                                         variant: &'static str,
                                                         value: &T)
                                                         -> Result<Self::Ok, Self::Error>;
@@ -686,7 +686,7 @@ pub trait Serializer: Sized {
     /// ```
     fn serialize_tuple_variant(self,
                                name: &'static str,
-                               variant_index: usize,
+                               variant_index: u32,
                                variant: &'static str,
                                len: usize)
                                -> Result<Self::SerializeTupleVariant, Self::Error>;
@@ -806,7 +806,7 @@ pub trait Serializer: Sized {
     /// ```
     fn serialize_struct_variant(self,
                                 name: &'static str,
-                                variant_index: usize,
+                                variant_index: u32,
                                 variant: &'static str,
                                 len: usize)
                                 -> Result<Self::SerializeStructVariant, Self::Error>;

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1190,7 +1190,7 @@ fn deserialize_field_visitor(fields: Vec<(String, Ident)>,
                     }
                 }
 
-                _serde::Deserializer::deserialize_struct_field(__deserializer, __FieldVisitor)
+                _serde::Deserializer::deserialize_identifier(__deserializer, __FieldVisitor)
             }
         }
     }

--- a/serde_test/src/de.rs
+++ b/serde_test/src/de.rs
@@ -78,7 +78,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
 
     forward_to_deserialize! {
         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string unit
-        seq bytes byte_buf map struct_field ignored_any
+        seq bytes byte_buf map identifier ignored_any
     }
 
     fn deserialize<V>(self, visitor: V) -> Result<V::Value, Error>
@@ -645,6 +645,6 @@ impl<'de> de::Deserializer<'de> for BytesDeserializer {
     forward_to_deserialize! {
         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string unit option
         seq seq_fixed_size bytes map unit_struct newtype_struct tuple_struct
-        struct struct_field tuple enum ignored_any byte_buf
+        struct identifier tuple enum ignored_any byte_buf
     }
 }

--- a/serde_test/src/ser.rs
+++ b/serde_test/src/ser.rs
@@ -146,7 +146,7 @@ impl<'s, 'a> ser::Serializer for &'s mut Serializer<'a> {
 
     fn serialize_unit_variant(self,
                               name: &'static str,
-                              _variant_index: usize,
+                              _variant_index: u32,
                               variant: &'static str)
                               -> Result<(), Error> {
         if self.tokens.first() == Some(&Token::Enum(name)) {
@@ -168,7 +168,7 @@ impl<'s, 'a> ser::Serializer for &'s mut Serializer<'a> {
 
     fn serialize_newtype_variant<T: ?Sized>(self,
                                             name: &'static str,
-                                            _variant_index: usize,
+                                            _variant_index: u32,
                                             variant: &'static str,
                                             value: &T)
                                             -> Result<(), Error>
@@ -217,7 +217,7 @@ impl<'s, 'a> ser::Serializer for &'s mut Serializer<'a> {
 
     fn serialize_tuple_variant(self,
                                name: &'static str,
-                               _variant_index: usize,
+                               _variant_index: u32,
                                variant: &'static str,
                                len: usize)
                                -> Result<Self, Error> {
@@ -237,7 +237,7 @@ impl<'s, 'a> ser::Serializer for &'s mut Serializer<'a> {
 
     fn serialize_struct_variant(self,
                                 name: &'static str,
-                                _variant_index: usize,
+                                _variant_index: u32,
                                 variant: &'static str,
                                 len: usize)
                                 -> Result<Self, Error> {


### PR DESCRIPTION
- Rename `deserialize_struct_field` to `deserialize_identifier` to indicate that it is used not just for struct fields but also for enum discriminants.
- Use u32 as the type of variant indices in the serializer API to match the way that our generated visitors expect visit_u32.

Fixes #722.