### PR TITLE
Inline various deserialization helper methods.

### DIFF
--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -198,6 +198,7 @@ pub mod size_hint {
         helper(iter.size_hint())
     }
 
+    #[inline]
     pub fn cautious(hint: Option<usize>) -> usize {
         cmp::min(hint.unwrap_or(0), 4096)
     }


### PR DESCRIPTION
Inlining `cautious` helps LLVM figure out what is going on with array deserialization.  I figured we might as well do the others while we're here.