### PR TITLE
Don't generate code with redundant closures

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -2476,7 +2476,7 @@ fn deserialize_map(
 
     let collected_deny_unknown_fields = if cattrs.has_flatten() && cattrs.deny_unknown_fields() {
         Some(quote! {
-            if let _serde::export::Some(_serde::export::Some((__key, _))) = __collect.into_iter().filter(|x| x.is_some()).next() {
+            if let _serde::export::Some(_serde::export::Some((__key, _))) = __collect.into_iter().filter(Option::is_some).next() {
                 if let _serde::export::Some(__key) = __key.as_str() {
                     return _serde::export::Err(
                         _serde::de::Error::custom(format_args!("unknown field `{}`", &__key)));


### PR DESCRIPTION
This PR resolves #1491.

I also changed the .travis.yml file to properly install clippy and removed the job from the "allow_failure_ matrix. Further explanations in #1491.

If that is not welcomed, I am happy to remove the last commit again but then I am not sure how to actually test the code change to prevent regressions.