### PR TITLE
Adds support for the default attr to tuple variants in enums.

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -661,11 +661,18 @@ fn deserialize_seq(
                     })
                 }
             };
+            let value = match *field.attrs.default() {
+                attr::Default::Default => quote!(_serde::export::Default::default()),
+                attr::Default::Path(ref path) => quote!(#path()),
+                attr::Default::None => quote!(
+                    return _serde::export::Err(_serde::de::Error::invalid_length(#index_in_seq, &#expecting));
+                ),
+            };
             let assign = quote! {
                 let #var = match #visit {
                     _serde::export::Some(__value) => __value,
                     _serde::export::None => {
-                        return _serde::export::Err(_serde::de::Error::invalid_length(#index_in_seq, &#expecting));
+                        #value
                     }
                 };
             };


### PR DESCRIPTION
This allows the following to work:

```rust
#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
pub enum DOM {
    Text(
        String,
        #[serde(default, skip_serializing_if = "HashMap::is_empty")] HashMap<...>), // optional data
    ),
    Element(...),
    Comment(...),
}
```

`DOM::Text("...", HashMap::new())` becomes encoded as an adjacently tagged enum tuple variant, but because of the skip_serializing_if parameter we may omit the second field of the variant when serializing, if the condition is true. When deserializing, at the moment, serde complains that it was expecting a tuple of two types, but found 1. The new behavior after this PR is if the `default` attr was used, Default::default() (or a program-supplied method) is called to populate that value.

This survives the round trip for me with both `serde_json` and `ron`.