### PR TITLE
Port ser::Error and de::Error to use failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ members = [
     "serde_test",
     "test_suite",
 ]
+
+[patch.crates-io]
+failure = { git = "https://github.com/withoutboats/failure" }

--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -17,6 +17,7 @@ travis-ci = { repository = "serde-rs/serde" }
 appveyor = { repository = "serde-rs/serde" }
 
 [dependencies]
+failure = { version = "0.1", default-features = false }
 serde_derive = { version = "1.0", optional = true, path = "../serde_derive" }
 
 [dev-dependencies]
@@ -40,7 +41,7 @@ derive = ["serde_derive"]
 
 # Provide impls for common standard library types like Vec<T> and HashMap<K, V>.
 # Requires a dependency on the Rust standard library.
-std = []
+std = ["failure/std"]
 
 # Provide impls for types that require unstable functionality. For tracking and
 # discussion of unstable functionality please refer to this issue:

--- a/serde/src/de/value.rs
+++ b/serde/src/de/value.rs
@@ -37,7 +37,9 @@
 
 use lib::*;
 
-use de::{self, IntoDeserializer, Expected, SeqAccess};
+use failure::Fail;
+
+use de::{self, Expected, IntoDeserializer, SeqAccess};
 use private::de::size_hint;
 use ser;
 use self::private::{First, Second};
@@ -96,12 +98,7 @@ impl Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        &self.err
-    }
-}
+impl Fail for Error {}
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -137,6 +137,8 @@ extern crate alloc;
 #[cfg(all(feature = "unstable", feature = "std"))]
 extern crate core;
 
+extern crate failure;
+
 /// A facade around all the types we need from the `std`, `core`, and `alloc`
 /// crates. This avoids elaborate import wrangling having to happen in every
 /// module.

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -200,7 +200,7 @@ mod lib {
     pub use alloc::{BinaryHeap, BTreeMap, BTreeSet, LinkedList, VecDeque};
 
     #[cfg(feature = "std")]
-    pub use std::{error, net};
+    pub use std::net;
 
     #[cfg(feature = "std")]
     pub use std::collections::{HashMap, HashSet};

--- a/serde/src/private/ser.rs
+++ b/serde/src/private/ser.rs
@@ -8,7 +8,9 @@
 
 use lib::*;
 
-use ser::{self, Serialize, Serializer, SerializeMap, SerializeStruct, Impossible};
+use failure::Fail;
+
+use ser::{self, Impossible, Serialize, SerializeMap, SerializeStruct, Serializer};
 
 #[cfg(any(feature = "std", feature = "alloc"))]
 use self::content::{SerializeTupleVariantAsMapValue, SerializeStructVariantAsMapValue};
@@ -350,12 +352,7 @@ impl ser::Error for Error {
     }
 }
 
-#[cfg(feature = "std")]
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        unimplemented!()
-    }
-}
+impl Fail for Error {}
 
 impl Display for Error {
     fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {

--- a/test_suite/no_std/Cargo.toml
+++ b/test_suite/no_std/Cargo.toml
@@ -9,3 +9,6 @@ serde = { path = "../../serde", default-features = false }
 serde_derive = { path = "../../serde_derive" }
 
 [workspace]
+
+[patch.crates-io]
+failure = { git = "https://github.com/withoutboats/failure" }


### PR DESCRIPTION
First pass at using `Fail` as the constraint for `ser::Error` and `de::Error` rather than `std::error::Error`.

From my testing thus far, it appears to play nicely with pre-existing code, even though it's a potentially breaking api change, so migration shouldn't be very painful.

I'm not 100% sure that I've gotten the `std` feature-gating right, but all of the tests are passing.

Edit: Not actually building with `--no-default-features` yet. Stay tuned.