### PR TITLE
Add Avro to the list of supported data formats

### DIFF
--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -59,6 +59,8 @@
 //!   *(deserialization only)*
 //! - [Redis], deserialize values from Redis when using [redis-rs].
 //!   *(deserialization only)*
+//! - [Avro], a binary data serialization format with support for
+//!   schematized data.
 //!
 //! [JSON]: https://github.com/serde-rs/json
 //! [Bincode]: https://github.com/TyOverby/bincode
@@ -73,6 +75,7 @@
 //! [XML]: https://github.com/RReverser/serde-xml-rs
 //! [Envy]: https://github.com/softprops/envy
 //! [Redis]: https://github.com/OneSignal/serde-redis
+//! [Avro]: https://github.com/flavray/avro-rs
 //! [Cargo]: http://doc.crates.io/manifest.html
 //! [redis-rs]: https://crates.io/crates/redis
 


### PR DESCRIPTION
Hello there,

We've been working on a serde-compatible [Apache Avro](http://avro.apache.org/docs/current/) rust client library. It supports all the main Avro features, with a serde-friendly interface.

The crate is documented, tested and (slightly 🙂) benchmarked.

Crate link: https://crates.io/crates/avro-rs
Crate repository: https://github.com/flavray/avro-rs