### PR TITLE
Fix warning and link error in compiletest

### DIFF
--- a/test_suite/tests/compiletest.rs
+++ b/test_suite/tests/compiletest.rs
@@ -13,7 +13,7 @@ extern crate compiletest_rs as compiletest;
 use std::env;
 
 fn run_mode(mode: &'static str) {
-    let mut config = compiletest::default_config();
+    let mut config = compiletest::Config::default();
 
     config.mode = mode.parse().expect("invalid mode");
     config.target_rustcflags = Some("-L deps/target/debug/deps".to_owned());
@@ -21,6 +21,7 @@ fn run_mode(mode: &'static str) {
         config.filter = Some(name);
     }
     config.src_base = format!("tests/{}", mode).into();
+    config.link_deps();
 
     compiletest::run_tests(&config);
 }


### PR DESCRIPTION
This first fixes a deprecation warning in compiletest: compiletest::default_config() is being replaced by compiletest::Config::default().

Secondly, all the compiletests were failing due to rustc not being able to locate the serde_derive crate. The [compiletest README][0] recommends using config.link_deps() to ensure dependency paths are properly set. Adding this to serde's compiletest.rs causes the compiletests to run properly.

[0]: https://github.com/laumann/compiletest-rs#to-use-in-your-project