### PR TITLE
Bug fix to support the tag attribute on braced structs with zero fields

### DIFF
--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -333,7 +333,8 @@ fn serialize_struct_as_struct(
         .filter(|&field| !field.attrs.skip_serializing())
         .peekable();
 
-    let let_mut = mut_if(serialized_fields.peek().is_some());
+    let let_mut = mut_if(serialized_fields.peek().is_some() ||
+                         additional_field_count > 0);
 
     let len = serialized_fields
         .map(|field| match field.attrs.skip_serializing_if() {

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -1414,6 +1414,26 @@ fn test_internally_tagged_struct() {
 }
 
 #[test]
+fn test_internally_tagged_braced_struct_with_zero_fields() {
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    #[serde(tag = "type")]
+    struct S {}
+
+    assert_tokens(
+        &S{ },
+        &[
+            Token::Struct {
+                name: "S",
+                len: 1,
+            },
+            Token::Str("type"),
+            Token::Str("S"),
+            Token::StructEnd,
+        ],
+    );
+}
+
+#[test]
 fn test_enum_in_untagged_enum() {
     #[derive(Debug, PartialEq, Serialize, Deserialize)]
     #[serde(untagged)]


### PR DESCRIPTION
Bug fix for #1449

Modified serialize_struct_as_struct.
Added test test_internally_tagged_braced_struct_with_zero_fields