### PR TITLE
Fix compilation under `rc` feature

### DIFF
--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -196,7 +196,7 @@ mod lib {
     pub use std::rc::{Rc, Weak as RcWeak};
 
     #[cfg(all(feature = "rc", feature = "alloc", not(feature = "std")))]
-    pub use alloc::arc::{Arc, Weak as ArcWeak};
+    pub use alloc::sync::{Arc, Weak as ArcWeak};
     #[cfg(all(feature = "rc", feature = "std"))]
     pub use std::sync::{Arc, Weak as ArcWeak};
 


### PR DESCRIPTION
Currently compilation fails when enabling both the `alloc` and `rc` features because of an update to `liballoc`. A previous PR (https://github.com/serde-rs/serde/issues/1335) to fix this didn't catch that `Arc` now lives under `alloc::sync`. This is a quick fix =)