### PR TITLE
Prefer call site spans

### DIFF
--- a/serde_derive/src/bound.rs
+++ b/serde_derive/src/bound.rs
@@ -249,7 +249,7 @@ pub fn with_self_bound(
 }
 
 pub fn with_lifetime_bound(generics: &syn::Generics, lifetime: &str) -> syn::Generics {
-    let bound = syn::Lifetime::new(Term::intern(lifetime), Span::def_site());
+    let bound = syn::Lifetime::new(Term::intern(lifetime), Span::call_site());
     let def = syn::LifetimeDef {
         attrs: Vec::new(),
         lifetime: bound,

--- a/serde_derive/src/lib.rs
+++ b/serde_derive/src/lib.rs
@@ -41,6 +41,14 @@ extern crate proc_macro2;
 use proc_macro::TokenStream;
 use syn::DeriveInput;
 
+// Quote's default is def_site but it appears call_site is likely to stabilize
+// before def_site. Thus we try to use only call_site.
+macro_rules! quote {
+    ($($tt:tt)*) => {
+        quote_spanned!($crate::proc_macro2::Span::call_site()=> $($tt)*)
+    }
+}
+
 #[macro_use]
 mod bound;
 #[macro_use]

--- a/serde_derive_internals/src/attr.rs
+++ b/serde_derive_internals/src/attr.rs
@@ -939,10 +939,10 @@ impl Field {
                     leading_colon: None,
                     segments: Punctuated::new(),
                 };
-                path.segments.push(Ident::new("_serde", Span::def_site()).into());
-                path.segments.push(Ident::new("private", Span::def_site()).into());
-                path.segments.push(Ident::new("de", Span::def_site()).into());
-                path.segments.push(Ident::new("borrow_cow_str", Span::def_site()).into());
+                path.segments.push(Ident::new("_serde", Span::call_site()).into());
+                path.segments.push(Ident::new("private", Span::call_site()).into());
+                path.segments.push(Ident::new("de", Span::call_site()).into());
+                path.segments.push(Ident::new("borrow_cow_str", Span::call_site()).into());
                 let expr = syn::ExprPath {
                     attrs: Vec::new(),
                     qself: None,
@@ -954,10 +954,10 @@ impl Field {
                     leading_colon: None,
                     segments: Punctuated::new(),
                 };
-                path.segments.push(Ident::new("_serde", Span::def_site()).into());
-                path.segments.push(Ident::new("private", Span::def_site()).into());
-                path.segments.push(Ident::new("de", Span::def_site()).into());
-                path.segments.push(Ident::new("borrow_cow_bytes", Span::def_site()).into());
+                path.segments.push(Ident::new("_serde", Span::call_site()).into());
+                path.segments.push(Ident::new("private", Span::call_site()).into());
+                path.segments.push(Ident::new("de", Span::call_site()).into());
+                path.segments.push(Ident::new("borrow_cow_bytes", Span::call_site()).into());
                 let expr = syn::ExprPath {
                     attrs: Vec::new(),
                     qself: None,


### PR DESCRIPTION
Quote's default is def_site but it appears call_site is likely to stabilize before def_site. Thus we try to use only call_site.

```rust
macro_rules! quote {
    ($($tt:tt)*) => {
        quote_spanned!($crate::proc_macro2::Span::call_site()=> $($tt)*)
    }
}
```

@alexcrichton 