### PR TITLE
Implement for std::num::NonZero* on Rust 1.28+

### DIFF
--- a/serde/build.rs
+++ b/serde/build.rs
@@ -38,4 +38,10 @@ fn main() {
     if minor >= 26 {
         println!("cargo:rustc-cfg=integer128");
     }
+
+    // Non-zero integers stabilized in Rust 1.28:
+    // https://github.com/rust-lang/rust/pull/50808
+    if minor >= 28 {
+        println!("cargo:rustc-cfg=num_nonzero");
+    }
 }

--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -2006,16 +2006,16 @@ where
 ////////////////////////////////////////////////////////////////////////////////
 
 macro_rules! nonzero_integers {
-    ( $( $T: ty, )+ ) => {
+    ( $( $T: ident, )+ ) => {
         $(
-            #[cfg(feature = "unstable")]
-            impl<'de> Deserialize<'de> for $T {
+            #[cfg(num_nonzero)]
+            impl<'de> Deserialize<'de> for num::$T {
                 fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
                 where
                     D: Deserializer<'de>,
                 {
                     let value = try!(Deserialize::deserialize(deserializer));
-                    match <$T>::new(value) {
+                    match <num::$T>::new(value) {
                         Some(nonzero) => Ok(nonzero),
                         None => Err(Error::custom("expected a non-zero value")),
                     }

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -144,7 +144,7 @@ mod lib {
         pub use std::*;
     }
 
-    pub use self::core::{cmp, iter, mem, ops, slice, str};
+    pub use self::core::{cmp, iter, mem, num, ops, slice, str};
     pub use self::core::{f32, f64};
     pub use self::core::{i16, i32, i64, i8, isize};
     pub use self::core::{u16, u32, u64, u8, usize};
@@ -212,9 +212,6 @@ mod lib {
     pub use std::sync::{Mutex, RwLock};
     #[cfg(feature = "std")]
     pub use std::time::{Duration, SystemTime, UNIX_EPOCH};
-
-    #[cfg(feature = "unstable")]
-    pub use core::num::{NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize};
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -411,8 +411,8 @@ where
 macro_rules! nonzero_integers {
     ( $( $T: ident, )+ ) => {
         $(
-            #[cfg(feature = "unstable")]
-            impl Serialize for $T {
+            #[cfg(num_nonzero)]
+            impl Serialize for num::$T {
                 fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
                 where
                     S: Serializer,


### PR DESCRIPTION
… regardless of the `unstable` feature. Fix #1274.