### PR TITLE
Transparent attribute to specify that representation is the same as its only field

### DIFF
--- a/serde_derive/src/internals/ast.rs
+++ b/serde_derive/src/internals/ast.rs
@@ -8,7 +8,7 @@
 
 use internals::attr;
 use internals::check;
-use internals::Ctxt;
+use internals::{Ctxt, Derive};
 use syn;
 use syn::punctuated::Punctuated;
 
@@ -47,7 +47,7 @@ pub enum Style {
 }
 
 impl<'a> Container<'a> {
-    pub fn from_ast(cx: &Ctxt, item: &'a syn::DeriveInput) -> Container<'a> {
+    pub fn from_ast(cx: &Ctxt, item: &'a syn::DeriveInput, derive: Derive) -> Container<'a> {
         let mut attrs = attr::Container::from_ast(cx, item);
 
         let mut data = match item.data {
@@ -86,13 +86,13 @@ impl<'a> Container<'a> {
             attrs.mark_has_flatten();
         }
 
-        let item = Container {
+        let mut item = Container {
             ident: item.ident.clone(),
             attrs: attrs,
             data: data,
             generics: &item.generics,
         };
-        check::check(cx, &item);
+        check::check(cx, &mut item, derive);
         item
     }
 }

--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -231,7 +231,7 @@ impl Container {
                     }
 
                     // Parse `#[serde(transparent)]`
-                    Meta(Word(word)) if word == "transparent" => {
+                    Meta(Word(ref word)) if word == "transparent" => {
                         transparent.set_true();
                     }
 

--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -776,6 +776,7 @@ pub struct Field {
     borrowed_lifetimes: BTreeSet<syn::Lifetime>,
     getter: Option<syn::ExprPath>,
     flatten: bool,
+    transparent: bool,
 }
 
 /// Represents the default to use for a field when deserializing.
@@ -1077,6 +1078,7 @@ impl Field {
             borrowed_lifetimes: borrowed_lifetimes,
             getter: getter.get(),
             flatten: flatten.get(),
+            transparent: false,
         }
     }
 
@@ -1135,6 +1137,14 @@ impl Field {
 
     pub fn flatten(&self) -> bool {
         self.flatten
+    }
+
+    pub fn transparent(&self) -> bool {
+        self.transparent
+    }
+
+    pub fn mark_transparent(&mut self) {
+        self.transparent = true;
     }
 }
 

--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -789,7 +789,6 @@ pub enum Default {
 }
 
 impl Default {
-    #[cfg(feature = "deserialize_in_place")]
     pub fn is_none(&self) -> bool {
         match *self {
             Default::None => true,

--- a/serde_derive/src/internals/check.rs
+++ b/serde_derive/src/internals/check.rs
@@ -8,19 +8,19 @@
 
 use internals::ast::{Container, Data, Field, Style};
 use internals::attr::{EnumTag, Identifier};
-use internals::Ctxt;
-use syn::Member;
+use internals::{Ctxt, Derive};
+use syn::{Member, Type};
 
 /// Cross-cutting checks that require looking at more than a single attrs
 /// object. Simpler checks should happen when parsing and building the attrs.
-pub fn check(cx: &Ctxt, cont: &Container) {
+pub fn check(cx: &Ctxt, cont: &mut Container, derive: Derive) {
     check_getter(cx, cont);
     check_flatten(cx, cont);
     check_identifier(cx, cont);
     check_variant_skip_attrs(cx, cont);
     check_internal_tag_field_name_conflict(cx, cont);
     check_adjacent_tag_conflict(cx, cont);
-    check_transparent(cx, cont);
+    check_transparent(cx, cont, derive);
 }
 
 /// Getters are only allowed inside structs (not enums) with the `remote`
@@ -280,7 +280,7 @@ fn check_adjacent_tag_conflict(cx: &Ctxt, cont: &Container) {
 }
 
 /// Enums and unit structs cannot be transparent.
-fn check_transparent(cx: &Ctxt, cont: &Container) {
+fn check_transparent(cx: &Ctxt, cont: &mut Container, derive: Derive) {
     if !cont.attrs.transparent() {
         return;
     }
@@ -293,14 +293,40 @@ fn check_transparent(cx: &Ctxt, cont: &Container) {
         cx.error("#[serde(transparent)] is not allowed with #[serde(into = \"...\")]");
     }
 
-    match cont.data {
+    let fields = match cont.data {
         Data::Enum(_) => {
             cx.error("#[serde(transparent)] is not allowed on an enum");
+            return;
         }
         Data::Struct(Style::Unit, _) => {
             cx.error("#[serde(transparent)] is not allowed on a unit struct");
+            return;
         }
-        _ => {}
+        Data::Struct(_, ref mut fields) => fields,
+    };
+
+    let mut transparent_field = None;
+
+    for field in fields {
+        if allow_transparent(field, derive) {
+            if transparent_field.is_some() {
+                cx.error("#[serde(transparent)] requires struct to have at most one transparent field");
+                return;
+            }
+            transparent_field = Some(field);
+        }
+    }
+
+    match transparent_field {
+        Some(transparent_field) => transparent_field.attrs.mark_transparent(),
+        None => match derive {
+            Derive::Serialize => {
+                cx.error("#[serde(transparent)] requires at least one field that is not skipped");
+            }
+            Derive::Deserialize => {
+                cx.error("#[serde(transparent)] requires at least one field that is neither skipped nor has a default");
+            }
+        }
     }
 }
 
@@ -308,5 +334,20 @@ fn member_message(member: &Member) -> String {
     match *member {
         Member::Named(ref ident) => format!("`{}`", ident),
         Member::Unnamed(ref i) => i.index.to_string(),
+    }
+}
+
+fn allow_transparent(field: &Field, derive: Derive) -> bool {
+    if let Type::Path(ref ty) = *field.ty {
+        if let Some(seg) = ty.path.segments.last() {
+            if seg.into_value().ident == "PhantomData" {
+                return false;
+            }
+        }
+    }
+
+    match derive {
+        Derive::Serialize => !field.attrs.skip_serializing(),
+        Derive::Deserialize => !field.attrs.skip_deserializing() && field.attrs.default().is_none(),
     }
 }

--- a/serde_derive/src/internals/mod.rs
+++ b/serde_derive/src/internals/mod.rs
@@ -14,3 +14,9 @@ pub use self::ctxt::Ctxt;
 
 mod case;
 mod check;
+
+#[derive(Copy, Clone)]
+pub enum Derive {
+    Serialize,
+    Deserialize,
+}

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -193,7 +193,7 @@ fn serialize_transparent(cont: &Container, params: &Parameters) -> Fragment {
         Data::Enum(_) => unreachable!(),
     };
 
-    let self_var = params.self_var;
+    let self_var = &params.self_var;
     let transparent_field = fields.iter().find(|f| f.attrs.transparent()).unwrap();
     let member = &transparent_field.member;
 

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -166,7 +166,9 @@ fn needs_serialize_bound(field: &attr::Field, variant: Option<&attr::Variant>) -
 }
 
 fn serialize_body(cont: &Container, params: &Parameters) -> Fragment {
-    if let Some(type_into) = cont.attrs.type_into() {
+    if cont.attrs.transparent() {
+        serialize_transparent(cont, params)
+    } else if let Some(type_into) = cont.attrs.type_into() {
         serialize_into(params, type_into)
     } else {
         match cont.data {
@@ -182,6 +184,52 @@ fn serialize_body(cont: &Container, params: &Parameters) -> Fragment {
             }
             Data::Struct(Style::Unit, _) => serialize_unit_struct(&cont.attrs),
         }
+    }
+}
+
+fn serialize_transparent(cont: &Container, params: &Parameters) -> Fragment {
+    let fields = match cont.data {
+        Data::Struct(_, ref fields) => fields,
+        Data::Enum(_) => unreachable!(),
+    };
+
+    let self_var = params.self_var;
+    let transparent_field = find_transparent_field(fields);
+    let member = &transparent_field.member;
+
+    let path = match transparent_field.attrs.serialize_with() {
+        Some(path) => quote!(#path),
+        None => quote!(_serde::Serialize::serialize),
+    };
+
+    quote_block! {
+        #path(&#self_var.#member, __serializer)
+    }
+}
+
+fn find_transparent_field<'a>(fields: &'a [Field<'a>]) -> &'a Field<'a> {
+    let mut transparent_field = None;
+
+    for field in fields {
+        if field.attrs.skip_serializing() {
+            continue;
+        }
+        if let syn::Type::Path(ref ty) = field.ty {
+            if let Some(seg) = ty.path.segments.last() {
+                if seg.into_value().ident == "PhantomData" {
+                    continue;
+                }
+            }
+        }
+        if transparent_field.is_some() {
+            panic!("Ambiguous transparent field");
+        }
+        transparent_field = Some(field);
+    }
+
+    match transparent_field {
+        Some(transparent_field) => transparent_field,
+        None => panic!("No field can be transparent"),
     }
 }
 

--- a/test_suite/tests/compile-fail/transparent/at_most_one.rs
+++ b/test_suite/tests/compile-fail/transparent/at_most_one.rs
@@ -1,0 +1,20 @@
+// Copyright 2018 Serde Developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_use]
+extern crate serde_derive;
+
+#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+#[serde(transparent)]
+struct S {
+    //~^^^ HELP: #[serde(transparent)] requires struct to have at most one transparent field
+    a: u8,
+    b: u8,
+}
+
+fn main() {}

--- a/test_suite/tests/compile-fail/transparent/de_at_least_one.rs
+++ b/test_suite/tests/compile-fail/transparent/de_at_least_one.rs
@@ -1,0 +1,22 @@
+// Copyright 2018 Serde Developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_use]
+extern crate serde_derive;
+
+#[derive(Deserialize)] //~ ERROR: proc-macro derive panicked
+#[serde(transparent)]
+struct S {
+    //~^^^ HELP: #[serde(transparent)] requires at least one field that is neither skipped nor has a default
+    #[serde(skip)]
+    a: u8,
+    #[serde(default)]
+    b: u8,
+}
+
+fn main() {}

--- a/test_suite/tests/compile-fail/transparent/ser_at_least_one.rs
+++ b/test_suite/tests/compile-fail/transparent/ser_at_least_one.rs
@@ -1,0 +1,20 @@
+// Copyright 2018 Serde Developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_use]
+extern crate serde_derive;
+
+#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+#[serde(transparent)]
+struct S {
+    //~^^^ HELP: #[serde(transparent)] requires at least one field that is not skipped
+    #[serde(skip)]
+    a: u8,
+}
+
+fn main() {}

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -15,6 +15,7 @@ extern crate serde;
 use self::serde::de::{self, Unexpected};
 use self::serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::HashMap;
+use std::marker::PhantomData;
 
 extern crate serde_test;
 use self::serde_test::{
@@ -2160,4 +2161,42 @@ fn test_flatten_option() {
         },
         &[Token::Map { len: None }, Token::MapEnd],
     );
+}
+
+#[test]
+fn test_transparent_struct() {
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    #[serde(transparent)]
+    struct Transparent {
+        #[serde(skip)]
+        a: bool,
+        b: u32,
+        #[serde(skip)]
+        c: bool,
+        d: PhantomData<()>,
+    }
+
+    assert_tokens(
+        &Transparent {
+            a: false,
+            b: 1,
+            c: false,
+            d: PhantomData,
+        },
+        &[Token::U32(1)],
+    );
+}
+
+#[test]
+fn test_transparent_tuple_struct() {
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    #[serde(transparent)]
+    struct Transparent(
+        #[serde(skip)] bool,
+        u32,
+        #[serde(skip)] bool,
+        PhantomData<()>,
+    );
+
+    assert_tokens(&Transparent(false, 1, false, PhantomData), &[Token::U32(1)]);
 }

--- a/test_suite/tests/test_gen.rs
+++ b/test_suite/tests/test_gen.rs
@@ -653,6 +653,14 @@ fn test_gen() {
             X,
         ),
     }
+
+    #[derive(Serialize, Deserialize)]
+    #[serde(transparent)]
+    struct TransparentWith {
+        #[serde(serialize_with = "ser_x")]
+        #[serde(deserialize_with = "de_x")]
+        x: X,
+    }
 }
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes #1054.