### PR TITLE
Use compile_error! instead of panicking

### DIFF
--- a/serde_derive/src/lib.rs
+++ b/serde_derive/src/lib.rs
@@ -53,6 +53,7 @@ extern crate proc_macro2;
 
 mod internals;
 
+use std::str::FromStr;
 use proc_macro::TokenStream;
 use syn::DeriveInput;
 
@@ -71,7 +72,7 @@ pub fn derive_serialize(input: TokenStream) -> TokenStream {
     let input: DeriveInput = syn::parse(input).unwrap();
     match ser::expand_derive_serialize(&input) {
         Ok(expanded) => expanded.into(),
-        Err(msg) => panic!(msg),
+        Err(msg) => TokenStream::from_str(&format!("compile_error!({:?});", msg)).unwrap(),
     }
 }
 
@@ -80,6 +81,6 @@ pub fn derive_deserialize(input: TokenStream) -> TokenStream {
     let input: DeriveInput = syn::parse(input).unwrap();
     match de::expand_derive_deserialize(&input) {
         Ok(expanded) => expanded.into(),
-        Err(msg) => panic!(msg),
+        Err(msg) => TokenStream::from_str(&format!("compile_error!({:?});", msg)).unwrap(),
     }
 }

--- a/serde_derive/src/lib.rs
+++ b/serde_derive/src/lib.rs
@@ -72,7 +72,7 @@ pub fn derive_serialize(input: TokenStream) -> TokenStream {
     let input: DeriveInput = syn::parse(input).unwrap();
     match ser::expand_derive_serialize(&input) {
         Ok(expanded) => expanded.into(),
-        Err(msg) => TokenStream::from_str(&format!("compile_error!({:?});", msg)).unwrap(),
+        Err(msg) => quote! {compile_error!(#msg);}.into(),
     }
 }
 
@@ -81,6 +81,6 @@ pub fn derive_deserialize(input: TokenStream) -> TokenStream {
     let input: DeriveInput = syn::parse(input).unwrap();
     match de::expand_derive_deserialize(&input) {
         Ok(expanded) => expanded.into(),
-        Err(msg) => TokenStream::from_str(&format!("compile_error!({:?});", msg)).unwrap(),
+        Err(msg) => quote! {compile_error!(#msg);}.into(),
     }
 }

--- a/test_suite/tests/compile-fail/borrow/bad_lifetimes.rs
+++ b/test_suite/tests/compile-fail/borrow/bad_lifetimes.rs
@@ -9,9 +9,9 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Deserialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Deserialize)] //~ ERROR: 12:10: 12:21: failed to parse borrowed lifetimes: "zzz"
 struct Test<'a> {
-    #[serde(borrow = "zzz")] //~^^ HELP: failed to parse borrowed lifetimes: "zzz"
+    #[serde(borrow = "zzz")]
     s: &'a str,
 }
 

--- a/test_suite/tests/compile-fail/borrow/duplicate_lifetime.rs
+++ b/test_suite/tests/compile-fail/borrow/duplicate_lifetime.rs
@@ -9,9 +9,9 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Deserialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Deserialize)] //~ ERROR: 12:10: 12:21: duplicate borrowed lifetime `'a`
 struct Test<'a> {
-    #[serde(borrow = "'a + 'a")] //~^^ HELP: duplicate borrowed lifetime `'a`
+    #[serde(borrow = "'a + 'a")]
     s: &'a str,
 }
 

--- a/test_suite/tests/compile-fail/borrow/duplicate_variant.rs
+++ b/test_suite/tests/compile-fail/borrow/duplicate_variant.rs
@@ -12,9 +12,9 @@ extern crate serde_derive;
 #[derive(Deserialize)]
 struct Str<'a>(&'a str);
 
-#[derive(Deserialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Deserialize)] //~ ERROR: 15:10: 15:21: duplicate serde attribute `borrow`
 enum Test<'a> {
-    #[serde(borrow)] //~^^ HELP: duplicate serde attribute `borrow`
+    #[serde(borrow)]
     S(#[serde(borrow)] Str<'a>)
 }
 

--- a/test_suite/tests/compile-fail/borrow/empty_lifetimes.rs
+++ b/test_suite/tests/compile-fail/borrow/empty_lifetimes.rs
@@ -9,9 +9,9 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Deserialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Deserialize)] //~ ERROR: 12:10: 12:21: at least one lifetime must be borrowed
 struct Test<'a> {
-    #[serde(borrow = "")] //~^^ HELP: at least one lifetime must be borrowed
+    #[serde(borrow = "")]
     s: &'a str,
 }
 

--- a/test_suite/tests/compile-fail/borrow/no_lifetimes.rs
+++ b/test_suite/tests/compile-fail/borrow/no_lifetimes.rs
@@ -9,9 +9,9 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Deserialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Deserialize)] //~ ERROR: 12:10: 12:21: field `s` has no lifetimes to borrow
 struct Test {
-    #[serde(borrow)] //~^^ HELP: field `s` has no lifetimes to borrow
+    #[serde(borrow)]
     s: String,
 }
 

--- a/test_suite/tests/compile-fail/borrow/struct_variant.rs
+++ b/test_suite/tests/compile-fail/borrow/struct_variant.rs
@@ -12,9 +12,9 @@ extern crate serde_derive;
 #[derive(Deserialize)]
 struct Str<'a>(&'a str);
 
-#[derive(Deserialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Deserialize)] //~ ERROR: 15:10: 15:21: #[serde(borrow)] may only be used on newtype variants
 enum Test<'a> {
-    #[serde(borrow)] //~^^ HELP: #[serde(borrow)] may only be used on newtype variants
+    #[serde(borrow)]
     S { s: Str<'a> }
 }
 

--- a/test_suite/tests/compile-fail/borrow/wrong_lifetime.rs
+++ b/test_suite/tests/compile-fail/borrow/wrong_lifetime.rs
@@ -9,9 +9,9 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Deserialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Deserialize)] //~ ERROR: 12:10: 12:21: field `s` does not have lifetime 'b
 struct Test<'a> {
-    #[serde(borrow = "'b")] //~^^ HELP: field `s` does not have lifetime 'b
+    #[serde(borrow = "'b")]
     s: &'a str,
 }
 

--- a/test_suite/tests/compile-fail/conflict/adjacent-tag.rs
+++ b/test_suite/tests/compile-fail/conflict/adjacent-tag.rs
@@ -9,9 +9,8 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: enum tags `conflict` for type and content conflict with each other
 #[serde(tag = "conflict", content = "conflict")]
-//~^^ HELP: enum tags `conflict` for type and content conflict with each other
 enum E {
     A,
     B,

--- a/test_suite/tests/compile-fail/conflict/flatten-newtype-struct.rs
+++ b/test_suite/tests/compile-fail/conflict/flatten-newtype-struct.rs
@@ -9,8 +9,7 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
-//~^ HELP: #[serde(flatten)] cannot be used on newtype structs
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: #[serde(flatten)] cannot be used on newtype structs
 struct Foo(#[serde(flatten)] HashMap<String, String>);
 
 fn main() {}

--- a/test_suite/tests/compile-fail/conflict/flatten-skip-deserializing.rs
+++ b/test_suite/tests/compile-fail/conflict/flatten-skip-deserializing.rs
@@ -9,8 +9,7 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Deserialize)] //~ ERROR: proc-macro derive panicked
-//~^ HELP: #[serde(flatten] can not be combined with #[serde(skip_deserializing)]
+#[derive(Deserialize)] //~ ERROR: 12:10: 12:21: #[serde(flatten] can not be combined with #[serde(skip_deserializing)]
 struct Foo {
     #[serde(flatten, skip_deserializing)]
     other: Other,

--- a/test_suite/tests/compile-fail/conflict/flatten-skip-serializing-if.rs
+++ b/test_suite/tests/compile-fail/conflict/flatten-skip-serializing-if.rs
@@ -9,8 +9,7 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
-//~^ HELP: #[serde(flatten] can not be combined with #[serde(skip_serializing_if = "...")]
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: #[serde(flatten] can not be combined with #[serde(skip_serializing_if = "...")]
 struct Foo {
     #[serde(flatten, skip_serializing_if="Option::is_none")]
     other: Option<Other>,

--- a/test_suite/tests/compile-fail/conflict/flatten-skip-serializing.rs
+++ b/test_suite/tests/compile-fail/conflict/flatten-skip-serializing.rs
@@ -9,8 +9,7 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
-//~^ HELP: #[serde(flatten] can not be combined with #[serde(skip_serializing)]
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: #[serde(flatten] can not be combined with #[serde(skip_serializing)]
 struct Foo {
     #[serde(flatten, skip_serializing)]
     other: Other,

--- a/test_suite/tests/compile-fail/conflict/flatten-tuple-struct.rs
+++ b/test_suite/tests/compile-fail/conflict/flatten-tuple-struct.rs
@@ -9,8 +9,7 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
-//~^ HELP: #[serde(flatten)] cannot be used on tuple structs
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: #[serde(flatten)] cannot be used on tuple structs
 struct Foo(u32, #[serde(flatten)] HashMap<String, String>);
 
 fn main() {}

--- a/test_suite/tests/compile-fail/conflict/internal-tag.rs
+++ b/test_suite/tests/compile-fail/conflict/internal-tag.rs
@@ -9,9 +9,8 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: variant field name `conflict` conflicts with internal tag
 #[serde(tag = "conflict")]
-//~^^ HELP: variant field name `conflict` conflicts with internal tag
 enum E {
     A {
         #[serde(rename = "conflict")]

--- a/test_suite/tests/compile-fail/default-attribute/enum.rs
+++ b/test_suite/tests/compile-fail/default-attribute/enum.rs
@@ -9,8 +9,8 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Deserialize)] //~ ERROR: proc-macro derive panicked
-#[serde(default)] //~^ HELP: #[serde(default)] can only be used on structs
+#[derive(Deserialize)] //~ ERROR: 12:10: 12:21: #[serde(default)] can only be used on structs with named fields
+#[serde(default)]
 enum E {
     S { f: u8 },
 }

--- a/test_suite/tests/compile-fail/default-attribute/nameless_struct_fields.rs
+++ b/test_suite/tests/compile-fail/default-attribute/nameless_struct_fields.rs
@@ -9,8 +9,8 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Deserialize)] //~ ERROR: proc-macro derive panicked
-#[serde(default)] //~^ HELP: #[serde(default)] can only be used on structs
+#[derive(Deserialize)] //~ ERROR: 12:10: 12:21: #[serde(default)] can only be used on structs with named fields
+#[serde(default)]
 struct T(u8, u8);
 
 fn main() { }

--- a/test_suite/tests/compile-fail/duplicate-attribute/rename-and-ser.rs
+++ b/test_suite/tests/compile-fail/duplicate-attribute/rename-and-ser.rs
@@ -9,9 +9,9 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: unknown serde field attribute `serialize`
 struct S {
-    #[serde(rename="x", serialize="y")] //~^^ HELP: unknown serde field attribute `serialize`
+    #[serde(rename="x", serialize="y")]
     x: (),
 }
 

--- a/test_suite/tests/compile-fail/duplicate-attribute/rename-rename-de.rs
+++ b/test_suite/tests/compile-fail/duplicate-attribute/rename-rename-de.rs
@@ -9,10 +9,10 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: duplicate serde attribute `rename`
 struct S {
     #[serde(rename="x")]
-    #[serde(rename(deserialize="y"))] //~^^^ HELP: duplicate serde attribute `rename`
+    #[serde(rename(deserialize="y"))]
     x: (),
 }
 

--- a/test_suite/tests/compile-fail/duplicate-attribute/rename-ser-rename-ser.rs
+++ b/test_suite/tests/compile-fail/duplicate-attribute/rename-ser-rename-ser.rs
@@ -9,9 +9,9 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: duplicate serde attribute `rename`
 struct S {
-    #[serde(rename(serialize="x"), rename(serialize="y"))] //~^^ HELP: duplicate serde attribute `rename`
+    #[serde(rename(serialize="x"), rename(serialize="y"))]
     x: (),
 }
 

--- a/test_suite/tests/compile-fail/duplicate-attribute/rename-ser-rename.rs
+++ b/test_suite/tests/compile-fail/duplicate-attribute/rename-ser-rename.rs
@@ -9,10 +9,10 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: duplicate serde attribute `rename`
 struct S {
     #[serde(rename(serialize="x"))]
-    #[serde(rename="y")] //~^^^ HELP: duplicate serde attribute `rename`
+    #[serde(rename="y")]
     x: (),
 }
 

--- a/test_suite/tests/compile-fail/duplicate-attribute/rename-ser-ser.rs
+++ b/test_suite/tests/compile-fail/duplicate-attribute/rename-ser-ser.rs
@@ -9,9 +9,9 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: duplicate serde attribute `rename`
 struct S {
-    #[serde(rename(serialize="x", serialize="y"))] //~^^ HELP: duplicate serde attribute `rename`
+    #[serde(rename(serialize="x", serialize="y"))]
     x: (),
 }
 

--- a/test_suite/tests/compile-fail/duplicate-attribute/two-rename-ser.rs
+++ b/test_suite/tests/compile-fail/duplicate-attribute/two-rename-ser.rs
@@ -9,10 +9,10 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: duplicate serde attribute `rename`
 struct S {
     #[serde(rename(serialize="x"))]
-    #[serde(rename(serialize="y"))] //~^^^ HELP: duplicate serde attribute `rename`
+    #[serde(rename(serialize="y"))]
     x: (),
 }
 

--- a/test_suite/tests/compile-fail/duplicate-attribute/with-and-serialize-with.rs
+++ b/test_suite/tests/compile-fail/duplicate-attribute/with-and-serialize-with.rs
@@ -9,9 +9,9 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: duplicate serde attribute `serialize_with`
 struct S {
-    #[serde(with = "w", serialize_with = "s")] //~^^ HELP: duplicate serde attribute `serialize_with`
+    #[serde(with = "w", serialize_with = "s")]
     x: (),
 }
 

--- a/test_suite/tests/compile-fail/enum-representation/internal-tuple-variant.rs
+++ b/test_suite/tests/compile-fail/enum-representation/internal-tuple-variant.rs
@@ -9,8 +9,8 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
-#[serde(tag = "type")] //~^ HELP: #[serde(tag = "...")] cannot be used with tuple variants
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: #[serde(tag = "...")] cannot be used with tuple variants
+#[serde(tag = "type")]
 enum E {
     Tuple(u8, u8),
 }

--- a/test_suite/tests/compile-fail/enum-representation/internally-tagged-struct.rs
+++ b/test_suite/tests/compile-fail/enum-representation/internally-tagged-struct.rs
@@ -9,8 +9,8 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
-#[serde(tag = "type")] //~^ HELP: #[serde(tag = "...")] can only be used on enums
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: #[serde(tag = "...")] can only be used on enums
+#[serde(tag = "type")]
 struct S;
 
 fn main() {}

--- a/test_suite/tests/compile-fail/enum-representation/untagged-and-internal.rs
+++ b/test_suite/tests/compile-fail/enum-representation/untagged-and-internal.rs
@@ -9,9 +9,9 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: enum cannot be both untagged and internally tagged
 #[serde(untagged)]
-#[serde(tag = "type")] //~^^ HELP: enum cannot be both untagged and internally tagged
+#[serde(tag = "type")]
 enum E {
     A(u8),
     B(String),

--- a/test_suite/tests/compile-fail/enum-representation/untagged-struct.rs
+++ b/test_suite/tests/compile-fail/enum-representation/untagged-struct.rs
@@ -9,8 +9,8 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
-#[serde(untagged)] //~^ HELP: #[serde(untagged)] can only be used on enums
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: #[serde(untagged)] can only be used on enums
+#[serde(untagged)]
 struct S;
 
 fn main() {}

--- a/test_suite/tests/compile-fail/identifier/both.rs
+++ b/test_suite/tests/compile-fail/identifier/both.rs
@@ -9,8 +9,8 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Deserialize)] //~ ERROR: proc-macro derive panicked
-#[serde(field_identifier, variant_identifier)] //~^ HELP: `field_identifier` and `variant_identifier` cannot both be set
+#[derive(Deserialize)] //~ ERROR: 12:10: 12:21: `field_identifier` and `variant_identifier` cannot both be set
+#[serde(field_identifier, variant_identifier)]
 enum F {
     A,
     B,

--- a/test_suite/tests/compile-fail/identifier/field_struct.rs
+++ b/test_suite/tests/compile-fail/identifier/field_struct.rs
@@ -9,8 +9,8 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Deserialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Deserialize)] //~ ERROR: 12:10: 12:21: `field_identifier` can only be used on an enum
 #[serde(field_identifier)]
-struct S; //~^^ HELP: `field_identifier` can only be used on an enum
+struct S;
 
 fn main() {}

--- a/test_suite/tests/compile-fail/identifier/field_tuple.rs
+++ b/test_suite/tests/compile-fail/identifier/field_tuple.rs
@@ -9,11 +9,11 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Deserialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Deserialize)] //~ ERROR: 12:10: 12:21: field_identifier may only contain unit variants
 #[serde(field_identifier)]
 enum F {
     A,
-    B(u8, u8), //~^^^^ HELP: field_identifier may only contain unit variants
+    B(u8, u8),
 }
 
 fn main() {}

--- a/test_suite/tests/compile-fail/identifier/newtype_not_last.rs
+++ b/test_suite/tests/compile-fail/identifier/newtype_not_last.rs
@@ -9,11 +9,11 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Deserialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Deserialize)] //~ ERROR: 12:10: 12:21: `Other` must be the last variant
 #[serde(field_identifier)]
 enum F {
     A,
-    Other(String), //~^^^^ HELP: `Other` must be the last variant
+    Other(String),
     B,
 }
 

--- a/test_suite/tests/compile-fail/identifier/not_identifier.rs
+++ b/test_suite/tests/compile-fail/identifier/not_identifier.rs
@@ -9,10 +9,10 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Deserialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Deserialize)] //~ ERROR: 12:10: 12:21: #[serde(other)] may only be used inside a field_identifier
 enum F {
     A,
-    #[serde(other)] //~^^^ HELP: #[serde(other)] may only be used inside a field_identifier
+    #[serde(other)]
     B,
 }
 

--- a/test_suite/tests/compile-fail/identifier/not_unit.rs
+++ b/test_suite/tests/compile-fail/identifier/not_unit.rs
@@ -9,11 +9,11 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Deserialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Deserialize)] //~ ERROR: 12:10: 12:21: #[serde(other)] must be on a unit variant
 #[serde(field_identifier)]
 enum F {
     A,
-    #[serde(other)] //~^^^^ HELP: #[serde(other)] must be on a unit variant
+    #[serde(other)]
     Other(u8, u8),
 }
 

--- a/test_suite/tests/compile-fail/identifier/other_not_last.rs
+++ b/test_suite/tests/compile-fail/identifier/other_not_last.rs
@@ -9,11 +9,11 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Deserialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Deserialize)] //~ ERROR: 12:10: 12:21: #[serde(other)] must be the last variant
 #[serde(field_identifier)]
 enum F {
     A,
-    #[serde(other)] //~^^^^ HELP: #[serde(other)] must be the last variant
+    #[serde(other)]
     Other,
     B,
 }

--- a/test_suite/tests/compile-fail/identifier/serialize.rs
+++ b/test_suite/tests/compile-fail/identifier/serialize.rs
@@ -9,8 +9,8 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
-#[serde(field_identifier)] //~^ HELP: field identifiers cannot be serialized
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: field identifiers cannot be serialized
+#[serde(field_identifier)]
 enum F {
     A,
     B,

--- a/test_suite/tests/compile-fail/identifier/variant_struct.rs
+++ b/test_suite/tests/compile-fail/identifier/variant_struct.rs
@@ -9,8 +9,8 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Deserialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Deserialize)] //~ ERROR: 12:10: 12:21: `variant_identifier` can only be used on an enum
 #[serde(variant_identifier)]
-struct S; //~^^ HELP: `variant_identifier` can only be used on an enum
+struct S;
 
 fn main() {}

--- a/test_suite/tests/compile-fail/identifier/variant_tuple.rs
+++ b/test_suite/tests/compile-fail/identifier/variant_tuple.rs
@@ -9,11 +9,11 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Deserialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Deserialize)] //~ ERROR: 12:10: 12:21: variant_identifier may only contain unit variants
 #[serde(variant_identifier)]
 enum F {
     A,
-    B(u8, u8), //~^^^^ HELP: variant_identifier may only contain unit variants
+    B(u8, u8),
 }
 
 fn main() {}

--- a/test_suite/tests/compile-fail/precondition/deserialize_de_lifetime.rs
+++ b/test_suite/tests/compile-fail/precondition/deserialize_de_lifetime.rs
@@ -9,7 +9,7 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Deserialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Deserialize)] //~ ERROR: 12:10: 12:21: cannot deserialize when there is a lifetime parameter called 'de
 struct S<'de> {
-    s: &'de str, //~^^ HELP: cannot deserialize when there is a lifetime parameter called 'de
+    s: &'de str,
 }

--- a/test_suite/tests/compile-fail/precondition/deserialize_dst.rs
+++ b/test_suite/tests/compile-fail/precondition/deserialize_dst.rs
@@ -9,8 +9,8 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Deserialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Deserialize)] //~ ERROR: 12:10: 12:21: cannot deserialize a dynamically sized struct
 struct S {
     string: String,
-    slice: [u8], //~^^^ HELP: cannot deserialize a dynamically sized struct
+    slice: [u8],
 }

--- a/test_suite/tests/compile-fail/remote/bad_getter.rs
+++ b/test_suite/tests/compile-fail/remote/bad_getter.rs
@@ -15,10 +15,10 @@ mod remote {
     }
 }
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Serialize)] //~ ERROR: 18:10: 18:19: failed to parse path: "~~~"
 #[serde(remote = "remote::S")]
 struct S {
-    #[serde(getter = "~~~")] //~^^^ HELP: failed to parse path: "~~~"
+    #[serde(getter = "~~~")]
     a: u8,
 }
 

--- a/test_suite/tests/compile-fail/remote/bad_remote.rs
+++ b/test_suite/tests/compile-fail/remote/bad_remote.rs
@@ -15,8 +15,8 @@ mod remote {
     }
 }
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
-#[serde(remote = "~~~")] //~^ HELP: failed to parse path: "~~~"
+#[derive(Serialize)] //~ ERROR: 18:10: 18:19: failed to parse path: "~~~"
+#[serde(remote = "~~~")]
 struct S {
     a: u8,
 }

--- a/test_suite/tests/compile-fail/remote/enum_getter.rs
+++ b/test_suite/tests/compile-fail/remote/enum_getter.rs
@@ -15,11 +15,11 @@ mod remote {
     }
 }
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Serialize)] //~ ERROR: 18:10: 18:19: #[serde(getter = "...")] is not allowed in an enum
 #[serde(remote = "remote::E")]
 pub enum E {
     A {
-        #[serde(getter = "get_a")] //~^^^^ HELP: #[serde(getter = "...")] is not allowed in an enum
+        #[serde(getter = "get_a")]
         a: u8,
     }
 }

--- a/test_suite/tests/compile-fail/remote/nonremote_getter.rs
+++ b/test_suite/tests/compile-fail/remote/nonremote_getter.rs
@@ -9,9 +9,9 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: #[serde(getter = "...")] can only be used in structs that have #[serde(remote = "...")]
 struct S {
-    #[serde(getter = "S::get")] //~^^ HELP: #[serde(getter = "...")] can only be used in structs that have #[serde(remote = "...")]
+    #[serde(getter = "S::get")]
     a: u8,
 }
 

--- a/test_suite/tests/compile-fail/transparent/at_most_one.rs
+++ b/test_suite/tests/compile-fail/transparent/at_most_one.rs
@@ -9,10 +9,9 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: #[serde(transparent)] requires struct to have at most one transparent field
 #[serde(transparent)]
 struct S {
-    //~^^^ HELP: #[serde(transparent)] requires struct to have at most one transparent field
     a: u8,
     b: u8,
 }

--- a/test_suite/tests/compile-fail/transparent/de_at_least_one.rs
+++ b/test_suite/tests/compile-fail/transparent/de_at_least_one.rs
@@ -9,10 +9,9 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Deserialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Deserialize)] //~ ERROR: 12:10: 12:21: #[serde(transparent)] requires at least one field that is neither skipped nor has a default
 #[serde(transparent)]
 struct S {
-    //~^^^ HELP: #[serde(transparent)] requires at least one field that is neither skipped nor has a default
     #[serde(skip)]
     a: u8,
     #[serde(default)]

--- a/test_suite/tests/compile-fail/transparent/ser_at_least_one.rs
+++ b/test_suite/tests/compile-fail/transparent/ser_at_least_one.rs
@@ -9,10 +9,9 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: #[serde(transparent)] requires at least one field that is not skipped
 #[serde(transparent)]
 struct S {
-    //~^^^ HELP: #[serde(transparent)] requires at least one field that is not skipped
     #[serde(skip)]
     a: u8,
 }

--- a/test_suite/tests/compile-fail/type-attribute/from.rs
+++ b/test_suite/tests/compile-fail/type-attribute/from.rs
@@ -9,8 +9,8 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Deserialize)] //~ ERROR: proc-macro derive panicked
-#[serde(from = "Option<T")] //~^ HELP: failed to parse type: from = "Option<T"
+#[derive(Deserialize)] //~ ERROR: 12:10: 12:21: failed to parse type: from = "Option<T"
+#[serde(from = "Option<T")]
 enum TestOne {
     Testing,
     One,

--- a/test_suite/tests/compile-fail/type-attribute/into.rs
+++ b/test_suite/tests/compile-fail/type-attribute/into.rs
@@ -9,8 +9,8 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
-#[serde(into = "Option<T")] //~^ HELP: failed to parse type: into = "Option<T"
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: failed to parse type: into = "Option<T"
+#[serde(into = "Option<T")]
 enum TestOne {
     Testing,
     One,

--- a/test_suite/tests/compile-fail/unknown-attribute/container.rs
+++ b/test_suite/tests/compile-fail/unknown-attribute/container.rs
@@ -9,8 +9,8 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
-#[serde(abc="xyz")] //~^ HELP: unknown serde container attribute `abc`
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: unknown serde container attribute `abc`
+#[serde(abc="xyz")]
 struct A {
     x: u32,
 }

--- a/test_suite/tests/compile-fail/unknown-attribute/field.rs
+++ b/test_suite/tests/compile-fail/unknown-attribute/field.rs
@@ -9,9 +9,9 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: unknown serde field attribute `abc`
 struct C {
-    #[serde(abc="xyz")] //~^^ HELP: unknown serde field attribute `abc`
+    #[serde(abc="xyz")]
     x: u32,
 }
 

--- a/test_suite/tests/compile-fail/unknown-attribute/variant.rs
+++ b/test_suite/tests/compile-fail/unknown-attribute/variant.rs
@@ -9,9 +9,9 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: unknown serde variant attribute `abc`
 enum E {
-    #[serde(abc="xyz")] //~^^ HELP: unknown serde variant attribute `abc`
+    #[serde(abc="xyz")]
     V,
 }
 

--- a/test_suite/tests/compile-fail/with-variant/skip_de_newtype_field.rs
+++ b/test_suite/tests/compile-fail/with-variant/skip_de_newtype_field.rs
@@ -9,8 +9,7 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Deserialize)] //~ ERROR: proc-macro derive panicked
-//~^ HELP: variant `Newtype` cannot have both #[serde(deserialize_with)] and a field 0 marked with #[serde(skip_deserializing)]
+#[derive(Deserialize)] //~ ERROR: 12:10: 12:21: variant `Newtype` cannot have both #[serde(deserialize_with)] and a field 0 marked with #[serde(skip_deserializing)]
 enum Enum {
     #[serde(deserialize_with = "deserialize_some_newtype_variant")]
     Newtype(#[serde(skip_deserializing)] String),

--- a/test_suite/tests/compile-fail/with-variant/skip_de_struct_field.rs
+++ b/test_suite/tests/compile-fail/with-variant/skip_de_struct_field.rs
@@ -9,8 +9,7 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Deserialize)] //~ ERROR: proc-macro derive panicked
-//~^ HELP: variant `Struct` cannot have both #[serde(deserialize_with)] and a field `f1` marked with #[serde(skip_deserializing)]
+#[derive(Deserialize)] //~ ERROR: 12:10: 12:21: variant `Struct` cannot have both #[serde(deserialize_with)] and a field `f1` marked with #[serde(skip_deserializing)]
 enum Enum {
     #[serde(deserialize_with = "deserialize_some_other_variant")]
     Struct {

--- a/test_suite/tests/compile-fail/with-variant/skip_de_tuple_field.rs
+++ b/test_suite/tests/compile-fail/with-variant/skip_de_tuple_field.rs
@@ -9,8 +9,7 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Deserialize)] //~ ERROR: proc-macro derive panicked
-//~^ HELP: variant `Tuple` cannot have both #[serde(deserialize_with)] and a field 0 marked with #[serde(skip_deserializing)]
+#[derive(Deserialize)] //~ ERROR: 12:10: 12:21: variant `Tuple` cannot have both #[serde(deserialize_with)] and a field 0 marked with #[serde(skip_deserializing)]
 enum Enum {
     #[serde(deserialize_with = "deserialize_some_other_variant")]
     Tuple(#[serde(skip_deserializing)] String, u8),

--- a/test_suite/tests/compile-fail/with-variant/skip_de_whole_variant.rs
+++ b/test_suite/tests/compile-fail/with-variant/skip_de_whole_variant.rs
@@ -9,8 +9,7 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Deserialize)] //~ ERROR: proc-macro derive panicked
-//~^ HELP: variant `Unit` cannot have both #[serde(deserialize_with)] and #[serde(skip_deserializing)]
+#[derive(Deserialize)] //~ ERROR: 12:10: 12:21: variant `Unit` cannot have both #[serde(deserialize_with)] and #[serde(skip_deserializing)]
 enum Enum {
     #[serde(deserialize_with = "deserialize_some_unit_variant")]
     #[serde(skip_deserializing)]

--- a/test_suite/tests/compile-fail/with-variant/skip_ser_newtype_field.rs
+++ b/test_suite/tests/compile-fail/with-variant/skip_ser_newtype_field.rs
@@ -9,8 +9,7 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
-//~^ HELP: variant `Newtype` cannot have both #[serde(serialize_with)] and a field 0 marked with #[serde(skip_serializing)]
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: variant `Newtype` cannot have both #[serde(serialize_with)] and a field 0 marked with #[serde(skip_serializing)]
 enum Enum {
     #[serde(serialize_with = "serialize_some_newtype_variant")]
     Newtype(#[serde(skip_serializing)] String),

--- a/test_suite/tests/compile-fail/with-variant/skip_ser_newtype_field_if.rs
+++ b/test_suite/tests/compile-fail/with-variant/skip_ser_newtype_field_if.rs
@@ -9,8 +9,7 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
-//~^ HELP: variant `Newtype` cannot have both #[serde(serialize_with)] and a field 0 marked with #[serde(skip_serializing_if)]
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: variant `Newtype` cannot have both #[serde(serialize_with)] and a field 0 marked with #[serde(skip_serializing_if)]
 enum Enum {
     #[serde(serialize_with = "serialize_some_newtype_variant")]
     Newtype(#[serde(skip_serializing_if = "always")] String),

--- a/test_suite/tests/compile-fail/with-variant/skip_ser_struct_field.rs
+++ b/test_suite/tests/compile-fail/with-variant/skip_ser_struct_field.rs
@@ -9,8 +9,7 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
-//~^ HELP: variant `Struct` cannot have both #[serde(serialize_with)] and a field `f1` marked with #[serde(skip_serializing)]
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: variant `Struct` cannot have both #[serde(serialize_with)] and a field `f1` marked with #[serde(skip_serializing)]
 enum Enum {
     #[serde(serialize_with = "serialize_some_other_variant")]
     Struct {

--- a/test_suite/tests/compile-fail/with-variant/skip_ser_struct_field_if.rs
+++ b/test_suite/tests/compile-fail/with-variant/skip_ser_struct_field_if.rs
@@ -9,8 +9,7 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
-//~^ HELP: variant `Struct` cannot have both #[serde(serialize_with)] and a field `f1` marked with #[serde(skip_serializing_if)]
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: variant `Struct` cannot have both #[serde(serialize_with)] and a field `f1` marked with #[serde(skip_serializing_if)]
 enum Enum {
     #[serde(serialize_with = "serialize_some_newtype_variant")]
     Struct {

--- a/test_suite/tests/compile-fail/with-variant/skip_ser_tuple_field.rs
+++ b/test_suite/tests/compile-fail/with-variant/skip_ser_tuple_field.rs
@@ -9,8 +9,7 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
-//~^ HELP: variant `Tuple` cannot have both #[serde(serialize_with)] and a field 0 marked with #[serde(skip_serializing)]
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: variant `Tuple` cannot have both #[serde(serialize_with)] and a field 0 marked with #[serde(skip_serializing)]
 enum Enum {
     #[serde(serialize_with = "serialize_some_other_variant")]
     Tuple(#[serde(skip_serializing)] String, u8),

--- a/test_suite/tests/compile-fail/with-variant/skip_ser_tuple_field_if.rs
+++ b/test_suite/tests/compile-fail/with-variant/skip_ser_tuple_field_if.rs
@@ -9,8 +9,7 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
-//~^ HELP: variant `Tuple` cannot have both #[serde(serialize_with)] and a field 0 marked with #[serde(skip_serializing_if)]
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: variant `Tuple` cannot have both #[serde(serialize_with)] and a field 0 marked with #[serde(skip_serializing_if)]
 enum Enum {
     #[serde(serialize_with = "serialize_some_other_variant")]
     Tuple(#[serde(skip_serializing_if = "always")] String, u8),

--- a/test_suite/tests/compile-fail/with-variant/skip_ser_whole_variant.rs
+++ b/test_suite/tests/compile-fail/with-variant/skip_ser_whole_variant.rs
@@ -9,8 +9,7 @@
 #[macro_use]
 extern crate serde_derive;
 
-#[derive(Serialize)] //~ ERROR: proc-macro derive panicked
-//~^ HELP: variant `Unit` cannot have both #[serde(serialize_with)] and #[serde(skip_serializing)]
+#[derive(Serialize)] //~ ERROR: 12:10: 12:19: variant `Unit` cannot have both #[serde(serialize_with)] and #[serde(skip_serializing)]
 enum Enum {
     #[serde(serialize_with = "serialize_some_unit_variant")]
     #[serde(skip_serializing)]


### PR DESCRIPTION
As a side effect, this changes error messages from:

```
error: proc-macro derive panicked
   --> test_suite/tests/test_ser.rs:597:10
    |
597 | #[derive(Serialize)]
    |          ^^^^^^^^^
    |
    = help: message: 2 errors:
                # unknown serde field attribute `typo`
                # expected serde with attribute to be a string: `with = "..."`
```

to

```
error: 2 errors:
    # unknown serde field attribute `typo`
    # expected serde with attribute to be a string: `with = "..."`
   --> test_suite/tests/test_ser.rs:597:10
    |
597 | #[derive(Serialize)]
    |          ^^^^^^^^^
```