### PR TITLE
Add methods to provide field indices

### DIFF
--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -1703,9 +1703,9 @@ pub trait SerializeMap {
 ///         where S: Serializer
 ///     {
 ///         let mut rgb = serializer.serialize_struct("Rgb", 3)?;
-///         rgb.serialize_field("r", &self.r)?;
-///         rgb.serialize_field("g", &self.g)?;
-///         rgb.serialize_field("b", &self.b)?;
+///         rgb.serialize_indexed_field("r", 0, &self.r)?;
+///         rgb.serialize_indexed_field("g", 1, &self.g)?;
+///         rgb.serialize_indexed_field("b", 2, &self.b)?;
 ///         rgb.end()
 ///     }
 /// }
@@ -1718,6 +1718,8 @@ pub trait SerializeStruct {
     type Error: Error;
 
     /// Serialize a struct field.
+    ///
+    /// `serialize_indexed_field` should be used in preference to this method when serializing.
     fn serialize_field<T: ?Sized>(
         &mut self,
         key: &'static str,
@@ -1725,6 +1727,23 @@ pub trait SerializeStruct {
     ) -> Result<(), Self::Error>
     where
         T: Serialize;
+
+    /// Serialize a struct field with its index in the struct definition provided.
+    ///
+    /// The default implementation delegates to `serialize_field`.
+    #[inline]
+    fn serialize_indexed_field<T: ?Sized>(
+        &mut self,
+        key: &'static str,
+        key_index: u32,
+        value: &T,
+    ) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        let _ = key_index;
+        self.serialize_field(key, value)
+    }
 
     /// Finish serializing a struct.
     fn end(self) -> Result<Self::Ok, Self::Error>;
@@ -1746,9 +1765,9 @@ pub trait SerializeStruct {
 ///         match *self {
 ///             E::S { ref r, ref g, ref b } => {
 ///                 let mut sv = serializer.serialize_struct_variant("E", 0, "S", 3)?;
-///                 sv.serialize_field("r", r)?;
-///                 sv.serialize_field("g", g)?;
-///                 sv.serialize_field("b", b)?;
+///                 sv.serialize_indexed_field("r", 0, r)?;
+///                 sv.serialize_indexed_field("g", 1, g)?;
+///                 sv.serialize_indexed_field("b", 2, b)?;
 ///                 sv.end()
 ///             }
 ///         }
@@ -1763,6 +1782,8 @@ pub trait SerializeStructVariant {
     type Error: Error;
 
     /// Serialize a struct variant field.
+    ///
+    /// `serialize_indexed_field` should be used in preference to this method when serializing.
     fn serialize_field<T: ?Sized>(
         &mut self,
         key: &'static str,
@@ -1770,6 +1791,23 @@ pub trait SerializeStructVariant {
     ) -> Result<(), Self::Error>
     where
         T: Serialize;
+
+    /// Serialize a struct variant field with its index in the struct definition provided.
+    ///
+    /// The default implementation delegates to `serialize_field`.
+    #[inline]
+    fn serialize_indexed_field<T: ?Sized>(
+        &mut self,
+        key: &'static str,
+        key_index: u32,
+        value: &T,
+    ) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        let _ = key_index;
+        self.serialize_field(key, value)
+    }
 
     /// Finish serializing a struct variant.
     fn end(self) -> Result<Self::Ok, Self::Error>;

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1386,26 +1386,21 @@ fn deserialize_identifier(
         "field identifier"
     };
 
-    let visit_index = if is_variant {
-        let variant_indices = 0u32..;
-        let fallthrough_msg = format!("variant index 0 <= i < {}", fields.len());
-        let visit_index = quote! {
-            fn visit_u32<__E>(self, __value: u32) -> _serde::export::Result<Self::Value, __E>
-                where __E: _serde::de::Error
-            {
-                match __value {
-                    #(
-                        #variant_indices => _serde::export::Ok(#constructors),
-                    )*
-                    _ => _serde::export::Err(_serde::de::Error::invalid_value(
-                                _serde::de::Unexpected::Unsigned(__value as u64),
-                                &#fallthrough_msg))
-                }
+    let variant_indices = 0u32..;
+    let fallthrough_msg = format!("variant index 0 <= i < {}", fields.len());
+    let visit_index = quote! {
+        fn visit_u32<__E>(self, __value: u32) -> _serde::export::Result<Self::Value, __E>
+            where __E: _serde::de::Error
+        {
+            match __value {
+                #(
+                    #variant_indices => _serde::export::Ok(#constructors),
+                )*
+                _ => _serde::export::Err(_serde::de::Error::invalid_value(
+                            _serde::de::Unexpected::Unsigned(__value as u64),
+                            &#fallthrough_msg))
             }
-        };
-        Some(visit_index)
-    } else {
-        None
+        }
     };
 
     let bytes_to_str = if fallthrough.is_some() {

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -51,7 +51,8 @@ pub fn expand_derive_serialize(input: &syn::DeriveInput) -> Result<Tokens, Strin
         }
     };
 
-    let generated = quote! {
+    let generated =
+        quote! {
         #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
         const #dummy_const: () = {
             extern crate serde as _serde;
@@ -240,7 +241,7 @@ fn serialize_struct(params: &Parameters, fields: &[Field], cattrs: &attr::Contai
         fields,
         params,
         false,
-        quote!(_serde::ser::SerializeStruct::serialize_field),
+        quote!(_serde::ser::SerializeStruct::serialize_indexed_field),
     );
 
     let type_name = cattrs.name().serialize_name();
@@ -253,16 +254,14 @@ fn serialize_struct(params: &Parameters, fields: &[Field], cattrs: &attr::Contai
     let let_mut = mut_if(serialized_fields.peek().is_some());
 
     let len = serialized_fields
-        .map(
-            |field| match field.attrs.skip_serializing_if() {
-                None => quote!(1),
-                Some(path) => {
-                    let ident = field.ident.clone().expect("struct has unnamed fields");
-                    let field_expr = get_field(params, field, ident);
-                    quote!(if #path(#field_expr) { 0 } else { 1 })
-                }
-            },
-        )
+        .map(|field| match field.attrs.skip_serializing_if() {
+            None => quote!(1),
+            Some(path) => {
+                let ident = field.ident.clone().expect("struct has unnamed fields");
+                let field_expr = get_field(params, field, ident);
+                quote!(if #path(#field_expr) { 0 } else { 1 })
+            }
+        })
         .fold(quote!(0), |sum, expr| quote!(#sum + #expr));
 
     quote_block! {
@@ -280,11 +279,9 @@ fn serialize_enum(params: &Parameters, variants: &[Variant], cattrs: &attr::Cont
     let arms: Vec<_> = variants
         .iter()
         .enumerate()
-        .map(
-            |(variant_index, variant)| {
-                serialize_variant(params, variant, variant_index as u32, cattrs)
-            },
-        )
+        .map(|(variant_index, variant)| {
+            serialize_variant(params, variant, variant_index as u32, cattrs)
+        })
         .collect();
 
     quote_expr! {
@@ -309,18 +306,17 @@ fn serialize_variant(
             params.type_name(),
             variant_ident
         );
-        let skipped_err = quote! {
+        let skipped_err =
+            quote! {
             _serde::export::Err(_serde::ser::Error::custom(#skipped_msg))
         };
         let fields_pat = match variant.style {
             Style::Unit => quote!(),
             Style::Newtype | Style::Tuple => quote!((..)),
             Style::Struct => {
-                quote!(
-                    {
-                        ..
-                    }
-                )
+                quote!({
+                    ..
+                })
             }
         };
         quote! {
@@ -347,37 +343,28 @@ fn serialize_variant(
                 }
             }
             Style::Struct => {
-                let fields = variant
-                    .fields
-                    .iter()
-                    .map(
-                        |f| {
-                            f.ident
-                                .clone()
-                                .expect("struct variant has unnamed fields")
-                        },
-                    );
+                let fields = variant.fields.iter().map(|f| {
+                    f.ident.clone().expect("struct variant has unnamed fields")
+                });
                 quote! {
                     #this::#variant_ident { #(ref #fields),* }
                 }
             }
         };
 
-        let body = Match(
-            match *cattrs.tag() {
-                attr::EnumTag::External => {
-                    serialize_externally_tagged_variant(params, variant, variant_index, cattrs)
-                }
-                attr::EnumTag::Internal { ref tag } => {
-                    serialize_internally_tagged_variant(params, variant, cattrs, tag)
-                }
-                attr::EnumTag::Adjacent {
-                    ref tag,
-                    ref content,
-                } => serialize_adjacently_tagged_variant(params, variant, cattrs, tag, content),
-                attr::EnumTag::None => serialize_untagged_variant(params, variant, cattrs),
-            },
-        );
+        let body = Match(match *cattrs.tag() {
+            attr::EnumTag::External => {
+                serialize_externally_tagged_variant(params, variant, variant_index, cattrs)
+            }
+            attr::EnumTag::Internal { ref tag } => {
+                serialize_internally_tagged_variant(params, variant, cattrs, tag)
+            }
+            attr::EnumTag::Adjacent {
+                ref tag,
+                ref content,
+            } => serialize_adjacently_tagged_variant(params, variant, cattrs, tag, content),
+            attr::EnumTag::None => serialize_untagged_variant(params, variant, cattrs),
+        });
 
         quote! {
             #case => #body
@@ -513,41 +500,37 @@ fn serialize_adjacently_tagged_variant(
     let type_name = cattrs.name().serialize_name();
     let variant_name = variant.attrs.name().serialize_name();
 
-    let inner = Stmts(
-        match variant.style {
-            Style::Unit => {
-                return quote_block! {
+    let inner = Stmts(match variant.style {
+        Style::Unit => {
+            return quote_block! {
                     let mut __struct = try!(_serde::Serializer::serialize_struct(
                         __serializer, #type_name, 1));
                     try!(_serde::ser::SerializeStruct::serialize_field(
                         &mut __struct, #tag, #variant_name));
                     _serde::ser::SerializeStruct::end(__struct)
                 };
+        }
+        Style::Newtype => {
+            let field = &variant.fields[0];
+            let mut field_expr = quote!(__field0);
+            if let Some(path) = field.attrs.serialize_with() {
+                field_expr = wrap_serialize_with(params, field.ty, path, field_expr);
             }
-            Style::Newtype => {
-                let field = &variant.fields[0];
-                let mut field_expr = quote!(__field0);
-                if let Some(path) = field.attrs.serialize_with() {
-                    field_expr = wrap_serialize_with(params, field.ty, path, field_expr);
-                }
 
-                quote_expr! {
+            quote_expr! {
                     _serde::Serialize::serialize(#field_expr, __serializer)
                 }
-            }
-            Style::Tuple => {
-                serialize_tuple_variant(TupleVariant::Untagged, params, &variant.fields)
-            }
-            Style::Struct => {
-                serialize_struct_variant(
-                    StructVariant::Untagged,
-                    params,
-                    &variant.fields,
-                    &variant_name,
-                )
-            }
-        },
-    );
+        }
+        Style::Tuple => serialize_tuple_variant(TupleVariant::Untagged, params, &variant.fields),
+        Style::Struct => {
+            serialize_struct_variant(
+                StructVariant::Untagged,
+                params,
+                &variant.fields,
+                &variant_name,
+            )
+        }
+    });
 
     let fields_ty = variant.fields.iter().map(|f| &f.ty);
     let ref fields_ident: Vec<_> = match variant.style {
@@ -562,13 +545,9 @@ fn serialize_adjacently_tagged_variant(
             variant
                 .fields
                 .iter()
-                .map(
-                    |f| {
-                        f.ident
-                            .clone()
-                            .expect("struct variant has unnamed fields")
-                    },
-                )
+                .map(|f| {
+                    f.ident.clone().expect("struct variant has unnamed fields")
+                })
                 .collect()
         }
     };
@@ -708,10 +687,10 @@ fn serialize_struct_variant<'a>(
 ) -> Fragment {
     let method = match context {
         StructVariant::ExternallyTagged { .. } => {
-            quote!(_serde::ser::SerializeStructVariant::serialize_field)
+            quote!(_serde::ser::SerializeStructVariant::serialize_indexed_field)
         }
         StructVariant::InternallyTagged { .. } |
-        StructVariant::Untagged => quote!(_serde::ser::SerializeStruct::serialize_field),
+        StructVariant::Untagged => quote!(_serde::ser::SerializeStruct::serialize_indexed_field),
     };
 
     let serialize_fields = serialize_struct_visitor(fields, params, true, method);
@@ -724,16 +703,14 @@ fn serialize_struct_variant<'a>(
     let let_mut = mut_if(serialized_fields.peek().is_some());
 
     let len = serialized_fields
-        .map(
-            |field| {
-                let ident = field.ident.clone().expect("struct has unnamed fields");
+        .map(|field| {
+            let ident = field.ident.clone().expect("struct has unnamed fields");
 
-                match field.attrs.skip_serializing_if() {
-                    Some(path) => quote!(if #path(#ident) { 0 } else { 1 }),
-                    None => quote!(1),
-                }
-            },
-        )
+            match field.attrs.skip_serializing_if() {
+                Some(path) => quote!(if #path(#ident) { 0 } else { 1 }),
+                None => quote!(1),
+            }
+        })
         .fold(quote!(0), |sum, expr| quote!(#sum + #expr));
 
     match context {
@@ -792,34 +769,32 @@ fn serialize_tuple_struct_visitor(
     fields
         .iter()
         .enumerate()
-        .map(
-            |(i, field)| {
-                let mut field_expr = if is_enum {
-                    let id = Ident::new(format!("__field{}", i));
-                    quote!(#id)
-                } else {
-                    get_field(params, field, i)
-                };
+        .map(|(i, field)| {
+            let mut field_expr = if is_enum {
+                let id = Ident::new(format!("__field{}", i));
+                quote!(#id)
+            } else {
+                get_field(params, field, i)
+            };
 
-                let skip = field
-                    .attrs
-                    .skip_serializing_if()
-                    .map(|path| quote!(#path(#field_expr)));
+            let skip = field.attrs.skip_serializing_if().map(
+                |path| quote!(#path(#field_expr)),
+            );
 
-                if let Some(path) = field.attrs.serialize_with() {
-                    field_expr = wrap_serialize_with(params, field.ty, path, field_expr);
-                }
+            if let Some(path) = field.attrs.serialize_with() {
+                field_expr = wrap_serialize_with(params, field.ty, path, field_expr);
+            }
 
-                let ser = quote! {
+            let ser =
+                quote! {
                     try!(#func(&mut __serde_state, #field_expr));
                 };
 
-                match skip {
-                    None => ser,
-                    Some(skip) => quote!(if !#skip { #ser }),
-                }
-            },
-        )
+            match skip {
+                None => ser,
+                Some(skip) => quote!(if !#skip { #ser }),
+            }
+        })
         .collect()
 }
 
@@ -831,37 +806,38 @@ fn serialize_struct_visitor(
 ) -> Vec<Tokens> {
     fields
         .iter()
-        .filter(|&field| !field.attrs.skip_serializing())
-        .map(
-            |field| {
-                let field_ident = field.ident.clone().expect("struct has unnamed field");
-                let mut field_expr = if is_enum {
-                    quote!(#field_ident)
-                } else {
-                    get_field(params, field, field_ident)
+        .enumerate()
+        .filter(|&(_, field)| !field.attrs.skip_serializing())
+        .map(|(i, field)| {
+            let field_ident = field.ident.clone().expect("struct has unnamed field");
+            let mut field_expr = if is_enum {
+                quote!(#field_ident)
+            } else {
+                get_field(params, field, field_ident)
+            };
+
+            let key_expr = field.attrs.name().serialize_name();
+
+            let skip = field.attrs.skip_serializing_if().map(
+                |path| quote!(#path(#field_expr)),
+            );
+
+            if let Some(path) = field.attrs.serialize_with() {
+                field_expr = wrap_serialize_with(params, field.ty, path, field_expr)
+            }
+
+            let key_index_expr = i as u32;
+
+            let ser =
+                quote! {
+                    try!(#func(&mut __serde_state, #key_expr, #key_index_expr, #field_expr));
                 };
 
-                let key_expr = field.attrs.name().serialize_name();
-
-                let skip = field
-                    .attrs
-                    .skip_serializing_if()
-                    .map(|path| quote!(#path(#field_expr)));
-
-                if let Some(path) = field.attrs.serialize_with() {
-                    field_expr = wrap_serialize_with(params, field.ty, path, field_expr)
-                }
-
-                let ser = quote! {
-                    try!(#func(&mut __serde_state, #key_expr, #field_expr));
-                };
-
-                match skip {
-                    None => ser,
-                    Some(skip) => quote!(if !#skip { #ser }),
-                }
-            },
-        )
+            match skip {
+                None => ser,
+                Some(skip) => quote!(if !#skip { #ser }),
+            }
+        })
         .collect()
 }
 

--- a/test_suite/tests/test_de.rs
+++ b/test_suite/tests/test_de.rs
@@ -605,6 +605,17 @@ declare_tests! {
             Token::StructEnd,
         ],
     }
+    test_struct_integer_keys {
+        Struct { a: 1, b: 2, c: 0 } => &[
+            Token::Struct { name: "Struct", len: 2 },
+                Token::U32(0),
+                Token::I32(1),
+
+                Token::U32(1),
+                Token::I32(2),
+            Token::StructEnd,
+        ],
+    }
     test_enum_unit {
         Enum::Unit => &[
             Token::UnitVariant { name: "Enum", variant: "Unit" },


### PR DESCRIPTION
Closes #960

This change does mean that if you run a new serde_derive with an old serde the build will fail. That seems like an uncommon situation to be stuck in though.