### PR TITLE
Inherit the visibility of remote struct definition

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -28,9 +28,10 @@ pub fn expand_derive_deserialize(input: &syn::DeriveInput) -> Result<Tokens, Str
     let body = Stmts(deserialize_body(&cont, &params));
 
     let impl_block = if let Some(remote) = cont.attrs.remote() {
+        let vis = &input.vis;
         quote! {
             impl #de_impl_generics #ident #ty_generics #where_clause {
-                fn deserialize<__D>(__deserializer: __D) -> _serde::export::Result<#remote #ty_generics, __D::Error>
+                #vis fn deserialize<__D>(__deserializer: __D) -> _serde::export::Result<#remote #ty_generics, __D::Error>
                     where __D: _serde::Deserializer<'de>
                 {
                     #body

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -29,9 +29,10 @@ pub fn expand_derive_serialize(input: &syn::DeriveInput) -> Result<Tokens, Strin
     let body = Stmts(serialize_body(&cont, &params));
 
     let impl_block = if let Some(remote) = cont.attrs.remote() {
+        let vis = &input.vis;
         quote! {
             impl #impl_generics #ident #ty_generics #where_clause {
-                fn serialize<__S>(__self: &#remote #ty_generics, __serializer: __S) -> _serde::export::Result<__S::Ok, __S::Error>
+                #vis fn serialize<__S>(__self: &#remote #ty_generics, __serializer: __S) -> _serde::export::Result<__S::Ok, __S::Error>
                     where __S: _serde::Serializer
                 {
                     #body

--- a/test_suite/tests/test_gen.rs
+++ b/test_suite/tests/test_gen.rs
@@ -358,6 +358,21 @@ fn test_gen() {
         #[serde(borrow, with = "StrDef")]
         s: Str<'a>,
     }
+
+    mod vis {
+        pub struct S;
+
+        #[derive(Serialize, Deserialize)]
+        #[serde(remote = "S")]
+        pub struct SDef;
+    }
+
+    // This would not work if SDef::serialize / deserialize are private.
+    #[derive(Serialize, Deserialize)]
+    struct RemoteVisibility {
+        #[serde(with = "vis::SDef")]
+        s: vis::S,
+    }
 }
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
For remote derive this will give the derived methods the same visibility as the definition.

```rust
#[serde(remote = "...")]
struct Def; // Def::serialize and deserialize are private to this module

#[serde(remote = "...")]
pub struct Def; // Def::serialize and deserialize are public

#[serde(remote = "...")]
pub(crate) struct Def; // Def::serialize and deserialize are pub(crate)
```

Fixes #1000. @arcnmx