### PR TITLE
Rename deserialize_from to deserialize_in_place

### DIFF
--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -518,18 +518,18 @@ pub trait Deserialize<'de>: Sized {
     /// when the next deserialization occurs.
     ///
     /// If you manually implement this, your recursive deserializations should
-    /// use `deserialize_from`.
+    /// use `deserialize_in_place`.
     ///
     /// This method is stable and an official public API, but hidden from the
     /// documentation because it is almost never what newbies are looking for.
     /// Showing it in rustdoc would cause it to be featured more prominently
     /// than it deserves.
     #[doc(hidden)]
-    fn deserialize_from<D>(&mut self, deserializer: D) -> Result<(), D::Error>
+    fn deserialize_in_place<D>(deserializer: D, place: &mut Self) -> Result<(), D::Error>
         where D: Deserializer<'de>
     {
         // Default implementation just delegates to `deserialize` impl.
-        *self = Deserialize::deserialize(deserializer)?;
+        *place = Deserialize::deserialize(deserializer)?;
         Ok(())
     }
 }

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -2010,12 +2010,12 @@ where
     }
 }
 
-/// A DeserializeSeed helper for implementing deserialize_from Visitors.
+/// A DeserializeSeed helper for implementing deserialize_in_place Visitors.
 ///
-/// Wraps a mutable reference and calls deserialize_from on it.
-pub struct DeserializeFromSeed<'a, T: 'a>(pub &'a mut T);
+/// Wraps a mutable reference and calls deserialize_in_place on it.
+pub struct InPlaceSeed<'a, T: 'a>(pub &'a mut T);
 
-impl<'a, 'de, T> DeserializeSeed<'de> for DeserializeFromSeed<'a, T>
+impl<'a, 'de, T> DeserializeSeed<'de> for InPlaceSeed<'a, T>
     where T: Deserialize<'de>,
 {
     type Value = ();
@@ -2023,6 +2023,6 @@ impl<'a, 'de, T> DeserializeSeed<'de> for DeserializeFromSeed<'a, T>
     where
         D: Deserializer<'de>,
     {
-       self.0.deserialize_from(deserializer)
+        T::deserialize_in_place(deserializer, self.0)
     }
 }

--- a/serde_derive/Cargo.toml
+++ b/serde_derive/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = { repository = "serde-rs/serde" }
 
 [features]
 default = []
-deserialize_from = []
+deserialize_in_place = []
 
 [lib]
 name = "serde_derive"

--- a/serde_test/src/assert.rs
+++ b/serde_test/src/assert.rs
@@ -195,15 +195,15 @@ where
         panic!("{} remaining tokens", de.remaining());
     }
 
-    // Do the same thing for deserialize_from. This isn't *great* because a no-op
-    // impl of deserialize_from can technically succeed here. Still, this should
-    // catch a lot of junk.
+    // Do the same thing for deserialize_in_place. This isn't *great* because a
+    // no-op impl of deserialize_in_place can technically succeed here. Still,
+    // this should catch a lot of junk.
     let mut de = Deserializer::new(tokens);
-    match deserialized_val.deserialize_from(&mut de) {
+    match T::deserialize_in_place(&mut de, &mut deserialized_val) {
         Ok(()) => {
             assert_eq!(deserialized_val, *value);
         }
-        Err(e) => panic!("tokens failed to deserialize_from: {}", e),
+        Err(e) => panic!("tokens failed to deserialize_in_place: {}", e),
     }
     if de.remaining() > 0 {
         panic!("{} remaining tokens", de.remaining());

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -11,7 +11,7 @@ unstable = ["serde/unstable", "compiletest_rs"]
 fnv = "1.0"
 rustc-serialize = "0.3.16"
 serde = { path = "../serde", features = ["rc"] }
-serde_derive = { path = "../serde_derive", features = ["deserialize_from"] }
+serde_derive = { path = "../serde_derive", features = ["deserialize_in_place"] }
 serde_test = { path = "../serde_test" }
 
 [dependencies]


### PR DESCRIPTION
Fixes #1122. @Gankro @nox @oli-obk I am basically prepared to release this. Any objections?

I believe `deserialize_in_place`, even to the extent that it conflicts with [placement-in](https://github.com/rust-lang/rust/issues/27779) and [`std::ops::InPlace`](https://doc.rust-lang.org/std/ops/trait.InPlace.html), has all the right connotations for this API. People recognize placement as a way to avoid copies and leverage existing allocations.

```rust
vec.push(create_element());
let x = T::deserialize(de)?;

vec.place_back() <- create_element();
T::deserialize_in_place(de, &mut x)?;

```

Tellingly, @Gankro even used the phrase ["in place"](https://github.com/serde-rs/serde/commit/bc221abb04ed942afed87a41147802f1c7d3955a#diff-222404300d4750d007f9d729af3ec439R559) when describing the functionality in English.