### PR TITLE
Mark error construction as cold code

### DIFF
--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -196,6 +196,7 @@ macro_rules! declare_error_trait {
             /// For example if we try to deserialize a String out of a JSON file
             /// containing an integer, the unexpected type is the integer and the
             /// expected type is the string.
+            #[cold]
             fn invalid_type(unexp: Unexpected, exp: &Expected) -> Self {
                 Error::custom(format_args!("invalid type: {}, expected {}", unexp, exp))
             }
@@ -213,6 +214,7 @@ macro_rules! declare_error_trait {
             /// For example if we try to deserialize a String out of some binary data
             /// that is not valid UTF-8, the unexpected value is the bytes and the
             /// expected value is a string.
+            #[cold]
             fn invalid_value(unexp: Unexpected, exp: &Expected) -> Self {
                 Error::custom(format_args!("invalid value: {}, expected {}", unexp, exp))
             }
@@ -226,12 +228,14 @@ macro_rules! declare_error_trait {
             /// The `exp` argument provides information about what data was being
             /// expected. For example `exp` might say that a tuple of size 6 was
             /// expected.
+            #[cold]
             fn invalid_length(len: usize, exp: &Expected) -> Self {
                 Error::custom(format_args!("invalid length {}, expected {}", len, exp))
             }
 
             /// Raised when a `Deserialize` enum type received a variant with an
             /// unrecognized name.
+            #[cold]
             fn unknown_variant(variant: &str, expected: &'static [&'static str]) -> Self {
                 if expected.is_empty() {
                     Error::custom(format_args!("unknown variant `{}`, there are no variants",
@@ -245,6 +249,7 @@ macro_rules! declare_error_trait {
 
             /// Raised when a `Deserialize` struct type received a field with an
             /// unrecognized name.
+            #[cold]
             fn unknown_field(field: &str, expected: &'static [&'static str]) -> Self {
                 if expected.is_empty() {
                     Error::custom(format_args!("unknown field `{}`, there are no fields",
@@ -259,12 +264,14 @@ macro_rules! declare_error_trait {
             /// Raised when a `Deserialize` struct type expected to receive a required
             /// field with a particular name but that field was not present in the
             /// input.
+            #[cold]
             fn missing_field(field: &'static str) -> Self {
                 Error::custom(format_args!("missing field `{}`", field))
             }
 
             /// Raised when a `Deserialize` struct type received more than one of the
             /// same field.
+            #[cold]
             fn duplicate_field(field: &'static str) -> Self {
                 Error::custom(format_args!("duplicate field `{}`", field))
             }

--- a/serde/src/de/value.rs
+++ b/serde/src/de/value.rs
@@ -58,6 +58,7 @@ type ErrorImpl = ();
 
 impl de::Error for Error {
     #[cfg(any(feature = "std", feature = "alloc"))]
+    #[cold]
     fn custom<T>(msg: T) -> Self
     where
         T: Display,
@@ -68,6 +69,7 @@ impl de::Error for Error {
     }
 
     #[cfg(not(any(feature = "std", feature = "alloc")))]
+    #[cold]
     fn custom<T>(msg: T) -> Self
     where
         T: Display,
@@ -78,6 +80,7 @@ impl de::Error for Error {
 }
 
 impl ser::Error for Error {
+    #[cold]
     fn custom<T>(msg: T) -> Self
     where
         T: Display,

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -277,6 +277,7 @@ mod content {
             }
         }
 
+        #[cold]
         fn unexpected(&self) -> Unexpected {
             match *self {
                 Content::Bool(b) => Unexpected::Bool(b),


### PR DESCRIPTION
This eliminates 12% of the Serde-related code in the Xi release binary as measured by:

```bash
nm -S target/release/xi-core \
    | awk '/serde/{sum += strtonum("0x"$2)} END{print sum}'
```