### PR TITLE
Ignore skipped fields when looking for borrowed lifetimes

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -203,7 +203,9 @@ impl BorrowedLifetimes {
 fn borrowed_lifetimes(cont: &Container) -> BorrowedLifetimes {
     let mut lifetimes = BTreeSet::new();
     for field in cont.body.all_fields() {
-        lifetimes.extend(field.attrs.borrowed_lifetimes().iter().cloned());
+        if !field.attrs.skip_deserializing() {
+            lifetimes.extend(field.attrs.borrowed_lifetimes().iter().cloned());
+        }
     }
     if lifetimes.iter().any(|b| b.ident == "'static") {
         BorrowedLifetimes::Static

--- a/test_suite/tests/test_gen.rs
+++ b/test_suite/tests/test_gen.rs
@@ -511,6 +511,14 @@ fn test_gen() {
         Tuple(&'a str, &'static str),
         Newtype(&'static str),
     }
+
+    #[derive(Serialize, Deserialize)]
+    struct SkippedStaticStr {
+        #[serde(skip_deserializing)]
+        skipped: &'static str,
+        other: isize,
+    }
+    assert::<SkippedStaticStr>();
 }
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes #1078.