### PR TITLE
Serialize to binary if the serde format is not human readable

### DIFF
--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -911,13 +911,13 @@ impl<'de> Deserialize<'de> for net::IpAddr {
                     A: EnumAccess<'de>,
                 {
                     match try!(data.variant()) {
-                        (0u32, v) => v.newtype_variant().map(net::IpAddr::V4),
-                        (1u32, v) => v.newtype_variant().map(net::IpAddr::V6),
+                        (0_u32, v) => v.newtype_variant().map(net::IpAddr::V4),
+                        (1_u32, v) => v.newtype_variant().map(net::IpAddr::V6),
                         (_, _) => Err(Error::custom("Invalid IpAddr variant")),
                     }
                 }
             }
-            const VARIANTS: &[&str] = &["V4", "V6"];
+            const VARIANTS: &'static [&'static str] = &["V4", "V6"];
             deserializer.deserialize_enum("IpAddr", VARIANTS, EnumVisitor)
         }
     }

--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -1007,7 +1007,7 @@ impl<'de> Deserialize<'de> for net::IpAddr {
             let s = try!(String::deserialize(deserializer));
             s.parse().map_err(Error::custom)
         } else {
-            use self::net::IpAddr;
+            use lib::net::IpAddr;
             deserialize_enum!{
                 IpAddr IpAddrKind (V4; b"V4"; 0, V6; b"V6"; 1)
                 "`V4` or `V6`",
@@ -1052,7 +1052,7 @@ impl<'de> Deserialize<'de> for net::SocketAddr {
             let s = try!(String::deserialize(deserializer));
             s.parse().map_err(Error::custom)
         } else {
-            use self::net::SocketAddr;
+            use lib::net::SocketAddr;
             deserialize_enum!{
                 SocketAddr SocketAddrKind (V4; b"V4"; 0, V6; b"V6"; 1)
                 "`V4` or `V6`",

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -1011,6 +1011,12 @@ pub trait Deserializer<'de>: Sized {
     fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>;
+
+    /// Returns whether the serialized data is human readable or not.
+    ///
+    /// Some formats are not intended to be human readable. For these formats
+    /// a type being serialized may opt to serialize into a more compact form.
+    fn is_human_readable(&self) -> bool { true }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -1016,6 +1016,9 @@ pub trait Deserializer<'de>: Sized {
     ///
     /// Some formats are not intended to be human readable. For these formats
     /// a type being serialized may opt to serialize into a more compact form.
+    ///
+    /// NOTE: Implementing this method and returning `false` is considered a breaking
+    /// change as it may alter how any given type tries to deserialize itself.
     fn is_human_readable(&self) -> bool { true }
 }
 

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -519,9 +519,13 @@ impl Serialize for net::Ipv4Addr {
     where
         S: Serializer,
     {
-        /// "101.102.103.104".len()
-        const MAX_LEN: usize = 15;
-        serialize_display_bounded_length!(self, MAX_LEN, serializer)
+        if serializer.is_human_readable() {
+            /// "101.102.103.104".len()
+            const MAX_LEN: usize = 15;
+            serialize_display_bounded_length!(self, MAX_LEN, serializer)
+        } else {
+            self.octets().serialize(serializer)
+        }
     }
 }
 
@@ -531,9 +535,13 @@ impl Serialize for net::Ipv6Addr {
     where
         S: Serializer,
     {
-        /// "1000:1002:1003:1004:1005:1006:1007:1008".len()
-        const MAX_LEN: usize = 39;
-        serialize_display_bounded_length!(self, MAX_LEN, serializer)
+        if serializer.is_human_readable() {
+            /// "1000:1002:1003:1004:1005:1006:1007:1008".len()
+            const MAX_LEN: usize = 39;
+            serialize_display_bounded_length!(self, MAX_LEN, serializer)
+        } else {
+            self.octets().serialize(serializer)
+        }
     }
 }
 
@@ -556,9 +564,13 @@ impl Serialize for net::SocketAddrV4 {
     where
         S: Serializer,
     {
-        /// "101.102.103.104:65000".len()
-        const MAX_LEN: usize = 21;
-        serialize_display_bounded_length!(self, MAX_LEN, serializer)
+        if serializer.is_human_readable() {
+            /// "101.102.103.104:65000".len()
+            const MAX_LEN: usize = 21;
+            serialize_display_bounded_length!(self, MAX_LEN, serializer)
+        } else {
+            (self.ip().octets(), self.port()).serialize(serializer)
+        }
     }
 }
 
@@ -568,9 +580,13 @@ impl Serialize for net::SocketAddrV6 {
     where
         S: Serializer,
     {
-        /// "[1000:1002:1003:1004:1005:1006:1007:1008]:65000".len()
-        const MAX_LEN: usize = 47;
-        serialize_display_bounded_length!(self, MAX_LEN, serializer)
+        if serializer.is_human_readable() {
+            /// "[1000:1002:1003:1004:1005:1006:1007:1008]:65000".len()
+            const MAX_LEN: usize = 47;
+            serialize_display_bounded_length!(self, MAX_LEN, serializer)
+        } else {
+            (self.ip().octets(), self.port()).serialize(serializer)
+        }
     }
 }
 

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -506,9 +506,16 @@ impl Serialize for net::IpAddr {
     where
         S: Serializer,
     {
-        match *self {
-            net::IpAddr::V4(ref a) => a.serialize(serializer),
-            net::IpAddr::V6(ref a) => a.serialize(serializer),
+        if serializer.is_human_readable() {
+            match *self {
+                net::IpAddr::V4(ref a) => a.serialize(serializer),
+                net::IpAddr::V6(ref a) => a.serialize(serializer),
+            }
+        } else {
+            match *self {
+                net::IpAddr::V4(ref a) => (0u8, a).serialize(serializer),
+                net::IpAddr::V6(ref a) => (1u8, a).serialize(serializer),
+            }
         }
     }
 }

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -513,8 +513,10 @@ impl Serialize for net::IpAddr {
             }
         } else {
             match *self {
-                net::IpAddr::V4(ref a) => (0u8, a).serialize(serializer),
-                net::IpAddr::V6(ref a) => (1u8, a).serialize(serializer),
+                net::IpAddr::V4(ref a) => 
+                    serializer.serialize_newtype_variant("IpAddr", 0, "V4", a),
+                net::IpAddr::V6(ref a) =>
+                    serializer.serialize_newtype_variant("IpAddr", 1, "V6", a),
             }
         }
     }
@@ -558,9 +560,18 @@ impl Serialize for net::SocketAddr {
     where
         S: Serializer,
     {
-        match *self {
-            net::SocketAddr::V4(ref addr) => addr.serialize(serializer),
-            net::SocketAddr::V6(ref addr) => addr.serialize(serializer),
+        if serializer.is_human_readable() {
+            match *self {
+                net::SocketAddr::V4(ref addr) => addr.serialize(serializer),
+                net::SocketAddr::V6(ref addr) => addr.serialize(serializer),
+            }
+        } else {
+            match *self {
+                net::SocketAddr::V4(ref addr) =>
+                    serializer.serialize_newtype_variant("SocketAddr", 0, "V4", addr),
+                net::SocketAddr::V6(ref addr) =>
+                    serializer.serialize_newtype_variant("SocketAddr", 1, "V6", addr),
+            }
         }
     }
 }

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -569,7 +569,7 @@ impl Serialize for net::SocketAddrV4 {
             const MAX_LEN: usize = 21;
             serialize_display_bounded_length!(self, MAX_LEN, serializer)
         } else {
-            (self.ip().octets(), self.port()).serialize(serializer)
+            (self.ip(), self.port()).serialize(serializer)
         }
     }
 }
@@ -585,7 +585,7 @@ impl Serialize for net::SocketAddrV6 {
             const MAX_LEN: usize = 47;
             serialize_display_bounded_length!(self, MAX_LEN, serializer)
         } else {
-            (self.ip().octets(), self.port()).serialize(serializer)
+            (self.ip(), self.port()).serialize(serializer)
         }
     }
 }

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -1363,6 +1363,12 @@ pub trait Serializer: Sized {
     fn collect_str<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
     where
         T: Display;
+
+    /// Returns wheter the data format is human readable or not.
+    ///
+    /// Some formats are not intended to be human readable. For these formats
+    /// a type being serialized may opt to serialize into a more compact form.
+    fn is_human_readable(&self) -> bool { true }
 }
 
 /// Returned from `Serializer::serialize_seq`.

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -1368,6 +1368,9 @@ pub trait Serializer: Sized {
     ///
     /// Some formats are not intended to be human readable. For these formats
     /// a type being serialized may opt to serialize into a more compact form.
+    ///
+    /// NOTE: Implementing this method and returning `false` is considered a breaking
+    /// change as it may alter how any given type tries to serialize itself.
     fn is_human_readable(&self) -> bool { true }
 }
 

--- a/serde_test/src/assert.rs
+++ b/serde_test/src/assert.rs
@@ -47,8 +47,18 @@ pub fn assert_tokens<'de, T>(value: &T, tokens: &'de [Token])
 where
     T: Serialize + Deserialize<'de> + PartialEq + Debug,
 {
-    assert_ser_tokens(value, tokens);
-    assert_de_tokens(value, tokens);
+    assert_tokens_readable(value, tokens, true);
+}
+
+/// Runs both `assert_ser_tokens` and `assert_de_tokens`.
+///
+/// See: `assert_tokens`
+pub fn assert_tokens_readable<'de, T>(value: &T, tokens: &'de [Token], human_readable: bool)
+where
+    T: Serialize + Deserialize<'de> + PartialEq + Debug,
+{
+    assert_ser_tokens_readable(value, tokens, human_readable);
+    assert_de_tokens_readable(value, tokens, human_readable);
 }
 
 /// Asserts that `value` serializes to the given `tokens`.

--- a/serde_test/src/assert.rs
+++ b/serde_test/src/assert.rs
@@ -50,6 +50,8 @@ where
     assert_tokens_readable(value, tokens, true);
 }
 
+// Not public API
+#[doc(hidden)]
 /// Runs both `assert_ser_tokens` and `assert_de_tokens`.
 ///
 /// See: `assert_tokens`
@@ -97,6 +99,8 @@ where
     assert_ser_tokens_readable(value, tokens, true)
 }
 
+// Not public API
+#[doc(hidden)]
 /// Asserts that `value` serializes to the given `tokens`.
 ///
 /// See: `assert_ser_tokens`
@@ -206,6 +210,8 @@ where
     assert_de_tokens_readable(value, tokens, true)
 }
 
+// Not public API
+#[doc(hidden)]
 pub fn assert_de_tokens_readable<'de, T>(value: &T, tokens: &'de [Token], human_readable: bool)
 where
     T: Deserialize<'de> + PartialEq + Debug,

--- a/serde_test/src/assert.rs
+++ b/serde_test/src/assert.rs
@@ -84,7 +84,17 @@ pub fn assert_ser_tokens<T>(value: &T, tokens: &[Token])
 where
     T: Serialize,
 {
-    let mut ser = Serializer::new(tokens);
+    assert_ser_tokens_readable(value, tokens, true)
+}
+
+/// Asserts that `value` serializes to the given `tokens`.
+///
+/// See: `assert_ser_tokens`
+pub fn assert_ser_tokens_readable<T>(value: &T, tokens: &[Token], human_readable: bool)
+where
+    T: Serialize,
+{
+    let mut ser = Serializer::readable(tokens, human_readable);
     match value.serialize(&mut ser) {
         Ok(_) => {}
         Err(err) => panic!("value failed to serialize: {}", err),
@@ -183,7 +193,14 @@ pub fn assert_de_tokens<'de, T>(value: &T, tokens: &'de [Token])
 where
     T: Deserialize<'de> + PartialEq + Debug,
 {
-    let mut de = Deserializer::new(tokens);
+    assert_de_tokens_readable(value, tokens, true)
+}
+
+pub fn assert_de_tokens_readable<'de, T>(value: &T, tokens: &'de [Token], human_readable: bool)
+where
+    T: Deserialize<'de> + PartialEq + Debug,
+{
+    let mut de = Deserializer::readable(tokens, human_readable);
     match T::deserialize(&mut de) {
         Ok(v) => assert_eq!(v, *value),
         Err(e) => panic!("tokens failed to deserialize: {}", e),

--- a/serde_test/src/de.rs
+++ b/serde_test/src/de.rs
@@ -16,6 +16,7 @@ use token::Token;
 #[derive(Debug)]
 pub struct Deserializer<'de> {
     tokens: &'de [Token],
+    is_human_readable: bool,
 }
 
 macro_rules! assert_next_token {
@@ -48,7 +49,11 @@ macro_rules! end_of_tokens {
 
 impl<'de> Deserializer<'de> {
     pub fn new(tokens: &'de [Token]) -> Self {
-        Deserializer { tokens: tokens }
+        Deserializer::readable(tokens, true)
+    }
+
+    pub fn readable(tokens: &'de [Token], is_human_readable: bool) -> Self {
+        Deserializer { tokens: tokens, is_human_readable: is_human_readable }
     }
 
     fn peek_token_opt(&self) -> Option<Token> {
@@ -363,6 +368,10 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             }
             _ => self.deserialize_any(visitor),
         }
+    }
+
+    fn is_human_readable(&self) -> bool {
+        self.is_human_readable
     }
 }
 

--- a/serde_test/src/de.rs
+++ b/serde_test/src/de.rs
@@ -52,6 +52,8 @@ impl<'de> Deserializer<'de> {
         Deserializer::readable(tokens, true)
     }
 
+    // Not public API
+    #[doc(hidden)]
     pub fn readable(tokens: &'de [Token], is_human_readable: bool) -> Self {
         Deserializer { tokens: tokens, is_human_readable: is_human_readable }
     }

--- a/serde_test/src/lib.rs
+++ b/serde_test/src/lib.rs
@@ -168,8 +168,8 @@ mod token;
 mod assert;
 
 pub use token::Token;
-pub use assert::{assert_tokens, assert_ser_tokens, assert_ser_tokens_error, assert_de_tokens,
-                 assert_de_tokens_error};
+pub use assert::{assert_tokens, assert_ser_tokens, assert_ser_tokens_error, assert_ser_tokens_readable,
+                 assert_de_tokens, assert_de_tokens_error, assert_de_tokens_readable};
 
 // Not public API.
 #[doc(hidden)]

--- a/serde_test/src/lib.rs
+++ b/serde_test/src/lib.rs
@@ -168,7 +168,7 @@ mod token;
 mod assert;
 
 pub use token::Token;
-pub use assert::{assert_tokens, assert_ser_tokens, assert_ser_tokens_error, assert_ser_tokens_readable,
+pub use assert::{assert_tokens, assert_tokens_readable, assert_ser_tokens, assert_ser_tokens_error, assert_ser_tokens_readable,
                  assert_de_tokens, assert_de_tokens_error, assert_de_tokens_readable};
 
 // Not public API.

--- a/serde_test/src/lib.rs
+++ b/serde_test/src/lib.rs
@@ -168,8 +168,12 @@ mod token;
 mod assert;
 
 pub use token::Token;
-pub use assert::{assert_tokens, assert_tokens_readable, assert_ser_tokens, assert_ser_tokens_error, assert_ser_tokens_readable,
-                 assert_de_tokens, assert_de_tokens_error, assert_de_tokens_readable};
+pub use assert::{assert_tokens, assert_ser_tokens, assert_ser_tokens_error,
+                 assert_de_tokens, assert_de_tokens_error};
+
+// Not public API.
+#[doc(hidden)]
+pub use assert::{assert_tokens_readable, assert_de_tokens_readable, assert_ser_tokens_readable};
 
 // Not public API.
 #[doc(hidden)]

--- a/serde_test/src/ser.rs
+++ b/serde_test/src/ser.rs
@@ -24,6 +24,8 @@ impl<'a> Serializer<'a> {
         Serializer::readable(tokens, true)
     }
 
+    // Not public API
+    #[doc(hidden)]
     pub fn readable(tokens: &'a [Token], is_human_readable: bool) -> Self {
         Serializer { tokens: tokens, is_human_readable: is_human_readable }
     }

--- a/serde_test/src/ser.rs
+++ b/serde_test/src/ser.rs
@@ -15,12 +15,17 @@ use token::Token;
 #[derive(Debug)]
 pub struct Serializer<'a> {
     tokens: &'a [Token],
+    is_human_readable: bool,
 }
 
 impl<'a> Serializer<'a> {
     /// Creates the serializer.
     pub fn new(tokens: &'a [Token]) -> Self {
-        Serializer { tokens: tokens }
+        Serializer::readable(tokens, true)
+    }
+
+    pub fn readable(tokens: &'a [Token], is_human_readable: bool) -> Self {
+        Serializer { tokens: tokens, is_human_readable: is_human_readable }
     }
 
     /// Pulls the next token off of the serializer, ignoring it.
@@ -281,6 +286,10 @@ impl<'s, 'a> ser::Serializer for &'s mut Serializer<'a> {
             assert_next_token!(self, StructVariant { name, variant, len });
             Ok(Variant { ser: self, end: Token::StructVariantEnd })
         }
+    }
+
+    fn is_human_readable(&self) -> bool {
+        self.is_human_readable
     }
 }
 

--- a/test_suite/tests/macros/mod.rs
+++ b/test_suite/tests/macros/mod.rs
@@ -73,3 +73,29 @@ macro_rules! hashmap {
         }
     }
 }
+
+macro_rules! seq_impl {
+    (seq $first:expr,) => {
+        seq_impl!(seq $first)
+    };
+    ($first:expr,) => {
+        seq_impl!($first)
+    };
+    (seq $first:expr) => {
+        $first.into_iter()
+    };
+    ($first:expr) => {
+        Some($first).into_iter()
+    };
+    (seq $first:expr , $( $elem: tt)*) => {
+        $first.into_iter().chain(seq!( $($elem)* ))
+    };
+    ($first:expr , $($elem: tt)*) => {
+        Some($first).into_iter().chain(seq!( $($elem)* ))
+    }
+}
+macro_rules! seq {
+    ($($tt: tt)*) => {
+        seq_impl!($($tt)*).collect::<Vec<_>>()
+    };
+}

--- a/test_suite/tests/test_de.rs
+++ b/test_suite/tests/test_de.rs
@@ -781,9 +781,9 @@ declare_non_human_readable_tests!{
     }
     test_non_human_readable_net_socketaddr {
         net::SocketAddr::from((*b"1234567890123456", 1234)) => &seq![
+            Token::NewtypeVariant { name: "SocketAddr", variant: "V6" },
+
             Token::Tuple { len: 2 },
-            Token::Enum { name: "IpAddr" },
-            Token::U32(1),
 
             Token::Tuple { len: 16 },
             seq b"1234567890123456".iter().map(|&b| Token::U8(b)),
@@ -793,9 +793,9 @@ declare_non_human_readable_tests!{
             Token::TupleEnd
         ],
         net::SocketAddr::from((*b"1234", 1234)) => &seq![
+            Token::NewtypeVariant { name: "SocketAddr", variant: "V4" },
+
             Token::Tuple { len: 2 },
-            Token::Enum { name: "IpAddr" },
-            Token::U32(0),
 
             Token::Tuple { len: 4 },
             seq b"1234".iter().map(|&b| Token::U8(b)),

--- a/test_suite/tests/test_roundtrip.rs
+++ b/test_suite/tests/test_roundtrip.rs
@@ -1,0 +1,45 @@
+extern crate serde_test;
+use self::serde_test::{Token, assert_tokens_readable};
+
+use std::net;
+
+#[macro_use]
+#[allow(unused_macros)]
+mod macros;
+
+#[test]
+fn ip_addr_roundtrip() {
+
+    assert_tokens_readable(
+        &net::IpAddr::from(*b"1234"),
+        &seq![
+            Token::NewtypeVariant { name: "IpAddr", variant: "V4" },
+
+            Token::Tuple { len: 4 },
+            seq b"1234".iter().map(|&b| Token::U8(b)),
+            Token::TupleEnd,
+        ],
+        false,
+    );
+}
+
+#[test]
+fn socked_addr_roundtrip() {
+
+    assert_tokens_readable(
+        &net::SocketAddr::from((*b"1234567890123456", 1234)),
+        &seq![
+            Token::NewtypeVariant { name: "SocketAddr", variant: "V6" },
+
+            Token::Tuple { len: 2 },
+
+            Token::Tuple { len: 16 },
+            seq b"1234567890123456".iter().map(|&b| Token::U8(b)),
+            Token::TupleEnd,
+
+            Token::U16(1234),
+            Token::TupleEnd,
+        ],
+        false,
+    );
+}

--- a/test_suite/tests/test_ser.rs
+++ b/test_suite/tests/test_ser.rs
@@ -426,8 +426,19 @@ declare_non_human_readable_tests!{
             Token::TupleEnd,
         ],
     }
+    test_non_human_readable_net_ipaddr {
+        net::IpAddr::from(*b"1234") => &seq![
+            Token::NewtypeVariant { name: "IpAddr", variant: "V4" },
+
+            Token::Tuple { len: 4 },
+            seq b"1234".iter().map(|&b| Token::U8(b)),
+            Token::TupleEnd,
+        ],
+    }
     test_non_human_readable_net_socketaddr {
         net::SocketAddr::from((*b"1234567890123456", 1234)) => &seq![
+            Token::NewtypeVariant { name: "SocketAddr", variant: "V6" },
+
             Token::Tuple { len: 2 },
 
             Token::Tuple { len: 16 },


### PR DESCRIPTION
This implements the KISS suggested in https://github.com/serde-rs/serde/issues/790.
It is possible that one of the other approaches may be better but this
seemed like the simplest one to reignite som discussion.

Personally I find the original suggestion of adding two traits perhaps slightly
cleaner in theory but I think it ends up more complicated in the end
since the added traits also need to be duplicated to to the `Seed`
traits.

Example usage in https://github.com/rust-lang-nursery/uuid: https://github.com/Marwes/uuid/commit/f908fd3ec7a564b79dab99dc2a519a698b7f9d7d

Closes #790