### PR TITLE
Fix a compile error in derive(Deserialize) with no_std + alloc

### DIFF
--- a/serde/src/export.rs
+++ b/serde/src/export.rs
@@ -9,7 +9,7 @@ pub use lib::result::Result::{self, Err, Ok};
 pub use self::string::from_utf8_lossy;
 
 #[cfg(any(feature = "alloc", feature = "std"))]
-pub use lib::Vec;
+pub use lib::{ToString, Vec};
 
 mod string {
     use lib::*;

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -2059,7 +2059,7 @@ fn deserialize_identifier(
     ) = if collect_other_fields {
         (
             Some(quote! {
-                let __value = _serde::private::de::Content::String(__value.to_string());
+                let __value = _serde::private::de::Content::String(_serde::export::ToString::to_string(__value));
             }),
             Some(quote! {
                 let __value = _serde::private::de::Content::Str(__value);


### PR DESCRIPTION
The fact that the existing `no_std` test suite only runs on Nightly (why is it a binary crate instead of a library crate?) and that there seems to be no test suite for the alloc feature at all makes me uncertain on how to add a test for this, but I'm happy to add it after being told where / how. This is it, anyway:

```rust
#![no_std]

use serde::Deserialize;

#[derive(Deserialize)]
struct Foo;

#[derive(Deserialize)]
struct Bar {
    #[serde(flatten)]
    foo: Foo,
}
```

Without this PR, it fails with this:

```
error[E0599]: no method named `to_string` found for type `&str` in the current scope
 --> src/lib.rs:8:10
  |
8 | #[derive(Deserialize)]
  |          ^^^^^^^^^^^
  |
  = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope, perhaps add a `use` for it:
  |
3 | use alloc::string::ToString;
```