### PR TITLE
Add #[serde(empty_struct)]

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -187,11 +187,15 @@ fn deserialize_body(cont: &Container, params: &Parameters) -> Fragment {
     } else if let attr::Identifier::No = cont.attrs.identifier() {
         match cont.body {
             Body::Enum(ref variants) => deserialize_enum(params, variants, &cont.attrs),
-            Body::Struct(Style::Struct, ref fields) => {
+            Body::Struct(Style::Unit, _) if !cont.attrs.empty_struct() => {
+                deserialize_unit_struct(params, &cont.attrs)
+            }
+            Body::Struct(Style::Struct, ref fields) | Body::Struct(Style::Unit, ref fields) => {
                 if fields.iter().any(|field| field.ident.is_none()) {
                     panic!("struct has unnamed fields");
                 }
-                deserialize_struct(None, params, fields, &cont.attrs, None)
+                deserialize_struct(None, params, fields, cont.attrs.empty_struct(), &cont.attrs,
+                                   None)
             }
             Body::Struct(Style::Tuple, ref fields) |
             Body::Struct(Style::Newtype, ref fields) => {
@@ -200,7 +204,6 @@ fn deserialize_body(cont: &Container, params: &Parameters) -> Fragment {
                 }
                 deserialize_tuple(None, params, fields, &cont.attrs, None)
             }
-            Body::Struct(Style::Unit, _) => deserialize_unit_struct(params, &cont.attrs),
         }
     } else {
         match cont.body {
@@ -286,7 +289,7 @@ fn deserialize_tuple(
         None
     };
 
-    let visit_seq = Stmts(deserialize_seq(&type_path, params, fields, false, cattrs));
+    let visit_seq = Stmts(deserialize_seq(&type_path, params, fields, false, false, cattrs));
 
     let visitor_expr = quote! {
         __Visitor {
@@ -347,6 +350,7 @@ fn deserialize_seq(
     params: &Parameters,
     fields: &[Field],
     is_struct: bool,
+    is_unit: bool,
     cattrs: &attr::Container,
 ) -> Fragment {
     let vars = (0..fields.len()).map(field_i as fn(_) -> _);
@@ -395,7 +399,11 @@ fn deserialize_seq(
             }
         });
 
-    let mut result = if is_struct {
+    let mut result = if is_unit {
+        quote! {
+            #type_path
+        }
+    } else if is_struct {
         let names = fields.iter().map(|f| &f.ident);
         quote! {
             #type_path { #( #names: #vars ),* }
@@ -458,6 +466,7 @@ fn deserialize_struct(
     variant_ident: Option<&syn::Ident>,
     params: &Parameters,
     fields: &[Field],
+    is_unit: bool,
     cattrs: &attr::Container,
     deserializer: Option<Tokens>,
 ) -> Fragment {
@@ -486,10 +495,10 @@ fn deserialize_struct(
         None => format!("struct {}", params.type_name()),
     };
 
-    let visit_seq = Stmts(deserialize_seq(&type_path, params, fields, true, cattrs));
+    let visit_seq = Stmts(deserialize_seq(&type_path, params, fields, true, is_unit, cattrs));
 
     let (field_visitor, fields_stmt, visit_map) =
-        deserialize_struct_visitor(type_path, params, fields, cattrs);
+        deserialize_struct_visitor(type_path, params, fields, is_unit, cattrs);
     let field_visitor = Stmts(field_visitor);
     let fields_stmt = Stmts(fields_stmt);
     let visit_map = Stmts(visit_map);
@@ -814,8 +823,8 @@ fn deserialize_adjacently_tagged_enum(
 
     fn is_unit(variant: &Variant) -> bool {
         match variant.style {
-            Style::Unit => true,
-            Style::Struct | Style::Tuple | Style::Newtype => false,
+            Style::Unit if !variant.attrs.empty_struct() => true,
+            Style::Struct | Style::Tuple | Style::Newtype | Style::Unit => false,
         }
     }
 
@@ -1088,7 +1097,7 @@ fn deserialize_externally_tagged_variant(
     let variant_ident = &variant.ident;
 
     match variant.style {
-        Style::Unit => {
+        Style::Unit if !variant.attrs.empty_struct() => {
             let this = &params.this;
             quote_block! {
                 try!(_serde::de::VariantAccess::unit_variant(__variant));
@@ -1101,8 +1110,9 @@ fn deserialize_externally_tagged_variant(
         Style::Tuple => {
             deserialize_tuple(Some(variant_ident), params, &variant.fields, cattrs, None)
         }
-        Style::Struct => {
-            deserialize_struct(Some(variant_ident), params, &variant.fields, cattrs, None)
+        Style::Struct | Style::Unit => {
+            deserialize_struct(Some(variant_ident), params, &variant.fields,
+                               variant.attrs.empty_struct(), cattrs, None)
         }
     }
 }
@@ -1116,7 +1126,7 @@ fn deserialize_internally_tagged_variant(
     let variant_ident = &variant.ident;
 
     match variant.style {
-        Style::Unit => {
+        Style::Unit if !variant.attrs.empty_struct() => {
             let this = &params.this;
             let type_name = params.type_name();
             let variant_name = variant.ident.as_ref();
@@ -1125,7 +1135,7 @@ fn deserialize_internally_tagged_variant(
                 _serde::export::Ok(#this::#variant_ident)
             }
         }
-        Style::Newtype | Style::Struct => {
+        Style::Newtype | Style::Struct | Style::Unit => {
             deserialize_untagged_variant(params, variant, cattrs, deserializer)
         }
         Style::Tuple => unreachable!("checked in serde_derive_internals"),
@@ -1141,7 +1151,7 @@ fn deserialize_untagged_variant(
     let variant_ident = &variant.ident;
 
     match variant.style {
-        Style::Unit => {
+        Style::Unit if !variant.attrs.empty_struct() => {
             let this = &params.this;
             let type_name = params.type_name();
             let variant_name = variant.ident.as_ref();
@@ -1171,11 +1181,12 @@ fn deserialize_untagged_variant(
                 Some(deserializer),
             )
         }
-        Style::Struct => {
+        Style::Struct | Style::Unit => {
             deserialize_struct(
                 Some(variant_ident),
                 params,
                 &variant.fields,
+                variant.attrs.empty_struct(),
                 cattrs,
                 Some(deserializer),
             )
@@ -1466,6 +1477,7 @@ fn deserialize_struct_visitor(
     struct_path: Tokens,
     params: &Parameters,
     fields: &[Field],
+    is_unit: bool,
     cattrs: &attr::Container,
 ) -> (Fragment, Fragment, Fragment) {
     let field_names_idents: Vec<_> = fields
@@ -1484,7 +1496,7 @@ fn deserialize_struct_visitor(
 
     let field_visitor = deserialize_generated_identifier(field_names_idents, cattrs, false);
 
-    let visit_map = deserialize_map(struct_path, params, fields, cattrs);
+    let visit_map = deserialize_map(struct_path, params, fields, is_unit, cattrs);
 
     (field_visitor, fields_stmt, visit_map)
 }
@@ -1493,6 +1505,7 @@ fn deserialize_map(
     struct_path: Tokens,
     params: &Parameters,
     fields: &[Field],
+    is_unit: bool,
     cattrs: &attr::Container,
 ) -> Fragment {
     // Create the field names for the fields.
@@ -1594,22 +1607,27 @@ fn deserialize_map(
             },
         );
 
-    let result = fields_names
-        .iter()
-        .map(
-            |&(field, ref name)| {
-                let ident = field
-                    .ident
-                    .clone()
-                    .expect("struct contains unnamed fields");
-                if field.attrs.skip_deserializing() {
-                    let value = Expr(expr_is_missing(&field, cattrs));
-                    quote!(#ident: #value)
-                } else {
-                    quote!(#ident: #name)
-                }
-            },
-        );
+    let result = if is_unit {
+        quote!()
+    } else {
+        let fields = fields_names
+            .iter()
+            .map(
+                |&(field, ref name)| {
+                    let ident = field
+                        .ident
+                        .clone()
+                        .expect("struct contains unnamed fields");
+                    if field.attrs.skip_deserializing() {
+                        let value = Expr(expr_is_missing(&field, cattrs));
+                        quote!(#ident: #value)
+                    } else {
+                        quote!(#ident: #name)
+                    }
+                },
+            );
+        quote!({ #(#fields),* })
+    };
 
     let let_default = match *cattrs.default() {
         attr::Default::Default => {
@@ -1633,7 +1651,7 @@ fn deserialize_map(
         }
     };
 
-    let mut result = quote!(#struct_path { #(#result),* });
+    let mut result = quote!(#struct_path #result);
     if params.has_getter {
         let this = &params.this;
         result = quote! {

--- a/test_suite/tests/compile-fail/empty-struct/enum.rs
+++ b/test_suite/tests/compile-fail/empty-struct/enum.rs
@@ -1,0 +1,20 @@
+// Copyright 2017 Serde Developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_use]
+extern crate serde_derive;
+
+#[derive(Serialize, Deserialize)] //~ ERROR: proc-macro derive panicked
+#[serde(empty_struct)] //~^ HELP: #[serde(empty_struct)] can't be attached to an enum
+enum Enum {
+    Hello {
+        world: String,
+    },
+}
+
+fn main() { }

--- a/test_suite/tests/compile-fail/empty-struct/non_unit_struct.rs
+++ b/test_suite/tests/compile-fail/empty-struct/non_unit_struct.rs
@@ -1,0 +1,18 @@
+// Copyright 2017 Serde Developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_use]
+extern crate serde_derive;
+
+#[derive(Serialize, Deserialize)] //~ ERROR: proc-macro derive panicked
+#[serde(empty_struct)] //~^ HELP: #[serde(empty_struct)] can't be attached to a non-unit struct
+struct NonUnitStruct {
+    hello_world: String,
+}
+
+fn main() { }

--- a/test_suite/tests/compile-fail/empty-struct/non_unit_variant.rs
+++ b/test_suite/tests/compile-fail/empty-struct/non_unit_variant.rs
@@ -1,0 +1,20 @@
+// Copyright 2017 Serde Developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_use]
+extern crate serde_derive;
+
+#[derive(Serialize, Deserialize)] //~ ERROR: proc-macro derive panicked
+enum Enum { //~^ HELP: #[serde(empty_struct)] can't be attached to a non-unit variant
+    #[serde(empty_struct)]
+    Hello {
+        world: String,
+    },
+}
+
+fn main() { }

--- a/test_suite/tests/compiletest.rs
+++ b/test_suite/tests/compiletest.rs
@@ -21,6 +21,7 @@ fn run_mode(mode: &'static str) {
         config.filter = Some(name);
     }
     config.src_base = format!("tests/{}", mode).into();
+    config.link_deps();
 
     compiletest::run_tests(&config);
 }

--- a/test_suite/tests/test_gen.rs
+++ b/test_suite/tests/test_gen.rs
@@ -373,6 +373,39 @@ fn test_gen() {
         #[serde(with = "vis::SDef")]
         s: vis::S,
     }
+
+    #[derive(Serialize, Deserialize)]
+    #[serde(empty_struct)]
+    struct SerEmptyStruct;
+
+    #[derive(Serialize, Deserialize)]
+    enum SerEmptyStructExternal {
+        Hello {
+            foo: String,
+        },
+        #[serde(empty_struct)]
+        World,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    #[serde(tag = "tag")]
+    enum SerEmptyStructInternal {
+        Hello {
+            foo: String,
+        },
+        #[serde(empty_struct)]
+        World,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    #[serde(tag = "tag", content = "content")]
+    enum SerEmptyStructAdjacent {
+        Hello {
+            foo: String,
+        },
+        #[serde(empty_struct)]
+        World,
+    }
 }
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This allows forcing unit variants and structs to be (de)serialized as an empty struct, so for example you get `{}` instead of `null` in JSON.

Sample usage:

```rust
#[derive(Serialize, Deserialize)]
#[serde(empty_struct)]
struct Empty;
```