### PR TITLE
Refactor the renaming code

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1855,7 +1855,7 @@ fn deserialize_untagged_newtype_variant(
 }
 
 fn deserialize_generated_identifier(
-    fields: &[(String, Ident)],
+    fields: &[(&str, Ident)],
     cattrs: &attr::Container,
     is_variant: bool,
     other_idx: Option<usize>,
@@ -2017,7 +2017,7 @@ fn deserialize_custom_identifier(
 
 fn deserialize_identifier(
     this: &TokenStream,
-    fields: &[(String, Ident)],
+    fields: &[(&str, Ident)],
     is_variant: bool,
     fallthrough: Option<TokenStream>,
     collect_other_fields: bool,

--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -100,7 +100,7 @@ fn unraw(ident: &Ident) -> String {
 impl Name {
     pub fn new(original: String) -> Name {
         Name {
-            original,
+            original: original,
             serialize: None,
             deserialize: None,
         }
@@ -439,7 +439,7 @@ impl Container {
             name.set_deserialize_name(de);
         }
         Container {
-            name,
+            name: name,
             transparent: transparent.get(),
             deny_unknown_fields: deny_unknown_fields.get(),
             default: default.get().unwrap_or(Default::None),
@@ -754,7 +754,7 @@ impl Variant {
             name.set_deserialize_name(de);
         }
         Variant {
-            name,
+            name: name,
             rename_all: rename_all.get().unwrap_or(RenameRule::None),
             ser_bound: ser_bound.get(),
             de_bound: de_bound.get(),
@@ -1108,7 +1108,7 @@ impl Field {
             name.set_deserialize_name(de);
         }
         Field {
-            name,
+            name: name,
             skip_serializing: skip_serializing.get(),
             skip_deserializing: skip_deserializing.get(),
             skip_serializing_if: skip_serializing_if.get(),

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -525,9 +525,9 @@ fn serialize_externally_tagged_variant(
         }
         Style::Tuple => serialize_tuple_variant(
             TupleVariant::ExternallyTagged {
-                type_name: type_name,
+                type_name: type_name.to_string(),
                 variant_index: variant_index,
-                variant_name: variant_name,
+                variant_name: variant_name.to_string(),
             },
             params,
             &variant.fields,
@@ -535,7 +535,7 @@ fn serialize_externally_tagged_variant(
         Style::Struct => serialize_struct_variant(
             StructVariant::ExternallyTagged {
                 variant_index: variant_index,
-                variant_name: variant_name,
+                variant_name: variant_name.to_string(),
             },
             params,
             &variant.fields,
@@ -601,7 +601,7 @@ fn serialize_internally_tagged_variant(
         Style::Struct => serialize_struct_variant(
             StructVariant::InternallyTagged {
                 tag: tag,
-                variant_name: variant_name,
+                variant_name: variant_name.to_string(),
             },
             params,
             &variant.fields,


### PR DESCRIPTION
It's now concentrated in the Name struct. Some clones were avoided,
too.

Partly in preparation for #1427