### PR TITLE
update a deb for minimal-versions

### DIFF
--- a/serde_derive/Cargo.toml
+++ b/serde_derive/Cargo.toml
@@ -25,7 +25,7 @@ proc-macro = true
 
 [dependencies]
 proc-macro2 = "0.4"
-quote = "0.6"
+quote = "0.6.3"
 syn = { version = "0.14", features = ["visit"] }
 
 [dev-dependencies]


### PR DESCRIPTION
This bumps the minimal acceptable versions in Cargo.toml to versions that are compatible with `-Z minimal-versions`. This is part of the process of seeing how hard this is for crates to use in preparation for getting it stabilized for use in CI, specifically upstreaming the changes required to get criterion working with it. It is easy to use if all of your dependencies support it, but much harder if trying to impose it on them.

I am not sure that this is all the changes needed for all users of all the crates, but it is enough to `handlebars-rust` to work with `minimal-versions`