### PR TITLE
Merge crate `collections` into `alloc`

### DIFF
--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -48,21 +48,14 @@ std = []
 #    https://github.com/serde-rs/serde/issues/812
 unstable = []
 
-# Provide impls for types that require memory allocation like Box<T> and Rc<T>.
-# This is a subset of std but may be enabled without depending on all of std.
+# Provide impls for types in the Rust core allocation and collections library
+# including String, Box<T>, Vec<T>, and Cow<T>. This is a subset of std but may
+# be enabled without depending on all of std.
 #
 # Requires a dependency on the unstable core allocation library:
 #
 #    https://doc.rust-lang.org/alloc/
 alloc = ["unstable"]
-
-# Provide impls for collection types like String and Cow<T>. This is a subset of
-# std but may be enabled without depending on all of std.
-#
-# Requires a dependency on the unstable collections library:
-#
-#    https://doc.rust-lang.org/collections/
-collections = ["alloc"]
 
 # Opt into impls for Rc<T> and Arc<T>. Serializing and deserializing these types
 # does not preserve identity and may result in multiple copies of the same data.

--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -11,12 +11,12 @@ use lib::*;
 use de::{Deserialize, Deserializer, EnumAccess, Error, SeqAccess, Unexpected, VariantAccess,
          Visitor};
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 use de::MapAccess;
 
 use de::from_primitive::FromPrimitive;
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 use private::de::size_hint;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -208,10 +208,10 @@ impl<'de> Deserialize<'de> for char {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 struct StringVisitor;
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 impl<'de> Visitor<'de> for StringVisitor {
     type Value = String;
 
@@ -254,7 +254,7 @@ impl<'de> Visitor<'de> for StringVisitor {
     }
 }
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 impl<'de> Deserialize<'de> for String {
     fn deserialize<D>(deserializer: D) -> Result<String, D::Error>
     where
@@ -497,7 +497,7 @@ impl<'de, T> Deserialize<'de> for PhantomData<T> {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 macro_rules! seq_impl {
     (
         $ty:ident < T $(: $tbound1:ident $(+ $tbound2:ident)*)* $(, $typaram:ident : $bound1:ident $(+ $bound2:ident)*)* >,
@@ -552,7 +552,7 @@ macro_rules! seq_impl {
     }
 }
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 seq_impl!(
     BinaryHeap<T: Ord>,
     seq,
@@ -560,7 +560,7 @@ seq_impl!(
     BinaryHeap::with_capacity(size_hint::cautious(seq.size_hint())),
     BinaryHeap::push);
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 seq_impl!(
     BTreeSet<T: Eq + Ord>,
     seq,
@@ -568,7 +568,7 @@ seq_impl!(
     BTreeSet::new(),
     BTreeSet::insert);
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 seq_impl!(
     LinkedList<T>,
     seq,
@@ -584,7 +584,7 @@ seq_impl!(
     HashSet::with_capacity_and_hasher(size_hint::cautious(seq.size_hint()), S::default()),
     HashSet::insert);
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 seq_impl!(
     Vec<T>,
     seq,
@@ -592,7 +592,7 @@ seq_impl!(
     Vec::with_capacity(size_hint::cautious(seq.size_hint())),
     Vec::push);
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 seq_impl!(
     VecDeque<T>,
     seq,
@@ -790,7 +790,7 @@ tuple_impls! {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 macro_rules! map_impl {
     (
         $ty:ident < K $(: $kbound1:ident $(+ $kbound2:ident)*)*, V $(, $typaram:ident : $bound1:ident $(+ $bound2:ident)*)* >,
@@ -846,7 +846,7 @@ macro_rules! map_impl {
     }
 }
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 map_impl!(
     BTreeMap<K: Ord, V>,
     map,
@@ -1110,7 +1110,7 @@ where
     }
 }
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 impl<'de, T> Deserialize<'de> for Box<[T]>
 where
     T: Deserialize<'de>,
@@ -1123,7 +1123,7 @@ where
     }
 }
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 impl<'de> Deserialize<'de> for Box<str> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -1159,7 +1159,7 @@ where
     }
 }
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 impl<'de, 'a, T: ?Sized> Deserialize<'de> for Cow<'a, T>
 where
     T: ToOwned,

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -1262,7 +1262,7 @@ pub trait Visitor<'de>: Sized {
     /// The default implementation forwards to `visit_str` and then drops the
     /// `String`.
     #[inline]
-    #[cfg(any(feature = "std", feature = "collections"))]
+    #[cfg(any(feature = "std", feature = "alloc"))]
     fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
     where
         E: Error,
@@ -1321,7 +1321,7 @@ pub trait Visitor<'de>: Sized {
     ///
     /// The default implementation forwards to `visit_bytes` and then drops the
     /// `Vec<u8>`.
-    #[cfg(any(feature = "std", feature = "collections"))]
+    #[cfg(any(feature = "std", feature = "alloc"))]
     fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
     where
         E: Error,

--- a/serde/src/de/value.rs
+++ b/serde/src/de/value.rs
@@ -51,13 +51,13 @@ pub struct Error {
     err: ErrorImpl,
 }
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 type ErrorImpl = Box<str>;
-#[cfg(not(any(feature = "std", feature = "collections")))]
+#[cfg(not(any(feature = "std", feature = "alloc")))]
 type ErrorImpl = ();
 
 impl de::Error for Error {
-    #[cfg(any(feature = "std", feature = "collections"))]
+    #[cfg(any(feature = "std", feature = "alloc"))]
     fn custom<T>(msg: T) -> Self
     where
         T: Display,
@@ -65,7 +65,7 @@ impl de::Error for Error {
         Error { err: msg.to_string().into_boxed_str() }
     }
 
-    #[cfg(not(any(feature = "std", feature = "collections")))]
+    #[cfg(not(any(feature = "std", feature = "alloc")))]
     fn custom<T>(msg: T) -> Self
     where
         T: Display,
@@ -85,12 +85,12 @@ impl ser::Error for Error {
 }
 
 impl Display for Error {
-    #[cfg(any(feature = "std", feature = "collections"))]
+    #[cfg(any(feature = "std", feature = "alloc"))]
     fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         formatter.write_str(&self.err)
     }
 
-    #[cfg(not(any(feature = "std", feature = "collections")))]
+    #[cfg(not(any(feature = "std", feature = "alloc")))]
     fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         formatter.write_str("Serde deserialization error")
     }
@@ -425,14 +425,14 @@ where
 ////////////////////////////////////////////////////////////////////////////////
 
 /// A deserializer holding a `String`.
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 #[derive(Clone, Debug)]
 pub struct StringDeserializer<E> {
     value: String,
     marker: PhantomData<E>,
 }
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 impl<'de, E> IntoDeserializer<'de, E> for String
 where
     E: de::Error,
@@ -447,7 +447,7 @@ where
     }
 }
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 impl<'de, E> de::Deserializer<'de> for StringDeserializer<E>
 where
     E: de::Error,
@@ -482,7 +482,7 @@ where
     }
 }
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 impl<'de, 'a, E> de::EnumAccess<'de> for StringDeserializer<E>
 where
     E: de::Error,
@@ -501,14 +501,14 @@ where
 ////////////////////////////////////////////////////////////////////////////////
 
 /// A deserializer holding a `Cow<str>`.
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 #[derive(Clone, Debug)]
 pub struct CowStrDeserializer<'a, E> {
     value: Cow<'a, str>,
     marker: PhantomData<E>,
 }
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 impl<'de, 'a, E> IntoDeserializer<'de, E> for Cow<'a, str>
 where
     E: de::Error,
@@ -523,7 +523,7 @@ where
     }
 }
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 impl<'de, 'a, E> de::Deserializer<'de> for CowStrDeserializer<'a, E>
 where
     E: de::Error,
@@ -561,7 +561,7 @@ where
     }
 }
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 impl<'de, 'a, E> de::EnumAccess<'de> for CowStrDeserializer<'a, E>
 where
     E: de::Error,
@@ -727,7 +727,7 @@ impl Expected for ExpectedInSeq {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 impl<'de, T, E> IntoDeserializer<'de, E> for Vec<T>
 where
     T: IntoDeserializer<'de, E>,
@@ -740,7 +740,7 @@ where
     }
 }
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 impl<'de, T, E> IntoDeserializer<'de, E> for BTreeSet<T>
 where
     T: IntoDeserializer<'de, E> + Eq + Ord,
@@ -1145,7 +1145,7 @@ impl Expected for ExpectedInMap {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 impl<'de, K, V, E> IntoDeserializer<'de, E> for BTreeMap<K, V>
 where
     K: IntoDeserializer<'de, E> + Eq + Ord,

--- a/serde/src/export.rs
+++ b/serde/src/export.rs
@@ -19,7 +19,7 @@ pub use self::string::from_utf8_lossy;
 mod string {
     use lib::*;
 
-    #[cfg(any(feature = "std", feature = "collections"))]
+    #[cfg(any(feature = "std", feature = "alloc"))]
     pub fn from_utf8_lossy(bytes: &[u8]) -> Cow<str> {
         String::from_utf8_lossy(bytes)
     }
@@ -31,7 +31,7 @@ mod string {
     //
     // so it is okay for the return type to be different from the std case as long
     // as the above works.
-    #[cfg(not(any(feature = "std", feature = "collections")))]
+    #[cfg(not(any(feature = "std", feature = "alloc")))]
     pub fn from_utf8_lossy(bytes: &[u8]) -> &str {
         // Three unicode replacement characters if it fails. They look like a
         // white-on-black question mark. The user will recognize it as invalid

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -91,7 +91,6 @@
 #![cfg_attr(feature = "unstable", feature(nonzero, specialization))]
 #![cfg_attr(all(feature = "std", feature = "unstable"), feature(into_boxed_c_str))]
 #![cfg_attr(feature = "alloc", feature(alloc))]
-#![cfg_attr(feature = "collections", feature(collections))]
 
 // Whitelisted clippy lints.
 #![cfg_attr(feature = "cargo-clippy", allow(doc_markdown))]
@@ -104,18 +103,15 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#[cfg(feature = "collections")]
-extern crate collections;
-
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
 #[cfg(all(feature = "unstable", feature = "std"))]
 extern crate core;
 
-/// A facade around all the types we need from the `std`, `core`, `alloc`, and
-/// `collections` crates. This avoids elaborate import wrangling having to
-/// happen in every module.
+/// A facade around all the types we need from the `std`, `core`, and `alloc`
+/// crates. This avoids elaborate import wrangling having to happen in every
+/// module.
 mod lib {
     mod core {
         #[cfg(feature = "std")]
@@ -140,18 +136,18 @@ mod lib {
 
     #[cfg(feature = "std")]
     pub use std::borrow::{Cow, ToOwned};
-    #[cfg(all(feature = "collections", not(feature = "std")))]
-    pub use collections::borrow::{Cow, ToOwned};
+    #[cfg(all(feature = "alloc", not(feature = "std")))]
+    pub use alloc::borrow::{Cow, ToOwned};
 
     #[cfg(feature = "std")]
     pub use std::string::String;
-    #[cfg(all(feature = "collections", not(feature = "std")))]
-    pub use collections::string::{String, ToString};
+    #[cfg(all(feature = "alloc", not(feature = "std")))]
+    pub use alloc::string::{String, ToString};
 
     #[cfg(feature = "std")]
     pub use std::vec::Vec;
-    #[cfg(all(feature = "collections", not(feature = "std")))]
-    pub use collections::vec::Vec;
+    #[cfg(all(feature = "alloc", not(feature = "std")))]
+    pub use alloc::vec::Vec;
 
     #[cfg(feature = "std")]
     pub use std::boxed::Box;
@@ -170,8 +166,8 @@ mod lib {
 
     #[cfg(feature = "std")]
     pub use std::collections::{BinaryHeap, BTreeMap, BTreeSet, LinkedList, VecDeque};
-    #[cfg(all(feature = "collections", not(feature = "std")))]
-    pub use collections::{BinaryHeap, BTreeMap, BTreeSet, LinkedList, VecDeque};
+    #[cfg(all(feature = "alloc", not(feature = "std")))]
+    pub use alloc::{BinaryHeap, BTreeMap, BTreeSet, LinkedList, VecDeque};
 
     #[cfg(feature = "std")]
     pub use std::{error, net};

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -10,10 +10,10 @@ use lib::*;
 
 use de::{Deserialize, Deserializer, IntoDeserializer, Error, Visitor};
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 use de::Unexpected;
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 pub use self::content::{Content, ContentRefDeserializer, ContentDeserializer,
                         TaggedContentVisitor, TagOrContentField, TagOrContentFieldVisitor,
                         TagContentOtherField, TagContentOtherFieldVisitor,
@@ -59,7 +59,7 @@ where
     Deserialize::deserialize(deserializer)
 }
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 pub fn borrow_cow_str<'de: 'a, 'a, D>(deserializer: D) -> Result<Cow<'a, str>, D::Error>
 where
     D: Deserializer<'de>,
@@ -128,7 +128,7 @@ where
     deserializer.deserialize_str(CowStrVisitor)
 }
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 pub fn borrow_cow_bytes<'de: 'a, 'a, D>(deserializer: D) -> Result<Cow<'a, [u8]>, D::Error>
 where
     D: Deserializer<'de>,
@@ -210,7 +210,7 @@ pub mod size_hint {
     }
 }
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 mod content {
     // This module is private and nothing here should be used outside of
     // generated code.

--- a/serde/src/private/ser.rs
+++ b/serde/src/private/ser.rs
@@ -10,7 +10,7 @@ use lib::*;
 
 use ser::{self, Serialize, Serializer, SerializeMap, SerializeStruct, Impossible};
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 use self::content::{SerializeTupleVariantAsMapValue, SerializeStructVariantAsMapValue};
 
 /// Used to check that serde(getter) attributes return the expected type.
@@ -64,7 +64,7 @@ enum Unsupported {
     Sequence,
     Tuple,
     TupleStruct,
-    #[cfg(not(any(feature = "std", feature = "collections")))]
+    #[cfg(not(any(feature = "std", feature = "alloc")))]
     Enum,
 }
 
@@ -83,7 +83,7 @@ impl Display for Unsupported {
             Unsupported::Sequence => formatter.write_str("a sequence"),
             Unsupported::Tuple => formatter.write_str("a tuple"),
             Unsupported::TupleStruct => formatter.write_str("a tuple struct"),
-            #[cfg(not(any(feature = "std", feature = "collections")))]
+            #[cfg(not(any(feature = "std", feature = "alloc")))]
             Unsupported::Enum => formatter.write_str("an enum"),
         }
     }
@@ -117,14 +117,14 @@ where
     type SerializeMap = S::SerializeMap;
     type SerializeStruct = S::SerializeStruct;
 
-    #[cfg(not(any(feature = "std", feature = "collections")))]
+    #[cfg(not(any(feature = "std", feature = "alloc")))]
     type SerializeTupleVariant = Impossible<S::Ok, S::Error>;
-    #[cfg(any(feature = "std", feature = "collections"))]
+    #[cfg(any(feature = "std", feature = "alloc"))]
     type SerializeTupleVariant = SerializeTupleVariantAsMapValue<S::SerializeMap>;
 
-    #[cfg(not(any(feature = "std", feature = "collections")))]
+    #[cfg(not(any(feature = "std", feature = "alloc")))]
     type SerializeStructVariant = Impossible<S::Ok, S::Error>;
-    #[cfg(any(feature = "std", feature = "collections"))]
+    #[cfg(any(feature = "std", feature = "alloc"))]
     type SerializeStructVariant = SerializeStructVariantAsMapValue<S::SerializeMap>;
 
     fn serialize_bool(self, _: bool) -> Result<Self::Ok, Self::Error> {
@@ -257,7 +257,7 @@ where
         Err(self.bad_type(Unsupported::TupleStruct))
     }
 
-    #[cfg(not(any(feature = "std", feature = "collections")))]
+    #[cfg(not(any(feature = "std", feature = "alloc")))]
     fn serialize_tuple_variant(
         self,
         _: &'static str,
@@ -270,7 +270,7 @@ where
         Err(self.bad_type(Unsupported::Enum))
     }
 
-    #[cfg(any(feature = "std", feature = "collections"))]
+    #[cfg(any(feature = "std", feature = "alloc"))]
     fn serialize_tuple_variant(
         self,
         _: &'static str,
@@ -300,7 +300,7 @@ where
         Ok(state)
     }
 
-    #[cfg(not(any(feature = "std", feature = "collections")))]
+    #[cfg(not(any(feature = "std", feature = "alloc")))]
     fn serialize_struct_variant(
         self,
         _: &'static str,
@@ -313,7 +313,7 @@ where
         Err(self.bad_type(Unsupported::Enum))
     }
 
-    #[cfg(any(feature = "std", feature = "collections"))]
+    #[cfg(any(feature = "std", feature = "alloc"))]
     fn serialize_struct_variant(
         self,
         _: &'static str,
@@ -327,7 +327,7 @@ where
         Ok(SerializeStructVariantAsMapValue::new(map, inner_variant, len),)
     }
 
-    #[cfg(not(any(feature = "std", feature = "collections")))]
+    #[cfg(not(any(feature = "std", feature = "alloc")))]
     fn collect_str<T: ?Sized>(self, _: &T) -> Result<Self::Ok, Self::Error>
     where
         T: Display,
@@ -363,7 +363,7 @@ impl Display for Error {
     }
 }
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 mod content {
     use lib::*;
 

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -56,7 +56,7 @@ impl Serialize for str {
     }
 }
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 impl Serialize for String {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -195,22 +195,22 @@ macro_rules! seq_impl {
     }
 }
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 seq_impl!(BinaryHeap<T: Ord>);
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 seq_impl!(BTreeSet<T: Ord>);
 
 #[cfg(feature = "std")]
 seq_impl!(HashSet<T: Eq + Hash, H: BuildHasher>);
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 seq_impl!(LinkedList<T>);
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 seq_impl!(Vec<T>);
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 seq_impl!(VecDeque<T>);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -309,7 +309,7 @@ macro_rules! map_impl {
     }
 }
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 map_impl!(BTreeMap<K: Ord, V>);
 
 #[cfg(feature = "std")]
@@ -343,7 +343,7 @@ deref_impl!(<T> Serialize for Rc<T> where T: Serialize);
 #[cfg(all(feature = "rc", any(feature = "std", feature = "alloc")))]
 deref_impl!(<T> Serialize for Arc<T> where T: Serialize);
 
-#[cfg(any(feature = "std", feature = "collections"))]
+#[cfg(any(feature = "std", feature = "alloc"))]
 deref_impl!(<'a, T: ?Sized> Serialize for Cow<'a, T> where T: Serialize + ToOwned);
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -1321,7 +1321,7 @@ pub trait Serializer: Sized {
     ///
     /// [`String`]: https://doc.rust-lang.org/std/string/struct.String.html
     /// [`serialize_str`]: #tymethod.serialize_str
-    #[cfg(any(feature = "std", feature = "collections"))]
+    #[cfg(any(feature = "std", feature = "alloc"))]
     fn collect_str<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
     where
         T: Display,
@@ -1358,7 +1358,7 @@ pub trait Serializer: Sized {
     ///     }
     /// }
     /// ```
-    #[cfg(not(any(feature = "std", feature = "collections")))]
+    #[cfg(not(any(feature = "std", feature = "alloc")))]
     fn collect_str<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
     where
         T: Display;

--- a/travis.sh
+++ b/travis.sh
@@ -46,7 +46,6 @@ else
     channel build
     channel build --no-default-features
     channel build --no-default-features --features alloc
-    channel build --no-default-features --features collections
     channel test --features 'rc unstable'
     cd "$DIR/test_suite/deps"
     channel build


### PR DESCRIPTION
This PR removes the unstable `collections` feature to align with https://github.com/rust-lang/rust/pull/42648. Removing the feature is a breaking change but the feature is unstable and anyone using it is already broken on the most recent nightly.

No impls were harmed in the making of this PR.

Fixes #955.