### PR TITLE
de: Make flattened structs and aliases interact correctly.

### DIFF
--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -1112,6 +1112,28 @@ pub trait Deserializer<'de>: Sized {
     where
         V: Visitor<'de>;
 
+    /// Hint that the `Deserialize` type is expecting a struct with a particular
+    /// name and fields.
+    ///
+    /// `_fields_with_aliases` includes all valid field names, including
+    /// aliases.  `fields` only includes the canonical struct fields.
+    ///
+    /// Use this if you care about aliased fields. For backwards compatibility,
+    /// by default this calls `deserialize_struct`. If you implement this, you
+    /// probably want `deserialize_struct` to call this instead.
+    fn deserialize_struct_with_aliases<V>(
+        self,
+        name: &'static str,
+        fields: &'static [&'static str],
+        _fields_with_aliases: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        self.deserialize_struct(name, fields, visitor)
+    }
+
     /// Hint that the `Deserialize` type is expecting an enum value with a
     /// particular name and possible variants.
     fn deserialize_enum<V>(
@@ -2191,6 +2213,30 @@ pub trait VariantAccess<'de>: Sized {
     ) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>;
+
+    /// Called when deserializing a struct-like variant.
+    ///
+    /// The `fields` are the names of the fields of the struct variant.
+    ///
+    /// `_fields_with_aliases` includes all valid field names, including
+    /// aliases.  `fields` only includes the canonical struct fields.
+    ///
+    /// Use this if you care about aliased fields. For backwards compatibility,
+    /// by default this calls `struct_variant`. If you implement this, you
+    /// probably want `struct_variant` to call this instead.
+    ///
+    /// Same constraints as `struct_vriant` applies.
+    fn struct_variant_with_aliases<V>(
+        self,
+        fields: &'static [&'static str],
+        _fields_with_aliases: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        self.struct_variant(fields, visitor)
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -2723,14 +2723,27 @@ where
 
     fn deserialize_struct<V>(
         self,
-        _: &'static str,
+        name: &'static str,
         fields: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_map(FlatStructAccess::new(self.0.iter_mut(), fields))
+        self.deserialize_struct_with_aliases(name, fields, fields, visitor)
+    }
+
+    fn deserialize_struct_with_aliases<V>(
+        self,
+        _: &'static str,
+        _: &'static [&'static str],
+        fields_with_aliases: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_map(FlatStructAccess::new(self.0.iter_mut(), fields_with_aliases))
     }
 
     fn deserialize_newtype_struct<V>(self, _name: &str, visitor: V) -> Result<V::Value, Self::Error>

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -617,7 +617,6 @@ fn test_rename_struct() {
 }
 
 #[test]
-#[should_panic] // FIXME(emilio): It shouldn't!
 fn test_alias_flattened() {
     #[derive(Debug, PartialEq, Deserialize)]
     struct Flattened {

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -617,6 +617,64 @@ fn test_rename_struct() {
 }
 
 #[test]
+#[should_panic] // FIXME(emilio): It shouldn't!
+fn test_alias_flattened() {
+    #[derive(Debug, PartialEq, Deserialize)]
+    struct Flattened {
+        #[serde(flatten)]
+        with_aliases: AliasStruct,
+    }
+
+    // First without the aliases.
+    assert_de_tokens(
+        &Flattened {
+            with_aliases: AliasStruct {
+                a1: 1,
+                a2: 2,
+                a4: 3,
+            },
+        },
+        &[
+            Token::Struct {
+                name: "Flattened",
+                len: 3,
+            },
+            Token::Str("a1"),
+            Token::I32(1),
+            Token::Str("a2"),
+            Token::I32(2),
+            Token::Str("a6"),
+            Token::I32(3),
+            Token::StructEnd,
+        ],
+    );
+
+    // Now with them
+    assert_de_tokens(
+        &Flattened {
+            with_aliases: AliasStruct {
+                a1: 1,
+                a2: 2,
+                a4: 3,
+            },
+        },
+        &[
+            Token::Struct {
+                name: "Flattened",
+                len: 3,
+            },
+            Token::Str("a1"),
+            Token::I32(1),
+            Token::Str("a3"),
+            Token::I32(2),
+            Token::Str("a6"),
+            Token::I32(3),
+            Token::StructEnd,
+        ],
+    );
+}
+
+#[test]
 fn test_unknown_field_rename_struct() {
     assert_de_tokens_error::<AliasStruct>(
         &[


### PR DESCRIPTION
The issue is that FlatStructAccess has no access to the aliases of the struct
it's deserializing.

Ideally we'd try to serialize the key rather than checking whether we're going
to use it before-hand, then actually take the value out, but that happens to be
tricky with the current seed API.

So we need to somehow get the aliased names back to FlatStructAccess. Introduce
a serialize_struct-like API that takes them in a backwards-compatible way. For
parallelism, and since we also support aliases on enum variants, also extend the
struct_variant API in a similar way. I'm open to better ways to fix it, but I
can't think of any other that isn't a breaking change...

Fixes #1504.