### PR TITLE
Allow `#[serde(crate = "...")]` to override `extern crate serde`

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -60,7 +60,7 @@ pub fn expand_derive_deserialize(input: &syn::DeriveInput) -> Result<TokenStream
         }
     };
 
-    Ok(dummy::wrap_in_const("DESERIALIZE", ident, impl_block))
+    Ok(dummy::wrap_in_const(cont.attrs.serde_path(), "DESERIALIZE", ident, impl_block))
 }
 
 fn precondition(cx: &Ctxt, cont: &Container) {

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -60,7 +60,7 @@ pub fn expand_derive_deserialize(input: &syn::DeriveInput) -> Result<TokenStream
         }
     };
 
-    Ok(dummy::wrap_in_const(cont.attrs.serde_path(), "DESERIALIZE", ident, impl_block))
+    Ok(dummy::wrap_in_const(cont.attrs.custom_serde_path(), "DESERIALIZE", ident, impl_block))
 }
 
 fn precondition(cx: &Ctxt, cont: &Container) {

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -27,15 +27,16 @@ pub fn expand_derive_deserialize(input: &syn::DeriveInput) -> Result<TokenStream
     let (de_impl_generics, _, ty_generics, where_clause) = split_with_de_lifetime(&params);
     let body = Stmts(deserialize_body(&cont, &params));
     let delife = params.borrowed.de_lifetime();
+    let serde = cont.attrs.serde_path();
 
     let impl_block = if let Some(remote) = cont.attrs.remote() {
         let vis = &input.vis;
         let used = pretend::pretend_used(&cont);
         quote! {
             impl #de_impl_generics #ident #ty_generics #where_clause {
-                #vis fn deserialize<__D>(__deserializer: __D) -> _serde::export::Result<#remote #ty_generics, __D::Error>
+                #vis fn deserialize<__D>(__deserializer: __D) -> #serde::export::Result<#remote #ty_generics, __D::Error>
                 where
-                    __D: _serde::Deserializer<#delife>,
+                    __D: #serde::Deserializer<#delife>,
                 {
                     #used
                     #body
@@ -47,10 +48,10 @@ pub fn expand_derive_deserialize(input: &syn::DeriveInput) -> Result<TokenStream
 
         quote! {
             #[automatically_derived]
-            impl #de_impl_generics _serde::Deserialize<#delife> for #ident #ty_generics #where_clause {
-                fn deserialize<__D>(__deserializer: __D) -> _serde::export::Result<Self, __D::Error>
+            impl #de_impl_generics #serde::Deserialize<#delife> for #ident #ty_generics #where_clause {
+                fn deserialize<__D>(__deserializer: __D) -> #serde::export::Result<Self, __D::Error>
                 where
-                    __D: _serde::Deserializer<#delife>,
+                    __D: #serde::Deserializer<#delife>,
                 {
                     #body
                 }

--- a/serde_derive/src/dummy.rs
+++ b/serde_derive/src/dummy.rs
@@ -1,5 +1,6 @@
 use proc_macro2::{Ident, Span, TokenStream};
 
+use syn;
 use try;
 
 pub fn wrap_in_const(serde_path: Option<&syn::Path>, trait_: &str, ty: &Ident, code: TokenStream) -> TokenStream {

--- a/serde_derive/src/dummy.rs
+++ b/serde_derive/src/dummy.rs
@@ -2,7 +2,7 @@ use proc_macro2::{Ident, Span, TokenStream};
 
 use try;
 
-pub fn wrap_in_const(trait_: &str, ty: &Ident, code: TokenStream) -> TokenStream {
+pub fn wrap_in_const(serde_path: Option<&syn::Path>, trait_: &str, ty: &Ident, code: TokenStream) -> TokenStream {
     let try_replacement = try::replacement();
 
     let dummy_const = Ident::new(
@@ -10,13 +10,21 @@ pub fn wrap_in_const(trait_: &str, ty: &Ident, code: TokenStream) -> TokenStream
         Span::call_site(),
     );
 
-    quote! {
-        #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
-        const #dummy_const: () = {
+    let use_serde = serde_path.map(|path| {
+        quote!(use #path as _serde;)
+    }).unwrap_or_else(|| {
+        quote! {
             #[allow(unknown_lints)]
             #[cfg_attr(feature = "cargo-clippy", allow(useless_attribute))]
             #[allow(rust_2018_idioms)]
             extern crate serde as _serde;
+        }
+    });
+
+    quote! {
+        #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
+        const #dummy_const: () = {
+            #use_serde
             #try_replacement
             #code
         };

--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -687,7 +687,7 @@ impl Container {
         self.serde_path.as_ref()
     }
 
-    pub fn serde_path<'a>(&'a self) -> Cow<'a, syn::Path> {
+    pub fn serde_path(&self) -> Cow<syn::Path> {
         self.custom_serde_path()
             .map(Cow::Borrowed)
             .unwrap_or_else(|| Cow::Owned(parse_quote!(_serde)))

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -51,7 +51,7 @@ pub fn expand_derive_serialize(input: &syn::DeriveInput) -> Result<TokenStream, 
         }
     };
 
-    Ok(dummy::wrap_in_const("SERIALIZE", ident, impl_block))
+    Ok(dummy::wrap_in_const(cont.attrs.serde_path(), "SERIALIZE", ident, impl_block))
 }
 
 fn precondition(cx: &Ctxt, cont: &Container) {

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -22,15 +22,16 @@ pub fn expand_derive_serialize(input: &syn::DeriveInput) -> Result<TokenStream, 
     let params = Parameters::new(&cont);
     let (impl_generics, ty_generics, where_clause) = params.generics.split_for_impl();
     let body = Stmts(serialize_body(&cont, &params));
+    let serde = cont.attrs.serde_path();
 
     let impl_block = if let Some(remote) = cont.attrs.remote() {
         let vis = &input.vis;
         let used = pretend::pretend_used(&cont);
         quote! {
             impl #impl_generics #ident #ty_generics #where_clause {
-                #vis fn serialize<__S>(__self: &#remote #ty_generics, __serializer: __S) -> _serde::export::Result<__S::Ok, __S::Error>
+                #vis fn serialize<__S>(__self: &#remote #ty_generics, __serializer: __S) -> #serde::export::Result<__S::Ok, __S::Error>
                 where
-                    __S: _serde::Serializer,
+                    __S: #serde::Serializer,
                 {
                     #used
                     #body
@@ -40,10 +41,10 @@ pub fn expand_derive_serialize(input: &syn::DeriveInput) -> Result<TokenStream, 
     } else {
         quote! {
             #[automatically_derived]
-            impl #impl_generics _serde::Serialize for #ident #ty_generics #where_clause {
-                fn serialize<__S>(&self, __serializer: __S) -> _serde::export::Result<__S::Ok, __S::Error>
+            impl #impl_generics #serde::Serialize for #ident #ty_generics #where_clause {
+                fn serialize<__S>(&self, __serializer: __S) -> #serde::export::Result<__S::Ok, __S::Error>
                 where
-                    __S: _serde::Serializer,
+                    __S: #serde::Serializer,
                 {
                     #body
                 }
@@ -51,7 +52,7 @@ pub fn expand_derive_serialize(input: &syn::DeriveInput) -> Result<TokenStream, 
         }
     };
 
-    Ok(dummy::wrap_in_const(cont.attrs.serde_path(), "SERIALIZE", ident, impl_block))
+    Ok(dummy::wrap_in_const(cont.attrs.custom_serde_path(), "SERIALIZE", ident, impl_block))
 }
 
 fn precondition(cx: &Ctxt, cont: &Container) {

--- a/test_suite/tests/test_serde_path.rs
+++ b/test_suite/tests/test_serde_path.rs
@@ -1,0 +1,39 @@
+#[test]
+fn test_gen_custom_serde() {
+    #[derive(serde::Serialize, serde::Deserialize)]
+    #[serde(serde_path = "fake_serde")]
+    struct Foo;
+
+    // Would be overlapping if serde::Serialize were implemented
+    impl AssertNotSerdeSerialize for Foo {}
+    // Would be overlapping if serde::Deserialize were implemented
+    impl<'a> AssertNotSerdeDeserialize<'a> for Foo {}
+
+    fake_serde::assert::<Foo>();
+}
+
+mod fake_serde {
+    pub use serde::*;
+
+    pub fn assert<T>()
+    where
+        T: Serialize,
+        T: for<'a> Deserialize<'a>,
+    {}
+
+    pub trait Serialize {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error>;
+    }
+
+    pub trait Deserialize<'a>: Sized {
+        fn deserialize<D: Deserializer<'a>>(deserializer: D) -> Result<Self, D::Error>;
+    }
+}
+
+trait AssertNotSerdeSerialize {}
+
+impl<T: serde::Serialize> AssertNotSerdeSerialize for T {}
+
+trait AssertNotSerdeDeserialize<'a> {}
+
+impl<'a, T: serde::Deserialize<'a>> AssertNotSerdeDeserialize<'a> for T {}

--- a/test_suite/tests/test_serde_path.rs
+++ b/test_suite/tests/test_serde_path.rs
@@ -1,7 +1,7 @@
 #[test]
 fn test_gen_custom_serde() {
     #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(serde_path = "fake_serde")]
+    #[serde(crate = "fake_serde")]
     struct Foo;
 
     // Would be overlapping if serde::Serialize were implemented


### PR DESCRIPTION
This is intended to be used by other crates which provide their own proc
macros and use serde internally. Today there's no consistent way to put
`#[derive(Deserialize)]` on a struct that consistently works, since
crates may be using either `features = ["derive"]` or relying on
`serde_derive` separately.

Even if we assume that everyone is using `features = ["derive"]`,
without this commit, any crate which generates
`#[derive(serde::Deserialize)]` forces its consumers to put `serde` in
their `Cargo.toml`, even if they aren't otherwise using serde for
anything.

Examples of crates which suffer from this in the real world are
tower-web and swirl.

With this feature, it's expected that these crates would have `pub
extern crate serde;` in some accessible path, and add
`#[serde(serde_path = "that_crate::wherever::serde")]` anywhere they
place serde's derives. Those crates would also have to derive
`that_crate::whatever::serde::Deserialize`, or `use` the macros
explicitly beforehand.

The test for this is a little funky, as it's testing this in a way that
is not the intended use case, or even one we want to support. It has its
own module which re-exports all of serde, but defines its own
`Serialize` and `Deserialize` traits. We then test that we generated
impls for those traits, instead of serde's. The only other way to test
this would be to create a new test crate which does not depend on serde,
but instead depends on `serde_derive` and a third crate which publicly
re-exports serde. This feels like way too much overhead for a single
test case, hence the funky test given.

I didn't see anywhere in this repo to document this attribute, so I
assume the docs will have to be done as a separate PR to a separate
repo.

Fixes #1487