### PR TITLE
Array impls using MaybeUninit

### DIFF
--- a/serde/build.rs
+++ b/serde/build.rs
@@ -25,8 +25,12 @@ fn main() {
 
     // CString::into_boxed_c_str stabilized in Rust 1.20:
     // https://doc.rust-lang.org/std/ffi/struct.CString.html#method.into_boxed_c_str
+    //
+    // Also ManuallyDrop
+    // https://doc.rust-lang.org/std/mem/struct.ManuallyDrop.html
     if minor >= 20 {
         println!("cargo:rustc-cfg=de_boxed_c_str");
+        println!("cargo:rustc-cfg=manually_drop");
     }
 
     // From<Box<T>> for Rc<T> / Arc<T> stabilized in Rust 1.21:

--- a/serde/src/backport.rs
+++ b/serde/src/backport.rs
@@ -1,0 +1,30 @@
+use lib::*;
+
+// An opaque chunk of bytes that is at least as big as T.
+//
+// We can't use core::mem::MaybeUninit because it is not stable yet.
+// https://github.com/rust-lang/rust/issues/53491
+//
+// We can't use [u8; core::mem::size_of::<T>()] because type parameters are not
+// supported in an array length expression.
+// https://github.com/rust-lang/rust/issues/43408
+pub struct MaybeUninit<T> {
+    #[allow(dead_code)]
+    mem: ManuallyDrop<MemAtLeast<T>>,
+}
+
+enum MemAtLeast<T> {
+    Uninit,
+    #[allow(dead_code)]
+    Value(T),
+}
+
+impl<T> MaybeUninit<T> {
+    pub fn uninitialized() -> Self {
+        debug_assert!(mem::size_of::<Self>() >= mem::size_of::<T>());
+
+        MaybeUninit {
+            mem: ManuallyDrop::new(MemAtLeast::Uninit),
+        }
+    }
+}

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -132,7 +132,7 @@ mod lib {
         pub use std::*;
     }
 
-    pub use self::core::{cmp, iter, mem, num, slice, str};
+    pub use self::core::{cmp, iter, mem, num, ptr, slice, str};
     pub use self::core::{f32, f64};
     pub use self::core::{i16, i32, i64, i8, isize};
     pub use self::core::{u16, u32, u64, u8, usize};
@@ -213,6 +213,9 @@ mod lib {
 
     #[cfg(ops_bound)]
     pub use self::core::ops::Bound;
+
+    #[cfg(manually_drop)]
+    pub use self::core::mem::ManuallyDrop;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -222,6 +225,9 @@ mod macros;
 
 #[macro_use]
 mod integer128;
+
+#[cfg(manually_drop)]
+mod backport;
 
 pub mod de;
 pub mod ser;


### PR DESCRIPTION
This commit improves compile time of Serde by 13% in exchange for three lines of unsafe code deserializing fixed size arrays and 1.9x slower performance on the following array deserialization microbenchmark:

```rust
#![feature(test)]

extern crate test;
use test::Bencher;

#[bench]
fn bench(b: &mut Bencher) {
    let array: [u32; 32] = [
        01, 02, 03, 04, 05, 06, 07, 08, 09, 10,
        11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
        21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
        31, 32,
    ];
    let bytes = bincode::serialize(&array).unwrap();
    assert_eq!(bytes.len(), 32 * 4);
    b.iter(|| {
        for _ in 0..100 {
            let _ = bincode::deserialize::<[u32; 32]>(&bytes).unwrap();
        }
    });
}
```

Will need to do some profiling and figure out whether the performance can be recouped.