### PR TITLE
Fix internally tagged enum deserialization with unknown fields

### DIFF
--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -231,8 +231,8 @@ mod content {
 
     use super::size_hint;
     use de::{
-        self, Deserialize, DeserializeSeed, Deserializer, EnumAccess, Expected, MapAccess,
-        SeqAccess, Unexpected, Visitor,
+        self, Deserialize, DeserializeSeed, Deserializer, EnumAccess, Expected, IgnoredAny,
+        MapAccess, SeqAccess, Unexpected, Visitor,
     };
 
     /// Used from generated code to buffer the contents of the Deserializer when
@@ -2470,10 +2470,11 @@ mod content {
             Ok(())
         }
 
-        fn visit_map<M>(self, _: M) -> Result<(), M::Error>
+        fn visit_map<M>(self, mut access: M) -> Result<(), M::Error>
         where
             M: MapAccess<'de>,
         {
+            while let Some(_) = try!(access.next_entry::<IgnoredAny, IgnoredAny>()) {}
             Ok(())
         }
     }

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -2269,3 +2269,45 @@ fn test_internally_tagged_unit_enum_with_unknown_fields() {
         ],
     );
 }
+
+#[test]
+fn test_flattened_internally_tagged_unit_enum_with_unknown_fields() {
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct S {
+        #[serde(flatten)]
+        x: X,
+        #[serde(flatten)]
+        y: Y,
+    }
+
+    #[derive(Deserialize, PartialEq, Debug)]
+    #[serde(tag = "typeX")]
+    enum X {
+        A,
+    }
+
+    #[derive(Deserialize, PartialEq, Debug)]
+    #[serde(tag = "typeY")]
+    enum Y {
+        B { c: u32 },
+    }
+
+    let s = S {
+        x: X::A,
+        y: Y::B { c: 0 },
+    };
+
+    assert_de_tokens(
+        &s,
+        &[
+            Token::Map { len: None },
+            Token::Str("typeX"),
+            Token::Str("A"),
+            Token::Str("typeY"),
+            Token::Str("B"),
+            Token::Str("c"),
+            Token::I32(0),
+            Token::MapEnd,
+        ],
+    );
+}

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -2246,3 +2246,26 @@ fn test_transparent_tuple_struct() {
 
     assert_tokens(&Transparent(false, 1, false, PhantomData), &[Token::U32(1)]);
 }
+
+#[test]
+fn test_internally_tagged_unit_enum_with_unknown_fields() {
+    #[derive(Deserialize, PartialEq, Debug)]
+    #[serde(tag = "t")]
+    enum Data {
+        A,
+    }
+
+    let data = Data::A;
+
+    assert_de_tokens(
+        &data,
+        &[
+            Token::Map { len: None },
+            Token::Str("t"),
+            Token::Str("A"),
+            Token::Str("b"),
+            Token::I32(0),
+            Token::MapEnd,
+        ],
+    );
+}


### PR DESCRIPTION
Currently an internally tagged enum with a unit variant will fail to deserialize if the map contains unknown fields.

[Example on Playground](https://play.rust-lang.org/?gist=58c1609b0ed43cb8275ea3f1e4fa0c31&version=nightly&mode=debug&edition=2015)

This change attempts to address that by having the `InternallyTaggedUnitVisitor.visit_map` method consume the map before returning.

I've added a test case for the simple enum case and for the case where the unit enum variant is flattened into a struct.