### PR TITLE
Allow rename with str|bool|int type for internally tagged enums

### DIFF
--- a/serde/src/export.rs
+++ b/serde/src/export.rs
@@ -21,6 +21,7 @@ pub use lib::Vec;
 
 mod string {
     use lib::*;
+    use lib::fmt::Write;
 
     #[cfg(any(feature = "std", feature = "alloc"))]
     pub fn from_utf8_lossy(bytes: &[u8]) -> Cow<str> {
@@ -40,5 +41,20 @@ mod string {
         // white-on-black question mark. The user will recognize it as invalid
         // UTF-8.
         str::from_utf8(bytes).unwrap_or("\u{fffd}\u{fffd}\u{fffd}")
+    }
+
+    pub fn from_bool(b : bool) -> &'static str {
+        if b {
+            "true"
+        } else {
+            "false"
+        }
+    }
+
+    pub fn from_int(i: u64) -> Vec<u8> {
+        let mut buf = String::with_capacity(20);
+
+        write!(&mut buf, "{}", i).ok();
+        buf.into_bytes()
     }
 }

--- a/serde/src/export.rs
+++ b/serde/src/export.rs
@@ -14,7 +14,7 @@ pub use lib::marker::PhantomData;
 pub use lib::option::Option::{self, None, Some};
 pub use lib::result::Result::{self, Err, Ok};
 
-pub use self::string::from_utf8_lossy;
+pub use self::string::{from_utf8_lossy, from_int, from_bool};
 
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub use lib::Vec;

--- a/serde/src/private/ser.rs
+++ b/serde/src/private/ser.rs
@@ -21,24 +21,62 @@ pub fn constrain<T: ?Sized>(t: &T) -> &T {
     t
 }
 
+pub enum VariantNameType {
+    Str(&'static str),
+    Bool(bool),
+    Int(u64),
+}
+
+impl From<&'static str> for VariantNameType {
+    fn from(src: &'static str) -> Self {
+        VariantNameType::Str(src)
+    }
+}
+
+impl<'a> From<&'a bool> for VariantNameType {
+    fn from(src: &bool) -> Self {
+        VariantNameType::Bool(*src)
+    }
+}
+
+impl<'a> From<&'a u64> for VariantNameType {
+    fn from(src: &u64) -> Self {
+        VariantNameType::Int(*src)
+    }
+}
+
+impl Serialize for VariantNameType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+        S: Serializer
+    {
+        match *self {
+            VariantNameType::Str(s) => serializer.serialize_str(s),
+            VariantNameType::Bool(b) => serializer.serialize_bool(b),
+            VariantNameType::Int(i) => serializer.serialize_u64(i),
+        }
+    }
+}
+
 /// Not public API.
-pub fn serialize_tagged_newtype<S, T>(
+pub fn serialize_tagged_newtype<S, T, U>(
     serializer: S,
     type_ident: &'static str,
     variant_ident: &'static str,
     tag: &'static str,
-    variant_name: &'static str,
+    variant_name: U,
     value: &T,
 ) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
     T: Serialize,
+    U: Into<VariantNameType>,
 {
     value.serialize(TaggedSerializer {
         type_ident: type_ident,
         variant_ident: variant_ident,
         tag: tag,
-        variant_name: variant_name,
+        variant_name: variant_name.into(),
         delegate: serializer,
     })
 }
@@ -47,7 +85,7 @@ struct TaggedSerializer<S> {
     type_ident: &'static str,
     variant_ident: &'static str,
     tag: &'static str,
-    variant_name: &'static str,
+    variant_name: VariantNameType,
     delegate: S,
 }
 
@@ -197,7 +235,7 @@ where
 
     fn serialize_unit_struct(self, _: &'static str) -> Result<Self::Ok, Self::Error> {
         let mut map = try!(self.delegate.serialize_map(Some(1)));
-        try!(map.serialize_entry(self.tag, self.variant_name));
+        try!(map.serialize_entry(self.tag, &self.variant_name));
         map.end()
     }
 
@@ -208,7 +246,7 @@ where
         inner_variant: &'static str,
     ) -> Result<Self::Ok, Self::Error> {
         let mut map = try!(self.delegate.serialize_map(Some(2)));
-        try!(map.serialize_entry(self.tag, self.variant_name));
+        try!(map.serialize_entry(self.tag, &self.variant_name));
         try!(map.serialize_entry(inner_variant, &()));
         map.end()
     }
@@ -235,7 +273,7 @@ where
         T: Serialize,
     {
         let mut map = try!(self.delegate.serialize_map(Some(2)));
-        try!(map.serialize_entry(self.tag, self.variant_name));
+        try!(map.serialize_entry(self.tag, &self.variant_name));
         try!(map.serialize_entry(inner_variant, inner_value));
         map.end()
     }
@@ -278,7 +316,7 @@ where
         len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
         let mut map = try!(self.delegate.serialize_map(Some(2)));
-        try!(map.serialize_entry(self.tag, self.variant_name));
+        try!(map.serialize_entry(self.tag, &self.variant_name));
         try!(map.serialize_key(inner_variant));
         Ok(SerializeTupleVariantAsMapValue::new(
             map,
@@ -289,7 +327,7 @@ where
 
     fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
         let mut map = try!(self.delegate.serialize_map(len.map(|len| len + 1)));
-        try!(map.serialize_entry(self.tag, self.variant_name));
+        try!(map.serialize_entry(self.tag, &self.variant_name));
         Ok(map)
     }
 
@@ -299,7 +337,7 @@ where
         len: usize,
     ) -> Result<Self::SerializeStruct, Self::Error> {
         let mut state = try!(self.delegate.serialize_struct(name, len + 1));
-        try!(state.serialize_field(self.tag, self.variant_name));
+        try!(state.serialize_field(self.tag, &self.variant_name));
         Ok(state)
     }
 
@@ -325,7 +363,7 @@ where
         len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
         let mut map = try!(self.delegate.serialize_map(Some(2)));
-        try!(map.serialize_entry(self.tag, self.variant_name));
+        try!(map.serialize_entry(self.tag, &self.variant_name));
         try!(map.serialize_key(inner_variant));
         Ok(SerializeStructVariantAsMapValue::new(
             map,

--- a/serde/src/private/ser.rs
+++ b/serde/src/private/ser.rs
@@ -45,6 +45,18 @@ impl<'a> From<&'a u64> for VariantNameType {
     }
 }
 
+impl From<bool> for VariantNameType {
+    fn from(src: bool) -> Self {
+        VariantNameType::Bool(src)
+    }
+}
+
+impl From<u64> for VariantNameType {
+    fn from(src: u64) -> Self {
+        VariantNameType::Int(src)
+    }
+}
+
 impl Serialize for VariantNameType {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1252,11 +1252,11 @@ fn deserialize_internally_tagged_enum(
         .iter()
         .enumerate()
         .filter(|&(_, variant)| !variant.attrs.skip_deserializing())
-        .map(|(i, variant)| (variant.attrs.name().deserialize_name(), field_i(i)))
+        .map(|(i, variant)| (attr::VariantNameType::from(variant.attrs.name().deserialize_name()), field_i(i)))
         .collect();
 
     let variants_stmt = {
-        let variant_names = variant_names_idents.iter().map(|&(ref name, _)| name);
+        let variant_names = variant_names_idents.iter().map(|&(ref name, _)| name.stringify());
         quote! {
             const VARIANTS: &'static [&'static str] = &[ #(#variant_names),* ];
         }
@@ -1839,7 +1839,7 @@ fn deserialize_untagged_newtype_variant(
 }
 
 fn deserialize_generated_identifier(
-    fields: &[(String, Ident)],
+    fields: &[(attr::VariantNameType, Ident)],
     cattrs: &attr::Container,
     is_variant: bool,
 ) -> Fragment {
@@ -1995,7 +1995,7 @@ fn deserialize_custom_identifier(
 
 fn deserialize_identifier(
     this: &TokenStream,
-    fields: &[(String, Ident)],
+    fields: &[(attr::VariantNameType, Ident)],
     is_variant: bool,
     fallthrough: Option<TokenStream>,
     collect_other_fields: bool,
@@ -2004,10 +2004,10 @@ fn deserialize_identifier(
     let field_borrowed_strs = fields.iter().map(|&(ref name, _)| name);
     let field_bytes = fields
         .iter()
-        .map(|&(ref name, _)| Literal::byte_string(name.as_bytes()));
+        .map(|&(ref name, _)| Literal::byte_string(name.stringify().as_bytes()));
     let field_borrowed_bytes = fields
         .iter()
-        .map(|&(ref name, _)| Literal::byte_string(name.as_bytes()));
+        .map(|&(ref name, _)| Literal::byte_string(name.stringify().as_bytes()));
 
     let constructors: &Vec<_> = &fields
         .iter()
@@ -2262,7 +2262,7 @@ fn deserialize_struct_as_struct_visitor(
         .iter()
         .enumerate()
         .filter(|&(_, field)| !field.attrs.skip_deserializing())
-        .map(|(i, field)| (field.attrs.name().deserialize_name(), field_i(i)))
+        .map(|(i, field)| (attr::VariantNameType::from(field.attrs.name().deserialize_name()), field_i(i)))
         .collect();
 
     let fields_stmt = {
@@ -2289,7 +2289,7 @@ fn deserialize_struct_as_map_visitor(
         .iter()
         .enumerate()
         .filter(|&(_, field)| !field.attrs.skip_deserializing() && !field.attrs.flatten())
-        .map(|(i, field)| (field.attrs.name().deserialize_name(), field_i(i)))
+        .map(|(i, field)| (attr::VariantNameType::from(field.attrs.name().deserialize_name()), field_i(i)))
         .collect();
 
     let field_visitor = deserialize_generated_identifier(&field_names_idents, cattrs, false);
@@ -2517,11 +2517,11 @@ fn deserialize_struct_as_struct_in_place_visitor(
         .iter()
         .enumerate()
         .filter(|&(_, field)| !field.attrs.skip_deserializing())
-        .map(|(i, field)| (field.attrs.name().deserialize_name(), field_i(i)))
+        .map(|(i, field)| (attr::VariantNameType::from(field.attrs.name().deserialize_name()), field_i(i)))
         .collect();
 
     let fields_stmt = {
-        let field_names = field_names_idents.iter().map(|&(ref name, _)| name);
+        let field_names = field_names_idents.iter().map(|&(ref name, _)| name.stringify());
         quote_block! {
             const FIELDS: &'static [&'static str] = &[ #(#field_names),* ];
         }

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1872,25 +1872,29 @@ fn deserialize_generated_identifier(
         None
     };
 
-    let first_field_ident = &fields[0].0;
-    let same_variant_type = fields.iter().all(|ref f| {
-        match (&f.0, first_field_ident) {
-            (attr::VariantNameType::Bool(_), attr::VariantNameType::Bool(_)) => true,
-            (attr::VariantNameType::Int(_), attr::VariantNameType::Int(_)) => true,
-            (attr::VariantNameType::Str(_), attr::VariantNameType::Str(_)) => true,
-            _ => false
-        }
-    });
+    let serde_deserializer = if !fields.is_empty() {
+        let first_field_ident = &fields[0].0;
+        let same_variant_type = fields.iter().all(|ref f| {
+            match (&f.0, first_field_ident) {
+                (attr::VariantNameType::Bool(_), attr::VariantNameType::Bool(_)) => true,
+                (attr::VariantNameType::Int(_), attr::VariantNameType::Int(_)) => true,
+                (attr::VariantNameType::Str(_), attr::VariantNameType::Str(_)) => true,
+                _ => false
+            }
+        });
 
-    let serde_deserializer = if same_variant_type {
-        match first_field_ident {
-            attr::VariantNameType::Bool(_) => quote!(_serde::Deserializer::deserialize_bool(__deserializer, __FieldVisitor)),
-            attr::VariantNameType::Int(_) => quote!(_serde::Deserializer::deserialize_u64(__deserializer, __FieldVisitor)),
-            attr::VariantNameType::Str(_) => quote!(_serde::Deserializer::deserialize_str(__deserializer, __FieldVisitor)),
+        if same_variant_type {
+            match first_field_ident {
+                attr::VariantNameType::Bool(_) => quote!(_serde::Deserializer::deserialize_bool(__deserializer, __FieldVisitor)),
+                attr::VariantNameType::Int(_) => quote!(_serde::Deserializer::deserialize_u64(__deserializer, __FieldVisitor)),
+                attr::VariantNameType::Str(_) => quote!(_serde::Deserializer::deserialize_str(__deserializer, __FieldVisitor)),
+            }
         }
-    }
-    else {
-        quote!(_serde::Deserializer::deserialize_any(__deserializer, __FieldVisitor))
+        else {
+            quote!(_serde::Deserializer::deserialize_any(__deserializer, __FieldVisitor))
+        }
+    } else {
+        quote!(_serde::Deserializer::deserialize_identifier(__deserializer, __FieldVisitor))
     };
 
     quote_block! {

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -476,7 +476,10 @@ fn serialize_externally_tagged_variant(
     cattrs: &attr::Container,
 ) -> Fragment {
     let type_name = cattrs.name().serialize_name();
-    let variant_name = variant.attrs.name().serialize_name();
+    let variant_name = match variant.attrs.name().serialize_name() {
+        attr::VariantNameType::Str(s) => s,
+        _ => unreachable!(), // check_variant_name prevents this case
+    };
 
     if let Some(path) = variant.attrs.serialize_with() {
         let ser = wrap_serialize_variant_with(params, path, variant);
@@ -547,7 +550,7 @@ fn serialize_internally_tagged_variant(
     tag: &str,
 ) -> Fragment {
     let type_name = cattrs.name().serialize_name();
-    let variant_name = variant.attrs.name().serialize_name();
+    let variant_name = attr::VariantNameType::from(variant.attrs.name().serialize_name());
 
     let enum_ident_str = params.type_name();
     let variant_ident_str = variant.ident.to_string();
@@ -658,7 +661,7 @@ fn serialize_adjacently_tagged_variant(
                 StructVariant::Untagged,
                 params,
                 &variant.fields,
-                &variant_name,
+                &variant_name.stringify(),
             ),
         }
     });
@@ -828,7 +831,7 @@ enum StructVariant<'a> {
     },
     InternallyTagged {
         tag: &'a str,
-        variant_name: String,
+        variant_name: attr::VariantNameType,
     },
     Untagged,
 }

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -575,7 +575,7 @@ fn serialize_internally_tagged_variant(
                 let mut __struct = try!(_serde::Serializer::serialize_struct(
                     __serializer, #type_name, 1));
                 try!(_serde::ser::SerializeStruct::serialize_field(
-                    &mut __struct, #tag, #variant_name));
+                    &mut __struct, #tag, &#variant_name));
                 _serde::ser::SerializeStruct::end(__struct)
             }
         }
@@ -899,7 +899,7 @@ fn serialize_struct_variant<'a>(
                 try!(_serde::ser::SerializeStruct::serialize_field(
                     &mut __serde_state,
                     #tag,
-                    #variant_name,
+                    &#variant_name,
                 ));
                 #(#serialize_fields)*
                 _serde::ser::SerializeStruct::end(__serde_state)

--- a/serde_derive_internals/Cargo.toml
+++ b/serde_derive_internals/Cargo.toml
@@ -17,6 +17,7 @@ path = "lib.rs"
 [dependencies]
 proc-macro2 = "0.4"
 syn = { version = "0.14", default-features = false, features = ["derive", "parsing", "clone-impls"] }
+quote = "0.6.3"
 
 [badges]
 travis-ci = { repository = "serde-rs/serde" }

--- a/serde_derive_internals/lib.rs
+++ b/serde_derive_internals/lib.rs
@@ -21,6 +21,7 @@
 extern crate syn;
 
 extern crate proc_macro2;
+extern crate quote;
 
 #[path = "src/mod.rs"]
 mod internals;

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -1036,6 +1036,157 @@ fn test_internally_tagged_borrow() {
 }
 
 #[test]
+fn test_internally_tagged_enum_renamed() {
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct Newtype(BTreeMap<String, String>);
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct Struct {
+        f: u8,
+    }
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    #[serde(tag = "type")]
+    enum InternallyTagged {
+        #[serde(rename=1)]
+        A,
+        #[serde(rename=2)]
+        B,
+        #[serde(rename=true)]
+        C,
+        #[serde(rename=false)]
+        D,
+        #[serde(rename="abc")]
+        E,
+    }
+
+    assert_tokens(
+        &InternallyTagged::A,
+        &[
+            Token::Struct {
+                name: "InternallyTagged",
+                len: 2,
+            },
+            Token::Str("type"),
+            Token::U64(1),
+            Token::StructEnd,
+        ],
+    );
+
+    assert_de_tokens(
+        &InternallyTagged::A,
+        &[
+            Token::Seq { len: Some(1) },
+            Token::Str("type"),
+            Token::U64(1),
+            Token::SeqEnd
+        ],
+    );
+
+
+    assert_tokens(
+        &InternallyTagged::B,
+        &[
+            Token::Struct {
+                name: "InternallyTagged",
+                len: 1,
+            },
+            Token::Str("type"),
+            Token::U64(2),
+            Token::StructEnd,
+        ],
+    );
+
+     assert_de_tokens(
+        &InternallyTagged::B,
+         &[
+             Token::Seq { len: Some(1) },
+             Token::Str("type"),
+             Token::U64(2),
+             Token::SeqEnd
+         ],
+    );
+
+    assert_tokens(
+        &InternallyTagged::C,
+        &[
+            Token::Struct {
+                name: "InternallyTagged",
+                len: 1,
+            },
+            Token::Str("type"),
+            Token::Bool(true),
+            Token::StructEnd,
+        ],
+    );
+
+    assert_tokens(
+        &InternallyTagged::C,
+        &[
+            Token::Struct {
+                name: "InternallyTagged",
+                len: 1,
+            },
+            Token::Str("type"),
+            Token::Bool(true),
+            Token::StructEnd,
+        ],
+    );
+
+    assert_tokens(
+        &InternallyTagged::D,
+        &[
+            Token::Struct {
+                name: "InternallyTagged",
+                len: 1,
+            },
+            Token::Str("type"),
+            Token::Bool(false),
+            Token::StructEnd,
+        ],
+    );
+
+    assert_tokens(
+        &InternallyTagged::C,
+        &[
+            Token::Struct {
+                name: "InternallyTagged",
+                len: 1,
+            },
+            Token::Str("type"),
+            Token::Bool(false),
+            Token::StructEnd,
+        ],
+    );
+
+    assert_tokens(
+        &InternallyTagged::E,
+        &[
+            Token::Struct {
+                name: "InternallyTagged",
+                len: 1,
+            },
+            Token::Str("type"),
+            Token::Str("abc"),
+            Token::StructEnd,
+        ],
+    );
+
+    assert_tokens(
+        &InternallyTagged::E,
+        &[
+            Token::Struct {
+                name: "InternallyTagged",
+                len: 1,
+            },
+            Token::Str("type"),
+            Token::Str("abc"),
+            Token::StructEnd,
+        ],
+    );
+}
+
+#[test]
 fn test_adjacently_tagged_enum() {
     #[derive(Debug, PartialEq, Serialize, Deserialize)]
     #[serde(tag = "t", content = "c")]

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -1058,6 +1058,30 @@ fn test_internally_tagged_enum_renamed() {
         D,
         #[serde(rename="abc")]
         E,
+        #[serde(rename=1)]
+        F(BTreeMap<String, String>),
+        #[serde(rename=1)]
+        G(Newtype),
+        #[serde(rename=1)]
+        H(Struct),
+        #[serde(rename=true)]
+        I(BTreeMap<String, String>),
+        #[serde(rename=true)]
+        J(Newtype),
+        #[serde(rename=true)]
+        K(Struct),
+        #[serde(rename="abc")]
+        L(BTreeMap<String, String>),
+        #[serde(rename="abc")]
+        M(Newtype),
+        #[serde(rename="abc")]
+        N(Struct),
+        #[serde(rename=1)]
+        O { a: u8 },
+        #[serde(rename=true)]
+        P { a: u8 },
+        #[serde(rename="abc")]
+        Q { a: u8 },
     }
 
     assert_tokens(
@@ -1065,7 +1089,7 @@ fn test_internally_tagged_enum_renamed() {
         &[
             Token::Struct {
                 name: "InternallyTagged",
-                len: 2,
+                len: 1,
             },
             Token::Str("type"),
             Token::U64(1),
@@ -1073,49 +1097,15 @@ fn test_internally_tagged_enum_renamed() {
         ],
     );
 
-    assert_de_tokens(
-        &InternallyTagged::A,
-        &[
-            Token::Seq { len: Some(1) },
-            Token::Str("type"),
-            Token::U64(1),
-            Token::SeqEnd
-        ],
-    );
-
-
     assert_tokens(
         &InternallyTagged::B,
         &[
             Token::Struct {
                 name: "InternallyTagged",
-                len: 1,
+                len: 1
             },
             Token::Str("type"),
             Token::U64(2),
-            Token::StructEnd,
-        ],
-    );
-
-     assert_de_tokens(
-        &InternallyTagged::B,
-         &[
-             Token::Seq { len: Some(1) },
-             Token::Str("type"),
-             Token::U64(2),
-             Token::SeqEnd
-         ],
-    );
-
-    assert_tokens(
-        &InternallyTagged::C,
-        &[
-            Token::Struct {
-                name: "InternallyTagged",
-                len: 1,
-            },
-            Token::Str("type"),
-            Token::Bool(true),
             Token::StructEnd,
         ],
     );
@@ -1138,20 +1128,7 @@ fn test_internally_tagged_enum_renamed() {
         &[
             Token::Struct {
                 name: "InternallyTagged",
-                len: 1,
-            },
-            Token::Str("type"),
-            Token::Bool(false),
-            Token::StructEnd,
-        ],
-    );
-
-    assert_tokens(
-        &InternallyTagged::C,
-        &[
-            Token::Struct {
-                name: "InternallyTagged",
-                len: 1,
+                len: 1
             },
             Token::Str("type"),
             Token::Bool(false),
@@ -1164,7 +1141,7 @@ fn test_internally_tagged_enum_renamed() {
         &[
             Token::Struct {
                 name: "InternallyTagged",
-                len: 1,
+                len: 1
             },
             Token::Str("type"),
             Token::Str("abc"),
@@ -1173,14 +1150,133 @@ fn test_internally_tagged_enum_renamed() {
     );
 
     assert_tokens(
-        &InternallyTagged::E,
+        &InternallyTagged::F(BTreeMap::new()),
         &[
-            Token::Struct {
-                name: "InternallyTagged",
-                len: 1,
-            },
+            Token::Map { len: Some(1) },
+            Token::Str("type"),
+            Token::U64(1),
+            Token::MapEnd,
+        ],
+    );
+
+    assert_tokens(
+        &InternallyTagged::G(Newtype(BTreeMap::new())),
+        &[
+            Token::Map { len: Some(1) },
+            Token::Str("type"),
+            Token::U64(1),
+            Token::MapEnd,
+        ],
+    );
+
+    assert_tokens(
+        &InternallyTagged::H(Struct { f: 6 }),
+        &[
+            Token::Struct { name: "Struct", len: 2 },
+            Token::Str("type"),
+            Token::U64(1),
+            Token::Str("f"),
+            Token::U8(6),
+            Token::StructEnd,
+        ],
+    );
+
+    assert_tokens(
+        &InternallyTagged::I(BTreeMap::new()),
+        &[
+            Token::Map { len: Some(1) },
+            Token::Str("type"),
+            Token::Bool(true),
+            Token::MapEnd,
+        ],
+    );
+
+    assert_tokens(
+        &InternallyTagged::J(Newtype(BTreeMap::new())),
+        &[
+            Token::Map { len: Some(1) },
+            Token::Str("type"),
+            Token::Bool(true),
+            Token::MapEnd,
+        ],
+    );
+
+    assert_tokens(
+        &InternallyTagged::K(Struct { f: 6 }),
+        &[
+            Token::Struct { name: "Struct", len: 2 },
+            Token::Str("type"),
+            Token::Bool(true),
+            Token::Str("f"),
+            Token::U8(6),
+            Token::StructEnd,
+        ],
+    );
+
+    assert_tokens(
+        &InternallyTagged::L(BTreeMap::new()),
+        &[
+            Token::Map { len: Some(1) },
             Token::Str("type"),
             Token::Str("abc"),
+            Token::MapEnd,
+        ],
+    );
+
+    assert_tokens(
+        &InternallyTagged::M(Newtype(BTreeMap::new())),
+        &[
+            Token::Map { len: Some(1) },
+            Token::Str("type"),
+            Token::Str("abc"),
+            Token::MapEnd,
+        ],
+     );
+
+    assert_tokens(
+        &InternallyTagged::N(Struct { f: 6 }),
+        &[
+            Token::Struct { name: "Struct", len: 2 },
+            Token::Str("type"),
+            Token::Str("abc"),
+            Token::Str("f"),
+            Token::U8(6),
+            Token::StructEnd,
+        ],
+    );
+
+    assert_tokens(
+        &InternallyTagged::O { a: 1 },
+        &[
+            Token::Struct { name: "InternallyTagged", len: 2 },
+            Token::Str("type"),
+            Token::U64(1),
+            Token::Str("a"),
+            Token::U8(1),
+            Token::StructEnd,
+        ],
+    );
+
+    assert_tokens(
+        &InternallyTagged::P { a: 1 },
+        &[
+            Token::Struct { name: "InternallyTagged", len: 2 },
+            Token::Str("type"),
+            Token::Bool(true),
+            Token::Str("a"),
+            Token::U8(1),
+            Token::StructEnd,
+        ],
+    );
+
+    assert_tokens(
+        &InternallyTagged::Q { a: 1 },
+        &[
+            Token::Struct { name: "InternallyTagged", len: 2 },
+            Token::Str("type"),
+            Token::Str("abc"),
+            Token::Str("a"),
+            Token::U8(1),
             Token::StructEnd,
         ],
     );


### PR DESCRIPTION
This is the WIP for #745 (my work is based on #973).
I have some troubles to understand what I have to do to complete the `serde_derive/de.rs` and `serde_derive/se.rs` modifications. I don't understand what I've to do in the method [deserialize_identifier: serde_derive/src/de.rs#L2016](https://github.com/serde-rs/serde/blob/3f0f739e17dde92be582917dbed3d5b09fc4177d/serde_derive/src/de.rs#L2016) and if I have to modify other `deserialize_*` methods in `serde_derive/de.rs`. Does the `serde_derive/de.rs` part seem correct ?


For now the [unit test](https://github.com/NotBad4U/serde/blob/268b8a05d110f4988cbfd8fa8211201865949c0b/test_suite/tests/test_macros.rs#L1039) doesn't compile and I get this error. Do I have to modify something in [serde_derive/src/internals/ast.rs](https://github.com/serde-rs/serde/blob/master/serde_derive/src/internals/ast.rs) to pass the compilation ?
```bash
   Compiling serde_test_suite v0.0.0 (file:///home/escanor/Junk/serde/test_suite)
error[E0308]: mismatched types
    --> test_suite/tests/test_macros.rs:1048:32
     |
1048 |     #[derive(Debug, PartialEq, Serialize, Deserialize)]
     |                                ^^^^^^^^^
     |                                |
     |                                expected reference, found u64
     |                                help: consider borrowing here: `&Serialize`
     |
     = note: expected type `&_`
                found type `u64`

error[E0308]: mismatched types
    --> test_suite/tests/test_macros.rs:1048:32
     |
1048 |     #[derive(Debug, PartialEq, Serialize, Deserialize)]
     |                                ^^^^^^^^^
     |                                |
     |                                expected reference, found bool
     |                                help: consider borrowing here: `&Serialize`
     |
     = note: expected type `&_`
                found type `bool`

error[E0308]: mismatched types
    --> test_suite/tests/test_macros.rs:1048:43
     |
1048 |     #[derive(Debug, PartialEq, Serialize, Deserialize)]
     |                                           ^^^^^^^^^^^ expected str, found u64
     |
     = note: expected type `str`
                found type `u64`

error[E0308]: mismatched types
    --> test_suite/tests/test_macros.rs:1048:43
     |
1048 |     #[derive(Debug, PartialEq, Serialize, Deserialize)]
     |                                           ^^^^^^^^^^^ expected str, found bool
     |
     = note: expected type `str`
                found type `bool`

error: aborting due to 4 previous errors
``` 