### PR TITLE
Centralize all import wrangling

### DIFF
--- a/serde/src/de/from_primitive.rs
+++ b/serde/src/de/from_primitive.rs
@@ -8,9 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::{usize, u8, u16, u32, u64};
-use core::{isize, i8, i16, i32, i64};
-use core::{f32, f64};
+use lib::*;
 
 macro_rules! int_to_int {
     ($dst:ident, $n:ident) => (

--- a/serde/src/de/ignored_any.rs
+++ b/serde/src/de/ignored_any.rs
@@ -1,4 +1,4 @@
-use core::fmt;
+use lib::*;
 
 use de::{Deserialize, Deserializer, Visitor, SeqVisitor, MapVisitor, Error};
 

--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -1,63 +1,11 @@
-#[cfg(feature = "std")]
-use std::borrow::Cow;
-#[cfg(all(feature = "collections", not(feature = "std")))]
-use collections::borrow::Cow;
-
-#[cfg(all(feature = "collections", not(feature = "std")))]
-use collections::{BinaryHeap, BTreeMap, BTreeSet, LinkedList, VecDeque, Vec, String};
-
-#[cfg(feature = "std")]
-use std::collections::{HashMap, HashSet, BinaryHeap, BTreeMap, BTreeSet, LinkedList, VecDeque};
-
-#[cfg(feature = "collections")]
-use collections::borrow::ToOwned;
-
-#[cfg(any(feature = "std", feature = "collections"))]
-use core::cmp;
-use core::fmt;
-#[cfg(feature = "std")]
-use core::hash::{Hash, BuildHasher};
-use core::marker::PhantomData;
-#[cfg(feature = "std")]
-use std::net;
-#[cfg(feature = "std")]
-use std::path;
-use core::str;
-#[cfg(feature = "std")]
-use std::ffi::{CString, OsString};
-#[cfg(all(feature = "std", feature = "unstable"))]
-use std::ffi::CStr;
-
-#[cfg(all(feature = "rc", feature = "std"))]
-use std::rc::Rc;
-#[cfg(all(feature = "rc", feature = "alloc", not(feature = "std")))]
-use alloc::rc::Rc;
-
-#[cfg(all(feature = "rc", feature = "std"))]
-use std::sync::Arc;
-#[cfg(all(feature = "rc", feature = "alloc", not(feature = "std")))]
-use alloc::arc::Arc;
-
-#[cfg(all(feature = "alloc", not(feature = "std")))]
-use alloc::boxed::Box;
-
-#[cfg(feature = "std")]
-use std::time::Duration;
-
-#[cfg(feature = "std")]
-use std;
-
-#[cfg(feature = "unstable")]
-use core::nonzero::{NonZero, Zeroable};
-
-#[cfg(feature = "unstable")]
-#[allow(deprecated)] // required for impl Deserialize for NonZero<T>
-use core::num::Zero;
+use lib::*;
 
 use de::{Deserialize, Deserializer, EnumVisitor, Error, SeqVisitor, Unexpected,
          VariantVisitor, Visitor};
+
 #[cfg(any(feature = "std", feature = "collections"))]
 use de::MapVisitor;
+
 use de::from_primitive::FromPrimitive;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1312,7 +1260,7 @@ impl<'de> Deserialize<'de> for Duration {
 //         end: u32,
 //     }
 #[cfg(feature = "std")]
-impl<'de, Idx: Deserialize<'de>> Deserialize<'de> for std::ops::Range<Idx> {
+impl<'de, Idx: Deserialize<'de>> Deserialize<'de> for ops::Range<Idx> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where D: Deserializer<'de>
     {
@@ -1367,13 +1315,13 @@ impl<'de, Idx: Deserialize<'de>> Deserialize<'de> for std::ops::Range<Idx> {
         }
 
         impl<'de, Idx: Deserialize<'de>> Visitor<'de> for RangeVisitor<Idx> {
-            type Value = std::ops::Range<Idx>;
+            type Value = ops::Range<Idx>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("struct Range")
             }
 
-            fn visit_seq<V>(self, mut visitor: V) -> Result<std::ops::Range<Idx>, V::Error>
+            fn visit_seq<V>(self, mut visitor: V) -> Result<ops::Range<Idx>, V::Error>
                 where V: SeqVisitor<'de>
             {
                 let start: Idx = match try!(visitor.visit()) {
@@ -1391,7 +1339,7 @@ impl<'de, Idx: Deserialize<'de>> Deserialize<'de> for std::ops::Range<Idx> {
                 Ok(start..end)
             }
 
-            fn visit_map<V>(self, mut visitor: V) -> Result<std::ops::Range<Idx>, V::Error>
+            fn visit_map<V>(self, mut visitor: V) -> Result<ops::Range<Idx>, V::Error>
                 where V: MapVisitor<'de>
             {
                 let mut start: Option<Idx> = None;

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -94,16 +94,7 @@
 //! [bincode]: https://github.com/TyOverby/bincode
 //! [data-formats]: https://serde.rs/#data-formats
 
-#[cfg(feature = "std")]
-use std::error;
-
-#[cfg(all(not(feature = "std"), feature = "collections"))]
-use collections::{String, Vec};
-
-use core::fmt::{self, Display};
-#[cfg(not(feature = "std"))]
-use core::fmt::Debug;
-use core::marker::PhantomData;
+use lib::*;
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/serde/src/de/utf8.rs
+++ b/serde/src/de/utf8.rs
@@ -1,3 +1,5 @@
+use lib::*;
+
 const TAG_CONT: u8 = 0b1000_0000;
 const TAG_TWO_B: u8 = 0b1100_0000;
 const TAG_THREE_B: u8 = 0b1110_0000;
@@ -43,6 +45,6 @@ pub struct Encode {
 impl Encode {
     // FIXME: use this from_utf8_unchecked, since we know it can never fail
     pub fn as_str(&self) -> &str {
-        ::core::str::from_utf8(&self.buf[self.pos..]).unwrap()
+        str::from_utf8(&self.buf[self.pos..]).unwrap()
     }
 }

--- a/serde/src/de/value.rs
+++ b/serde/src/de/value.rs
@@ -1,30 +1,6 @@
 //! This module supports deserializing from primitives with the `ValueDeserializer` trait.
 
-#[cfg(feature = "std")]
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, btree_map, btree_set, hash_map,
-                       hash_set};
-#[cfg(feature = "std")]
-use std::borrow::Cow;
-#[cfg(feature = "std")]
-use std::vec;
-
-#[cfg(all(feature = "collections", not(feature = "std")))]
-use collections::{BTreeMap, BTreeSet, Vec, String, btree_map, btree_set, vec};
-#[cfg(all(feature = "collections", not(feature = "std")))]
-use collections::borrow::Cow;
-#[cfg(all(feature = "collections", not(feature = "std")))]
-use collections::boxed::Box;
-#[cfg(all(feature = "collections", not(feature = "std")))]
-use collections::string::ToString;
-
-#[cfg(feature = "std")]
-use core::hash::Hash;
-#[cfg(feature = "std")]
-use std::error;
-
-use core::fmt::{self, Display};
-use core::iter::{self, Iterator};
-use core::marker::PhantomData;
+use lib::*;
 
 use de::{self, Expected, SeqVisitor};
 
@@ -542,7 +518,7 @@ impl<'de, T, E> ValueDeserializer<'de, E> for Vec<T>
     where T: ValueDeserializer<'de, E>,
           E: de::Error
 {
-    type Deserializer = SeqDeserializer<vec::IntoIter<T>, E>;
+    type Deserializer = SeqDeserializer<<Vec<T> as IntoIterator>::IntoIter, E>;
 
     fn into_deserializer(self) -> Self::Deserializer {
         SeqDeserializer::new(self.into_iter())
@@ -554,7 +530,7 @@ impl<'de, T, E> ValueDeserializer<'de, E> for BTreeSet<T>
     where T: ValueDeserializer<'de, E> + Eq + Ord,
           E: de::Error
 {
-    type Deserializer = SeqDeserializer<btree_set::IntoIter<T>, E>;
+    type Deserializer = SeqDeserializer<<BTreeSet<T> as IntoIterator>::IntoIter, E>;
 
     fn into_deserializer(self) -> Self::Deserializer {
         SeqDeserializer::new(self.into_iter())
@@ -566,7 +542,7 @@ impl<'de, T, E> ValueDeserializer<'de, E> for HashSet<T>
     where T: ValueDeserializer<'de, E> + Eq + Hash,
           E: de::Error
 {
-    type Deserializer = SeqDeserializer<hash_set::IntoIter<T>, E>;
+    type Deserializer = SeqDeserializer<<HashSet<T> as IntoIterator>::IntoIter, E>;
 
     fn into_deserializer(self) -> Self::Deserializer {
         SeqDeserializer::new(self.into_iter())
@@ -895,7 +871,7 @@ impl<'de, K, V, E> ValueDeserializer<'de, E> for BTreeMap<K, V>
           V: ValueDeserializer<'de, E>,
           E: de::Error
 {
-    type Deserializer = MapDeserializer<'de, btree_map::IntoIter<K, V>, E>;
+    type Deserializer = MapDeserializer<'de, <BTreeMap<K, V> as IntoIterator>::IntoIter, E>;
 
     fn into_deserializer(self) -> Self::Deserializer {
         MapDeserializer::new(self.into_iter())
@@ -908,7 +884,7 @@ impl<'de, K, V, E> ValueDeserializer<'de, E> for HashMap<K, V>
           V: ValueDeserializer<'de, E>,
           E: de::Error
 {
-    type Deserializer = MapDeserializer<'de, hash_map::IntoIter<K, V>, E>;
+    type Deserializer = MapDeserializer<'de, <HashMap<K, V> as IntoIterator>::IntoIter, E>;
 
     fn into_deserializer(self) -> Self::Deserializer {
         MapDeserializer::new(self.into_iter())
@@ -952,8 +928,9 @@ impl<'de, V_> de::Deserializer<'de> for MapVisitorDeserializer<V_>
 ///////////////////////////////////////////////////////////////////////////////
 
 mod private {
+    use lib::*;
+
     use de::{self, Unexpected};
-    use core::marker::PhantomData;
 
     pub struct UnitOnly<E> {
         marker: PhantomData<E>,

--- a/serde/src/export.rs
+++ b/serde/src/export.rs
@@ -1,5 +1,3 @@
-use lib::*;
-
 pub use lib::clone::Clone;
 pub use lib::convert::{From, Into};
 pub use lib::default::Default;
@@ -8,22 +6,28 @@ pub use lib::marker::PhantomData;
 pub use lib::option::Option::{self, None, Some};
 pub use lib::result::Result::{self, Ok, Err};
 
-#[cfg(any(feature = "std", feature = "collections"))]
-pub fn from_utf8_lossy(bytes: &[u8]) -> Cow<str> {
-    String::from_utf8_lossy(bytes)
-}
+pub use self::string::from_utf8_lossy;
 
-// The generated code calls this like:
-//
-//     let value = &_serde::export::from_utf8_lossy(bytes);
-//     Err(_serde::de::Error::unknown_variant(value, VARIANTS))
-//
-// so it is okay for the return type to be different from the std case as long
-// as the above works.
-#[cfg(not(any(feature = "std", feature = "collections")))]
-pub fn from_utf8_lossy(bytes: &[u8]) -> &str {
-    // Three unicode replacement characters if it fails. They look like a
-    // white-on-black question mark. The user will recognize it as invalid
-    // UTF-8.
-    str::from_utf8(bytes).unwrap_or("\u{fffd}\u{fffd}\u{fffd}")
+mod string {
+    use lib::*;
+
+    #[cfg(any(feature = "std", feature = "collections"))]
+    pub fn from_utf8_lossy(bytes: &[u8]) -> Cow<str> {
+        String::from_utf8_lossy(bytes)
+    }
+
+    // The generated code calls this like:
+    //
+    //     let value = &_serde::export::from_utf8_lossy(bytes);
+    //     Err(_serde::de::Error::unknown_variant(value, VARIANTS))
+    //
+    // so it is okay for the return type to be different from the std case as long
+    // as the above works.
+    #[cfg(not(any(feature = "std", feature = "collections")))]
+    pub fn from_utf8_lossy(bytes: &[u8]) -> &str {
+        // Three unicode replacement characters if it fails. They look like a
+        // white-on-black question mark. The user will recognize it as invalid
+        // UTF-8.
+        str::from_utf8(bytes).unwrap_or("\u{fffd}\u{fffd}\u{fffd}")
+    }
 }

--- a/serde/src/export.rs
+++ b/serde/src/export.rs
@@ -1,20 +1,14 @@
-#[cfg(all(feature = "collections", not(feature = "std")))]
-use collections::String;
+use lib::*;
 
-#[cfg(feature = "std")]
-use std::borrow::Cow;
-#[cfg(all(feature = "collections", not(feature = "std")))]
-use collections::borrow::Cow;
+pub use lib::clone::Clone;
+pub use lib::convert::{From, Into};
+pub use lib::default::Default;
+pub use lib::fmt;
+pub use lib::marker::PhantomData;
+pub use lib::option::Option::{self, None, Some};
+pub use lib::result::Result::{self, Ok, Err};
 
-pub use core::clone::Clone;
-pub use core::convert::{From, Into};
-pub use core::default::Default;
-pub use core::fmt;
-pub use core::marker::PhantomData;
-pub use core::option::Option::{self, None, Some};
-pub use core::result::Result::{self, Ok, Err};
-
-#[cfg(any(feature = "collections", feature = "std"))]
+#[cfg(any(feature = "std", feature = "collections"))]
 pub fn from_utf8_lossy(bytes: &[u8]) -> Cow<str> {
     String::from_utf8_lossy(bytes)
 }
@@ -26,9 +20,8 @@ pub fn from_utf8_lossy(bytes: &[u8]) -> Cow<str> {
 //
 // so it is okay for the return type to be different from the std case as long
 // as the above works.
-#[cfg(not(any(feature = "collections", feature = "std")))]
+#[cfg(not(any(feature = "std", feature = "collections")))]
 pub fn from_utf8_lossy(bytes: &[u8]) -> &str {
-    use core::str;
     // Three unicode replacement characters if it fails. They look like a
     // white-on-black question mark. The user will recognize it as invalid
     // UTF-8.

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -74,16 +74,85 @@ extern crate collections;
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
-#[cfg(feature = "unstable")]
-extern crate core as actual_core;
+#[cfg(all(feature = "unstable", feature = "std"))]
+extern crate core;
 
-#[cfg(feature = "std")]
-mod core {
-    pub use std::{ops, hash, fmt, cmp, marker, mem, i8, i16, i32, i64, u8, u16, u32, u64, isize,
-                  usize, f32, f64, char, str, num, slice, iter, cell, default, result, option,
-                  clone, convert};
+/// A facade around all the types we need from the `std`, `core`, `alloc`, and
+/// `collections` crates. This avoids elaborate import wrangling having to
+/// happen in every module.
+mod lib {
+    #[cfg(feature = "std")]
+    use std as core;
+    #[cfg(not(feature = "std"))]
+    use core;
+
+    pub use self::core::{cmp, iter, mem, ops, str};
+    pub use self::core::{i8, i16, i32, i64, isize};
+    pub use self::core::{u8, u16, u32, u64, usize};
+    pub use self::core::{f32, f64};
+
+    pub use self::core::clone::{self, Clone};
+    pub use self::core::convert::{self, From, Into};
+    pub use self::core::default::{self, Default};
+    pub use self::core::fmt::{self, Debug, Display};
+    pub use self::core::marker::{self, PhantomData};
+    pub use self::core::option::{self, Option};
+    pub use self::core::result::{self, Result};
+
+    #[cfg(feature = "std")]
+    pub use std::borrow::{Cow, ToOwned};
+    #[cfg(all(feature = "collections", not(feature = "std")))]
+    pub use collections::borrow::{Cow, ToOwned};
+
+    #[cfg(feature = "std")]
+    pub use std::string::String;
+    #[cfg(all(feature = "collections", not(feature = "std")))]
+    pub use collections::string::{String, ToString};
+    
+    #[cfg(feature = "std")]
+    pub use std::vec::Vec;
+    #[cfg(all(feature = "collections", not(feature = "std")))]
+    pub use collections::vec::Vec;
+
+    #[cfg(feature = "std")]
+    pub use std::boxed::Box;
+    #[cfg(all(feature = "alloc", not(feature = "std")))]
+    pub use alloc::boxed::Box;
+
+    #[cfg(all(feature = "rc", feature = "std"))]
+    pub use std::rc::Rc;
+    #[cfg(all(feature = "rc", feature = "alloc", not(feature = "std")))]
+    pub use alloc::rc::Rc;
+
+    #[cfg(all(feature = "rc", feature = "std"))]
+    pub use std::sync::Arc;
+    #[cfg(all(feature = "rc", feature = "alloc", not(feature = "std")))]
+    pub use alloc::arc::Arc;
+
+    #[cfg(feature = "std")]
+    pub use std::collections::{BinaryHeap, BTreeMap, BTreeSet, LinkedList, VecDeque};
+    #[cfg(all(feature = "collections", not(feature = "std")))]
+    pub use collections::{BinaryHeap, BTreeMap, BTreeSet, LinkedList, VecDeque};
+
+    #[cfg(feature = "std")]
+    pub use std::{error, net, path};
+
+    #[cfg(feature = "std")]
+    pub use std::collections::{HashMap, HashSet};
+    #[cfg(feature = "std")]
+    pub use std::ffi::{CString, CStr, OsString, OsStr};
+    #[cfg(feature = "std")]
+    pub use std::hash::{Hash, BuildHasher};
+    #[cfg(feature = "std")]
+    pub use std::io::Write;
+    #[cfg(feature = "std")]
+    pub use std::time::Duration;
+
     #[cfg(feature = "unstable")]
-    pub use actual_core::nonzero;
+    pub use core::nonzero::{NonZero, Zeroable};
+    #[cfg(feature = "unstable")]
+    #[allow(deprecated)] // required for impl Deserialize for NonZero<T>
+    pub use core::num::Zero;
 }
 
 #[doc(inline)]

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -81,10 +81,12 @@ extern crate core;
 /// `collections` crates. This avoids elaborate import wrangling having to
 /// happen in every module.
 mod lib {
-    #[cfg(feature = "std")]
-    use std as core;
-    #[cfg(not(feature = "std"))]
-    use core;
+    mod core {
+        #[cfg(feature = "std")]
+        pub use std::*;
+        #[cfg(not(feature = "std"))]
+        pub use core::*;
+    }
 
     pub use self::core::{cmp, iter, mem, ops, str};
     pub use self::core::{i8, i16, i32, i64, isize};

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -1,18 +1,4 @@
-#[cfg(any(feature = "std", feature = "collections"))]
-use core::{fmt, str};
-
-use core::marker::PhantomData;
-
-#[cfg(feature = "collections")]
-use collections::borrow::ToOwned;
-
-#[cfg(feature = "std")]
-use std::borrow::Cow;
-#[cfg(all(feature = "collections", not(feature = "std")))]
-use collections::borrow::Cow;
-
-#[cfg(all(feature = "collections", not(feature = "std")))]
-use collections::{String, Vec};
+use lib::*;
 
 use de::{Deserialize, Deserializer, Error, Visitor};
 
@@ -187,17 +173,7 @@ mod content {
     // This issue is tracking making some of this stuff public:
     // https://github.com/serde-rs/serde/issues/741
 
-    #![doc(hidden)]
-
-    use core::cmp;
-    use core::fmt;
-    use core::marker::PhantomData;
-
-    #[cfg(all(not(feature = "std"), feature = "collections"))]
-    use collections::{String, Vec};
-
-    #[cfg(all(feature = "alloc", not(feature = "std")))]
-    use alloc::boxed::Box;
+    use lib::*;
 
     use de::{self, Deserialize, DeserializeSeed, Deserializer, Visitor, SeqVisitor, MapVisitor,
             EnumVisitor, Unexpected};

--- a/serde/src/private/ser.rs
+++ b/serde/src/private/ser.rs
@@ -1,12 +1,9 @@
-use core::fmt::{self, Display};
+use lib::*;
 
 use ser::{self, Serialize, Serializer, SerializeMap, SerializeStruct, Impossible};
 
 #[cfg(any(feature = "std", feature = "collections"))]
 use self::content::{SerializeTupleVariantAsMapValue, SerializeStructVariantAsMapValue};
-
-#[cfg(feature = "std")]
-use std::error;
 
 /// Used to check that serde(getter) attributes return the expected type.
 /// Not public API.
@@ -340,16 +337,7 @@ impl Display for Error {
 
 #[cfg(any(feature = "std", feature = "collections"))]
 mod content {
-    use core::marker::PhantomData;
-
-    #[cfg(all(not(feature = "std"), feature = "collections"))]
-    use collections::{String, Vec};
-
-    #[cfg(all(feature = "alloc", not(feature = "std")))]
-    use alloc::boxed::Box;
-
-    #[cfg(feature = "collections")]
-    use collections::borrow::ToOwned;
+    use lib::*;
 
     use ser::{self, Serialize, Serializer};
 

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -1,45 +1,9 @@
-#[cfg(feature = "std")]
-use std::borrow::Cow;
-#[cfg(all(feature = "collections", not(feature = "std")))]
-use collections::borrow::Cow;
+use lib::*;
+
+use ser::{Serialize, SerializeSeq, SerializeTuple, Serializer};
 
 #[cfg(feature = "std")]
-use std::collections::{BinaryHeap, BTreeMap, BTreeSet, LinkedList, HashMap, HashSet, VecDeque};
-#[cfg(all(feature = "collections", not(feature = "std")))]
-use collections::{BinaryHeap, BTreeMap, BTreeSet, LinkedList, VecDeque, String, Vec};
-
-#[cfg(feature = "collections")]
-use collections::borrow::ToOwned;
-
-#[cfg(feature = "std")]
-use core::hash::{Hash, BuildHasher};
-#[cfg(feature = "std")]
-use std::{net, ops, path};
-#[cfg(feature = "std")]
-use std::ffi::{CString, CStr, OsString, OsStr};
-#[cfg(all(feature = "rc", feature = "std"))]
-use std::rc::Rc;
-#[cfg(all(feature = "rc", feature = "alloc", not(feature = "std")))]
-use alloc::rc::Rc;
-#[cfg(feature = "std")]
-use std::time::Duration;
-
-#[cfg(all(feature = "rc", feature = "std"))]
-use std::sync::Arc;
-#[cfg(all(feature = "rc", feature = "alloc", not(feature = "std")))]
-use alloc::arc::Arc;
-
-#[cfg(all(feature = "alloc", not(feature = "std")))]
-use alloc::boxed::Box;
-
-use core::marker::PhantomData;
-
-#[cfg(feature = "unstable")]
-use core::nonzero::{NonZero, Zeroable};
-
-use super::{Serialize, SerializeSeq, SerializeTuple, Serializer};
-#[cfg(feature = "std")]
-use super::Error;
+use ser::Error;
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -635,8 +599,7 @@ impl Serialize for Duration {
 macro_rules! serialize_display_bounded_length {
     ($value: expr, $MAX_LEN: expr, $serializer: expr) => {
         {
-            use std::io::Write;
-            let mut buffer: [u8; $MAX_LEN] = unsafe { ::std::mem::uninitialized() };
+            let mut buffer: [u8; $MAX_LEN] = unsafe { mem::uninitialized() };
             let remaining_len;
             {
                 let mut remaining = &mut buffer[..];
@@ -646,11 +609,11 @@ macro_rules! serialize_display_bounded_length {
             let written_len = buffer.len() - remaining_len;
             let written = &buffer[..written_len];
 
-            // write! only provides std::fmt::Formatter to Display implementations,
+            // write! only provides fmt::Formatter to Display implementations,
             // which has methods write_str and write_char but no method to write arbitrary bytes.
             // Therefore, `written` is well-formed in UTF-8.
             let written_str = unsafe {
-                ::std::str::from_utf8_unchecked(written)
+                str::from_utf8_unchecked(written)
             };
             $serializer.serialize_str(written_str)
         }

--- a/serde/src/ser/impossible.rs
+++ b/serde/src/ser/impossible.rs
@@ -1,6 +1,6 @@
 //! This module contains `Impossible` serializer and its implementations.
 
-use core::marker::PhantomData;
+use lib::*;
 
 use ser::{self, Serialize, SerializeSeq, SerializeTuple, SerializeTupleStruct,
           SerializeTupleVariant, SerializeMap, SerializeStruct, SerializeStructVariant};

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -92,17 +92,7 @@
 //! [bincode]: https://github.com/TyOverby/bincode
 //! [data-formats]: https://serde.rs/#data-formats
 
-#[cfg(feature = "std")]
-use std::error;
-
-#[cfg(all(feature = "collections", not(feature = "std")))]
-use collections::string::String;
-#[cfg(not(feature = "std"))]
-use core::fmt::Debug;
-use core::fmt::Display;
-#[cfg(any(feature = "std", feature = "collections"))]
-use core::fmt::Write;
-use core::iter::IntoIterator;
+use lib::*;
 
 mod impls;
 mod impossible;
@@ -876,6 +866,7 @@ pub trait Serializer: Sized {
     fn collect_str<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
         where T: Display
     {
+        use self::fmt::Write;
         let mut string = String::new();
         write!(string, "{}", value).unwrap();
         self.serialize_str(&string)

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -866,7 +866,7 @@ pub trait Serializer: Sized {
     fn collect_str<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
         where T: Display
     {
-        use self::fmt::Write;
+        use lib::fmt::Write;
         let mut string = String::new();
         write!(string, "{}", value).unwrap();
         self.serialize_str(&string)


### PR DESCRIPTION
This sort of thing was getting out of hand:

```rust
#[cfg(feature = "std")]
use std::borrow::Cow;
#[cfg(all(feature = "collections", not(feature = "std")))]
use collections::borrow::Cow;

#[cfg(all(feature = "collections", not(feature = "std")))]
use collections::{BinaryHeap, BTreeMap, BTreeSet, LinkedList, VecDeque, Vec, String};

#[cfg(feature = "std")]
use std::collections::{HashMap, HashSet, BinaryHeap, BTreeMap, BTreeSet, LinkedList, VecDeque};

#[cfg(feature = "collections")]
use collections::borrow::ToOwned;

#[cfg(any(feature = "std", feature = "collections"))]
use core::cmp;
use core::fmt;
#[cfg(feature = "std")]
use core::hash::{Hash, BuildHasher};
use core::marker::PhantomData;
#[cfg(feature = "std")]
use std::net;
#[cfg(feature = "std")]
use std::path;
use core::str;
#[cfg(feature = "std")]
use std::ffi::{CString, OsString};
#[cfg(all(feature = "std", feature = "unstable"))]
use std::ffi::CStr;

#[cfg(all(feature = "rc", feature = "std"))]
use std::rc::Rc;
#[cfg(all(feature = "rc", feature = "alloc", not(feature = "std")))]
use alloc::rc::Rc;

#[cfg(all(feature = "rc", feature = "std"))]
use std::sync::Arc;
#[cfg(all(feature = "rc", feature = "alloc", not(feature = "std")))]
use alloc::arc::Arc;

#[cfg(all(feature = "alloc", not(feature = "std")))]
use alloc::boxed::Box;

#[cfg(feature = "std")]
use std::time::Duration;

#[cfg(feature = "std")]
use std;

#[cfg(feature = "unstable")]
use core::nonzero::{NonZero, Zeroable};

#[cfg(feature = "unstable")]
use core::num::Zero;
```