### PR TITLE
Add prefix_all attribute

### DIFF
--- a/serde_derive/src/internals/ast.rs
+++ b/serde_derive/src/internals/ast.rs
@@ -86,11 +86,17 @@ impl<'a> Container<'a> {
             Data::Enum(ref mut variants) => {
                 for variant in variants {
                     variant.attrs.rename_by_rule(attrs.rename_all());
+                    if let Some(prefix) = attrs.prefix_all() {
+                        variant.attrs.apply_prefix(prefix);
+                    }
                     for field in &mut variant.fields {
                         if field.attrs.flatten() {
                             has_flatten = true;
                         }
                         field.attrs.rename_by_rule(variant.attrs.rename_all());
+                        if let Some(prefix) = variant.attrs.prefix_all() {
+                            field.attrs.apply_prefix(prefix);
+                        }
                     }
                 }
             }
@@ -100,6 +106,9 @@ impl<'a> Container<'a> {
                         has_flatten = true;
                     }
                     field.attrs.rename_by_rule(attrs.rename_all());
+                    if let Some(prefix) = attrs.prefix_all() {
+                        field.attrs.apply_prefix(prefix);
+                    }
                 }
             }
         }

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -1718,6 +1718,110 @@ fn test_rename_all() {
 }
 
 #[test]
+fn test_prefix_all() {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    #[serde(prefix_all = "E_")]
+    enum E {
+        #[serde(prefix_all = "serialize_variant_")]
+        Serialize {
+            serialize: bool,
+            serialize_seq: bool,
+        },
+        #[serde(prefix_all = "SerializeSeq_")]
+        SerializeSeq {
+            serialize: bool,
+            serialize_seq: bool,
+        },
+        SerializeMap {
+            serialize: bool,
+            serialize_seq: bool,
+        },
+    }
+    
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    #[serde(prefix_all = "skc", rename_all = "SCREAMING-KEBAB-CASE")]
+    struct ScreamingKebab {
+        serialize: bool,
+        serialize_seq: bool,
+    }
+
+    assert_tokens(
+        &E::Serialize {
+            serialize: true,
+            serialize_seq: true,
+        },
+        &[
+            Token::StructVariant {
+                name: "E",
+                variant: "E_Serialize",
+                len: 2,
+            },
+            Token::Str("serialize_variant_serialize"),
+            Token::Bool(true),
+            Token::Str("serialize_variant_serialize_seq"),
+            Token::Bool(true),
+            Token::StructVariantEnd,
+        ],
+    );
+
+    assert_tokens(
+        &E::SerializeSeq {
+            serialize: true,
+            serialize_seq: true,
+        },
+        &[
+            Token::StructVariant {
+                name: "E",
+                variant: "E_SerializeSeq",
+                len: 2,
+            },
+            Token::Str("SerializeSeq_serialize"),
+            Token::Bool(true),
+            Token::Str("SerializeSeq_serialize_seq"),
+            Token::Bool(true),
+            Token::StructVariantEnd,
+        ],
+    );
+
+    assert_tokens(
+        &E::SerializeMap {
+            serialize: true,
+            serialize_seq: true,
+        },
+        &[
+            Token::StructVariant {
+                name: "E",
+                variant: "E_SerializeMap",
+                len: 2,
+            },
+            Token::Str("serialize"),
+            Token::Bool(true),
+            Token::Str("serialize_seq"),
+            Token::Bool(true),
+            Token::StructVariantEnd,
+        ],
+    );
+
+    assert_tokens(
+        &ScreamingKebab {
+            serialize: true,
+            serialize_seq: true,
+        },
+        &[
+            Token::Struct {
+                name: "ScreamingKebab",
+                len: 2,
+            },
+            Token::Str("skcSERIALIZE"),
+            Token::Bool(true),
+            Token::Str("skcSERIALIZE-SEQ"),
+            Token::Bool(true),
+            Token::StructEnd,
+        ],
+    );
+}
+
+#[test]
 fn test_untagged_newtype_variant_containing_unit_struct_not_map() {
     #[derive(Debug, PartialEq, Serialize, Deserialize)]
     struct Unit;


### PR DESCRIPTION
The prefix_all attribute will add a given prefix to all the fields in
a struct, or all the variants in an enum. It is applied
after `rename_all` and respects `rename`.

This feature is incredibly useful when dealing with enum encodings that prefix each variant with the name of the enum. For example, in some work I'm doing:
```json
{
  "result": "NetworkResult_Success"
}
```

I may not have chosen the best way to add the prefix to a string. It required an extra allocation per rename. I did my best to keep it efficient.

I ran clippy, and added tests. I'm also opening a corresponding PR in the book's repo to add documentation for it. If I've forgotten anything, let me know, and I'll do my best to reply promptly.