### PR TITLE
Produce error message for use of flatten in tuple structs

### DIFF
--- a/serde_derive_internals/src/check.rs
+++ b/serde_derive_internals/src/check.rs
@@ -47,10 +47,19 @@ fn check_flatten(cx: &Ctxt, cont: &Container) {
         Data::Enum(_) => {
             assert!(!cont.attrs.has_flatten());
         }
-        Data::Struct(_, _) => {
+        Data::Struct(style, _) => {
             for field in cont.data.all_fields() {
                 if !field.attrs.flatten() {
                     continue;
+                }
+                match style {
+                    Style::Tuple => {
+                        cx.error("#[serde(flatten)] cannot be used on tuple structs");
+                    }
+                    Style::Newtype => {
+                        cx.error("#[serde(flatten)] cannot be used on newtype structs");
+                    }
+                    _ => {}
                 }
                 if field.attrs.skip_serializing() {
                     cx.error(

--- a/test_suite/tests/compile-fail/conflict/flatten-newtype-struct.rs
+++ b/test_suite/tests/compile-fail/conflict/flatten-newtype-struct.rs
@@ -1,0 +1,16 @@
+// Copyright 2018 Serde Developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_use]
+extern crate serde_derive;
+
+#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+//~^ HELP: #[serde(flatten)] cannot be used on newtype structs
+struct Foo(#[serde(flatten)] HashMap<String, String>);
+
+fn main() {}

--- a/test_suite/tests/compile-fail/conflict/flatten-tuple-struct.rs
+++ b/test_suite/tests/compile-fail/conflict/flatten-tuple-struct.rs
@@ -1,0 +1,16 @@
+// Copyright 2018 Serde Developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_use]
+extern crate serde_derive;
+
+#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+//~^ HELP: #[serde(flatten)] cannot be used on tuple structs
+struct Foo(u32, #[serde(flatten)] HashMap<String, String>);
+
+fn main() {}


### PR DESCRIPTION
This adds a missing error message for unsupported flattening on tuple structs.  Fixes #1188