### PR TITLE
Allow #[serde(tag="...")] on structs

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1145,15 +1145,15 @@ fn deserialize_enum(
     cattrs: &attr::Container,
 ) -> Fragment {
     match *cattrs.tag() {
-        attr::EnumTag::External => deserialize_externally_tagged_enum(params, variants, cattrs),
-        attr::EnumTag::Internal { ref tag } => {
+        attr::TagType::External => deserialize_externally_tagged_enum(params, variants, cattrs),
+        attr::TagType::Internal { ref tag } => {
             deserialize_internally_tagged_enum(params, variants, cattrs, tag)
         }
-        attr::EnumTag::Adjacent {
+        attr::TagType::Adjacent {
             ref tag,
             ref content,
         } => deserialize_adjacently_tagged_enum(params, variants, cattrs, tag, content),
-        attr::EnumTag::None => deserialize_untagged_enum(params, variants, cattrs),
+        attr::TagType::None => deserialize_untagged_enum(params, variants, cattrs),
     }
 }
 

--- a/serde_derive/src/internals/check.rs
+++ b/serde_derive/src/internals/check.rs
@@ -1,5 +1,5 @@
 use internals::ast::{Container, Data, Field, Style};
-use internals::attr::{EnumTag, Identifier};
+use internals::attr::{TagType, Identifier};
 use internals::{Ctxt, Derive};
 use syn::{Member, Type};
 
@@ -127,7 +127,7 @@ fn check_identifier(cx: &Ctxt, cont: &Container) {
             }
 
             // Variant with `other` attribute cannot appear in untagged enum
-            (_, Identifier::No, true, &EnumTag::None) => {
+            (_, Identifier::No, true, &TagType::None) => {
                 cx.error_spanned_by(
                     variant.original,
                     "#[serde(other)] cannot appear on untagged enum",
@@ -276,8 +276,8 @@ fn check_internal_tag_field_name_conflict(cx: &Ctxt, cont: &Container) {
     };
 
     let tag = match *cont.attrs.tag() {
-        EnumTag::Internal { ref tag } => tag.as_str(),
-        EnumTag::External | EnumTag::Adjacent { .. } | EnumTag::None => return,
+        TagType::Internal { ref tag } => tag.as_str(),
+        TagType::External | TagType::Adjacent { .. } | TagType::None => return,
     };
 
     let diagnose_conflict = || {
@@ -312,11 +312,11 @@ fn check_internal_tag_field_name_conflict(cx: &Ctxt, cont: &Container) {
 /// contents tag must differ, for the same reason.
 fn check_adjacent_tag_conflict(cx: &Ctxt, cont: &Container) {
     let (type_tag, content_tag) = match *cont.attrs.tag() {
-        EnumTag::Adjacent {
+        TagType::Adjacent {
             ref tag,
             ref content,
         } => (tag, content),
-        EnumTag::Internal { .. } | EnumTag::External | EnumTag::None => return,
+        TagType::Internal { .. } | TagType::External | TagType::None => return,
     };
 
     if type_tag == content_tag {

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -311,10 +311,22 @@ fn serialize_struct_as_struct(
     fields: &[Field],
     cattrs: &attr::Container,
 ) -> Fragment {
-    let serialize_fields =
+    let mut serialize_fields =
         serialize_struct_visitor(fields, params, false, &StructTrait::SerializeStruct);
 
     let type_name = cattrs.name().serialize_name();
+
+    let additional_field_count: usize = match cattrs.tag() {
+        attr::TagType::Internal{ref tag} => {
+            let func = StructTrait::SerializeStruct.serialize_field(Span::call_site());
+            serialize_fields.insert(0, quote! {
+                try!(#func(&mut __serde_state, #tag, #type_name));
+            });
+
+            1
+        }
+        _ => 0
+    };
 
     let mut serialized_fields = fields
         .iter()
@@ -331,7 +343,7 @@ fn serialize_struct_as_struct(
                 quote!(if #path(#field_expr) { 0 } else { 1 })
             }
         })
-        .fold(quote!(0), |sum, expr| quote!(#sum + #expr));
+        .fold(quote!(#additional_field_count), |sum, expr| quote!(#sum + #expr));
 
     quote_block! {
         let #let_mut __serde_state = try!(_serde::Serializer::serialize_struct(__serializer, #type_name, #len));
@@ -452,17 +464,17 @@ fn serialize_variant(
         };
 
         let body = Match(match *cattrs.tag() {
-            attr::EnumTag::External => {
+            attr::TagType::External => {
                 serialize_externally_tagged_variant(params, variant, variant_index, cattrs)
             }
-            attr::EnumTag::Internal { ref tag } => {
+            attr::TagType::Internal { ref tag } => {
                 serialize_internally_tagged_variant(params, variant, cattrs, tag)
             }
-            attr::EnumTag::Adjacent {
+            attr::TagType::Adjacent {
                 ref tag,
                 ref content,
             } => serialize_adjacently_tagged_variant(params, variant, cattrs, tag, content),
-            attr::EnumTag::None => serialize_untagged_variant(params, variant, cattrs),
+            attr::TagType::None => serialize_untagged_variant(params, variant, cattrs),
         });
 
         quote! {

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -317,7 +317,7 @@ fn serialize_struct_as_struct(
     let type_name = cattrs.name().serialize_name();
 
     let additional_field_count: usize = match cattrs.tag() {
-        attr::TagType::Internal{ref tag} => {
+        &attr::TagType::Internal{ref tag} => {
             let func = StructTrait::SerializeStruct.serialize_field(Span::call_site());
             serialize_fields.insert(0, quote! {
                 try!(#func(&mut __serde_state, #tag, #type_name));

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -1377,6 +1377,44 @@ fn test_enum_in_internally_tagged_enum() {
 }
 
 #[test]
+fn test_internally_tagged_struct() {
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    #[serde(tag="type")]
+    pub struct Struct {
+        a: u8,
+    }
+
+    assert_tokens(
+        &Struct{ a: 1 },
+        &[
+            Token::Struct {
+                name: "Struct",
+                len: 2,
+            },
+            Token::Str("type"),
+            Token::Str("Struct"),
+            Token::Str("a"),
+            Token::U8(1),
+            Token::StructEnd,
+        ],
+    );
+
+    assert_de_tokens(
+        &Struct { a: 1 },
+        &[
+            Token::Struct {
+                name: "Struct",
+                len: 1,
+            },
+            Token::Str("a"),
+            Token::U8(1),
+            Token::StructEnd,
+        ],
+    );
+
+}
+
+#[test]
 fn test_enum_in_untagged_enum() {
     #[derive(Debug, PartialEq, Serialize, Deserialize)]
     #[serde(untagged)]

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -1411,7 +1411,6 @@ fn test_internally_tagged_struct() {
             Token::StructEnd,
         ],
     );
-
 }
 
 #[test]

--- a/test_suite/tests/ui/enum-representation/internally-tagged-struct.rs
+++ b/test_suite/tests/ui/enum-representation/internally-tagged-struct.rs
@@ -1,8 +1,0 @@
-#[macro_use]
-extern crate serde_derive;
-
-#[derive(Serialize)]
-#[serde(tag = "type")]
-struct S;
-
-fn main() {}

--- a/test_suite/tests/ui/enum-representation/internally-tagged-struct.stderr
+++ b/test_suite/tests/ui/enum-representation/internally-tagged-struct.stderr
@@ -1,8 +1,0 @@
-error: #[serde(tag = "...")] can only be used on enums
- --> $DIR/internally-tagged-struct.rs:6:1
-  |
-6 | struct S;
-  | ^^^^^^
-
-error: aborting due to previous error
-

--- a/test_suite/tests/ui/struct-representation/internally-taged-tuple.rs
+++ b/test_suite/tests/ui/struct-representation/internally-taged-tuple.rs
@@ -1,0 +1,11 @@
+#[macro_use]
+extern crate serde_derive;
+
+#[derive(Serialize)]
+#[serde(tag = "type")]
+struct S (
+    u8,
+    u8
+);
+
+fn main() {}

--- a/test_suite/tests/ui/struct-representation/internally-taged-tuple.stderr
+++ b/test_suite/tests/ui/struct-representation/internally-taged-tuple.stderr
@@ -1,0 +1,12 @@
+error: #[serde(tag = "...")] can only be used on enums and structs with named fields
+ --> $DIR/internally-taged-tuple.rs:6:10
+  |
+6 |   struct S (
+  |  __________^
+7 | |     u8,
+8 | |     u8
+9 | | );
+  | |_^
+
+error: aborting due to previous error
+

--- a/test_suite/tests/ui/struct-representation/internally-tagged-unit.rs
+++ b/test_suite/tests/ui/struct-representation/internally-tagged-unit.rs
@@ -1,0 +1,8 @@
+#[macro_use]
+extern crate serde_derive;
+
+#[derive(Serialize)]
+#[serde(tag = "type")]
+struct U;
+
+fn main() {}

--- a/test_suite/tests/ui/struct-representation/internally-tagged-unit.stderr
+++ b/test_suite/tests/ui/struct-representation/internally-tagged-unit.stderr
@@ -1,0 +1,8 @@
+error: #[serde(tag = "...")] can only be used on enums and structs with named fields
+ --> $DIR/internally-tagged-unit.rs:4:10
+  |
+4 | #[derive(Serialize)]
+  |          ^^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This is a patch to address #760 to allow #[serde(tag="...")] on structs. I guess, this patch would require a change in the docs, so it is still WIP.

Added test test_internally_tagged_struct.
Renamed EnumTag to TagType as it now also used for structs.
Modified serialize_struct_as_struct.
Removed ui/enum-representation/internally-tagged-struct test