### PR TITLE
Implement serialization and deserialization for std::sync::atomic types

### DIFF
--- a/serde/build.rs
+++ b/serde/build.rs
@@ -68,6 +68,10 @@ fn main() {
     if minor >= 28 {
         println!("cargo:rustc-cfg=num_nonzero");
     }
+
+    if minor >= 34 {
+        println!("cargo:rustc-cfg=std_integer_atomics");
+    }
 }
 
 fn rustc_minor_version() -> Option<u32> {

--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -2544,11 +2544,11 @@ where
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(all(feature="std", std_integer_atomics))]
 use std::sync::atomic;
 
 
-#[cfg(feature = "std")]
+#[cfg(all(feature="std", std_integer_atomics))]
 macro_rules! atomic_impl {
     ($ty:path, $primitive:ident) => {
         impl<'de> Deserialize<'de> for $ty
@@ -2564,35 +2564,35 @@ macro_rules! atomic_impl {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(all(feature="std", std_integer_atomics))]
 atomic_impl!(atomic::AtomicBool, bool);
 
-#[cfg(feature = "std")]
+#[cfg(all(feature="std", std_integer_atomics))]
 atomic_impl!(atomic::AtomicI8, i8);
 
-#[cfg(feature = "std")]
+#[cfg(all(feature="std", std_integer_atomics))]
 atomic_impl!(atomic::AtomicI16, i16);
 
-#[cfg(feature = "std")]
+#[cfg(all(feature="std", std_integer_atomics))]
 atomic_impl!(atomic::AtomicI32, i32);
 
-#[cfg(feature = "std")]
+#[cfg(all(feature="std", std_integer_atomics))]
 atomic_impl!(atomic::AtomicI64, i64);
 
-#[cfg(feature = "std")]
+#[cfg(all(feature="std", std_integer_atomics))]
 atomic_impl!(atomic::AtomicIsize, isize);
 
-#[cfg(feature = "std")]
+#[cfg(all(feature="std", std_integer_atomics))]
 atomic_impl!(atomic::AtomicU8, u8);
 
-#[cfg(feature = "std")]
+#[cfg(all(feature="std", std_integer_atomics))]
 atomic_impl!(atomic::AtomicU16, u16);
 
-#[cfg(feature = "std")]
+#[cfg(all(feature="std", std_integer_atomics))]
 atomic_impl!(atomic::AtomicU32, u32);
 
-#[cfg(feature = "std")]
+#[cfg(all(feature="std", std_integer_atomics))]
 atomic_impl!(atomic::AtomicU64, u64);
 
-#[cfg(feature = "std")]
+#[cfg(all(feature="std", std_integer_atomics))]
 atomic_impl!(atomic::AtomicUsize, usize);

--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -2543,3 +2543,56 @@ where
         Deserialize::deserialize(deserializer).map(Wrapping)
     }
 }
+
+#[cfg(feature = "std")]
+use std::sync::atomic;
+
+
+#[cfg(feature = "std")]
+macro_rules! atomic_impl {
+    ($ty:path, $primitive:ident) => {
+        impl<'de> Deserialize<'de> for $ty
+        {
+            #[inline]
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+                where D: Deserializer<'de>
+            {
+                let val = $primitive::deserialize(deserializer)?;
+                Ok(Self::new(val))
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+atomic_impl!(atomic::AtomicBool, bool);
+
+#[cfg(feature = "std")]
+atomic_impl!(atomic::AtomicI8, i8);
+
+#[cfg(feature = "std")]
+atomic_impl!(atomic::AtomicI16, i16);
+
+#[cfg(feature = "std")]
+atomic_impl!(atomic::AtomicI32, i32);
+
+#[cfg(feature = "std")]
+atomic_impl!(atomic::AtomicI64, i64);
+
+#[cfg(feature = "std")]
+atomic_impl!(atomic::AtomicIsize, isize);
+
+#[cfg(feature = "std")]
+atomic_impl!(atomic::AtomicU8, u8);
+
+#[cfg(feature = "std")]
+atomic_impl!(atomic::AtomicU16, u16);
+
+#[cfg(feature = "std")]
+atomic_impl!(atomic::AtomicU32, u32);
+
+#[cfg(feature = "std")]
+atomic_impl!(atomic::AtomicU64, u64);
+
+#[cfg(feature = "std")]
+atomic_impl!(atomic::AtomicUsize, usize);

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -839,3 +839,55 @@ where
         self.0.serialize(serializer)
     }
 }
+
+////////////////////////////////////////////////////////////////////////////////
+#[cfg(feature = "std")]
+use std::sync::atomic;
+
+#[cfg(feature = "std")]
+macro_rules! atomic_impl {
+    ($ty:path, $method:ident $($cast:tt)*) => {
+        impl Serialize for $ty {
+            #[inline]
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                serializer.$method(self.load(atomic::Ordering::SeqCst) $($cast)*)
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+atomic_impl!(atomic::AtomicBool, serialize_bool);
+
+#[cfg(feature = "std")]
+atomic_impl!(atomic::AtomicI8, serialize_i8);
+
+#[cfg(feature = "std")]
+atomic_impl!(atomic::AtomicI16, serialize_i16);
+
+#[cfg(feature = "std")]
+atomic_impl!(atomic::AtomicI32, serialize_i32);
+
+#[cfg(feature = "std")]
+atomic_impl!(atomic::AtomicI64, serialize_i64);
+
+#[cfg(feature = "std")]
+atomic_impl!(atomic::AtomicIsize, serialize_i64 as i64);
+
+#[cfg(feature = "std")]
+atomic_impl!(atomic::AtomicU8, serialize_u8);
+
+#[cfg(feature = "std")]
+atomic_impl!(atomic::AtomicU16, serialize_u16);
+
+#[cfg(feature = "std")]
+atomic_impl!(atomic::AtomicU32, serialize_u32);
+
+#[cfg(feature = "std")]
+atomic_impl!(atomic::AtomicU64, serialize_u64);
+
+#[cfg(feature = "std")]
+atomic_impl!(atomic::AtomicUsize, serialize_u64 as u64);

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -841,10 +841,10 @@ where
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-#[cfg(feature = "std")]
+#[cfg(all(feature="std", std_integer_atomics))]
 use std::sync::atomic;
 
-#[cfg(feature = "std")]
+#[cfg(all(feature="std", std_integer_atomics))]
 macro_rules! atomic_impl {
     ($ty:path, $method:ident $($cast:tt)*) => {
         impl Serialize for $ty {
@@ -859,35 +859,35 @@ macro_rules! atomic_impl {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(all(feature="std", std_integer_atomics))]
 atomic_impl!(atomic::AtomicBool, serialize_bool);
 
-#[cfg(feature = "std")]
+#[cfg(all(feature="std", std_integer_atomics))]
 atomic_impl!(atomic::AtomicI8, serialize_i8);
 
-#[cfg(feature = "std")]
+#[cfg(all(feature="std", std_integer_atomics))]
 atomic_impl!(atomic::AtomicI16, serialize_i16);
 
-#[cfg(feature = "std")]
+#[cfg(all(feature="std", std_integer_atomics))]
 atomic_impl!(atomic::AtomicI32, serialize_i32);
 
-#[cfg(feature = "std")]
+#[cfg(all(feature="std", std_integer_atomics))]
 atomic_impl!(atomic::AtomicI64, serialize_i64);
 
-#[cfg(feature = "std")]
+#[cfg(all(feature="std", std_integer_atomics))]
 atomic_impl!(atomic::AtomicIsize, serialize_i64 as i64);
 
-#[cfg(feature = "std")]
+#[cfg(all(feature="std", std_integer_atomics))]
 atomic_impl!(atomic::AtomicU8, serialize_u8);
 
-#[cfg(feature = "std")]
+#[cfg(all(feature="std", std_integer_atomics))]
 atomic_impl!(atomic::AtomicU16, serialize_u16);
 
-#[cfg(feature = "std")]
+#[cfg(all(feature="std", std_integer_atomics))]
 atomic_impl!(atomic::AtomicU32, serialize_u32);
 
-#[cfg(feature = "std")]
+#[cfg(all(feature="std", std_integer_atomics))]
 atomic_impl!(atomic::AtomicU64, serialize_u64);
 
-#[cfg(feature = "std")]
+#[cfg(all(feature="std", std_integer_atomics))]
 atomic_impl!(atomic::AtomicUsize, serialize_u64 as u64);

--- a/test_suite/tests/test_de.rs
+++ b/test_suite/tests/test_de.rs
@@ -1141,7 +1141,6 @@ fn test_never_type() {
     );
 }
 
-
 macro_rules! assert_de_tokens_atomic {
     ($ty:ty, $val:expr, $tokens:expr) => {
         let mut de = serde_test::Deserializer::new($tokens);

--- a/test_suite/tests/test_ser.rs
+++ b/test_suite/tests/test_ser.rs
@@ -10,6 +10,7 @@ use std::ops::Bound;
 use std::path::{Path, PathBuf};
 use std::rc::{Rc, Weak as RcWeak};
 use std::sync::{Arc, Weak as ArcWeak};
+use std::sync::atomic;
 use std::time::{Duration, UNIX_EPOCH};
 
 #[cfg(unix)]
@@ -482,6 +483,20 @@ declare_tests! {
         format_args!("{}{}", 1, 'a') => &[
             Token::Str("1a"),
         ],
+    }
+    test_atomic {
+        atomic::AtomicBool::new(false) => &[Token::Bool(false)],
+        atomic::AtomicBool::new(true) => &[Token::Bool(true)],
+        atomic::AtomicI8::new(63i8) => &[Token::I8(63i8)],
+        atomic::AtomicI16::new(-318i16) => &[Token::I16(-318i16)],
+        atomic::AtomicI32::new(65792i32) => &[Token::I32(65792i32)],
+        atomic::AtomicI64::new(-4295032832i64) => &[Token::I64(-4295032832i64)],
+        atomic::AtomicIsize::new(-65792isize) => &[Token::I64(-65792i64)],
+        atomic::AtomicU8::new(192u8) => &[Token::U8(192u8)],
+        atomic::AtomicU16::new(510u16) => &[Token::U16(510u16)],
+        atomic::AtomicU32::new(131072u32) => &[Token::U32(131072u32)],
+        atomic::AtomicU64::new(12884901888u64) => &[Token::U64(12884901888u64)],
+        atomic::AtomicUsize::new(655360usize) => &[Token::U64(655360u64)],
     }
 }
 


### PR DESCRIPTION
Fixes #1496.

The tests for deserialization are kind of cheesy because Atomic* types don't implement PartialEq. Let me know if you want me to try to make them better.