### PR TITLE
serde_test requires serde 1.0.16 to work

### DIFF
--- a/serde_test/Cargo.toml
+++ b/serde_test/Cargo.toml
@@ -12,10 +12,10 @@ readme = "README.md"
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 
 [dependencies]
-serde = { version = "1.0", path = "../serde" }
+serde = { version = "1.0.16", path = "../serde" }
 
 [dev-dependencies]
-serde = { version = "1.0", path = "../serde", features = ["rc"] }
+serde = { version = "1.0.16", path = "../serde", features = ["rc"] }
 serde_derive = { version = "1.0", path = "../serde_derive" }
 
 [badges]


### PR DESCRIPTION
This is due to implementing is_human_readable which was added in serde 1.0.16.