### PR TITLE
Fix internally tagged struct variant containing unit variant containing borrowed string

### DIFF
--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -1082,7 +1082,7 @@ mod content {
                     }
                     (variant, Some(value))
                 }
-                Content::String(variant) => (Content::String(variant), None),
+                s @ Content::String(_) | s @ Content::Str(_) => (s, None),
                 other => {
                     return Err(de::Error::invalid_type(other.unexpected(), &"string or map"),);
                 }
@@ -1476,7 +1476,7 @@ mod content {
                     }
                     (variant, Some(value))
                 }
-                ref s @ Content::String(_) => (s, None),
+                ref s @ Content::String(_) | ref s @ Content::Str(_) => (s, None),
                 ref other => {
                     return Err(de::Error::invalid_type(other.unexpected(), &"string or map"),);
                 }

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -696,6 +696,35 @@ fn test_internally_tagged_enum() {
 }
 
 #[test]
+fn test_internally_tagged_struct_variant_containing_unit_variant() {
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    pub enum Level {
+        Info,
+    }
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    #[serde(tag = "action")]
+    pub enum Message {
+        Log { level: Level },
+    }
+
+    assert_de_tokens(
+        &Message::Log { level: Level::Info },
+        &[
+            Token::Struct { name: "Message", len: 2 },
+
+            Token::Str("action"),
+            Token::Str("Log"),
+
+            Token::Str("level"),
+            Token::BorrowedStr("Info"),
+
+            Token::StructEnd,
+        ],
+    );
+}
+
+#[test]
 fn test_internally_tagged_borrow() {
     #[derive(Debug, PartialEq, Serialize, Deserialize)]
     #[serde(tag = "type")]


### PR DESCRIPTION
Fixes #932.