### PR TITLE
de: ensure unique keys when deserializing to maps and sets

### DIFF
--- a/test_suite/tests/test_de.rs
+++ b/test_suite/tests/test_de.rs
@@ -1021,4 +1021,48 @@ declare_error_tests! {
         ],
         "invalid type: sequence, expected unit struct UnitStruct",
     }
+    test_btreemap_duplicate_key<BTreeMap<isize, isize>> {
+        &[
+            Token::Map { len: Some(2) },
+            Token::I32(1),
+            Token::I32(2),
+
+            Token::I32(1),
+            Token::I32(4),
+            Token::MapEnd,
+        ],
+       "invalid entry: found duplicate key",
+    }
+    test_hashmap_duplicate_key<HashMap<isize, isize>> {
+        &[
+            Token::Map { len: Some(2) },
+            Token::I32(1),
+            Token::I32(2),
+
+            Token::I32(1),
+            Token::I32(4),
+            Token::MapEnd,
+        ],
+        "invalid entry: found duplicate key",
+    }
+    test_btreeset_duplicate_entry<BTreeSet<isize>> {
+        &[
+            Token::Seq { len: Some(2) },
+            Token::I32(1),
+
+            Token::I32(1),
+            Token::SeqEnd,
+        ],
+        "invalid entry: found duplicate key",
+    }
+    test_hashset_duplicate_entry<HashSet<isize>> {
+        &[
+            Token::Seq { len: Some(2) },
+            Token::I32(1),
+
+            Token::I32(1),
+            Token::SeqEnd,
+        ],
+        "invalid entry: found duplicate key",
+    }
 }


### PR DESCRIPTION
BREAKING: deserializing inputs with duplicate keys to maps and sets now fails.

Sets and maps do not allow insertion of duplicate entries, which are
instead skipped or replaced.
This updates serde to check for duplicate entries when deserializing,
erroring when such cases are encourented.

Closes https://github.com/serde-rs/serde/issues/913