### PR TITLE
Remove impls for NonZero<T>

### DIFF
--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -2005,24 +2005,6 @@ where
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#[cfg(feature = "unstable")]
-#[allow(deprecated)]
-impl<'de, T> Deserialize<'de> for NonZero<T>
-where
-    T: Deserialize<'de> + Zeroable,
-{
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let value = try!(Deserialize::deserialize(deserializer));
-        match NonZero::new(value) {
-            Some(nonzero) => Ok(nonzero),
-            None => Err(Error::custom("expected a non-zero value")),
-        }
-    }
-}
-
 macro_rules! nonzero_integers {
     ( $( $T: ty, )+ ) => {
         $(

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -98,7 +98,6 @@
 //!    - Path
 //!    - PathBuf
 //!    - Range\<T\>
-//!    - NonZero\<T\> (unstable, deprecated)
 //!    - num::NonZero* (unstable)
 //!  - **Net types**:
 //!    - IpAddr

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -86,7 +86,7 @@
 // discussion of these features please refer to this issue:
 //
 //    https://github.com/serde-rs/serde/issues/812
-#![cfg_attr(feature = "unstable", feature(nonzero, specialization))]
+#![cfg_attr(feature = "unstable", feature(specialization))]
 #![cfg_attr(feature = "alloc", feature(alloc))]
 #![cfg_attr(feature = "cargo-clippy", deny(clippy, clippy_pedantic))]
 // Whitelisted clippy lints
@@ -212,10 +212,6 @@ mod lib {
     pub use std::sync::{Mutex, RwLock};
     #[cfg(feature = "std")]
     pub use std::time::{Duration, SystemTime, UNIX_EPOCH};
-
-    #[cfg(feature = "unstable")]
-    #[allow(deprecated)]
-    pub use core::nonzero::{NonZero, Zeroable};
 
     #[cfg(feature = "unstable")]
     pub use core::num::{NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize};

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -408,20 +408,6 @@ where
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#[cfg(feature = "unstable")]
-#[allow(deprecated)]
-impl<T> Serialize for NonZero<T>
-where
-    T: Serialize + Zeroable + Clone,
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        self.clone().get().serialize(serializer)
-    }
-}
-
 macro_rules! nonzero_integers {
     ( $( $T: ident, )+ ) => {
         $(

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -93,7 +93,6 @@
 //!    - Path
 //!    - PathBuf
 //!    - Range\<T\>
-//!    - NonZero\<T\> (unstable, deprecated)
 //!    - num::NonZero* (unstable)
 //!  - **Net types**:
 //!    - IpAddr


### PR DESCRIPTION
Fixes #1264. The NonZero type was removed from nightly in https://github.com/rust-lang/rust/pull/50808.