### PR TITLE
WIP: Support for collecting leftover fields into a container

### DIFF
--- a/serde/src/export.rs
+++ b/serde/src/export.rs
@@ -13,6 +13,7 @@ pub use lib::fmt::{self, Formatter};
 pub use lib::marker::PhantomData;
 pub use lib::option::Option::{self, None, Some};
 pub use lib::result::Result::{self, Err, Ok};
+pub use lib::iter::once;
 
 pub use self::string::from_utf8_lossy;
 

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -266,7 +266,7 @@ fn serialize_struct(params: &Parameters, fields: &[Field], cattrs: &attr::Contai
         .map(|field| {
             let ident = &field.ident;
             quote! {
-                for (ref __key, ref __value) in self.#ident.iter() {
+                for (ref __key, ref __value) in &self.#ident {
                     try!(_serde::ser::SerializeStruct::serialize_field(
                         &mut __serde_state,
                         unsafe { ::std::mem::transmute(__key.as_str()) },

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -259,6 +259,22 @@ fn serialize_struct(params: &Parameters, fields: &[Field], cattrs: &attr::Contai
         .filter(|&field| !field.attrs.skip_serializing())
         .peekable();
 
+    let collect_field = fields
+        .iter()
+        .filter(|&field| field.attrs.is_collect_field())
+        .next()
+        .map(|field| {
+            let ident = &field.ident;
+            quote! {
+                for (ref __key, ref __value) in self.#ident.iter() {
+                    try!(_serde::ser::SerializeStruct::serialize_field(
+                        &mut __serde_state,
+                        unsafe { ::std::mem::transmute(__key.as_str()) },
+                        __value));
+                }
+            }
+        });
+
     let let_mut = mut_if(serialized_fields.peek().is_some());
 
     let len = serialized_fields
@@ -275,6 +291,7 @@ fn serialize_struct(params: &Parameters, fields: &[Field], cattrs: &attr::Contai
     quote_block! {
         let #let_mut __serde_state = try!(_serde::Serializer::serialize_struct(__serializer, #type_name, #len));
         #(#serialize_fields)*
+        #collect_field
         _serde::ser::SerializeStruct::end(__serde_state)
     }
 }


### PR DESCRIPTION
This is a work in progress pull request to add support for #941.

Unlike what was proposed there I added a container attribute `#[collect_unknown_fields_into="a_field"]`. This I did for two reasons. One is that there is already `deny_unknown_fields` so this seems somewhat consistent. Secondly it makes it pretty obvious that it should only be added once. Internally in the ast processing step it adds a flag on the field.

I'm not sure if this approach is entirely correct and clearly there are more issues with this at the current stage. However I appreciate feedback on if what I'm doing here makes any sense at all.

Notes on things I know are not great:

* The `need_value` marker I introduced for `deserialize_generated_identifier` seems questionable. There must be a better approach
* A field that is internally marked as a collect field also returns true for the skip checks. This makes the code generation do the right thing as far as I can tell. Probably this should be done better though.
* Only strings keys are supported at this point
* Handling of duplicated keys is not implemented
* Serializer is missing at this point.

Example:

```rust
#[derive(Deserialize, Debug)]
#[serde(collect_unknown_fields_into="data")]
pub struct Breadcrumb {
    #[serde(rename="type")]
    ty: String,
    timestamp: f64,
    data: HashMap<String, String>,
}
```