### PR TITLE
Struct as map representation and leftover field collection

### DIFF
--- a/serde/src/export.rs
+++ b/serde/src/export.rs
@@ -13,6 +13,7 @@ pub use lib::fmt::{self, Formatter};
 pub use lib::marker::PhantomData;
 pub use lib::option::Option::{self, None, Some};
 pub use lib::result::Result::{self, Err, Ok};
+pub use lib::iter::once;
 
 pub use self::string::from_utf8_lossy;
 

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -2122,7 +2122,7 @@ fn deserialize_map(
     let result = fields_names.iter().map(|&(field, ref name)| {
         let ident = field.ident.expect("struct contains unnamed fields");
         if field.attrs.collection_field() {
-            quote_spanned!(Span::call_site()=> #ident: __collect)
+            quote_spanned!(Span::def_site()=> #ident: __collect)
         } else if field.attrs.skip_deserializing() {
             let value = Expr(expr_is_missing(field, cattrs));
             quote_spanned!(Span::call_site()=> #ident: #value)

--- a/serde_derive_internals/src/ast.rs
+++ b/serde_derive_internals/src/ast.rs
@@ -63,6 +63,7 @@ impl<'a> Container<'a> {
             }
         };
 
+        let mut have_collection_field = false;
         match data {
             Data::Enum(ref mut variants) => for variant in variants {
                 variant.attrs.rename_by_rule(attrs.rename_all());
@@ -71,8 +72,18 @@ impl<'a> Container<'a> {
                 }
             },
             Data::Struct(_, ref mut fields) => for field in fields {
+                if field.ident.is_some() && field.ident.as_ref() == attrs.unknown_fields_into() {
+                    field.attrs.mark_as_collection_field();
+                    have_collection_field = true;
+                }
                 field.attrs.rename_by_rule(attrs.rename_all());
             },
+        }
+
+        if attrs.unknown_fields_into().is_some() && !have_collection_field {
+            cx.error(format!("#[serde(unknown_fields_into)] was defined but target \
+                             field `{}` does not exist",
+                             attrs.unknown_fields_into().unwrap()));
         }
 
         let item = Container {

--- a/serde_derive_internals/src/attr.rs
+++ b/serde_derive_internals/src/attr.rs
@@ -15,6 +15,7 @@ use syn::punctuated::Punctuated;
 use syn::synom::{Synom, ParseError};
 use std::collections::BTreeSet;
 use std::str::FromStr;
+use std::fmt;
 use proc_macro2::{Span, TokenStream, TokenNode, TokenTree};
 
 // This module handles parsing of `#[serde(...)]` attributes. The entrypoints
@@ -27,6 +28,7 @@ use proc_macro2::{Span, TokenStream, TokenNode, TokenTree};
 
 pub use case::RenameRule;
 
+#[derive(Copy, Clone)]
 struct Attr<'c, T> {
     cx: &'c Ctxt,
     name: &'static str,
@@ -66,6 +68,10 @@ impl<'c, T> Attr<'c, T> {
     fn get(self) -> Option<T> {
         self.value
     }
+
+    fn is_set(&self) -> bool {
+        self.value.is_some()
+    }
 }
 
 struct BoolAttr<'c>(Attr<'c, ()>);
@@ -101,6 +107,35 @@ impl Name {
     }
 }
 
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum ContainerRepr {
+    Auto,
+    Struct,
+    Map,
+}
+
+impl fmt::Display for ContainerRepr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", match *self {
+            ContainerRepr::Auto => "auto",
+            ContainerRepr::Struct => "struct",
+            ContainerRepr::Map => "map",
+        })
+    }
+}
+
+impl FromStr for ContainerRepr {
+    type Err = ();
+    fn from_str(s: &str) -> Result<ContainerRepr, ()> {
+        match s {
+            "auto" => Ok(ContainerRepr::Auto),
+            "struct" => Ok(ContainerRepr::Struct),
+            "map" => Ok(ContainerRepr::Map),
+            _ => Err(()),
+        }
+    }
+}
+
 /// Represents container (e.g. struct) attribute information
 pub struct Container {
     name: Name,
@@ -114,6 +149,8 @@ pub struct Container {
     type_into: Option<syn::Type>,
     remote: Option<syn::Path>,
     identifier: Identifier,
+    repr: ContainerRepr,
+    unknown_fields_into: Option<syn::Ident>,
 }
 
 /// Styles of representing an enum.
@@ -191,6 +228,8 @@ impl Container {
         let mut remote = Attr::none(cx, "remote");
         let mut field_identifier = BoolAttr::none(cx, "field_identifier");
         let mut variant_identifier = BoolAttr::none(cx, "variant_identifier");
+        let mut repr = Attr::none(cx, "repr");
+        let mut unknown_fields_into = Attr::none(cx, "unknown_fields_into");
 
         for meta_items in item.attrs.iter().filter_map(get_serde_meta_items) {
             for meta_item in meta_items {
@@ -228,6 +267,31 @@ impl Container {
                     // Parse `#[serde(deny_unknown_fields)]`
                     Meta(Word(word)) if word == "deny_unknown_fields" => {
                         deny_unknown_fields.set_true();
+                        if unknown_fields_into.is_set() {
+                            cx.error("#[serde(deny_unknown_fields)] cannot be combined \
+                                     with #[serde(unknown_fields_into)]");
+                        }
+                    }
+
+                    // Parse `#[serde(unknown_fields_into = "foo")]`
+                    Meta(NameValue(ref m)) if m.ident == "unknown_fields_into" => {
+                        if let Ok(s) = get_lit_str(cx, m.ident.as_ref(), m.ident.as_ref(), &m.lit) {
+                            unknown_fields_into.set(Ident::new(&s.value(), Span::call_site()).into());
+                            if deny_unknown_fields.get() {
+                                cx.error("#[serde(deny_unknown_fields)] cannot be combined \
+                                         with #[serde(unknown_fields_into)]");
+                            }
+                        }
+                    }
+
+                    // Parse `#[serde(repr = "foo")]`
+                    Meta(NameValue(ref m)) if m.ident == "repr" => {
+                        if let Ok(s) = get_lit_str(cx, m.ident.as_ref(), m.ident.as_ref(), &m.lit) {
+                            match ContainerRepr::from_str(&s.value()) {
+                                Ok(value) => repr.set(value),
+                                Err(()) => cx.error(format!("unknown value for #[serde(repr = {})]", s.value()))
+                            }
+                        }
                     }
 
                     // Parse `#[serde(default)]`
@@ -358,6 +422,10 @@ impl Container {
             }
         }
 
+        if unknown_fields_into.get().is_some() && repr.get() != Some(ContainerRepr::Map) {
+            cx.error("#[serde(unknown_fields_into)] requires repr=\"map\"");
+        }
+
         Container {
             name: Name {
                 serialize: ser_name.get().unwrap_or_else(|| item.ident.to_string()),
@@ -373,6 +441,8 @@ impl Container {
             type_into: type_into.get(),
             remote: remote.get(),
             identifier: decide_identifier(cx, item, &field_identifier, &variant_identifier),
+            repr: repr.get().unwrap_or(ContainerRepr::Auto),
+            unknown_fields_into: unknown_fields_into.get(),
         }
     }
 
@@ -418,6 +488,14 @@ impl Container {
 
     pub fn identifier(&self) -> Identifier {
         self.identifier
+    }
+
+    pub fn repr(&self) -> ContainerRepr {
+        self.repr
+    }
+
+    pub fn unknown_fields_into(&self) -> Option<&syn::Ident> {
+        self.unknown_fields_into.as_ref()
     }
 }
 
@@ -699,6 +777,7 @@ pub struct Field {
     de_bound: Option<Vec<syn::WherePredicate>>,
     borrowed_lifetimes: BTreeSet<syn::Lifetime>,
     getter: Option<syn::Path>,
+    collection_field: bool,
 }
 
 /// Represents the default to use for a field when deserializing.
@@ -960,11 +1039,16 @@ impl Field {
             de_bound: de_bound.get(),
             borrowed_lifetimes: borrowed_lifetimes,
             getter: getter.get(),
+            collection_field: false,
         }
     }
 
     pub fn name(&self) -> &Name {
         &self.name
+    }
+
+    pub fn mark_as_collection_field(&mut self) {
+        self.collection_field = true;
     }
 
     pub fn rename_by_rule(&mut self, rule: &RenameRule) {
@@ -977,11 +1061,15 @@ impl Field {
     }
 
     pub fn skip_serializing(&self) -> bool {
-        self.skip_serializing
+        self.skip_serializing || self.collection_field
     }
 
     pub fn skip_deserializing(&self) -> bool {
-        self.skip_deserializing
+        self.skip_deserializing || self.collection_field
+    }
+
+    pub fn collection_field(&self) -> bool {
+        self.collection_field
     }
 
     pub fn skip_serializing_if(&self) -> Option<&syn::Path> {

--- a/test_suite/tests/compile-fail/conflict/collect-into-wrong-type.rs
+++ b/test_suite/tests/compile-fail/conflict/collect-into-wrong-type.rs
@@ -1,0 +1,19 @@
+// Copyright 2018 Serde Developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_use]
+extern crate serde_derive;
+
+#[derive(Serialize)] //~ ERROR: the trait bound `&std::string::String: std::iter::Iterator` is not satisfied
+#[serde(repr = "map", unknown_fields_into="other")]
+struct X {
+    a: u32,
+    other: String,
+}
+
+fn main() {}

--- a/test_suite/tests/compile-fail/conflict/repr-collect-struct.rs
+++ b/test_suite/tests/compile-fail/conflict/repr-collect-struct.rs
@@ -1,0 +1,20 @@
+// Copyright 2018 Serde Developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_use]
+extern crate serde_derive;
+
+#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+#[serde(repr = "struct", unknown_fields_into="other")]
+//~^^ HELP: #[serde(unknown_fields_into)] requires repr="map"
+struct X {
+    a: u32,
+    other: HashMap<String, String>,
+}
+
+fn main() {}

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -1295,7 +1295,7 @@ fn test_collect_other() {
         ],
     );
     assert_ser_tokens(
-        &CollectOther { a: 1, b: 2, extra: extra },
+        &CollectOther { a: 1, b: 2, extra },
         &[
             Token::Map { len: None },
             Token::Str("a"),

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -12,6 +12,7 @@
 extern crate serde_derive;
 
 extern crate serde;
+use std::collections::HashMap;
 use self::serde::{Deserialize, Deserializer, Serialize, Serializer};
 use self::serde::de::{self, Unexpected};
 
@@ -92,6 +93,14 @@ where
     a4: D,
     #[serde(skip_deserializing, default = "MyDefault::my_default")]
     a5: E,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(repr="map", unknown_fields_into="extra")]
+struct CollectOther {
+    a: u32,
+    b: u32,
+    extra: HashMap<String, u32>,
 }
 
 #[test]
@@ -1266,4 +1275,36 @@ fn test_from_into_traits() {
     assert_ser_tokens::<StructFromEnum>(&StructFromEnum(Some(5)), &[Token::None]);
     assert_ser_tokens::<StructFromEnum>(&StructFromEnum(None), &[Token::None]);
     assert_de_tokens::<StructFromEnum>(&StructFromEnum(Some(2)), &[Token::Some, Token::U32(2)]);
+}
+
+#[test]
+fn test_collect_other() {
+    let mut extra = HashMap::new();
+    extra.insert("c".into(), 3);
+    assert_de_tokens(
+        &CollectOther { a: 1, b: 2, extra: extra.clone() },
+        &[
+            Token::Map { len: None },
+            Token::Str("a"),
+            Token::U32(1),
+            Token::Str("b"),
+            Token::U32(2),
+            Token::Str("c"),
+            Token::U32(3),
+            Token::MapEnd,
+        ],
+    );
+    assert_ser_tokens(
+        &CollectOther { a: 1, b: 2, extra: extra },
+        &[
+            Token::Map { len: None },
+            Token::Str("a"),
+            Token::U32(1),
+            Token::Str("b"),
+            Token::U32(2),
+            Token::Str("c"),
+            Token::U32(3),
+            Token::MapEnd,
+        ],
+    );
 }


### PR DESCRIPTION
This PR is similar to #1177 in spirit but very different in implementation. Because of current restrictions that `serialize_field` on the struct visitor requires static strings *and* because there is a hint about the incoming field names on the struct visitor I think this "collect other things" feature currently only really works when serializing as maps.

I tried a different approach now which also adds a neat additional feature. A (struct) container can now be marked with `#[serde(repr="map")]` which serializes the struct not as a struct but as a map. This then also unlocks `#[serde(unknown_fields_into="...")]`

So the example looks slightly modified like this:

```rust
#[derive(Deserialize, Serialize, Debug)]
#[serde(unknown_fields_into="other", repr="map")]
pub struct Breadcrumb {
    #[serde(rename="type")]
    ty: String,
    timestamp: f64,
    other: HashMap<String, String>,
}
```

Unlike the other one this however has a chance of being merged I think because it can be made sound and user friendly without requiring changes to the already existing traits. In a far serde 2.0 future the `repr="map"` requirement could then be removed.

Known issues:

* calls `to_string` which does not work in `no_std`. Generally this right now does not work in `no_std` mode. That might be okay if it's shimmed properly.
* I don't like the fact that I added a second bool to some methods.
* duplicated key checking is missing
* needs tests
* the branch that decides on `__value` decoding is complex. Could need some refactoring