### PR TITLE
Build script that does nothing

### DIFF
--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -10,7 +10,8 @@ documentation = "https://docs.serde.rs/serde/"
 keywords = ["serde", "serialization", "no_std"]
 categories = ["encoding"]
 readme = "README.md"
-include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
+include = ["Cargo.toml", "build.rs", "src/**/*.rs", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
+build = "build.rs"
 
 [badges]
 travis-ci = { repository = "serde-rs/serde" }

--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -23,9 +23,6 @@ serde_derive = { version = "1.0", optional = true, path = "../serde_derive" }
 [dev-dependencies]
 serde_derive = { version = "1.0", path = "../serde_derive" }
 
-[build-dependencies]
-version_check = "0.1.3"
-
 
 ### FEATURES #################################################################
 

--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -23,6 +23,9 @@ serde_derive = { version = "1.0", optional = true, path = "../serde_derive" }
 [dev-dependencies]
 serde_derive = { version = "1.0", path = "../serde_derive" }
 
+[build-dependencies]
+version_check = "0.1.3"
+
 
 ### FEATURES #################################################################
 

--- a/serde/build.rs
+++ b/serde/build.rs
@@ -1,13 +1,39 @@
-extern crate version_check;
+use std::env;
+use std::process::Command;
+use std::str::{self, FromStr};
 
 fn main() {
-    match version_check::is_min_version("1.26.0") {
-        Some((true, _)) => {
-            println!("cargo:rustc-cfg=integer128");
-        },
-        Some((false, _)) => {}
-        None => {
-            println!("could not figure out the rustc version");
-        },
+    let rustc = match env::var_os("RUSTC") {
+        Some(rustc) => rustc,
+        None => return,
     };
+
+    let output = match Command::new(rustc).arg("--version").output() {
+        Ok(output) => output,
+        Err(_) => return,
+    };
+
+    let version = match str::from_utf8(&output.stdout) {
+        Ok(version) => version,
+        Err(_) => return,
+    };
+
+    let mut pieces = version.split('.');
+    if pieces.next() != Some("rustc 1") {
+        return;
+    }
+
+    let next = match pieces.next() {
+        Some(next) => next,
+        None => return,
+    };
+
+    let minor = match u32::from_str(next) {
+        Ok(minor) => minor,
+        Err(_) => return,
+    };
+
+    if minor >= 26 {
+        println!("cargo:rustc-cfg=integer128");
+    }
 }

--- a/serde/build.rs
+++ b/serde/build.rs
@@ -1,39 +1,13 @@
-use std::env;
-use std::process::Command;
-use std::str::{self, FromStr};
+extern crate version_check;
 
 fn main() {
-    let rustc = match env::var_os("RUSTC") {
-        Some(rustc) => rustc,
-        None => return,
+    match version_check::is_min_version("1.26.0") {
+        Some((true, _)) => {
+            println!("cargo:rustc-cfg=integer128");
+        },
+        Some((false, _)) => {}
+        None => {
+            println!("could not figure out the rustc version");
+        },
     };
-
-    let output = match Command::new(rustc).arg("--version").output() {
-        Ok(output) => output,
-        Err(_) => return,
-    };
-
-    let version = match str::from_utf8(&output.stdout) {
-        Ok(version) => version,
-        Err(_) => return,
-    };
-
-    let mut pieces = version.split('.');
-    if pieces.next() != Some("rustc 1") {
-        return;
-    }
-
-    let next = match pieces.next() {
-        Some(next) => next,
-        None => return,
-    };
-
-    let minor = match u32::from_str(next) {
-        Ok(minor) => minor,
-        Err(_) => return,
-    };
-
-    if minor >= 26 {
-        println!("cargo:rustc-cfg=integer128");
-    }
 }

--- a/serde/build.rs
+++ b/serde/build.rs
@@ -1,0 +1,39 @@
+use std::env;
+use std::process::Command;
+use std::str::{self, FromStr};
+
+fn main() {
+    let rustc = match env::var_os("RUSTC") {
+        Some(rustc) => rustc,
+        None => return,
+    };
+
+    let output = match Command::new(rustc).arg("--version").output() {
+        Ok(output) => output,
+        Err(_) => return,
+    };
+
+    let version = match str::from_utf8(&output.stdout) {
+        Ok(version) => version,
+        Err(_) => return,
+    };
+
+    let mut pieces = version.split('.');
+    if pieces.next() != Some("rustc 1") {
+        return;
+    }
+
+    let next = match pieces.next() {
+        Some(next) => next,
+        None => return,
+    };
+
+    let minor = match u32::from_str(next) {
+        Ok(minor) => minor,
+        Err(_) => return,
+    };
+
+    if minor >= 26 {
+        println!("cargo:rustc-cfg=integer128");
+    }
+}

--- a/serde/build.rs
+++ b/serde/build.rs
@@ -33,6 +33,8 @@ fn main() {
         Err(_) => return,
     };
 
+    // 128-bit integers stabilized in Rust 1.26:
+    // https://blog.rust-lang.org/2018/05/10/Rust-1.26.html
     if minor >= 26 {
         println!("cargo:rustc-cfg=integer128");
     }


### PR DESCRIPTION
Eventually we will want a build script that enables Serde impls for i128 and u128 -- https://github.com/serde-rs/serde/issues/1136. As a first step here is a build script that does nothing to see whether we can roll this out without breaking anyone's workflow, without having a supported feature at stake in the event that it needs to be rolled back.