### PR TITLE
Fix #816 - adjacently-tagged enums honor deny_unknown_fields

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -866,7 +866,7 @@ fn deserialize_adjacently_tagged_enum(
     } else {
         quote! {
             {
-                let mut __rk : Option<_serde::private::de::TagOrContentField> = None;
+                let mut __rk : _serde::export::Option<_serde::private::de::TagOrContentField> = _serde::export::None;
                 while let _serde::export::Some(__k) = #next_key {
                     match __k {
                         _serde::private::de::TagContentOtherField::Other => {
@@ -874,11 +874,11 @@ fn deserialize_adjacently_tagged_enum(
                             continue;
                         },
                         _serde::private::de::TagContentOtherField::Tag => {
-                            __rk = Some(_serde::private::de::TagOrContentField::Tag);
+                            __rk = _serde::export::Some(_serde::private::de::TagOrContentField::Tag);
                             break;
                         }
                         _serde::private::de::TagContentOtherField::Content => {
-                            __rk = Some(_serde::private::de::TagOrContentField::Content);
+                            __rk = _serde::export::Some(_serde::private::de::TagOrContentField::Content);
                             break;
                         }
                     }

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -751,6 +751,31 @@ fn test_adjacently_tagged_enum() {
         ],
     );
 
+    // unit with excess content (f, g, h)
+    assert_de_tokens(
+        &AdjacentlyTagged::Unit::<u8>,
+        &[
+            Token::Struct { name: "AdjacentlyTagged", len: 3 },
+
+            Token::Str("f"),
+            Token::Unit,
+
+            Token::Str("t"),
+            Token::Str("Unit"),
+
+            Token::Str("g"),
+            Token::Unit,
+
+            Token::Str("c"),
+            Token::Unit,
+
+            Token::Str("h"),
+            Token::Unit,
+
+            Token::StructEnd,
+        ],
+    );
+
     // newtype with tag first
     assert_tokens(
         &AdjacentlyTagged::Newtype::<u8>(1),

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -886,6 +886,66 @@ fn test_adjacently_tagged_enum() {
 }
 
 #[test]
+fn test_adjacently_tagged_enum_deny_unknown_fields() {
+    #[derive(Debug, PartialEq, Deserialize)]
+    #[serde(tag = "t", content = "c", deny_unknown_fields)]
+    enum AdjacentlyTagged {
+        Unit,
+    }
+
+    assert_de_tokens(
+        &AdjacentlyTagged::Unit,
+        &[
+            Token::Struct { name: "AdjacentlyTagged", len: 2},
+
+            Token::Str("t"),
+            Token::Str("Unit"),
+
+            Token::Str("c"),
+            Token::Unit,
+
+            Token::StructEnd,
+        ],
+    );
+
+    assert_de_tokens_error::<AdjacentlyTagged>(
+        &[
+            Token::Struct { name: "AdjacentlyTagged", len: 3},
+
+            Token::Str("t"),
+            Token::Str("Unit"),
+
+            Token::Str("c"),
+            Token::Unit,
+
+            Token::Str("h"),
+        ],
+        r#"invalid value: string "h", expected "t" or "c""#
+    );
+
+    assert_de_tokens_error::<AdjacentlyTagged>(
+        &[
+            Token::Struct { name: "AdjacentlyTagged", len: 3},
+
+            Token::Str("h"),
+        ],
+        r#"invalid value: string "h", expected "t" or "c""#
+    );
+
+    assert_de_tokens_error::<AdjacentlyTagged>(
+        &[
+            Token::Struct { name: "AdjacentlyTagged", len: 3},
+
+            Token::Str("c"),
+            Token::Unit,
+
+            Token::Str("h"),
+        ],
+        r#"invalid value: string "h", expected "t" or "c""#
+    );
+}
+
+#[test]
 fn test_enum_in_internally_tagged_enum() {
     #[derive(Debug, PartialEq, Serialize, Deserialize)]
     #[serde(tag = "type")]


### PR DESCRIPTION
Implementation includes happy-path test; wasn't sure where to put the test for `deny_unknown_fields`, but was able to verify that locally in another crate.

#816 