### PR TITLE
Fix error when deserializing untagged enum

### DIFF
--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -1246,6 +1246,9 @@ mod content {
                 Some(Content::Map(v)) => {
                     de::Deserializer::deserialize_any(MapDeserializer::new(v), visitor)
                 }
+                Some(Content::Seq(v)) => {
+                    de::Deserializer::deserialize_any(SeqDeserializer::new(v), visitor)
+                }
                 Some(other) => Err(de::Error::invalid_type(other.unexpected(), &"struct variant"),),
                 _ => Err(de::Error::invalid_type(de::Unexpected::UnitVariant, &"struct variant"),),
             }

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -1643,6 +1643,9 @@ mod content {
                 Some(&Content::Map(ref v)) => {
                     de::Deserializer::deserialize_any(MapRefDeserializer::new(v), visitor)
                 }
+                Some(&Content::Seq(ref v)) => {
+                    de::Deserializer::deserialize_any(SeqRefDeserializer::new(v), visitor)
+                }
                 Some(other) => Err(de::Error::invalid_type(other.unexpected(), &"struct variant"),),
                 _ => Err(de::Error::invalid_type(de::Unexpected::UnitVariant, &"struct variant"),),
             }


### PR DESCRIPTION
Serde's `ContentDeserializer` and `ContentRefDeserializer` cannot deserialize struct enum variant associated data when that data is encoded as a sequence. This failure leads to errors when decoding an enum nested in another untagged enum. For example:

```rust
#[derive(Serialize, Deserialize, Debug, PartialEq)]
#[serde(untagged)]
enum Foo {
    A(Bar),
}

#[derive(Serialize, Deserialize, Debug, PartialEq)]
enum Bar {
    B{f1: String},
}

let data1 = Foo::A(Bar::B{f1: "Hello".into()});
let bytes = rmp_serde::to_vec(&data1).unwrap();
let data2 = rmp_serde::from_slice(&bytes).unwrap();
```

Deserializing fails with the error `Syntax("data did not match any variant of untagged enum Foo")`, but the underlying failure occurs when decoding the associated data of `Bar::B`.

This pull request fixes the issue by allowing `ContentDeserializer` and `ContentRefDeserializer` to deserialize sequence-encoded struct enum variant data.