### PR TITLE
Replace deprecated MacroInput; completes c52e131

### DIFF
--- a/serde_derive_internals/src/ast.rs
+++ b/serde_derive_internals/src/ast.rs
@@ -45,7 +45,7 @@ pub enum Style {
 }
 
 impl<'a> Container<'a> {
-    pub fn from_ast(cx: &Ctxt, item: &'a syn::MacroInput) -> Container<'a> {
+    pub fn from_ast(cx: &Ctxt, item: &'a syn::DeriveInput) -> Container<'a> {
         let attrs = attr::Container::from_ast(cx, item);
 
         let mut body = match item.body {

--- a/serde_derive_internals/src/attr.rs
+++ b/serde_derive_internals/src/attr.rs
@@ -166,7 +166,7 @@ pub enum Identifier {
 
 impl Container {
     /// Extract out the `#[serde(...)]` attributes from an item.
-    pub fn from_ast(cx: &Ctxt, item: &syn::MacroInput) -> Self {
+    pub fn from_ast(cx: &Ctxt, item: &syn::DeriveInput) -> Self {
         let mut ser_name = Attr::none(cx, "rename");
         let mut de_name = Attr::none(cx, "rename");
         let mut deny_unknown_fields = BoolAttr::none(cx, "deny_unknown_fields");
@@ -421,7 +421,7 @@ impl Container {
 
 fn decide_tag(
     cx: &Ctxt,
-    item: &syn::MacroInput,
+    item: &syn::DeriveInput,
     untagged: BoolAttr,
     internal_tag: Attr<String>,
     content: Attr<String>,
@@ -477,7 +477,7 @@ fn decide_tag(
 
 fn decide_identifier(
     cx: &Ctxt,
-    item: &syn::MacroInput,
+    item: &syn::DeriveInput,
     field_identifier: BoolAttr,
     variant_identifier: BoolAttr,
 ) -> Identifier {


### PR DESCRIPTION
The deprecated `syn::MacroInput` is still used in some places in `serde_derive`. It looks like commit c52e131 didn't fully update all instances to `syn::DeriveInput`.

This fixes it.