### PR TITLE
Temporarily disable compiletest testing in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
         - cd "${TRAVIS_BUILD_DIR}/test_suite/deps"
         - cargo build
         - cd "${TRAVIS_BUILD_DIR}/test_suite"
-        - cargo test --features compiletest,unstable
+        - cargo test --features unstable
         - cd "${TRAVIS_BUILD_DIR}/test_suite/no_std"
         - cargo build
 


### PR DESCRIPTION
The nightly compiler just added a dependency on serde in https://github.com/rust-lang/rust/pull/60053, so libserde now ends up in the sysroot, breaking crate resolution inside of compiletest. We will need to figure out how else to run these tests.

```console
error[E0464]: multiple matching crates for `serde`
  --> $DIR/wrong_ser.rs:9:10
   |
 9 | #[derive(Serialize)]
   |          ^^^^^^^^^
   |
   = note: candidates:
           crate `serde`: /rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libserde-2b75907288aa7c40.rlib
           crate `serde`: /serde/test_suite/deps/target/debug/deps/libserde-33e0a319242344ce.rlib
```