### PR TITLE
Produce error message for use of flatten within struct variant

### DIFF
--- a/serde_derive_internals/src/ast.rs
+++ b/serde_derive_internals/src/ast.rs
@@ -68,6 +68,9 @@ impl<'a> Container<'a> {
             Data::Enum(ref mut variants) => for variant in variants {
                 variant.attrs.rename_by_rule(attrs.rename_all());
                 for field in &mut variant.fields {
+                    if field.attrs.flatten() {
+                        has_flatten = true;
+                    }
                     field.attrs.rename_by_rule(variant.attrs.rename_all());
                 }
             },

--- a/serde_derive_internals/src/check.rs
+++ b/serde_derive_internals/src/check.rs
@@ -45,7 +45,9 @@ fn check_getter(cx: &Ctxt, cont: &Container) {
 fn check_flatten(cx: &Ctxt, cont: &Container) {
     match cont.data {
         Data::Enum(_) => {
-            assert!(!cont.attrs.has_flatten());
+            if cont.attrs.has_flatten() {
+                cx.error("#[serde(flatten)] cannot be used within enums");
+            }
         }
         Data::Struct(_, _) => {
             for field in cont.data.all_fields() {

--- a/test_suite/tests/compile-fail/conflict/flatten-within-enum.rs
+++ b/test_suite/tests/compile-fail/conflict/flatten-within-enum.rs
@@ -1,0 +1,21 @@
+// Copyright 2018 Serde Developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_use]
+extern crate serde_derive;
+
+#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+//~^ HELP: #[serde(flatten)] cannot be used within enums
+enum Foo {
+    A {
+        #[serde(flatten)]
+        fields: HashMap<String, String>,
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
This adds an error message for the currently unsupported use of flatten within a struct variant.

Fixes #1185