### PR TITLE
Fix unused variable warning when field of adjacently tagged enum is skipped

### DIFF
--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -723,6 +723,8 @@ fn serialize_adjacently_tagged_variant(
             where
                 __S: _serde::Serializer,
             {
+                // Some members of this tuple will be unused if they're `skip_serializing`
+                #[allow(unused_variables)]
                 let (#(#fields_ident,)*) = self.data;
                 #inner
             }


### PR DESCRIPTION
Replace skip_seralizing tuple members with `_` in generated serializer.
I'm not totally convinced this is the right solution, since it requires creating 2x the `Vec`s, but it's the most "correct" solution I've found.