### PR TITLE
Allow borrow attribute on newtype variants

### DIFF
--- a/test_suite/tests/compile-fail/borrow/duplicate_variant.rs
+++ b/test_suite/tests/compile-fail/borrow/duplicate_variant.rs
@@ -1,0 +1,21 @@
+// Copyright 2017 Serde Developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_use]
+extern crate serde_derive;
+
+#[derive(Deserialize)]
+struct Str<'a>(&'a str);
+
+#[derive(Deserialize)] //~ ERROR: proc-macro derive panicked
+enum Test<'a> {
+    #[serde(borrow)] //~^^ HELP: duplicate serde attribute `borrow`
+    S(#[serde(borrow)] Str<'a>)
+}
+
+fn main() {}

--- a/test_suite/tests/compile-fail/borrow/struct_variant.rs
+++ b/test_suite/tests/compile-fail/borrow/struct_variant.rs
@@ -1,0 +1,21 @@
+// Copyright 2017 Serde Developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_use]
+extern crate serde_derive;
+
+#[derive(Deserialize)]
+struct Str<'a>(&'a str);
+
+#[derive(Deserialize)] //~ ERROR: proc-macro derive panicked
+enum Test<'a> {
+    #[serde(borrow)] //~^^ HELP: #[serde(borrow)] may only be used on newtype variants
+    S { s: Str<'a> }
+}
+
+fn main() {}

--- a/test_suite/tests/test_gen.rs
+++ b/test_suite/tests/test_gen.rs
@@ -357,6 +357,12 @@ fn test_gen() {
         s: Str<'a>,
     }
 
+    #[derive(Serialize, Deserialize)]
+    enum BorrowVariant<'a> {
+        #[serde(borrow, with = "StrDef")]
+        S(Str<'a>),
+    }
+
     mod vis {
         pub struct S;
 


### PR DESCRIPTION
```rust
#[derive(Deserialize)]
enum RelData<'a> {
    #[serde(borrow)]
    Single(RelObject<'a>),
    #[serde(borrow)]
    Many(Vec<RelObject<'a>>),
}
```

Fixes #929.