### PR TITLE
Customizable buffer type by Deserializer

### DIFF
--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -1204,6 +1204,27 @@ pub trait Deserializer<'de>: Sized {
     fn is_human_readable(&self) -> bool {
         true
     }
+
+    /// TODO
+    #[cfg(any(feature = "std", feature = "alloc"))]
+    fn call_with_buffer<F>(callback: F) -> F::Value
+    where
+        F: WithBuffer<'de, Self::Error>,
+    {
+        callback.run::<super::private::de::Content>()
+    }
+}
+
+/// TODO
+#[cfg(any(feature = "std", feature = "alloc"))]
+pub trait WithBuffer<'de, E: Error> {
+    /// TODO
+    type Value;
+    /// TODO
+    fn run<B>(self) -> Self::Value
+    where
+        B: Deserialize<'de> + IntoDeserializer<'de, E>,
+        for<'a> &'a B: IntoDeserializer<'de, E>;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1703,6 +1724,15 @@ pub trait SeqAccess<'de> {
     fn size_hint(&self) -> Option<usize> {
         None
     }
+
+    /// TODO
+    #[cfg(any(feature = "std", feature = "alloc"))]
+    fn call_with_buffer<F>(callback: F) -> F::Value
+    where
+        F: WithBuffer<'de, Self::Error>,
+    {
+        callback.run::<super::private::de::Content>()
+    }
 }
 
 impl<'de, 'a, A> SeqAccess<'de> for &'a mut A
@@ -1730,6 +1760,14 @@ where
     #[inline]
     fn size_hint(&self) -> Option<usize> {
         (**self).size_hint()
+    }
+
+    #[cfg(any(feature = "std", feature = "alloc"))]
+    fn call_with_buffer<F>(callback: F) -> F::Value
+    where
+        F: WithBuffer<'de, Self::Error>,
+    {
+        A::call_with_buffer(callback)
     }
 }
 
@@ -1856,6 +1894,15 @@ pub trait MapAccess<'de> {
     fn size_hint(&self) -> Option<usize> {
         None
     }
+
+    /// TODO
+    #[cfg(any(feature = "std", feature = "alloc"))]
+    fn call_with_buffer<F>(callback: F) -> F::Value
+    where
+        F: WithBuffer<'de, Self::Error>,
+    {
+        callback.run::<super::private::de::Content>()
+    }
 }
 
 impl<'de, 'a, A> MapAccess<'de> for &'a mut A
@@ -1921,6 +1968,14 @@ where
     #[inline]
     fn size_hint(&self) -> Option<usize> {
         (**self).size_hint()
+    }
+
+    #[cfg(any(feature = "std", feature = "alloc"))]
+    fn call_with_buffer<F>(callback: F) -> F::Value
+    where
+        F: WithBuffer<'de, Self::Error>,
+    {
+        A::call_with_buffer(callback)
     }
 }
 

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -2412,6 +2412,28 @@ mod content {
         }
     }
 
+    impl<'de, E> de::IntoDeserializer<'de, E> for Content<'de>
+    where
+        E: de::Error,
+    {
+        type Deserializer = ContentDeserializer<'de, E>;
+
+        fn into_deserializer(self) -> Self::Deserializer {
+            ContentDeserializer::new(self)
+        }
+    }
+
+    impl<'a, 'de, E> de::IntoDeserializer<'de, E> for &'a Content<'de>
+    where
+        E: de::Error,
+    {
+        type Deserializer = ContentRefDeserializer<'a, 'de, E>;
+
+        fn into_deserializer(self) -> Self::Deserializer {
+            ContentRefDeserializer::new(self)
+        }
+    }
+
     impl<'de, E> de::IntoDeserializer<'de, E> for ContentDeserializer<'de, E>
     where
         E: de::Error,

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1314,6 +1314,8 @@ fn deserialize_adjacently_tagged_enum(
     let (de_impl_generics, de_ty_generics, ty_generics, where_clause) =
         split_with_de_lifetime(params);
     let delife = params.borrowed.de_lifetime();
+    let callback_impl_generics = CallbackImplGenerics(params, parse_quote!(__A: _serde::de::MapAccess<#delife>));
+    let callback_ty_generics = CallbackTypeGenerics(params, parse_quote!(__A));
 
     let variant_names_idents: Vec<_> = variants
         .iter()
@@ -1542,24 +1544,43 @@ fn deserialize_adjacently_tagged_enum(
                     }
                     // First key is the content.
                     _serde::export::Some(_serde::private::de::TagOrContentField::Content) => {
-                        // Buffer up the content.
-                        let __content = try!(_serde::de::MapAccess::next_value::<_serde::private::de::Content>(&mut __map));
-                        // Visit the second key.
-                        match #next_relevant_key {
-                            // Second key is the tag.
-                            _serde::export::Some(_serde::private::de::TagOrContentField::Tag) => {
-                                let __deserializer = _serde::private::de::ContentDeserializer::<__A::Error>::new(__content);
-                                #finish_content_then_tag
-                            }
-                            // Second key is a duplicate of the content.
-                            _serde::export::Some(_serde::private::de::TagOrContentField::Content) => {
-                                _serde::export::Err(<__A::Error as _serde::de::Error>::duplicate_field(#content))
-                            }
-                            // There is no second key.
-                            _serde::export::None => {
-                                _serde::export::Err(<__A::Error as _serde::de::Error>::missing_field(#tag))
+                        struct __Callback #callback_impl_generics #where_clause {
+                            map: __A,
+                            marker: _serde::export::PhantomData<#this #ty_generics>,
+                            lifetime: _serde::export::PhantomData<&#delife ()>,
+                        }
+                        impl #callback_impl_generics _serde::de::WithBuffer<#delife, __A::Error> for __Callback #callback_ty_generics #where_clause {
+                            type Value = _serde::export::Result<#this #ty_generics, __A::Error>;
+                            fn run<__Buffer>(self) -> Self::Value
+                            where
+                                __Buffer: _serde::Deserialize<#delife> + _serde::de::IntoDeserializer<#delife, __A::Error>,
+                            {
+                                let mut __map = self.map;
+                                // Buffer up the content.
+                                let __content = try!(_serde::de::MapAccess::next_value::<__Buffer>(&mut __map));
+                                // Visit the second key.
+                                match #next_relevant_key {
+                                    // Second key is the tag.
+                                    _serde::export::Some(_serde::private::de::TagOrContentField::Tag) => {
+                                        let __deserializer = _serde::de::IntoDeserializer::into_deserializer(__content);
+                                        #finish_content_then_tag
+                                    }
+                                    // Second key is a duplicate of the content.
+                                    _serde::export::Some(_serde::private::de::TagOrContentField::Content) => {
+                                        _serde::export::Err(<__A::Error as _serde::de::Error>::duplicate_field(#content))
+                                    }
+                                    // There is no second key.
+                                    _serde::export::None => {
+                                        _serde::export::Err(<__A::Error as _serde::de::Error>::missing_field(#tag))
+                                    }
+                                }
                             }
                         }
+                        __A::call_with_buffer(__Callback {
+                            map: __map,
+                            marker: _serde::export::PhantomData,
+                            lifetime: _serde::export::PhantomData,
+                        })
                     }
                     // There is no first key.
                     _serde::export::None => {
@@ -1611,6 +1632,12 @@ fn deserialize_untagged_enum(
     variants: &[Variant],
     cattrs: &attr::Container,
 ) -> Fragment {
+    let this = &params.this;
+    let (_, ty_generics, where_clause) = params.generics.split_for_impl();
+    let delife = params.borrowed.de_lifetime();
+    let callback_impl_generics = CallbackImplGenerics(params, parse_quote!(__D: _serde::Deserializer<#delife>));
+    let callback_ty_generics = CallbackTypeGenerics(params, parse_quote!(__D));
+
     let attempts = variants
         .iter()
         .filter(|variant| !variant.attrs.skip_deserializing())
@@ -1619,7 +1646,7 @@ fn deserialize_untagged_enum(
                 params,
                 variant,
                 cattrs,
-                quote!(_serde::private::de::ContentRefDeserializer::<__D::Error>::new(&__content)),
+                quote!(_serde::de::IntoDeserializer::into_deserializer(&__content)),
             ))
         });
 
@@ -1635,15 +1662,37 @@ fn deserialize_untagged_enum(
     );
 
     quote_block! {
-        let __content = try!(<_serde::private::de::Content as _serde::Deserialize>::deserialize(__deserializer));
+        struct __Callback #callback_impl_generics #where_clause {
+            deserializer: __D,
+            marker: _serde::export::PhantomData<#this #ty_generics>,
+            lifetime: _serde::export::PhantomData<&#delife ()>,
+        }
 
-        #(
-            if let _serde::export::Ok(__ok) = #attempts {
-                return _serde::export::Ok(__ok);
+        impl #callback_impl_generics _serde::de::WithBuffer<#delife, __D::Error> for __Callback #callback_ty_generics #where_clause {
+            type Value = _serde::export::Result<#this #ty_generics, __D::Error>;
+
+            fn run<__Buffer>(self) -> Self::Value
+            where
+                __Buffer: _serde::Deserialize<#delife>,
+                for<'a> &'a __Buffer: _serde::de::IntoDeserializer<'de, __D::Error>,
+            {
+                let __content = try!(<__Buffer as _serde::Deserialize>::deserialize(self.deserializer));
+
+                #(
+                    if let _serde::export::Ok(__ok) = #attempts {
+                        return _serde::export::Ok(__ok);
+                    }
+                )*
+
+                _serde::export::Err(_serde::de::Error::custom(#fallthrough_msg))
             }
-        )*
+        }
 
-        _serde::export::Err(_serde::de::Error::custom(#fallthrough_msg))
+        __D::call_with_buffer(__Callback {
+            deserializer: __deserializer,
+            marker: _serde::export::PhantomData,
+            lifetime: _serde::export::PhantomData,
+        })
     }
 }
 
@@ -2862,6 +2911,20 @@ impl<'a> ToTokens for InPlaceImplGenerics<'a> {
     }
 }
 
+struct CallbackImplGenerics<'a>(&'a Parameters, syn::TypeParam);
+
+impl<'a> ToTokens for CallbackImplGenerics<'a> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let mut generics = self.0.generics.clone();
+        if let Some(de_lifetime) = self.0.borrowed.de_lifetime_def() {
+            generics.params.push(syn::GenericParam::Lifetime(de_lifetime));
+        }
+        generics.params.push(self.1.clone().into());
+        let (impl_generics, _, _) = generics.split_for_impl();
+        impl_generics.to_tokens(tokens);
+    }
+}
+
 #[cfg(feature = "deserialize_in_place")]
 impl<'a> DeImplGenerics<'a> {
     fn in_place(self) -> InPlaceImplGenerics<'a> {
@@ -2923,6 +2986,26 @@ impl<'a> ToTokens for InPlaceTypeGenerics<'a> {
 impl<'a> DeTypeGenerics<'a> {
     fn in_place(self) -> InPlaceTypeGenerics<'a> {
         InPlaceTypeGenerics(self.0)
+    }
+}
+
+struct CallbackTypeGenerics<'a>(&'a Parameters, Ident);
+
+impl<'a> ToTokens for CallbackTypeGenerics<'a> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let mut generics = self.0.generics.clone();
+        if self.0.borrowed.de_lifetime_def().is_some() {
+            let def = syn::LifetimeDef {
+                attrs: Vec::new(),
+                lifetime: syn::Lifetime::new("'de", Span::call_site()),
+                colon_token: None,
+                bounds: Punctuated::new(),
+            };
+            generics.params.push(syn::GenericParam::Lifetime(def));
+        }
+        generics.params.push(syn::GenericParam::from(syn::TypeParam::from(self.1.clone())));
+        let (_, ty_generics, _) = generics.split_for_impl();
+        ty_generics.to_tokens(tokens);
     }
 }
 


### PR DESCRIPTION
This change allows Deserializer impls to select some type to be used for temporary buffering of untagged, internally tagged, adjacently tagged, and flattened content. By default Serde will continue to use our own private `Content<'de>` buffer type, but for example serde_json could choose to use a serde_json::Value as its buffer to fix #1183.

Needs much more work and polish but it looks like this approach can work.