### PR TITLE
Inform serializers about skipped fields.

### DIFF
--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -1728,6 +1728,7 @@ pub trait SerializeStruct {
         T: Serialize;
 
     /// Indicate that a struct field has been skipped.
+    #[inline]
     fn skip_field(&mut self, key: &'static str) -> Result<(), Self::Error> {
         let _ = key;
         Ok(())
@@ -1779,6 +1780,7 @@ pub trait SerializeStructVariant {
         T: Serialize;
 
     /// Indicate that a struct variant field has been skipped.
+    #[inline]
     fn skip_field(&mut self, key: &'static str) -> Result<(), Self::Error> {
         let _ = key;
         Ok(())

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -1727,6 +1727,12 @@ pub trait SerializeStruct {
     where
         T: Serialize;
 
+    /// Indicate that a struct field has been skipped.
+    fn skip_field(&mut self, key: &'static str) -> Result<(), Self::Error> {
+        let _ = key;
+        Ok(())
+    }
+
     /// Finish serializing a struct.
     fn end(self) -> Result<Self::Ok, Self::Error>;
 }
@@ -1771,6 +1777,12 @@ pub trait SerializeStructVariant {
     ) -> Result<(), Self::Error>
     where
         T: Serialize;
+
+    /// Indicate that a struct variant field has been skipped.
+    fn skip_field(&mut self, key: &'static str) -> Result<(), Self::Error> {
+        let _ = key;
+        Ok(())
+    }
 
     /// Finish serializing a struct variant.
     fn end(self) -> Result<Self::Ok, Self::Error>;

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1384,26 +1384,27 @@ fn deserialize_identifier(
         "field identifier"
     };
 
-    let visit_index = if is_variant {
-        let variant_indices = 0u32..;
-        let fallthrough_msg = format!("variant index 0 <= i < {}", fields.len());
-        let visit_index = quote! {
-            fn visit_u32<__E>(self, __value: u32) -> _serde::export::Result<Self::Value, __E>
-                where __E: _serde::de::Error
-            {
-                match __value {
-                    #(
-                        #variant_indices => _serde::export::Ok(#constructors),
-                    )*
-                    _ => _serde::export::Err(_serde::de::Error::invalid_value(
-                                _serde::de::Unexpected::Unsigned(__value as u64),
-                                &#fallthrough_msg))
-                }
-            }
-        };
-        Some(visit_index)
+    let index_expecting = if is_variant {
+        "variant"
     } else {
-        None
+        "field"
+    };
+
+    let variant_indices = 0u32..;
+    let fallthrough_msg = format!("{} index 0 <= i < {}", index_expecting, fields.len());
+    let visit_index = quote! {
+        fn visit_u32<__E>(self, __value: u32) -> _serde::export::Result<Self::Value, __E>
+            where __E: _serde::de::Error
+        {
+            match __value {
+                #(
+                    #variant_indices => _serde::export::Ok(#constructors),
+                )*
+                _ => _serde::export::Err(_serde::de::Error::invalid_value(
+                            _serde::de::Unexpected::Unsigned(__value as u64),
+                            &#fallthrough_msg))
+            }
+        }
     };
 
     let bytes_to_str = if fallthrough.is_some() {

--- a/test_suite/tests/test_de.rs
+++ b/test_suite/tests/test_de.rs
@@ -522,6 +522,15 @@ declare_tests! {
             Token::MapEnd,
         ],
         Struct { a: 1, b: 2, c: 0 } => &[
+            Token::Map { len: Some(3) },
+                Token::U32(0),
+                Token::I32(1),
+
+                Token::U32(1),
+                Token::I32(2),
+            Token::MapEnd,
+        ],
+        Struct { a: 1, b: 2, c: 0 } => &[
             Token::Struct { name: "Struct", len: 3 },
                 Token::Str("a"),
                 Token::I32(1),


### PR DESCRIPTION
Closes #960.