### PR TITLE
Use `cfg guards` if `cargo-test` is used for no-std

### DIFF
--- a/test_suite/no_std/src/main.rs
+++ b/test_suite/no_std/src/main.rs
@@ -16,10 +16,12 @@ fn start(_argc: isize, _argv: *const *const u8) -> isize {
     0
 }
 
+#[cfg(not(test))]
 #[lang = "eh_personality"]
 #[no_mangle]
 pub extern "C" fn rust_eh_personality() {}
 
+#[cfg(not(test))]
 #[panic_implementation]
 fn panic(_info: &core::panic::PanicInfo) -> ! {
     unsafe {


### PR DESCRIPTION
Hey,

Unit tests are built for the host machine with the std library included, so I guess it's better to add guards for this. 

Even though, it seems like you don't test this via `cargo test`?!

However, if a I run
```bash
$ cargo test -p serde_derive_tests_no_std
   Compiling serde_derive_tests_no_std v0.0.0 (file:///home/niklasad1/Github/serde/test_suite/no_std)
error[E0152]: duplicate lang item found: `eh_personality`.
  --> src/main.rs:22:1
   |
22 | pub extern "C" fn rust_eh_personality() {}
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: first defined in crate `panic_unwind`.

error[E0152]: duplicate lang item found: `panic_impl`.
  --> src/main.rs:26:1
   |
26 | / fn panic(_info: &core::panic::PanicInfo) -> ! {
27 | |     unsafe {
28 | |         libc::abort();
29 | |     }
30 | | }
   | |_^
   |
   = note: first defined in crate `std`.

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0152`.
error: Could not compile `serde_derive_tests_no_std`.
```

With this change, it compiles successfully!

