### PR TITLE
Add serde attribute `try_from`

### DIFF
--- a/serde/src/export.rs
+++ b/serde/src/export.rs
@@ -1,5 +1,5 @@
 pub use lib::clone::Clone;
-pub use lib::convert::{From, Into};
+pub use lib::convert::{From, Into, TryFrom};
 pub use lib::default::Default;
 pub use lib::fmt::{self, Formatter};
 pub use lib::marker::PhantomData;

--- a/test_suite/tests/ui/conflict/from-try-from.rs
+++ b/test_suite/tests/ui/conflict/from-try-from.rs
@@ -1,0 +1,9 @@
+use serde_derive::Serialize;
+
+#[derive(Serialize)]
+#[serde(from = "u64", try_from = "u64")]
+struct S {
+    a: u8,
+}
+
+fn main() {}

--- a/test_suite/tests/ui/conflict/from-try-from.stderr
+++ b/test_suite/tests/ui/conflict/from-try-from.stderr
@@ -1,0 +1,8 @@
+error: #[serde(from = "...")] and #[serde(try_from = "...")] conflict with each other
+ --> $DIR/from-try-from.rs:4:1
+  |
+4 | / #[serde(from = "u64", try_from = "u64")]
+5 | | struct S {
+6 | |     a: u8,
+7 | | }
+  | |_^

--- a/test_suite/tests/ui/transparent/with_try_from.rs
+++ b/test_suite/tests/ui/transparent/with_try_from.rs
@@ -1,0 +1,9 @@
+use serde_derive::Serialize;
+
+#[derive(Serialize)]
+#[serde(transparent, try_from = "u64")]
+struct S {
+    a: u8,
+}
+
+fn main() {}

--- a/test_suite/tests/ui/transparent/with_try_from.stderr
+++ b/test_suite/tests/ui/transparent/with_try_from.stderr
@@ -1,0 +1,8 @@
+error: #[serde(transparent)] is not allowed with #[serde(try_from = "...")]
+ --> $DIR/with_try_from.rs:4:1
+  |
+4 | / #[serde(transparent, try_from = "u64")]
+5 | | struct S {
+6 | |     a: u8,
+7 | | }
+  | |_^

--- a/test_suite/tests/ui/type-attribute/try_from.rs
+++ b/test_suite/tests/ui/type-attribute/try_from.rs
@@ -1,0 +1,12 @@
+use serde_derive::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(try_from = "Option<T")]
+enum TestOne {
+    Testing,
+    One,
+    Two,
+    Three,
+}
+
+fn main() {}

--- a/test_suite/tests/ui/type-attribute/try_from.stderr
+++ b/test_suite/tests/ui/type-attribute/try_from.stderr
@@ -1,0 +1,5 @@
+error: failed to parse type: try_from = "Option<T"
+ --> $DIR/try_from.rs:4:20
+  |
+4 | #[serde(try_from = "Option<T")]
+  |                    ^^^^^^^^^^


### PR DESCRIPTION
This pull request adds a new serde attribute `try_from` which will make serde try to convert the type specified in the attribute to the type serde is trying to deserialize into. (#1524)

For example,

```rust
use serde::Deserialize;
use serde_json;
use std::convert::TryFrom;

#[derive(Deserialize, Debug)]
#[serde(try_from = "u32")]
enum Color {
    Red,
}

impl TryFrom<u32> for Color {
    type Error = String;

    fn try_from(value: u32) -> Result<Self, Self::Error> {
        if value > 10 {
            Err("out of range".into())
        } else {
            Ok(Color::Red)
        }
    }
}

fn main() {
    let result: Color = serde_json::from_str("2").unwrap();
    println!("result = {:?}", result);
    let _: Color = serde_json::from_str("100").unwrap();
}
```

will produce the following output:

```
result = Red
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error("out of range", line: 0, column: 0)', src/libcore/result.rs:997:5
note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```

## Details

* `serde_derive` will generate the `try_from` call when generating deserializing code
* The generated code will map the result type to a call to `serde::Error::custom`
* Similar to `from` attribute, `try_from` is incompatible with `transparent`
* `from` and `try_from` attributes cannot be specified at the same time