### PR TITLE
Avoid circular #[serde(from="")] using a AvoidFromMyself trait.

### DIFF
--- a/test_suite/tests/ui/type-attribute/from_self.rs
+++ b/test_suite/tests/ui/type-attribute/from_self.rs
@@ -1,0 +1,8 @@
+use serde_derive::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(from = "Point")]
+struct Point {}
+
+fn main() {
+}

--- a/test_suite/tests/ui/type-attribute/from_self.stderr
+++ b/test_suite/tests/ui/type-attribute/from_self.stderr
@@ -1,0 +1,10 @@
+error[E0119]: conflicting implementations of trait `_IMPL_DESERIALIZE_FOR_Point::AvoidFromMyself` for type `Point`:
+ --> $DIR/from_self.rs:3:10
+  |
+3 | #[derive(Deserialize)]
+  |          ^^^^^^^^^^^
+  |          |
+  |          first implementation here
+  |          conflicting implementation for `Point`
+
+For more information about this error, try `rustc --explain E0119`.


### PR DESCRIPTION
Fix to #1533.

I create a trait (AvoifFromMyself) and I try to impl it for the structure and for the "from".
If the structure and from are the same it cannot compile.

This is the best solution I have found but I hope there is a better one. 
This is a bit too complex.

 ps: the error message is terrible