### PR TITLE
Fix SystemTime serialization test on Windows

### DIFF
--- a/test_suite/tests/test_ser.rs
+++ b/test_suite/tests/test_ser.rs
@@ -331,13 +331,13 @@ declare_tests! {
         ],
     }
     test_system_time {
-        UNIX_EPOCH + Duration::new(1, 2) => &[
+        UNIX_EPOCH + Duration::new(1, 200) => &[
             Token::Struct { name: "SystemTime", len: 2 },
                 Token::Str("secs_since_epoch"),
                 Token::U64(1),
 
                 Token::Str("nanos_since_epoch"),
-                Token::U32(2),
+                Token::U32(200),
             Token::StructEnd,
         ],
     }


### PR DESCRIPTION
Windows's `SystemTime` do not have nanosecond resolution which caused the test duration to be truncated https://github.com/rust-lang/rust/blob/b1363a73ede57ae595f3a1be2bb75d308ba4f7f6/src/libstd/sys/windows/time.rs#L177