### PR TITLE
Trim the r# from raw identifiers in user-facing strings

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -30,8 +30,9 @@ pub fn expand_derive_deserialize(input: &syn::DeriveInput) -> Result<TokenStream
     let ident = &cont.ident;
     let params = Parameters::new(&cont);
     let (de_impl_generics, _, ty_generics, where_clause) = split_with_de_lifetime(&params);
+    let suffix = ident.to_string().trim_left_matches("r#").to_owned();
     let dummy_const = Ident::new(
-        &format!("_IMPL_DESERIALIZE_FOR_{}", ident),
+        &format!("_IMPL_DESERIALIZE_FOR_{}", suffix),
         Span::call_site(),
     );
     let body = Stmts(deserialize_body(&cont, &params));

--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -90,6 +90,10 @@ pub struct Name {
     deserialize: String,
 }
 
+fn unraw(ident: &Ident) -> String {
+    ident.to_string().trim_left_matches("r#").to_owned()
+}
+
 impl Name {
     /// Return the container name for the container when serializing.
     pub fn serialize_name(&self) -> String {
@@ -380,8 +384,8 @@ impl Container {
 
         Container {
             name: Name {
-                serialize: ser_name.get().unwrap_or_else(|| item.ident.to_string()),
-                deserialize: de_name.get().unwrap_or_else(|| item.ident.to_string()),
+                serialize: ser_name.get().unwrap_or_else(|| unraw(&item.ident)),
+                deserialize: de_name.get().unwrap_or_else(|| unraw(&item.ident)),
             },
             transparent: transparent.get(),
             deny_unknown_fields: deny_unknown_fields.get(),
@@ -697,8 +701,8 @@ impl Variant {
         let de_renamed = de_name.is_some();
         Variant {
             name: Name {
-                serialize: ser_name.unwrap_or_else(|| variant.ident.to_string()),
-                deserialize: de_name.unwrap_or_else(|| variant.ident.to_string()),
+                serialize: ser_name.unwrap_or_else(|| unraw(&variant.ident)),
+                deserialize: de_name.unwrap_or_else(|| unraw(&variant.ident)),
             },
             ser_renamed: ser_renamed,
             de_renamed: de_renamed,
@@ -822,7 +826,7 @@ impl Field {
         let mut flatten = BoolAttr::none(cx, "flatten");
 
         let ident = match field.ident {
-            Some(ref ident) => ident.to_string(),
+            Some(ref ident) => unraw(ident),
             None => index.to_string(),
         };
 

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -26,7 +26,8 @@ pub fn expand_derive_serialize(input: &syn::DeriveInput) -> Result<TokenStream, 
     let ident = &cont.ident;
     let params = Parameters::new(&cont);
     let (impl_generics, ty_generics, where_clause) = params.generics.split_for_impl();
-    let dummy_const = Ident::new(&format!("_IMPL_SERIALIZE_FOR_{}", ident), Span::call_site());
+    let suffix = ident.to_string().trim_left_matches("r#").to_owned();
+    let dummy_const = Ident::new(&format!("_IMPL_SERIALIZE_FOR_{}", suffix), Span::call_site());
     let body = Stmts(serialize_body(&cont, &params));
 
     let impl_block = if let Some(remote) = cont.attrs.remote() {

--- a/test_suite/tests/test_unstable.rs
+++ b/test_suite/tests/test_unstable.rs
@@ -1,0 +1,27 @@
+// Copyright 2018 Serde Developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![deny(warnings)]
+#![cfg_attr(feature = "unstable", feature(raw_identifiers))]
+
+#[cfg(feature = "unstable")]
+#[macro_use]
+extern crate serde_derive;
+
+#[cfg(feature = "unstable")]
+extern crate serde;
+#[cfg(feature = "unstable")]
+extern crate serde_test;
+
+// This test target is convoluted with the actual #[test] in a separate file to
+// get it so that the stable compiler does not need to parse the code of the
+// test. If the test were written with #[cfg(feature = "unstable")] #[test]
+// right here, the stable compiler would fail to parse those raw identifiers
+// even if the cfg were not enabled.
+#[cfg(feature = "unstable")]
+mod unstable;

--- a/test_suite/tests/unstable/mod.rs
+++ b/test_suite/tests/unstable/mod.rs
@@ -1,0 +1,30 @@
+// Copyright 2018 Serde Developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use serde_test::{assert_tokens, Token};
+
+#[test]
+fn test_raw_identifiers() {
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    #[allow(non_camel_case_types)]
+    enum r#type {
+        r#type {
+            r#type: (),
+        }
+    }
+
+    assert_tokens(
+        &r#type::r#type { r#type: () },
+        &[
+            Token::StructVariant { name: "type", variant: "type", len: 1 },
+            Token::Str("type"),
+            Token::Unit,
+            Token::StructVariantEnd,
+        ],
+    );
+}


### PR DESCRIPTION
Fixes #1362.

```rust
#[derive(Serialize, Deserialize)]
enum r#type {
    r#type {
        r#type: (),
    }
}
```

Serializes to: `{"type":{"type":null}}`