### PR TITLE
Fix bounds for macro named the same as a type parameter

### DIFF
--- a/serde_derive/src/bound.rs
+++ b/serde_derive/src/bound.rs
@@ -116,6 +116,14 @@ where
             }
             visit::walk_path(self, path);
         }
+
+        // Type parameter should not be considered used by a macro path.
+        //
+        //     struct TypeMacro<T> {
+        //         mac: T!(),
+        //         marker: PhantomData<T>,
+        //     }
+        fn visit_mac(&mut self, _mac: &syn::Mac) {}
     }
 
     let all_ty_params: HashSet<_> = generics

--- a/test_suite/tests/test_gen.rs
+++ b/test_suite/tests/test_gen.rs
@@ -519,6 +519,17 @@ fn test_gen() {
         other: isize,
     }
     assert::<SkippedStaticStr>();
+
+    macro_rules! T {
+        () => { () }
+    }
+
+    #[derive(Serialize, Deserialize)]
+    struct TypeMacro<T> {
+        mac: T!(),
+        marker: PhantomData<T>,
+    }
+    assert::<TypeMacro<X>>();
 }
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes #1081.