### PR TITLE
Updating README with instructions for 2018 use

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ fn main() {
     println!("deserialized = {:?}", deserialized);
 }
 ```
+### Rust 2018
+
+If you use Rust 2018 (by setting `edition = 2018` in your `Cargo.toml`), you don't need to `extern crate` and can instead just `use` directly:
+
+```rust
+use serde_derive::{Deserialize, Serialize};
+use serde_json;
+```
 
 ## Getting help
 


### PR DESCRIPTION
Addresses https://github.com/serde-rs/serde/issues/1439

Updates readme to add section explaining how to include Serde when using 2018 edition. 

If anyone needs to check, here's the [playground with 2018 import changes](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=e09320e7dfa414118287519bd5756775) to the example snippet from the readme