### PR TITLE
Special trait for deserialize_any

### DIFF
--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -559,6 +559,14 @@ pub trait Deserialize<'de>: Sized {
         *place = Deserialize::deserialize(deserializer)?;
         Ok(())
     }
+
+    #[warn(missing_docs)] //TODO
+    fn deserialize_with_any<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: DeserializerAny<'de>,
+    {
+        Self::deserialize(deserializer)
+    }
 }
 
 /// A data structure that can be deserialized without borrowing any data from
@@ -904,6 +912,11 @@ pub trait Deserializer<'de>: Sized {
     /// `Deserializer::deserialize_any` means your data type will be able to
     /// deserialize from self-describing formats only, ruling out Bincode and
     /// many others.
+    ///
+    /// # Deprecated
+    ///
+    /// TODO
+    #[deprecated]
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>;
@@ -1207,6 +1220,13 @@ pub trait Deserializer<'de>: Sized {
     fn is_human_readable(&self) -> bool {
         true
     }
+}
+
+#[warn(missing_docs)] //TODO
+pub trait DeserializerAny<'de>: Deserializer<'de> {
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, <Self as Deserializer<'de>>::Error>
+    where
+        V: Visitor<'de>;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -246,6 +246,14 @@ pub trait Serialize {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer;
+
+    #[warn(missing_docs)] //TODO
+    fn serialize_with_any<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer
+    {
+        self.serialize(serializer)
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Related issue: #1310 

Prototype implementation of the features discussed in related issue #1310. The goal is to create an effective way to distinguish "self-describing" data formats, the ones that can determine the type of the object during deserialization and can therefore implement  `Deserializer::deserialize_any`.  Currently this is being done by moving `deserialize_any` to a new trait so this check can be performed at compile-time.

The names that I have given to the new traits and functions are placeholders until we decide on proper names; I don't know what I want to call them yet.

Comments, suggestions, commits from maintainers, and any other contributions are more than welcome. This is my first time messing around in Serde source code, so I'm not familiar with a lot of the conventions and available utilities.

**TODO**

- [ ] Proper names
- [ ] Replace deprecated calls (should fix errors, wait until names are finalized)
- [ ] Documentation/doctests (wait until names are finalized)
- [ ] New tests?