### PR TITLE
conservatively limit atomic features

### DIFF
--- a/serde/build.rs
+++ b/serde/build.rs
@@ -110,7 +110,7 @@ fn target_has_at_least_atomic_u64(target: &str) -> bool {
     // so this data comes from the  src/librustc_target/spec/*.rs
     // files in the rust source. Generally, it's 64-bit platforms
     // plus i686.
-    if target.starts_with("x86-64") || target.starts_with("i686") ||
+    if target.starts_with("x86_64") || target.starts_with("i686") ||
         target.starts_with("aarch64") || target.starts_with("powerpc64") ||
         target.starts_with("sparc64") || target.starts_with("mips64el") {
         true

--- a/serde/build.rs
+++ b/serde/build.rs
@@ -14,6 +14,8 @@ fn main() {
     let target = env::var("TARGET").unwrap();
     let emscripten = target == "asmjs-unknown-emscripten" || target == "wasm32-unknown-emscripten";
 
+    let has_atomic_integers = target_has_at_least_atomic_u64(&target);
+
     // std::collections::Bound was stabilized in Rust 1.17
     // but it was moved to core::ops later in Rust 1.26:
     // https://doc.rust-lang.org/core/ops/enum.Bound.html
@@ -69,7 +71,7 @@ fn main() {
         println!("cargo:rustc-cfg=num_nonzero");
     }
 
-    if minor >= 34 {
+    if minor >= 34 && has_atomic_integers {
         println!("cargo:rustc-cfg=std_integer_atomics");
     }
 }
@@ -101,4 +103,18 @@ fn rustc_minor_version() -> Option<u32> {
     };
 
     u32::from_str(next).ok()
+}
+
+fn target_has_at_least_atomic_u64(target: &str) -> bool {
+    // The cfg variable target_has_atomic is unstable
+    // so this data comes from the  src/librustc_target/spec/*.rs
+    // files in the rust source. Generally, it's 64-bit platforms
+    // plus i686.
+    if target.starts_with("x86-64") || target.starts_with("i686") ||
+        target.starts_with("aarch64") || target.starts_with("powerpc64") ||
+        target.starts_with("sparc64") || target.starts_with("mips64el") {
+        true
+    } else {
+        false
+    }
 }


### PR DESCRIPTION
Fixes #1579 

I grepped through the rust target definitions. Here are the ones with at least 64-bit atomics:

```
aarch64-apple-ios
aarch64-fuchsia
aarch64-linux-android
aarch64-pc-windows-msvc
aarch64-unknown-cloudabi
aarch64-unknown-freebsd
aarch64-unknown-hermit
aarch64-unknown-linux-gnu
aarch64-unknown-linux-musl
aarch64-unknown-netbsd
aarch64-unknown-none
aarch64-unknown-openbsd
aarch64-wrs-vxworks
arm-unknown-linux-gnueabi
arm-unknown-linux-gnueabihf
arm-unknown-linux-musleabi
arm-unknown-linux-musleabihf
arm-wrs-vxworks
arm-wrs-vxworks-sf
armv6-unknown-freebsd
armv6-unknown-netbsd-eabihf
armv7-apple-ios
armv7-linux-androideabi
armv7-unknown-cloudabi-eabihf
armv7-unknown-freebsd
armv7-unknown-linux-gnueabihf
armv7-unknown-linux-musleabihf
armv7-unknown-netbsd-eabihf
armv7-wrs-vxworks
armv7s-apple-ios
i386-apple-ios
i686-apple-darwin
i686-linux-android
i686-pc-windows-gnu
i686-pc-windows-msvc
i686-unknown-cloudabi
i686-unknown-dragonfly
i686-unknown-freebsd
i686-unknown-haiku
i686-unknown-linux-gnu
i686-unknown-linux-musl
i686-unknown-netbsd
i686-unknown-openbsd
i686-wrs-vxworks
i686-wrs-vxworks-gnu
mips64-unknown-linux-gnuabi64
mips64el-unknown-linux-gnuabi64
mipsisa64r6-unknown-linux-gnuabi64
mipsisa64r6el-unknown-linux-gnuabi64
nvptx64-nvidia-cuda
powerpc64-unknown-freebsd
powerpc64-unknown-linux-gnu
powerpc64-unknown-linux-musl
powerpc64-wrs-vxworks
powerpc64-wrs-vxworks-gnusf
powerpc64le-unknown-linux-gnu
powerpc64le-unknown-linux-musl
riscv64gc-unknown-none-elf
riscv64imac-unknown-none-elf
s390x-unknown-linux-gnu
sparc-unknown-linux-gnu
sparc64-unknown-linux-gnu
sparc64-unknown-netbsd
sparcv9-sun-solaris
thumbv7a-pc-windows-msvc
thumbv7neon-linux-androideabi
thumbv7neon-unknown-linux-gnueabihf
wasm32-base
x86-64-apple-darwin
x86-64-apple-ios
x86-64-fortanix-unknown-sgx
x86-64-fuchsia
x86-64-linux-android
x86-64-pc-windows-gnu
x86-64-pc-windows-msvc
x86-64-rumprun-netbsd
x86-64-sun-solaris
x86-64-unknown-cloudabi
x86-64-unknown-dragonfly
x86-64-unknown-freebsd
x86-64-unknown-haiku
x86-64-unknown-hermit
x86-64-unknown-l4re-uclibc
x86-64-unknown-linux-gnu
x86-64-unknown-linux-gnux32
x86-64-unknown-linux-musl
x86-64-unknown-netbsd
x86-64-unknown-openbsd
x86-64-unknown-redox
x86-64-unknown-uefi
x86-64-wrs-vxworks
```

Here are the ones without:

```
arm-linux-androideabi
armebv7r-none-eabi
armebv7r-none-eabihf
armv4t-unknown-linux-gnueabi
armv5te-unknown-linux-gnueabi
armv5te-unknown-linux-musleabi
armv7r-none-eabi
armv7r-none-eabihf
asmjs-unknown-emscripten
mips-unknown-linux-gnu
mips-unknown-linux-musl
mips-unknown-linux-uclibc
mipsel-unknown-linux-gnu
mipsel-unknown-linux-musl
mipsel-unknown-linux-uclibc
mipsisa32r6-unknown-linux-gnu
mipsisa32r6el-unknown-linux-gnu
msp430-none-elf
powerpc-unknown-linux-gnu
powerpc-unknown-linux-gnuspe
powerpc-unknown-linux-musl
powerpc-unknown-netbsd
powerpc-wrs-vxworks
powerpc-wrs-vxworks-gnusf
powerpc-wrs-vxworks-gnuspesf
powerpc-wrs-vxworks-spe
riscv32imac-unknown-none-elf
riscv32imc-unknown-none-elf
thumbv7em-none-eabi
thumbv7em-none-eabihf
thumbv7m-none-eabi
thumbv8m-base-none-eabi
thumbv8m-main-none-eabi
thumbv8m-main-none-eabihf
wasm32-experimental-emscripten
wasm32-unknown-emscripten
```