### PR TITLE
Support #[derive(Serialize, Deserialize)] when using associated types

### DIFF
--- a/serde_derive/src/bound.rs
+++ b/serde_derive/src/bound.rs
@@ -65,18 +65,19 @@ where
         .all_fields()
         .flat_map(|field| {
             let field_ty = field.ty;
-            let matching_generic = |t: &syn::PathSegment, g| match g {
-                &syn::GenericParam::Type(ref generic_ty)
+            let matching_generic = |t: &syn::PathSegment, g: &syn::GenericParam| match *g {
+                syn::GenericParam::Type(ref generic_ty)
                     if generic_ty.ident == t.ident => true,
                 _ => false
             };
 
             let mut field_bound: Option<syn::WherePredicate> = None;
-            if let &syn::Type::Path(ref ty_path) = field_ty {
+            if let syn::Type::Path(ref ty_path) = *field_ty {
                 field_bound = match (gen_bound_where(&field.attrs), ty_path.path.segments.first()) {
-                    (true, Some(syn::punctuated::Pair::Punctuated(ref t, _)))
-                        if generics.params.iter().fold(false, |b, g| b || matching_generic(t, g))
-                        => Some(parse_quote!(#field_ty: #trait_bound)),
+                    (true, Some(syn::punctuated::Pair::Punctuated(ref t, _))) =>
+                        if generics.params.iter().any(|g| matching_generic(t, g)) {
+                            Some(parse_quote!(#field_ty: #trait_bound))
+                        } else {None},
                     (_, _) => None
                 };
             }

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -126,7 +126,13 @@ fn build_generics(cont: &Container, borrowed: &BorrowedLifetimes) -> syn::Generi
 
     let delife = borrowed.de_lifetime();
     let de_bound = parse_quote!(_serde::Deserialize<#delife>);
-    let generics = bound::with_where_predicates_from_fields(cont, &generics, &de_bound, attr::Field::de_bound, attr::Field::deserialize_with);
+    let generics = bound::with_where_predicates_from_fields(
+        cont,
+        &generics,
+        &de_bound,
+        attr::Field::de_bound,
+        |field| field.deserialize_with().is_none() && !field.skip_deserializing()
+    );
 
     match cont.attrs.de_bound() {
         Some(predicates) => bound::with_where_predicates(&generics, predicates),

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -130,8 +130,9 @@ impl Parameters {
 fn build_generics(cont: &Container) -> syn::Generics {
     let generics = bound::without_defaults(cont.generics);
 
+    let trait_bound = parse_quote!(_serde::Serialize);
     let generics =
-        bound::with_where_predicates_from_fields(cont, &generics, attr::Field::ser_bound);
+        bound::with_where_predicates_from_fields(cont, &generics, &trait_bound, attr::Field::ser_bound, attr::Field::serialize_with);
 
     match cont.attrs.ser_bound() {
         Some(predicates) => bound::with_where_predicates(&generics, predicates),
@@ -139,7 +140,7 @@ fn build_generics(cont: &Container) -> syn::Generics {
             cont,
             &generics,
             needs_serialize_bound,
-            &parse_quote!(_serde::Serialize),
+            &trait_bound
         ),
     }
 }

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -131,8 +131,13 @@ fn build_generics(cont: &Container) -> syn::Generics {
     let generics = bound::without_defaults(cont.generics);
 
     let trait_bound = parse_quote!(_serde::Serialize);
-    let generics =
-        bound::with_where_predicates_from_fields(cont, &generics, &trait_bound, attr::Field::ser_bound, attr::Field::serialize_with);
+    let generics = bound::with_where_predicates_from_fields(
+        cont,
+        &generics,
+        &trait_bound,
+        attr::Field::ser_bound,
+        |field| field.serialize_with().is_none() && !field.skip_serializing()
+    );
 
     match cont.attrs.ser_bound() {
         Some(predicates) => bound::with_where_predicates(&generics, predicates),

--- a/test_suite/tests/test_gen.rs
+++ b/test_suite/tests/test_gen.rs
@@ -555,6 +555,14 @@ fn test_gen() {
     }
 
     assert::<AssocDerive<NoSerdeImpl>>();
+
+    #[derive(Serialize, Deserialize)]
+    struct AssocDeriveMulti<S, T: AssocSerde> {
+        s: S,
+        assoc: T::Assoc,
+    }
+
+    assert::<AssocDeriveMulti<i32, NoSerdeImpl>>();
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/test_suite/tests/test_gen.rs
+++ b/test_suite/tests/test_gen.rs
@@ -539,6 +539,22 @@ fn test_gen() {
         array: [u8; 256],
     }
     assert_ser::<BigArray>();
+
+    trait AssocSerde {
+        type Assoc;
+    }
+
+    struct NoSerdeImpl;
+    impl AssocSerde for NoSerdeImpl {
+        type Assoc = u32;
+    }
+
+    #[derive(Serialize, Deserialize)]
+    struct AssocDerive<T: AssocSerde> {
+        assoc: T::Assoc
+    }
+
+    assert::<AssocDerive<NoSerdeImpl>>();
 }
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Prior to this, structs and enums that had fields using associated types wouldn't have the appropriate where bounds set. This fixes that, meaning that this now builds:

```rust
trait Trait {
    type Assoc;
}

#[derive(Serialize)]
struct Struct<T: Trait> {
    assoc: T::Assoc,
}
```

Fixes #1208.