### PR TITLE
Suppress 'extern crate' warning for rust 2018

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -74,6 +74,7 @@ pub fn expand_derive_deserialize(input: &syn::DeriveInput) -> Result<TokenStream
         #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
         const #dummy_const: () = {
             #[allow(unknown_lints)]
+            #[cfg_attr(feature = "cargo-clippy", allow(useless_attribute))]
             #[allow(rust_2018_idioms)]
             extern crate serde as _serde;
             #try_replacement

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -73,6 +73,8 @@ pub fn expand_derive_deserialize(input: &syn::DeriveInput) -> Result<TokenStream
     let generated = quote! {
         #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
         const #dummy_const: () = {
+            #[allow(unknown_lints)]
+            #[allow(rust_2018_idioms)]
             extern crate serde as _serde;
             #try_replacement
             #impl_block

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -61,6 +61,8 @@ pub fn expand_derive_serialize(input: &syn::DeriveInput) -> Result<TokenStream, 
     let generated = quote! {
         #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
         const #dummy_const: () = {
+            #[allow(unknown_lints)]
+            #[allow(rust_2018_idioms)]
             extern crate serde as _serde;
             #try_replacement
             #impl_block

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -62,6 +62,7 @@ pub fn expand_derive_serialize(input: &syn::DeriveInput) -> Result<TokenStream, 
         #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
         const #dummy_const: () = {
             #[allow(unknown_lints)]
+            #[cfg_attr(feature = "cargo-clippy", allow(useless_attribute))]
             #[allow(rust_2018_idioms)]
             extern crate serde as _serde;
             #try_replacement


### PR DESCRIPTION
With the 2018 preview, and presumably when the edition is officially released, `extern crate` will be unidiomatic, and will generate warnings.

This suppresses the warning for the `extern crate` generated in the `Serialize` and `Deserialize` derives.