### PR TITLE
WIP: Allow #[serde(rename=str|bool|int)] for enum variants.

### DIFF
--- a/serde/src/export.rs
+++ b/serde/src/export.rs
@@ -15,6 +15,8 @@ pub use lib::option::Option::{self, None, Some};
 pub use lib::result::Result::{self, Ok, Err};
 
 pub use self::string::from_utf8_lossy;
+pub use self::string::from_int;
+pub use self::string::from_bool;
 
 mod string {
     use lib::*;
@@ -37,5 +39,42 @@ mod string {
         // white-on-black question mark. The user will recognize it as invalid
         // UTF-8.
         str::from_utf8(bytes).unwrap_or("\u{fffd}\u{fffd}\u{fffd}")
+    }
+
+    pub fn from_bool(b : bool) -> &'static str {
+        match b {
+            true => "true",
+            false => "false",
+        }
+    }
+
+    #[cfg(any(feature = "std", feature = "alloc"))]
+    pub fn from_int(i: u64) -> Vec<u8> {
+        format!("{}", i).into_bytes()
+    }
+
+    #[cfg(not(any(feature = "std", feature = "alloc")))]
+    pub fn from_int(i: u64) -> [u8; 20] {
+        let buf = [0; 20];
+        let wrap = Wrapper { buf: &buf };
+        write!(wrap, "{}", i);
+        buf
+    }
+
+    #[cfg(not(any(feature = "std", feature = "alloc")))]
+    struct Wrapper<'a> {
+        buf: &'a mut [u8],
+    }
+
+    #[cfg(not(any(feature = "std", feature = "alloc")))]
+    impl<'a> fmt::Write for Wrapper<'a> {
+        // Could panic if buf is too small.
+        fn write_str(&mut self, s: &str) -> fmt::Result {
+            let bytes = s.as_bytes();
+            self.buf[..bytes.len()].copy_from_slice(bytes);
+            let this : &mut[u8] = mem::replace(&mut self.buf, &mut []);
+            self.buf = &mut this[bytes.len()..];
+            Ok(())
+        }
     }
 }

--- a/serde/src/private/ser.rs
+++ b/serde/src/private/ser.rs
@@ -19,25 +19,63 @@ pub fn constrain<T: ?Sized>(t: &T) -> &T {
     t
 }
 
+pub enum VariantName {
+    Str(&'static str),
+    Bool(bool),
+    Int(u64),
+}
+
+impl From<&'static str> for VariantName {
+    fn from(src: &'static str) -> VariantName {
+        VariantName::Str(src)
+    }
+}
+
+impl<'a> From<&'a bool> for VariantName {
+    fn from(src: &bool) -> VariantName {
+        VariantName::Bool(*src)
+    }
+}
+
+impl<'a> From<&'a u64> for VariantName {
+    fn from(src: &u64) -> VariantName {
+        VariantName::Int(*src)
+    }
+}
+
+impl Serialize for VariantName {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer
+    {
+        match self {
+            &VariantName::Str(s) => serializer.serialize_str(s),
+            &VariantName::Bool(b) => serializer.serialize_bool(b),
+            &VariantName::Int(i) => serializer.serialize_u64(i),
+        }
+    }
+}
+
 /// Not public API.
-pub fn serialize_tagged_newtype<S, T>(
+pub fn serialize_tagged_newtype<S, T, U>(
     serializer: S,
     type_ident: &'static str,
     variant_ident: &'static str,
     tag: &'static str,
-    variant_name: &'static str,
+    variant_name: U,
     value: &T,
 ) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
     T: Serialize,
+    U: Into<VariantName>
 {
     value.serialize(
         TaggedSerializer {
             type_ident: type_ident,
             variant_ident: variant_ident,
             tag: tag,
-            variant_name: variant_name,
+            variant_name: variant_name.into(),
             delegate: serializer,
         },
     )
@@ -47,7 +85,7 @@ struct TaggedSerializer<S> {
     type_ident: &'static str,
     variant_ident: &'static str,
     tag: &'static str,
-    variant_name: &'static str,
+    variant_name: VariantName,
     delegate: S,
 }
 
@@ -209,7 +247,7 @@ where
         inner_variant: &'static str,
     ) -> Result<Self::Ok, Self::Error> {
         let mut map = try!(self.delegate.serialize_map(Some(2)));
-        try!(map.serialize_entry(self.tag, self.variant_name));
+        try!(map.serialize_entry(self.tag, &self.variant_name));
         try!(map.serialize_entry(inner_variant, &()));
         map.end()
     }
@@ -236,7 +274,7 @@ where
         T: Serialize,
     {
         let mut map = try!(self.delegate.serialize_map(Some(2)));
-        try!(map.serialize_entry(self.tag, self.variant_name));
+        try!(map.serialize_entry(self.tag, &self.variant_name));
         try!(map.serialize_entry(inner_variant, inner_value));
         map.end()
     }
@@ -279,14 +317,14 @@ where
         len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
         let mut map = try!(self.delegate.serialize_map(Some(2)));
-        try!(map.serialize_entry(self.tag, self.variant_name));
+        try!(map.serialize_entry(self.tag, &self.variant_name));
         try!(map.serialize_key(inner_variant));
         Ok(SerializeTupleVariantAsMapValue::new(map, inner_variant, len),)
     }
 
     fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
         let mut map = try!(self.delegate.serialize_map(len.map(|len| len + 1)));
-        try!(map.serialize_entry(self.tag, self.variant_name));
+        try!(map.serialize_entry(self.tag, &self.variant_name));
         Ok(map)
     }
 
@@ -296,7 +334,7 @@ where
         len: usize,
     ) -> Result<Self::SerializeStruct, Self::Error> {
         let mut state = try!(self.delegate.serialize_struct(name, len + 1));
-        try!(state.serialize_field(self.tag, self.variant_name));
+        try!(state.serialize_field(self.tag, &self.variant_name));
         Ok(state)
     }
 
@@ -322,7 +360,7 @@ where
         len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
         let mut map = try!(self.delegate.serialize_map(Some(2)));
-        try!(map.serialize_entry(self.tag, self.variant_name));
+        try!(map.serialize_entry(self.tag, &self.variant_name));
         try!(map.serialize_key(inner_variant));
         Ok(SerializeStructVariantAsMapValue::new(map, inner_variant, len),)
     }

--- a/serde/src/private/ser.rs
+++ b/serde/src/private/ser.rs
@@ -48,10 +48,10 @@ impl Serialize for VariantName {
     where
         S: Serializer
     {
-        match self {
-            &VariantName::Str(s) => serializer.serialize_str(s),
-            &VariantName::Bool(b) => serializer.serialize_bool(b),
-            &VariantName::Int(i) => serializer.serialize_u64(i),
+        match *self {
+            VariantName::Str(s) => serializer.serialize_str(s),
+            VariantName::Bool(b) => serializer.serialize_bool(b),
+            VariantName::Int(i) => serializer.serialize_u64(i),
         }
     }
 }

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -705,11 +705,6 @@ fn deserialize_internally_tagged_enum(
         }
     };
 
-    // TODO: just to keep the compiler quiet for now, this must not be strinfied here!
-    let variant_names_idents = variant_names_idents.iter().map(|&(ref variant, ref ident)|
-                                                            (variant.clone(), ident.clone()))
-                                                     .collect();
-
     let variant_visitor = Stmts(deserialize_generated_identifier(variant_names_idents, cattrs, true),);
 
     // Match arms to extract a variant from a string

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -602,11 +602,7 @@ fn deserialize_externally_tagged_enum(
         .iter()
         .enumerate()
         .filter(|&(_, variant)| !variant.attrs.skip_deserializing())
-        .map(|(i, variant)| (match variant.attrs.name().deserialize_name() {
-                                 attr::StrBoolInt::Str(s) => s,
-                                 _ => unreachable!(),
-                             },
-                             field_i(i)),)
+        .map(|(i, variant)| (StrBoolInt::from(variant.attrs.name().deserialize_name()), field_i(i)))
         .collect();
 
     let variants_stmt = {
@@ -711,7 +707,7 @@ fn deserialize_internally_tagged_enum(
 
     // TODO: just to keep the compiler quiet for now, this must not be strinfied here!
     let variant_names_idents = variant_names_idents.iter().map(|&(ref variant, ref ident)|
-                                                            (variant.stringify(), ident.clone()))
+                                                            (variant.clone(), ident.clone()))
                                                      .collect();
 
     let variant_visitor = Stmts(deserialize_generated_identifier(variant_names_idents, cattrs, true),);
@@ -773,11 +769,6 @@ fn deserialize_adjacently_tagged_enum(
             const VARIANTS: &'static [&'static str] = &[ #(#variant_names),* ];
         }
     };
-
-    // TODO: just to keep the compiler quiet for now, this must not be strinfied here!
-    let variant_names_idents = variant_names_idents.iter().map(|&(ref variant, ref ident)|
-                                                            (variant.stringify(), ident.clone()))
-                                                     .collect();
 
     let variant_visitor = Stmts(deserialize_generated_identifier(variant_names_idents, cattrs, true),);
 
@@ -1252,7 +1243,7 @@ fn deserialize_untagged_newtype_variant(
 }
 
 fn deserialize_generated_identifier(
-    fields: Vec<(String, Ident)>,
+    fields: Vec<(StrBoolInt, Ident)>,
     cattrs: &attr::Container,
     is_variant: bool,
 ) -> Fragment {
@@ -1352,12 +1343,6 @@ fn deserialize_custom_identifier(
         Some(fields)
     };
 
-    // TODO: just to keep the compiler quiet for now, this must not be strinfied here!
-    let names_idents : Vec<_> = names_idents.iter().map(|&(ref variant, ref ident)|
-                                                 (variant.stringify(), ident.clone()))
-                                                     .collect();
-
-
     let (de_impl_generics, de_ty_generics, ty_generics, where_clause) = split_with_de_lifetime(params,);
     let visitor_impl =
         Stmts(deserialize_identifier(this.clone(), &names_idents, is_variant, fallthrough),);
@@ -1386,14 +1371,29 @@ fn deserialize_custom_identifier(
 
 fn deserialize_identifier(
     this: Tokens,
-    fields: &[(String, Ident)],
+    fields: &[(StrBoolInt, Ident)],
     is_variant: bool,
     fallthrough: Option<Tokens>,
 ) -> Fragment {
-    let field_strs = fields.iter().map(|&(ref name, _)| name);
-    let field_bytes = fields.iter().map(|&(ref name, _)| quote::ByteStr(name));
+    let field_strs = fields.iter().filter_map(|&(ref n, _)| n.as_str());
+    let field_bytes = fields.iter().filter_map(|&(ref n, _)| n.as_str().map(|n| quote::ByteStr(n)));
+    let field_ints = fields.iter().filter_map(|&(ref n, _)| n.as_int());
+    let field_bools = fields.iter().filter_map(|&(ref n, _)| n.as_bool());
 
-    let constructors: &Vec<_> = &fields
+    let constructors_strs : &Vec<_> = &fields.iter()
+                                             .filter_map(|&(ref n, ref i)| n.as_str().map(|_| i))
+                                             .map(|i| quote!(#this::#i))
+                                             .collect();
+    let constructors_bools : &Vec<_> = &fields.iter()
+                                              .filter_map(|&(ref n, ref i)| n.as_bool().map(|_| i))
+                                              .map(|i| quote!(#this::#i))
+                                              .collect();
+    let constructors_ints : &Vec<_> = &fields.iter()
+                                              .filter_map(|&(ref n, ref i)| n.as_int().map(|_| i))
+                                              .map(|i| quote!(#this::#i))
+                                              .collect();
+
+    let constructors_index: &Vec<_> = &fields
                                      .iter()
                                      .map(|&(_, ref ident)| quote!(#this::#ident))
                                      .collect();
@@ -1404,35 +1404,21 @@ fn deserialize_identifier(
         "field identifier"
     };
 
-    let visit_index = if is_variant {
-        let variant_indices = 0u32..;
-        let fallthrough_msg = format!("variant index 0 <= i < {}", fields.len());
-        let visit_index = quote! {
-            fn visit_u32<__E>(self, __value: u32) -> _serde::export::Result<Self::Value, __E>
-                where __E: _serde::de::Error
-            {
-                match __value {
-                    #(
-                        #variant_indices => _serde::export::Ok(#constructors),
-                    )*
-                    _ => _serde::export::Err(_serde::de::Error::invalid_value(
-                                _serde::de::Unexpected::Unsigned(__value as u64),
-                                &#fallthrough_msg))
-                }
-            }
-        };
-        Some(visit_index)
-    } else {
-        None
-    };
 
-    let bytes_to_str = if fallthrough.is_some() {
-        None
+    let (bytes_to_str, int_to_str, bool_to_str) = if fallthrough.is_some() {
+        (None, None, None)
     } else {
-        let conversion = quote! {
+        let conversion_bytes = quote! {
             let __value = &_serde::export::from_utf8_lossy(__value);
         };
-        Some(conversion)
+        let conversion_int = quote! {
+            let __value = &_serde::export::from_int(__value);
+            let __value = &_serde::export::from_utf8_lossy(__value);
+        };
+        let conversion_bool = quote! {
+            let __value = _serde::export::from_bool(__value);
+        };
+        (Some(conversion_bytes), Some(conversion_int), Some(conversion_bool))
     };
 
     let fallthrough_arm = if let Some(fallthrough) = fallthrough {
@@ -1447,19 +1433,82 @@ fn deserialize_identifier(
         }
     };
 
+    let visit_int = if constructors_ints.is_empty() && is_variant {
+        let variant_indices = 0u32..;
+        let fallthrough_msg = format!("variant index 0 <= i < {}", fields.len());
+        let visit_index = quote! {
+            fn visit_u32<__E>(self, __value: u32) -> _serde::export::Result<Self::Value, __E>
+                where __E: _serde::de::Error
+            {
+                match __value {
+                    #(
+                        #variant_indices => _serde::export::Ok(#constructors_index),
+                    )*
+                    _ => _serde::export::Err(_serde::de::Error::invalid_value(
+                                _serde::de::Unexpected::Unsigned(__value as u64),
+                                &#fallthrough_msg))
+                }
+            }
+        };
+        Some(visit_index)
+    } else if ! constructors_ints.is_empty() {
+        let visit_int = quote! {
+            fn visit_u64<__E>(self, __value: u64) -> _serde::export::Result<Self::Value, __E>
+                where __E: _serde::de::Error
+            {
+                match __value {
+                    #(
+                        #field_ints => _serde::export::Ok(#constructors_ints),
+                    )*
+                    _ => {
+                        #int_to_str
+                        #fallthrough_arm
+                    }
+                }
+            }
+        };
+        Some(visit_int)
+    } else {
+        None
+    };
+
+    let visit_bool = if constructors_bools.is_empty() {
+        None
+    } else {
+        let visit_bool = quote! {
+            fn visit_bool<__E>(self, __value: bool) -> _serde::export::Result<Self::Value, __E>
+                where __E: _serde::de::Error
+            {
+                match __value {
+                    #(
+                        #field_bools => _serde::export::Ok(#constructors_bools),
+                    )*
+                    _ => {
+                        #bool_to_str
+                        #fallthrough_arm
+                    }
+                }
+            }
+        };
+        Some(visit_bool)
+    };
+
+
     quote_block! {
         fn expecting(&self, formatter: &mut _serde::export::Formatter) -> _serde::export::fmt::Result {
             _serde::export::Formatter::write_str(formatter, #expecting)
         }
 
-        #visit_index
+        #visit_int
+
+        #visit_bool
 
         fn visit_str<__E>(self, __value: &str) -> _serde::export::Result<Self::Value, __E>
             where __E: _serde::de::Error
         {
             match __value {
                 #(
-                    #field_strs => _serde::export::Ok(#constructors),
+                    #field_strs => _serde::export::Ok(#constructors_strs),
                 )*
                 _ => #fallthrough_arm
             }
@@ -1470,7 +1519,7 @@ fn deserialize_identifier(
         {
             match __value {
                 #(
-                    #field_bytes => _serde::export::Ok(#constructors),
+                    #field_bytes => _serde::export::Ok(#constructors_strs),
                 )*
                 _ => {
                     #bytes_to_str
@@ -1491,7 +1540,7 @@ fn deserialize_struct_visitor(
         .iter()
         .enumerate()
         .filter(|&(_, field)| !field.attrs.skip_deserializing())
-        .map(|(i, field)| (field.attrs.name().deserialize_name(), field_i(i)),)
+        .map(|(i, field)| (StrBoolInt::from(field.attrs.name().deserialize_name()), field_i(i)),)
         .collect();
 
     let fields_stmt = {

--- a/serde_derive/src/fragment.rs
+++ b/serde_derive/src/fragment.rs
@@ -99,9 +99,30 @@ impl StrBoolInt {
     pub fn stringify(&self) -> String {
         match *self {
             StrBoolInt::Str(ref s) => s.clone(),
-            StrBoolInt::Bool(true) => "bool: true".to_owned(),
-            StrBoolInt::Bool(false) => "bool: false".to_owned(),
-            StrBoolInt::Int(i) => format!("integer: {}", i),
+            StrBoolInt::Bool(true) => "true".to_owned(),
+            StrBoolInt::Bool(false) => "false".to_owned(),
+            StrBoolInt::Int(i) => format!("{}", i),
+        }
+    }
+
+    pub fn as_str(&self) -> Option<&str> {
+        match *self {
+            StrBoolInt::Str(ref s) => Some(&s),
+            _ => None,
+        }
+    }
+
+    pub fn as_int(&self) -> Option<u64> {
+        match *self {
+            StrBoolInt::Int(i) => Some(i),
+            _ => None,
+        }
+    }
+
+    pub fn as_bool(&self) -> Option<bool> {
+        match *self {
+            StrBoolInt::Bool(b) => Some(b),
+            _ => None,
         }
     }
 }
@@ -113,6 +134,12 @@ impl From<StrBoolIntInternal> for StrBoolInt {
             StrBoolIntInternal::Bool(b) => StrBoolInt::Bool(b),
             StrBoolIntInternal::Int(i) => StrBoolInt::Int(i),
         }
+    }
+}
+
+impl From<String> for StrBoolInt {
+    fn from(src: String) -> StrBoolInt {
+        StrBoolInt::Str(src)
     }
 }
 

--- a/serde_derive/src/fragment.rs
+++ b/serde_derive/src/fragment.rs
@@ -120,8 +120,14 @@ impl ToTokens for StrBoolInt {
     fn to_tokens(&self, out: &mut Tokens) {
         match *self {
             StrBoolInt::Str(ref s) => s.to_tokens(out),
-            StrBoolInt::Bool(b) => b.to_tokens(out),
-            StrBoolInt::Int(i) => i.to_tokens(out),
+            StrBoolInt::Bool(b) => {
+                out.append("&");
+                b.to_tokens(out);
+            },
+            StrBoolInt::Int(i) => {
+                out.append("&");
+                i.to_tokens(out);
+            }
         }
     }
 }

--- a/serde_derive/src/fragment.rs
+++ b/serde_derive/src/fragment.rs
@@ -73,3 +73,55 @@ impl ToTokens for Match {
         }
     }
 }
+
+use internals::attr::StrBoolInt as StrBoolIntInternal;
+
+/// An extended name, used for the type tag for enums.
+#[derive(Debug, Clone)]
+pub enum StrBoolInt {
+    Str(String),
+    Bool(bool),
+    Int(u64),
+}
+
+impl StrBoolInt {
+    /// Get a string description for use in error messages.
+    ///
+    /// It will be used as second argument in
+    /// `_serde::Serializer::serialize_struct(__serializer, name, len)`
+    /// while serializing the inner struct in adjacently tagged enums.
+    ///
+    /// It will be used in the `VARIANTS` const array, that is given to
+    /// `serde::de::Error::unknown_variant(variant, expected)`.
+    /// and
+    /// `_serde::Deserializer::deserialize_enum(name, variants, visitor)`
+    ///
+    pub fn stringify(&self) -> String {
+        match *self {
+            StrBoolInt::Str(ref s) => s.clone(),
+            StrBoolInt::Bool(true) => "bool: true".to_owned(),
+            StrBoolInt::Bool(false) => "bool: false".to_owned(),
+            StrBoolInt::Int(i) => format!("integer: {}", i),
+        }
+    }
+}
+
+impl From<StrBoolIntInternal> for StrBoolInt {
+    fn from(src: StrBoolIntInternal) -> StrBoolInt {
+        match src {
+            StrBoolIntInternal::Str(s) => StrBoolInt::Str(s),
+            StrBoolIntInternal::Bool(b) => StrBoolInt::Bool(b),
+            StrBoolIntInternal::Int(i) => StrBoolInt::Int(i),
+        }
+    }
+}
+
+impl ToTokens for StrBoolInt {
+    fn to_tokens(&self, out: &mut Tokens) {
+        match *self {
+            StrBoolInt::Str(ref s) => s.to_tokens(out),
+            StrBoolInt::Bool(b) => b.to_tokens(out),
+            StrBoolInt::Int(i) => i.to_tokens(out),
+        }
+    }
+}

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -542,6 +542,8 @@ fn serialize_adjacently_tagged_variant(
                 serialize_tuple_variant(TupleVariant::Untagged, params, &variant.fields)
             }
             Style::Struct => {
+                // TODO: stringify variant name? See test_adjacently_tagged_enum_renamed()
+                //       AdjacentlyTagged::B for consequences.
                 let str_variant_name = variant_name.stringify();
                 serialize_struct_variant(
                     StructVariant::Untagged,

--- a/test_suite/no_std/Cargo.toml
+++ b/test_suite/no_std/Cargo.toml
@@ -6,3 +6,4 @@ publish = false
 [dependencies]
 serde = { path = "../../serde", default-features = false }
 serde_derive = { path = "../../serde_derive" }
+libc = "*"

--- a/test_suite/no_std/src/main.rs
+++ b/test_suite/no_std/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(lang_items, start, libc, compiler_builtins_lib)]
+#![feature(lang_items, start, compiler_builtins_lib)]
 #![no_std]
 
 extern crate libc;
@@ -9,23 +9,10 @@ fn start(_argc: isize, _argv: *const *const u8) -> isize {
     0
 }
 
-#[lang = "eh_personality"]
-#[no_mangle]
-pub extern fn rust_eh_personality() {}
-
 #[lang = "eh_unwind_resume"]
 #[no_mangle]
 pub extern fn rust_eh_unwind_resume() {}
 
-#[lang = "panic_fmt"]
-#[no_mangle]
-pub extern fn rust_begin_panic(_msg: core::fmt::Arguments,
-                               _file: &'static str,
-                               _line: u32) -> ! {
-    unsafe {
-        libc::abort()
-    }
-}
 
 //////////////////////////////////////////////////////////////////////////////
 

--- a/test_suite/tests/compile-fail/enum-representation/externally-renamed-as-bool.rs
+++ b/test_suite/tests/compile-fail/enum-representation/externally-renamed-as-bool.rs
@@ -1,0 +1,18 @@
+// Copyright 2017 Serde Developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_use]
+extern crate serde_derive;
+
+#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+enum E {
+    #[serde(rename = true)] //~^^ HELP: #[serde(rename = int|bool)] cannot be used with external tagging
+    Tuple(u8, u8),
+}
+
+fn main() {}

--- a/test_suite/tests/compile-fail/enum-representation/externally-renamed-as-int.rs
+++ b/test_suite/tests/compile-fail/enum-representation/externally-renamed-as-int.rs
@@ -1,0 +1,18 @@
+// Copyright 2017 Serde Developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_use]
+extern crate serde_derive;
+
+#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+enum E {
+    #[serde(rename = 3)] //~^^ HELP: #[serde(rename = int|bool)] cannot be used with external tagging
+    Tuple(u8, u8),
+}
+
+fn main() {}

--- a/test_suite/tests/compile-fail/enum-representation/rename-as-bool-parse-error.rs
+++ b/test_suite/tests/compile-fail/enum-representation/rename-as-bool-parse-error.rs
@@ -1,0 +1,19 @@
+// Copyright 2017 Serde Developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_use]
+extern crate serde_derive;
+
+#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+#[serde(tag = "type")]
+enum E {
+    #[serde(rename = "foo", rename_as = "bool")] //~^^^ HELP: failed to parse "foo" as bool
+    Newtype(u8),
+}
+
+fn main() {}

--- a/test_suite/tests/compile-fail/enum-representation/rename-as-int-parse-error.rs
+++ b/test_suite/tests/compile-fail/enum-representation/rename-as-int-parse-error.rs
@@ -1,0 +1,19 @@
+// Copyright 2017 Serde Developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_use]
+extern crate serde_derive;
+
+#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+#[serde(tag = "type")]
+enum E {
+    #[serde(rename = "foo", rename_as = "int")] //~^^^ HELP: failed to parse "foo" as int
+    Newtype(u8),
+}
+
+fn main() {}

--- a/test_suite/tests/compile-fail/enum-representation/renamed-as-wrong.rs
+++ b/test_suite/tests/compile-fail/enum-representation/renamed-as-wrong.rs
@@ -1,0 +1,19 @@
+// Copyright 2017 Serde Developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_use]
+extern crate serde_derive;
+
+#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+#[serde(tag = "type")]
+enum E {
+    #[serde(rename = "3.3", rename_as = "float")] //~^^^ HELP: unknown rename type for #[serde(rename_as = "float")]. expected "int" or "bool"
+    Newtype(u8),
+}
+
+fn main() {}

--- a/test_suite/tests/compile-fail/enum-representation/renamed-literal-and-renamed-as.rs
+++ b/test_suite/tests/compile-fail/enum-representation/renamed-literal-and-renamed-as.rs
@@ -1,0 +1,19 @@
+// Copyright 2017 Serde Developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_use]
+extern crate serde_derive;
+
+#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+#[serde(tag = "type")]
+enum E {
+    #[serde(rename = false, rename_as = "bool")] //~^^^ HELP: #[serde(rename = false)] is not compatible with #[serde(rename_as = ...)]. Use a string literal as in #[serde(rename = "false")]
+    Newtype(u8),
+}
+
+fn main() {}

--- a/test_suite/tests/compile-fail/enum-representation/renamed-wrong.rs
+++ b/test_suite/tests/compile-fail/enum-representation/renamed-wrong.rs
@@ -1,0 +1,20 @@
+// Copyright 2017 Serde Developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_use]
+extern crate serde_derive;
+
+#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+#[serde(tag = "type")]
+enum E {
+    #[serde(rename = 2.1)] //~^^^ HELP: expected serde rename attribute to be a string, an int or a bool: `rename = "..."` or `rename = 3 or `rename = true`
+    Newtype(u8),
+}
+
+
+fn main() {}

--- a/test_suite/tests/compile-fail/enum-representation/untagged-renamed-as-bool.rs
+++ b/test_suite/tests/compile-fail/enum-representation/untagged-renamed-as-bool.rs
@@ -1,0 +1,19 @@
+// Copyright 2017 Serde Developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_use]
+extern crate serde_derive;
+
+#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+#[serde(untagged)]
+enum E {
+    #[serde(rename = false)] //~^^^ HELP: #[serde(rename = int|bool)] cannot be used with #[serde(untagged)]
+    Tuple(u8, u8),
+}
+
+fn main() {}

--- a/test_suite/tests/compile-fail/enum-representation/untagged-renamed-as-int.rs
+++ b/test_suite/tests/compile-fail/enum-representation/untagged-renamed-as-int.rs
@@ -1,0 +1,19 @@
+// Copyright 2017 Serde Developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_use]
+extern crate serde_derive;
+
+#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+#[serde(untagged)]
+enum E {
+    #[serde(rename = 3)] //~^^^ HELP: #[serde(rename = int|bool)] cannot be used with #[serde(untagged)]
+    Tuple(u8, u8),
+}
+
+fn main() {}

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -696,6 +696,47 @@ fn test_internally_tagged_enum() {
 }
 
 #[test]
+fn test_internally_tagged_enum_renamed() {
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct Newtype(BTreeMap<String, String>);
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct Struct {
+        f: u8,
+    }
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    #[serde(tag = "type")]
+    enum InternallyTagged {
+        #[serde(rename="abc")]
+        A { a: u8 },
+        #[serde(rename="true", rename_as="bool")]
+        B { b: u8 },
+        #[serde(rename="3", rename_as="int")]
+        C,
+        D(BTreeMap<String, String>),
+        E(Newtype),
+        F(Struct),
+    }
+
+    // TODO: Deserialize also
+    assert_ser_tokens(
+        &InternallyTagged::A { a: 1 },
+        &[
+            Token::Struct { name: "InternallyTagged", len: 2 },
+
+            Token::Str("type"),
+            Token::Str("abc"),
+
+            Token::Str("a"),
+            Token::U8(1),
+
+            Token::StructEnd,
+        ],
+    );
+}
+
+#[test]
 fn test_internally_tagged_struct_variant_containing_unit_variant() {
     #[derive(Debug, PartialEq, Serialize, Deserialize)]
     pub enum Level {

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -722,7 +722,6 @@ fn test_internally_tagged_enum_renamed() {
         F(Struct),
     }
 
-    // TODO: Deserialize also
     assert_tokens(
         &InternallyTagged::A { a: 1 },
         &[
@@ -738,7 +737,7 @@ fn test_internally_tagged_enum_renamed() {
         ],
     );
 
-    assert_ser_tokens(
+    assert_tokens(
         &InternallyTagged::B { b: 1 },
         &[
             Token::Struct { name: "InternallyTagged", len: 2 },
@@ -753,7 +752,7 @@ fn test_internally_tagged_enum_renamed() {
         ],
     );
 
-    assert_ser_tokens(
+    assert_tokens(
         &InternallyTagged::C,
         &[
             Token::Struct { name: "InternallyTagged", len: 1 },
@@ -763,6 +762,63 @@ fn test_internally_tagged_enum_renamed() {
 
             Token::StructEnd,
         ],
+    );
+
+    assert_tokens(
+        &InternallyTagged::D(BTreeMap::new()),
+        &[
+            Token::Map { len: Some(1) },
+
+            Token::Str("type"),
+            Token::U64(4),
+
+            Token::MapEnd,
+        ],
+    );
+
+    assert_tokens(
+        &InternallyTagged::E(Newtype(BTreeMap::new())),
+        &[
+            Token::Map { len: Some(1) },
+
+            Token::Str("type"),
+            Token::U64(5),
+
+            Token::MapEnd,
+        ],
+    );
+
+    assert_tokens(
+        &InternallyTagged::F(Struct { f: 6 }),
+        &[
+            Token::Struct { name: "Struct", len: 2 },
+
+            Token::Str("type"),
+            Token::U64(6),
+
+            Token::Str("f"),
+            Token::U8(6),
+
+            Token::StructEnd,
+        ],
+    );
+
+    assert_de_tokens_error::<InternallyTagged>(
+        &[
+            Token::Map { len: Some(1) },
+            Token::Str("type"),
+            Token::Bool(false)
+        ],
+        "unknown variant `false`, expected one of `abc`, `true`, `3`, `4`, `5`, `6`",
+    );
+
+    assert_de_tokens_error::<InternallyTagged>(
+        &[
+            Token::Struct { name: "Struct", len: 2 },
+            Token::Str("type"),
+            Token::U8(9),
+        ],
+        "unknown variant `9`, expected one of `abc`, `true`, `3`, `4`, `5`, `6`",
     );
 }
 

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -714,13 +714,16 @@ fn test_internally_tagged_enum_renamed() {
         B { b: u8 },
         #[serde(rename="3", rename_as="int")]
         C,
+        #[serde(rename="4", rename_as="int")]
         D(BTreeMap<String, String>),
+        #[serde(rename="5", rename_as="int")]
         E(Newtype),
+        #[serde(rename="6", rename_as="int")]
         F(Struct),
     }
 
     // TODO: Deserialize also
-    assert_ser_tokens(
+    assert_tokens(
         &InternallyTagged::A { a: 1 },
         &[
             Token::Struct { name: "InternallyTagged", len: 2 },
@@ -730,6 +733,33 @@ fn test_internally_tagged_enum_renamed() {
 
             Token::Str("a"),
             Token::U8(1),
+
+            Token::StructEnd,
+        ],
+    );
+
+    assert_ser_tokens(
+        &InternallyTagged::B { b: 1 },
+        &[
+            Token::Struct { name: "InternallyTagged", len: 2 },
+
+            Token::Str("type"),
+            Token::Bool(true),
+
+            Token::Str("b"),
+            Token::U8(1),
+
+            Token::StructEnd,
+        ],
+    );
+
+    assert_ser_tokens(
+        &InternallyTagged::C,
+        &[
+            Token::Struct { name: "InternallyTagged", len: 1 },
+
+            Token::Str("type"),
+            Token::U64(3),
 
             Token::StructEnd,
         ],


### PR DESCRIPTION
(This commit contains untested code and a dirty hacks so that the rename="str" still works)

#745 Issue for this PR

I got started and it was not too hard, serde derive is written very well. (I'm still confused by the deserializiation part, but I have not looked into it to much)

Some questions:
1. Non string literals are not stabilized yet. I think we should support a fallback with `#[serde(rename="1", rename_as="int")]`. This is necessary since serde supports old rustc versions anyway, so even with [stabilization](https://github.com/rust-lang/rust/issues/34981) this will not go away.
    ```
    error: non-string literals in attributes, or string literals in top-level positions, are experimental (see issue #34981)
       --> tests/test_macros.rs:713:9
        |
    713 |         #[serde(rename=true)]
        |         ^^^^^^^^^^^^^^^^^^^^^
        |
        = help: add #![feature(attr_literals)] to the crate attributes to enable
    ```
2. Currently I implemented a type `StrBoolInt`, but I had to define it twice, once in `serde_derive_internals` and once again in `serde_derive`, so that I can implement `ToTokens`.
3. The second `StrBoolInt` is stuffed into `fragment.rs`. Should I use a new file or is that ok?
3. I decided to only allow non-string renames for internally and adjacently tagged enums. Correct?
4. As far as I understood it, `Serializers` have the choice to serialize either with the name of the variant or with the id. What happens if `rename=2` is stated for attribute with field number 1? Should I just replace the whole the `derserialize_u32` part as soon as an int-rename is encountered?
5. What is that `[#serde(field_identifier/variant_identifier)]` setting? It is not mentioned in the docs.

Thx, Daniel