### PR TITLE
Add support for NonZeroI* types

### DIFF
--- a/serde/build.rs
+++ b/serde/build.rs
@@ -69,11 +69,12 @@ fn main() {
         println!("cargo:rustc-cfg=num_nonzero");
     }
 
-    // TryFrom and Atomic types stabilized in Rust 1.34:
+    // TryFrom, Atomic types, and non-zero signed integers stabilized in Rust 1.34:
     // https://blog.rust-lang.org/2019/04/11/Rust-1.34.0.html#tryfrom-and-tryinto
     // https://blog.rust-lang.org/2019/04/11/Rust-1.34.0.html#library-stabilizations
     if minor >= 34 {
         println!("cargo:rustc-cfg=core_try_from");
+        println!("cargo:rustc-cfg=num_nonzero_signed");
 
         // Whitelist of archs that support std::sync::atomic module. Ideally we
         // would use #[cfg(target_has_atomic = "...")] but it is not stable yet.

--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -2404,12 +2404,16 @@ macro_rules! nonzero_integers {
 }
 
 nonzero_integers! {
-    // Not including signed NonZeroI* since they might be removed
     NonZeroU8,
     NonZeroU16,
     NonZeroU32,
     NonZeroU64,
     NonZeroUsize,
+    NonZeroI8,
+    NonZeroI16,
+    NonZeroI32,
+    NonZeroI64,
+    NonZeroIsize,
 }
 
 // Currently 128-bit integers do not work on Emscripten targets so we need an
@@ -2417,6 +2421,7 @@ nonzero_integers! {
 serde_if_integer128! {
     nonzero_integers! {
         NonZeroU128,
+        NonZeroI128,
     }
 }
 

--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -2409,6 +2409,10 @@ nonzero_integers! {
     NonZeroU32,
     NonZeroU64,
     NonZeroUsize,
+}
+
+#[cfg(num_nonzero_signed)]
+nonzero_integers! {
     NonZeroI8,
     NonZeroI16,
     NonZeroI32,
@@ -2421,6 +2425,10 @@ nonzero_integers! {
 serde_if_integer128! {
     nonzero_integers! {
         NonZeroU128,
+    }
+
+    #[cfg(num_nonzero_signed)]
+    nonzero_integers! {
         NonZeroI128,
     }
 }

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -486,6 +486,10 @@ nonzero_integers! {
     NonZeroU32,
     NonZeroU64,
     NonZeroUsize,
+}
+
+#[cfg(num_nonzero_signed)]
+nonzero_integers! {
     NonZeroI8,
     NonZeroI16,
     NonZeroI32,
@@ -498,6 +502,10 @@ nonzero_integers! {
 serde_if_integer128! {
     nonzero_integers! {
         NonZeroU128,
+    }
+
+    #[cfg(num_nonzero_signed)]
+    nonzero_integers! {
         NonZeroI128,
     }
 }

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -481,12 +481,16 @@ macro_rules! nonzero_integers {
 }
 
 nonzero_integers! {
-    // Not including signed NonZeroI* since they might be removed
     NonZeroU8,
     NonZeroU16,
     NonZeroU32,
     NonZeroU64,
     NonZeroUsize,
+    NonZeroI8,
+    NonZeroI16,
+    NonZeroI32,
+    NonZeroI64,
+    NonZeroIsize,
 }
 
 // Currently 128-bit integers do not work on Emscripten targets so we need an
@@ -494,6 +498,7 @@ nonzero_integers! {
 serde_if_integer128! {
     nonzero_integers! {
         NonZeroU128,
+        NonZeroI128,
     }
 }
 


### PR DESCRIPTION
Resolves issue #1574 - now that NonZeroI* types are stabilized, it's helpful to support them.