### PR TITLE
Accept integers variant encoding in Content

### DIFF
--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -1419,6 +1419,10 @@ mod content {
                 Content::Str(v) => visitor.visit_borrowed_str(v),
                 Content::ByteBuf(v) => visitor.visit_byte_buf(v),
                 Content::Bytes(v) => visitor.visit_borrowed_bytes(v),
+                Content::U8(v) => visitor.visit_u8(v),
+                Content::U16(v) => visitor.visit_u16(v),
+                Content::U32(v) => visitor.visit_u32(v),
+                Content::U64(v) => visitor.visit_u64(v),
                 _ => Err(self.invalid_type(&visitor)),
             }
         }
@@ -2121,6 +2125,10 @@ mod content {
                 Content::Str(v) => visitor.visit_borrowed_str(v),
                 Content::ByteBuf(ref v) => visitor.visit_bytes(v),
                 Content::Bytes(v) => visitor.visit_borrowed_bytes(v),
+                Content::U8(v) => visitor.visit_u8(v),
+                Content::U16(v) => visitor.visit_u16(v),
+                Content::U32(v) => visitor.visit_u32(v),
+                Content::U64(v) => visitor.visit_u64(v),
                 _ => Err(self.invalid_type(&visitor)),
             }
         }

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -1420,9 +1420,7 @@ mod content {
                 Content::ByteBuf(v) => visitor.visit_byte_buf(v),
                 Content::Bytes(v) => visitor.visit_borrowed_bytes(v),
                 Content::U8(v) => visitor.visit_u8(v),
-                Content::U16(v) => visitor.visit_u16(v),
                 Content::U32(v) => visitor.visit_u32(v),
-                Content::U64(v) => visitor.visit_u64(v),
                 _ => Err(self.invalid_type(&visitor)),
             }
         }
@@ -2126,9 +2124,7 @@ mod content {
                 Content::ByteBuf(ref v) => visitor.visit_bytes(v),
                 Content::Bytes(v) => visitor.visit_borrowed_bytes(v),
                 Content::U8(v) => visitor.visit_u8(v),
-                Content::U16(v) => visitor.visit_u16(v),
                 Content::U32(v) => visitor.visit_u32(v),
-                Content::U64(v) => visitor.visit_u64(v),
                 _ => Err(self.invalid_type(&visitor)),
             }
         }

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -1420,7 +1420,6 @@ mod content {
                 Content::ByteBuf(v) => visitor.visit_byte_buf(v),
                 Content::Bytes(v) => visitor.visit_borrowed_bytes(v),
                 Content::U8(v) => visitor.visit_u8(v),
-                Content::U32(v) => visitor.visit_u32(v),
                 _ => Err(self.invalid_type(&visitor)),
             }
         }
@@ -2124,7 +2123,6 @@ mod content {
                 Content::ByteBuf(ref v) => visitor.visit_bytes(v),
                 Content::Bytes(v) => visitor.visit_borrowed_bytes(v),
                 Content::U8(v) => visitor.visit_u8(v),
-                Content::U32(v) => visitor.visit_u32(v),
                 _ => Err(self.invalid_type(&visitor)),
             }
         }


### PR DESCRIPTION
This allows `ContentDeserializer` and `ContentRefDeserializer` to deserialize unsigned integers in `deserialize_identifier`, which then allows enums inside untagged enums to be correctly decoded in formats which encode the enum variant as an integer.

Fixes https://github.com/serde-rs/serde/issues/1437. CC https://github.com/3Hren/msgpack-rust/issues/178