### PR TITLE
Support deserializing internally tagged enum from seq

### DIFF
--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -834,26 +834,43 @@ mod content {
         type Value = TaggedContent<'de, T>;
 
         fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-            fmt.write_str("any value")
+            fmt.write_str("internally tagged enum")
         }
 
-        fn visit_map<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
+        fn visit_seq<S>(self, mut seq: S) -> Result<Self::Value, S::Error>
         where
-            V: MapAccess<'de>,
+            S: SeqAccess<'de>,
+        {
+            let tag = match try!(seq.next_element()) {
+                Some(tag) => tag,
+                None => {
+                    return Err(de::Error::missing_field(self.tag_name));
+                }
+            };
+            let rest = de::value::SeqAccessDeserializer::new(seq);
+            Ok(TaggedContent {
+                tag: tag,
+                content: try!(Content::deserialize(rest)),
+            })
+        }
+
+        fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
+        where
+            M: MapAccess<'de>,
         {
             let mut tag = None;
-            let mut vec = Vec::with_capacity(size_hint::cautious(visitor.size_hint()));
+            let mut vec = Vec::with_capacity(size_hint::cautious(map.size_hint()));
             while let Some(k) =
-                try!(visitor.next_key_seed(TagOrContentVisitor::new(self.tag_name))) {
+                try!(map.next_key_seed(TagOrContentVisitor::new(self.tag_name))) {
                 match k {
                     TagOrContent::Tag => {
                         if tag.is_some() {
                             return Err(de::Error::duplicate_field(self.tag_name));
                         }
-                        tag = Some(try!(visitor.next_value()));
+                        tag = Some(try!(map.next_value()));
                     }
                     TagOrContent::Content(k) => {
-                        let v = try!(visitor.next_value());
+                        let v = try!(map.next_value());
                         vec.push((k, v));
                     }
                 }
@@ -1802,9 +1819,16 @@ mod content {
             write!(formatter, "unit variant {}::{}", self.type_name, self.variant_name)
         }
 
-        fn visit_map<V>(self, _: V) -> Result<(), V::Error>
+        fn visit_seq<S>(self, _: S) -> Result<(), S::Error>
         where
-            V: MapAccess<'de>,
+            S: SeqAccess<'de>,
+        {
+            Ok(())
+        }
+
+        fn visit_map<M>(self, _: M) -> Result<(), M::Error>
+        where
+            M: MapAccess<'de>,
         {
             Ok(())
         }

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -591,11 +591,10 @@ fn test_internally_tagged_enum() {
     #[serde(tag = "type")]
     enum InternallyTagged {
         A { a: u8 },
-        B { b: u8 },
-        C,
-        D(BTreeMap<String, String>),
-        E(Newtype),
-        F(Struct),
+        B,
+        C(BTreeMap<String, String>),
+        D(Newtype),
+        E(Struct),
     }
 
     assert_tokens(
@@ -613,35 +612,62 @@ fn test_internally_tagged_enum() {
         ],
     );
 
-    assert_tokens(
-        &InternallyTagged::B { b: 2 },
+    assert_de_tokens(
+        &InternallyTagged::A { a: 1 },
         &[
-            Token::Struct { name: "InternallyTagged", len: 2 },
-
-            Token::Str("type"),
-            Token::Str("B"),
-
-            Token::Str("b"),
-            Token::U8(2),
-
-            Token::StructEnd,
+            Token::Seq { len: Some(2) },
+            Token::Str("A"),
+            Token::U8(1),
+            Token::SeqEnd,
         ],
     );
 
     assert_tokens(
-        &InternallyTagged::C,
+        &InternallyTagged::B,
         &[
             Token::Struct { name: "InternallyTagged", len: 1 },
 
             Token::Str("type"),
-            Token::Str("C"),
+            Token::Str("B"),
 
             Token::StructEnd,
         ],
     );
 
+    assert_de_tokens(
+        &InternallyTagged::B,
+        &[
+            Token::Seq { len: Some(1) },
+            Token::Str("B"),
+            Token::SeqEnd,
+        ],
+    );
+
     assert_tokens(
-        &InternallyTagged::D(BTreeMap::new()),
+        &InternallyTagged::C(BTreeMap::new()),
+        &[
+            Token::Map { len: Some(1) },
+
+            Token::Str("type"),
+            Token::Str("C"),
+
+            Token::MapEnd,
+        ],
+    );
+
+    assert_de_tokens_error::<InternallyTagged>(
+        &[
+            Token::Seq { len: Some(2) },
+            Token::Str("C"),
+            Token::Map { len: Some(0) },
+            Token::MapEnd,
+            Token::SeqEnd,
+        ],
+        "invalid type: sequence, expected a map",
+    );
+
+    assert_tokens(
+        &InternallyTagged::D(Newtype(BTreeMap::new())),
         &[
             Token::Map { len: Some(1) },
 
@@ -653,29 +679,27 @@ fn test_internally_tagged_enum() {
     );
 
     assert_tokens(
-        &InternallyTagged::E(Newtype(BTreeMap::new())),
-        &[
-            Token::Map { len: Some(1) },
-
-            Token::Str("type"),
-            Token::Str("E"),
-
-            Token::MapEnd,
-        ],
-    );
-
-    assert_tokens(
-        &InternallyTagged::F(Struct { f: 6 }),
+        &InternallyTagged::E(Struct { f: 6 }),
         &[
             Token::Struct { name: "Struct", len: 2 },
 
             Token::Str("type"),
-            Token::Str("F"),
+            Token::Str("E"),
 
             Token::Str("f"),
             Token::U8(6),
 
             Token::StructEnd,
+        ],
+    );
+
+    assert_de_tokens(
+        &InternallyTagged::E(Struct { f: 6 }),
+        &[
+            Token::Seq { len: Some(2) },
+            Token::Str("E"),
+            Token::U8(6),
+            Token::SeqEnd,
         ],
     );
 
@@ -693,7 +717,7 @@ fn test_internally_tagged_enum() {
 
             Token::MapEnd,
         ],
-        "unknown variant `Z`, expected one of `A`, `B`, `C`, `D`, `E`, `F`",
+        "unknown variant `Z`, expected one of `A`, `B`, `C`, `D`, `E`",
     );
 }
 


### PR DESCRIPTION
During serialization, internally tagged enums invoke the Serializer's serialize_struct. In JSON this turns into a map which uses visit_map when deserialized. But some formats employ visit_seq when deserializing a struct. One example is rmp-serde. Such formats were previously unable to deserialize an internally tagged enum. This change fixes it by adding visit_seq for internally tagged enums.

Fixes https://github.com/3Hren/msgpack-rust/issues/130.