### PR TITLE
Allow uint Unit enum variants

### DIFF
--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -1246,6 +1246,9 @@ mod content {
                 Some(Content::Map(v)) => {
                     de::Deserializer::deserialize_any(MapDeserializer::new(v), visitor)
                 }
+                Some(Content::Seq(v)) => {
+                    de::Deserializer::deserialize_any(SeqDeserializer::new(v), visitor)
+                }
                 Some(other) => Err(de::Error::invalid_type(other.unexpected(), &"struct variant"),),
                 _ => Err(de::Error::invalid_type(de::Unexpected::UnitVariant, &"struct variant"),),
             }

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -1643,6 +1643,9 @@ mod content {
                 Some(&Content::Map(ref v)) => {
                     de::Deserializer::deserialize_any(MapRefDeserializer::new(v), visitor)
                 }
+                Some(&Content::Seq(ref v)) => {
+                    de::Deserializer::deserialize_any(SeqRefDeserializer::new(v), visitor)
+                }
                 Some(other) => Err(de::Error::invalid_type(other.unexpected(), &"struct variant"),),
                 _ => Err(de::Error::invalid_type(de::Unexpected::UnitVariant, &"struct variant"),),
             }

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -1100,7 +1100,10 @@ mod content {
                     (variant, Some(value))
                 }
                 s @ Content::String(_) | s @ Content::Str(_) => (s, None),
-                u @ Content::U8(_) | u @ Content::U16(_) | u @ Content::U32(_) => (u, None),
+                u @ Content::U8(_) |
+                u @ Content::U16(_) |
+                u @ Content::U32(_) |
+                u @ Content::U64(_) => (u, None),
                 other => {
                     return Err(de::Error::invalid_type(other.unexpected(), &"string or map"),);
                 }
@@ -1527,7 +1530,10 @@ mod content {
                 }
 
                 ref s @ Content::String(_) | ref s @ Content::Str(_) => (s, None),
-                ref u @ Content::U8(_) | ref u @ Content::U16(_) | ref u @ Content::U32(_) => (u, None),
+                ref u @ Content::U8(_) |
+                ref u @ Content::U16(_) |
+                ref u @ Content::U32(_) |
+                ref u @ Content::U64(_) => (u, None),
                 ref other => {
                     return Err(de::Error::invalid_type(other.unexpected(), &"string or map"),);
                 }

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -1100,6 +1100,7 @@ mod content {
                     (variant, Some(value))
                 }
                 s @ Content::String(_) | s @ Content::Str(_) => (s, None),
+                u @ Content::U8(_) | u @ Content::U16(_) | u @ Content::U32(_) => (u, None),
                 other => {
                     return Err(de::Error::invalid_type(other.unexpected(), &"string or map"),);
                 }
@@ -1524,7 +1525,9 @@ mod content {
                     }
                     (variant, Some(value))
                 }
+
                 ref s @ Content::String(_) | ref s @ Content::Str(_) => (s, None),
+                ref u @ Content::U8(_) | ref u @ Content::U16(_) | ref u @ Content::U32(_) => (u, None),
                 ref other => {
                     return Err(de::Error::invalid_type(other.unexpected(), &"string or map"),);
                 }

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -1105,7 +1105,7 @@ mod content {
                 u @ Content::U32(_) |
                 u @ Content::U64(_) => (u, None),
                 other => {
-                    return Err(de::Error::invalid_type(other.unexpected(), &"string or map"),);
+                    return Err(de::Error::invalid_type(other.unexpected(), &"string, uint, or map"),);
                 }
             };
 
@@ -1534,7 +1534,7 @@ mod content {
                 ref u @ Content::U32(_) |
                 ref u @ Content::U64(_) => (u, None),
                 ref other => {
-                    return Err(de::Error::invalid_type(other.unexpected(), &"string or map"),);
+                    return Err(de::Error::invalid_type(other.unexpected(), &"string, uint, or map"),);
                 }
             };
 

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -1528,7 +1528,6 @@ mod content {
                     }
                     (variant, Some(value))
                 }
-
                 ref s @ Content::String(_) | ref s @ Content::Str(_) => (s, None),
                 ref u @ Content::U8(_) |
                 ref u @ Content::U16(_) |


### PR DESCRIPTION
Serde's `ContentDeserializer` and `ContentRefDeserializer` currently expect unit variants to be encoded as strings. This PR updates both deserializers to recognize `u8`, `u16`, `u32`, and `u64`  values as unit variants. 

This change allows `rmp_serde` to optimize unit variant encoding as the variant index (min size 1 byte), instead of its current representation as a map `{variant_idx => nil}` (min size 3 bytes).