### PR TITLE
Work around failing to parse manifest in 1.27 and 1.28 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,13 @@ matrix:
     - rust: 1.21.0
     - rust: 1.25.0
     - rust: 1.26.0
+
+    # Work around failing to parse manifest because editions are unstable.
     - rust: 1.27.0
+      before_script: sed -i /test_suite/d Cargo.toml
     - rust: 1.28.0
+      before_script: sed -i /test_suite/d Cargo.toml
+
     - rust: 1.34.0
 
     - rust: 1.36.0


### PR DESCRIPTION
```console
error: failed to parse manifest at `/home/travis/build/serde-rs/serde/test_suite/Cargo.toml`

Caused by:
  editions are unstable

Caused by:
  feature `edition` is required

this Cargo does not support nightly features, but if you
switch to nightly channel you can add
`cargo-features = ["edition"]` to enable this feature
```