### PR TITLE
CI builders for all versions mentioned in the build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,15 @@ cache: cargo
 
 # run builds for all the trains (and more)
 rust:
-  - 1.13.0
-  - 1.15.0
   - stable
   - beta
   - nightly
+  - 1.13.0
+  - 1.15.0
+  - 1.20.0
+  - 1.21.0
+  - 1.25.0
+  - 1.26.0
 
 matrix:
   include:

--- a/travis.sh
+++ b/travis.sh
@@ -93,4 +93,12 @@ else
     cargo clean
     cd "$DIR/serde_derive"
     channel build
+
+    for CHANNEL in 1.20.0 1.21.0 1.25.0 1.26.0; do
+        cd "$DIR"
+        cargo clean
+        cd "$DIR/serde"
+        channel build --no-default-features
+        channel build
+    done
 fi


### PR DESCRIPTION
As suggested in #1303. Thanks!

This should prevent accidentally inserting something under one of these cfgs that is available only on a newer rustc. For example if something is changed in the Duration serialization, but that change works only on a recent rustc, our test suite will not have caught it before.

In the interest of not taking forever to build in Travis, this only does a quick `cargo build --no-default-features` and `cargo build` of the serde crate on these versions.