### PR TITLE
Special case remote = "Self"

### DIFF
--- a/test_suite/tests/test_gen.rs
+++ b/test_suite/tests/test_gen.rs
@@ -386,6 +386,10 @@ fn test_gen() {
     }
 
     #[derive(Serialize, Deserialize)]
+    #[serde(remote = "Self")]
+    struct RemoteSelf;
+
+    #[derive(Serialize, Deserialize)]
     enum ExternallyTaggedVariantWith {
         #[allow(dead_code)]
         Normal { f1: String },


### PR DESCRIPTION
The following has worked since `remote` was introduced. It generates `fn serialize` and `fn deserialize` with the same signature as `Serialize::serialize` and `Deserialize::deserialize`.

```rust
#[derive(Serialize, Deserialize)]
#[serde(remote = "RemoteSelf")]
struct RemoteSelf;
```

This PR makes the following equivalent to the above. This did not work before due to our use of the `remote` path in places where `Self` had not the right meaning.

```rust
#[derive(Serialize, Deserialize)]
#[serde(remote = "Self")]
struct RemoteSelf;
```