### PR TITLE
Allow internally tagged newtype variant containing unit struct

### DIFF
--- a/serde/src/private/ser.rs
+++ b/serde/src/private/ser.rs
@@ -60,7 +60,6 @@ enum Unsupported {
     ByteArray,
     Optional,
     Unit,
-    UnitStruct,
     Sequence,
     Tuple,
     TupleStruct,
@@ -79,7 +78,6 @@ impl Display for Unsupported {
             Unsupported::ByteArray => formatter.write_str("a byte array"),
             Unsupported::Optional => formatter.write_str("an optional"),
             Unsupported::Unit => formatter.write_str("unit"),
-            Unsupported::UnitStruct => formatter.write_str("a unit struct"),
             Unsupported::Sequence => formatter.write_str("a sequence"),
             Unsupported::Tuple => formatter.write_str("a tuple"),
             Unsupported::TupleStruct => formatter.write_str("a tuple struct"),
@@ -199,7 +197,9 @@ where
     }
 
     fn serialize_unit_struct(self, _: &'static str) -> Result<Self::Ok, Self::Error> {
-        Err(self.bad_type(Unsupported::UnitStruct))
+        let mut map = try!(self.delegate.serialize_map(Some(1)));
+        try!(map.serialize_entry(self.tag, self.variant_name));
+        map.end()
     }
 
     fn serialize_unit_variant(

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -1267,3 +1267,48 @@ fn test_rename_all() {
         ]
     );
 }
+
+#[test]
+fn test_untagged_newtype_variant_containing_unit_struct_not_map() {
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct Unit;
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    #[serde(untagged)]
+    enum Message {
+        Unit(Unit),
+        Map(BTreeMap<String, String>),
+    }
+
+    assert_tokens(
+        &Message::Map(BTreeMap::new()),
+        &[
+            Token::Map { len: Some(0) },
+            Token::MapEnd,
+        ],
+    );
+}
+
+#[test]
+fn test_internally_tagged_newtype_variant_containing_unit_struct() {
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct Info;
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    #[serde(tag = "topic")]
+    enum Message {
+        Info(Info),
+    }
+
+    assert_tokens(
+        &Message::Info(Info),
+        &[
+            Token::Map { len: Some(1) },
+
+            Token::Str("topic"),
+            Token::Str("Info"),
+
+            Token::MapEnd,
+        ],
+    );
+}


### PR DESCRIPTION
Fixes https://github.com/serde-rs/json/issues/379.

```rust
#[derive(Deserialize)]
struct Info;

#[derive(Deserialize)]
#[serde(tag = "topic")]
enum Message {
    Info(Info),
}
```

This should serialize and deserialize as `{"topic":"Info"}` even though ordinarily unit structs are not allowed to deserialize from an empty map.