### PR TITLE
Implement representing enums as integers

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1675,6 +1675,7 @@ fn deserialize_integer_enum(
         .filter(|variant| !variant.attrs.skip_deserializing())
         .enumerate()
     {
+        assert!(variant.attrs.deserialize_with().is_none());
         let variant_ident = &variant.ident;
         let const_name = Ident::new(&format!("__variant{}", idx), Span::call_site());
         consts.push(quote!{

--- a/serde_derive/src/internals/check.rs
+++ b/serde_derive/src/internals/check.rs
@@ -258,7 +258,7 @@ fn check_internal_tag_field_name_conflict(cx: &Ctxt, cont: &Container) {
 
     let tag = match *cont.attrs.tag() {
         TagType::Internal { ref tag } => tag.as_str(),
-        TagType::External | TagType::Adjacent { .. } | TagType::None => return,
+        TagType::External | TagType::Adjacent { .. } | TagType::None | TagType::Integer => return,
     };
 
     let diagnose_conflict = || {
@@ -303,7 +303,7 @@ fn check_adjacent_tag_conflict(cx: &Ctxt, cont: &Container) {
             ref tag,
             ref content,
         } => (tag, content),
-        TagType::Internal { .. } | TagType::External | TagType::None => return,
+        TagType::Internal { .. } | TagType::External | TagType::None | TagType::Integer => return,
     };
 
     if type_tag == content_tag {

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -780,6 +780,7 @@ fn serialize_integer_variant(
     variant: &Variant,
     _cattrs: &attr::Container,
 ) -> Fragment {
+    assert!(variant.attrs.serialize_with().is_none());
     let this = &params.this;
     let variant_ident = &variant.ident;
     quote_expr! {

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -473,6 +473,7 @@ fn serialize_variant(
                 ref content,
             } => serialize_adjacently_tagged_variant(params, variant, cattrs, tag, content),
             attr::TagType::None => serialize_untagged_variant(params, variant, cattrs),
+            attr::TagType::Integer => serialize_integer_variant(params, variant, cattrs),
         });
 
         quote! {
@@ -771,6 +772,18 @@ fn serialize_untagged_variant(
             let type_name = cattrs.name().serialize_name();
             serialize_struct_variant(StructVariant::Untagged, params, &variant.fields, &type_name)
         }
+    }
+}
+
+fn serialize_integer_variant(
+    params: &Parameters,
+    variant: &Variant,
+    _cattrs: &attr::Container,
+) -> Fragment {
+    let this = &params.this;
+    let variant_ident = &variant.ident;
+    quote_expr! {
+        _serde::Serializer::serialize_u64(__serializer, #this::#variant_ident as u64)
     }
 }
 

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -1838,3 +1838,54 @@ fn test_internally_tagged_newtype_variant_containing_unit_struct() {
         ],
     );
 }
+
+#[test]
+fn test_integer_tagged_enum() {
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    #[serde(integer)]
+    enum MessageKind {
+        Info = 2,
+        Error = 4,
+    }
+
+    assert_tokens(
+        &MessageKind::Info,
+        &[
+            Token::U64(2),
+        ],
+    );
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    #[serde(integer)]
+    enum AutoNumberedEnum {
+        V0,
+        V1,
+        V3 = 3,
+        V4
+    }
+
+    assert_tokens(
+        &AutoNumberedEnum::V0,
+        &[
+            Token::U64(0),
+        ],
+    );
+    assert_tokens(
+        &AutoNumberedEnum::V1,
+        &[
+            Token::U64(1),
+        ],
+    );
+    assert_tokens(
+        &AutoNumberedEnum::V3,
+        &[
+            Token::U64(3),
+        ],
+    );
+    assert_tokens(
+        &AutoNumberedEnum::V4,
+        &[
+            Token::U64(4),
+        ],
+    );
+}

--- a/test_suite/tests/ui/enum-representation/integer-and-adjacent.rs
+++ b/test_suite/tests/ui/enum-representation/integer-and-adjacent.rs
@@ -1,0 +1,11 @@
+use serde_derive::Serialize;
+
+#[derive(Serialize)]
+#[serde(integer)]
+#[serde(tag = "t", content = "c")]
+enum E {
+    A(u8),
+    B(String),
+}
+
+fn main() {}

--- a/test_suite/tests/ui/enum-representation/integer-and-adjacent.stderr
+++ b/test_suite/tests/ui/enum-representation/integer-and-adjacent.stderr
@@ -1,0 +1,14 @@
+error: enum cannot be both represented as integer and carry a tag
+ --> $DIR/integer-and-adjacent.rs:4:9
+  |
+4 | #[serde(integer)]
+  |         ^^^^^^^
+
+error: enum cannot be both represented as integer and carry a tag
+ --> $DIR/integer-and-adjacent.rs:5:9
+  |
+5 | #[serde(tag = "t", content = "c")]
+  |         ^^^
+
+error: aborting due to 2 previous errors
+

--- a/test_suite/tests/ui/enum-representation/integer-and-content.rs
+++ b/test_suite/tests/ui/enum-representation/integer-and-content.rs
@@ -1,0 +1,11 @@
+use serde_derive::Serialize;
+
+#[derive(Serialize)]
+#[serde(integer)]
+#[serde(content = "c")]
+enum E {
+    A(u8),
+    B(String),
+}
+
+fn main() {}

--- a/test_suite/tests/ui/enum-representation/integer-and-content.stderr
+++ b/test_suite/tests/ui/enum-representation/integer-and-content.stderr
@@ -1,0 +1,8 @@
+error: #[serde(tag = "...", content = "...")] must be used together
+ --> $DIR/integer-and-content.rs:5:9
+  |
+5 | #[serde(content = "c")]
+  |         ^^^^^^^
+
+error: aborting due to previous error
+

--- a/test_suite/tests/ui/enum-representation/integer-and-internal.rs
+++ b/test_suite/tests/ui/enum-representation/integer-and-internal.rs
@@ -1,0 +1,11 @@
+use serde_derive::Serialize;
+
+#[derive(Serialize)]
+#[serde(integer)]
+#[serde(tag = "type")]
+enum E {
+    A(u8),
+    B(String),
+}
+
+fn main() {}

--- a/test_suite/tests/ui/enum-representation/integer-and-internal.stderr
+++ b/test_suite/tests/ui/enum-representation/integer-and-internal.stderr
@@ -1,0 +1,14 @@
+error: enum cannot be both represented as integer and carry a tag
+ --> $DIR/integer-and-internal.rs:4:9
+  |
+4 | #[serde(integer)]
+  |         ^^^^^^^
+
+error: enum cannot be both represented as integer and carry a tag
+ --> $DIR/integer-and-internal.rs:5:9
+  |
+5 | #[serde(tag = "type")]
+  |         ^^^
+
+error: aborting due to 2 previous errors
+

--- a/test_suite/tests/ui/enum-representation/integer-and-untagged.rs
+++ b/test_suite/tests/ui/enum-representation/integer-and-untagged.rs
@@ -1,0 +1,11 @@
+use serde_derive::Serialize;
+
+#[derive(Serialize)]
+#[serde(integer)]
+#[serde(untagged)]
+enum E {
+    A(u8),
+    B(String),
+}
+
+fn main() {}

--- a/test_suite/tests/ui/enum-representation/integer-and-untagged.stderr
+++ b/test_suite/tests/ui/enum-representation/integer-and-untagged.stderr
@@ -1,0 +1,14 @@
+error: enum cannot be both untagged and represented as integer
+ --> $DIR/integer-and-untagged.rs:5:9
+  |
+5 | #[serde(untagged)]
+  |         ^^^^^^^^
+
+error: enum cannot be both untagged and represented as integer
+ --> $DIR/integer-and-untagged.rs:4:9
+  |
+4 | #[serde(integer)]
+  |         ^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/test_suite/tests/ui/enum-representation/integer-de-serialize-with.rs
+++ b/test_suite/tests/ui/enum-representation/integer-de-serialize-with.rs
@@ -1,0 +1,19 @@
+use serde_derive::{Serialize, Deserialize};
+
+#[derive(Serialize, Deserialize)]
+#[serde(integer)]
+enum E {
+    #[serde(serialize_with = "serialize_some_variant")]
+    A,
+    B
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(integer)]
+enum F {
+    A,
+    #[serde(deserialize_with = "deserialize_some_variant")]
+    B
+}
+
+fn main() {}

--- a/test_suite/tests/ui/enum-representation/integer-de-serialize-with.stderr
+++ b/test_suite/tests/ui/enum-representation/integer-de-serialize-with.stderr
@@ -1,0 +1,16 @@
+error: enums represented as integers cannot have #[serde(serialize_with)]
+ --> $DIR/integer-de-serialize-with.rs:6:5
+  |
+6 | /     #[serde(serialize_with = "serialize_some_variant")]
+7 | |     A,
+  | |_____^
+
+error: enums represented as integers cannot have #[serde(deserialize_with)]
+  --> $DIR/integer-de-serialize-with.rs:15:5
+   |
+15 | /     #[serde(deserialize_with = "deserialize_some_variant")]
+16 | |     B
+   | |_____^
+
+error: aborting due to 2 previous errors
+

--- a/test_suite/tests/ui/enum-representation/integer-struct.rs
+++ b/test_suite/tests/ui/enum-representation/integer-struct.rs
@@ -1,0 +1,7 @@
+use serde_derive::Serialize;
+
+#[derive(Serialize)]
+#[serde(integer)]
+struct S;
+
+fn main() {}

--- a/test_suite/tests/ui/enum-representation/integer-struct.stderr
+++ b/test_suite/tests/ui/enum-representation/integer-struct.stderr
@@ -1,0 +1,8 @@
+error: #[serde(integer)] can only be used on enums
+ --> $DIR/integer-struct.rs:5:1
+  |
+5 | struct S;
+  | ^^^^^^
+
+error: aborting due to previous error
+

--- a/test_suite/tests/ui/enum-representation/integer-with-field.rs
+++ b/test_suite/tests/ui/enum-representation/integer-with-field.rs
@@ -1,0 +1,10 @@
+use serde_derive::{Serialize, Deserialize};
+
+#[derive(Serialize, Deserialize)]
+#[serde(integer)]
+enum E {
+    A(u8),
+    B(String),
+}
+
+fn main() {}

--- a/test_suite/tests/ui/enum-representation/integer-with-field.stderr
+++ b/test_suite/tests/ui/enum-representation/integer-with-field.stderr
@@ -1,0 +1,14 @@
+error: enums represented as integers cannot have variants with fields
+ --> $DIR/integer-with-field.rs:6:5
+  |
+6 |     A(u8),
+  |     ^^^^^
+
+error: enums represented as integers cannot have variants with fields
+ --> $DIR/integer-with-field.rs:7:5
+  |
+7 |     B(String),
+  |     ^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
I have not worked with syn/quote before, so I hope this makes some sense. I have no idea what the point of all the phantom stuff in `__Visitor` is, but I copied that from elsewhere in the same file. Also, I used `u64` because that's what is used in the [example in the docs](https://serde.rs/enum-representations.html), but I've been wondering if `u128` wouldn't be more correct. Maybe it should be `#[serde(u64)]` to leave room for expanding that to more integer types in the future?

Fixes https://github.com/serde-rs/json/issues/349