### PR TITLE
Workaround for "no bin target named serde_derive_tests_no_std"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,4 @@ members = [
     "serde_derive_internals",
     "serde_test",
     "test_suite",
-    "test_suite/no_std",
 ]

--- a/test_suite/no_std/Cargo.toml
+++ b/test_suite/no_std/Cargo.toml
@@ -7,3 +7,5 @@ publish = false
 libc = { version = "0.2", default-features = false }
 serde = { path = "../../serde", default-features = false }
 serde_derive = { path = "../../serde_derive" }
+
+[workspace]

--- a/travis.sh
+++ b/travis.sh
@@ -41,6 +41,7 @@ if [ -n "${CLIPPY}" ]; then
     cargo clippy -- -Dclippy
 else
     CHANNEL=nightly
+    cd "$DIR"
     cargo clean
     cd "$DIR/serde"
     channel build
@@ -55,6 +56,7 @@ else
     channel build
 
     CHANNEL=beta
+    cd "$DIR"
     cargo clean
     cd "$DIR/serde"
     channel build --features rc
@@ -62,6 +64,7 @@ else
     channel test
 
     CHANNEL=stable
+    cd "$DIR"
     cargo clean
     cd "$DIR/serde"
     channel build --features rc
@@ -71,6 +74,7 @@ else
     channel test
 
     CHANNEL=1.13.0
+    cd "$DIR"
     cargo clean
     cd "$DIR/serde"
     channel build --features rc


### PR DESCRIPTION
Fixes #988.