### PR TITLE
Fix borrowed Cow<'_, [u8]> deserializing as str.

### DIFF
--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -188,7 +188,7 @@ where
         }
     }
 
-    deserializer.deserialize_str(CowBytesVisitor)
+    deserializer.deserialize_bytes(CowBytesVisitor)
 }
 
 pub mod size_hint {


### PR DESCRIPTION
This changes the deserialize implementation for a borrowed Cow<[u8]> to specifically request a byte slice, rather than a borrowed string.

The old behavior breaks any program which relies on data being deserialized the same way as it was serialized and uses Cow<[u8]>. In serde_json, it just wouldn't deserialize. In bincode, it deserialized normally unless the bytes were invalid UTF8.

See https://github.com/TyOverby/bincode/issues/231 for error description, and test program.

I'm not sure where a test for this behavior would fit in, since it's a "what hint to provide the deserializer" failure, but if needed I can try and make one.

Thanks!