### PR TITLE
Add SemVer stability badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Serde &emsp; [![Build Status]][travis] [![Latest Version]][crates.io] [![Rustc Version 1.13+]][rustc]
+# Serde &emsp; [![Build Status]][travis] [![Latest Version]][crates.io] [![Rustc Version 1.13+]][rustc] [![SemVer Stability]][dependabot]
 
 [Build Status]: https://api.travis-ci.org/serde-rs/serde.svg?branch=master
 [travis]: https://travis-ci.org/serde-rs/serde
@@ -6,6 +6,8 @@
 [crates.io]: https://crates.io/crates/serde
 [Rustc Version 1.13+]: https://img.shields.io/badge/rustc-1.13+-lightgray.svg
 [rustc]: https://blog.rust-lang.org/2016/11/10/Rust-1.13.html
+[SemVer Stability]: https://api.dependabot.com/badges/compatibility_score?dependency-name=serde&package-manager=cargo&version-scheme=semver
+[dependabot]: https://dependabot.com/compatibility-score.html?dependency-name=serde&package-manager=cargo&version-scheme=semver
 
 **Serde is a framework for *ser*ializing and *de*serializing Rust data structures efficiently and generically.**
 


### PR DESCRIPTION
Adds a SemVer stability badge to the readme that displays the percentage of CI runs that pass when updating `serde` between SemVer compatible versions. Data comes from Dependabot (disclosure: I built it).

Here's what the badge looks like:

[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=serde&package-manager=cargo&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=serde&package-manager=cargo&version-scheme=semver)

The score isn't quite 100%, maybe because of users' flaky tests. I do my best to filter those out, but hopefully a 98% score still makes it clear that users can be confident that serde follows SemVer pretty much perfectly 🙂