### PR TITLE
Export std error type so no_std data formats don't need a "std" feature

### DIFF
--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -125,6 +125,13 @@ mod utf8;
 
 pub use self::ignored_any::IgnoredAny;
 
+#[cfg(feature = "std")]
+#[doc(no_inline)]
+pub use std::error::Error as StdError;
+#[cfg(not(feature = "std"))]
+#[doc(no_inline)]
+pub use std_error::Error as StdError;
+
 ////////////////////////////////////////////////////////////////////////////////
 
 macro_rules! declare_error_trait {
@@ -288,7 +295,7 @@ macro_rules! declare_error_trait {
 }
 
 #[cfg(feature = "std")]
-declare_error_trait!(Error: Sized + error::Error);
+declare_error_trait!(Error: Sized + StdError);
 
 #[cfg(not(feature = "std"))]
 declare_error_trait!(Error: Sized + Debug + Display);

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -250,6 +250,9 @@ pub mod export;
 #[doc(hidden)]
 pub mod private;
 
+#[cfg(not(feature = "std"))]
+mod std_error;
+
 // Re-export #[derive(Serialize, Deserialize)].
 //
 // The reason re-exporting is not enabled by default is that disabling it would

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -114,6 +114,13 @@ mod impossible;
 
 pub use self::impossible::Impossible;
 
+#[cfg(feature = "std")]
+#[doc(no_inline)]
+pub use std::error::Error as StdError;
+#[cfg(not(feature = "std"))]
+#[doc(no_inline)]
+pub use std_error::Error as StdError;
+
 ////////////////////////////////////////////////////////////////////////////////
 
 macro_rules! declare_error_trait {
@@ -172,7 +179,7 @@ macro_rules! declare_error_trait {
 }
 
 #[cfg(feature = "std")]
-declare_error_trait!(Error: Sized + error::Error);
+declare_error_trait!(Error: Sized + StdError);
 
 #[cfg(not(feature = "std"))]
 declare_error_trait!(Error: Sized + Debug + Display);

--- a/serde/src/std_error.rs
+++ b/serde/src/std_error.rs
@@ -1,0 +1,48 @@
+use lib::{Debug, Display};
+
+/// Either a re-export of std::error::Error or a new identical trait, depending
+/// on whether Serde's "std" feature is enabled.
+///
+/// Serde's error traits [`serde::ser::Error`] and [`serde::de::Error`] require
+/// [`std::error::Error`] as a supertrait, but only when Serde is built with
+/// "std" enabled. Data formats that don't care about no\_std support should
+/// generally provide their error types with a `std::error::Error` impl
+/// directly:
+///
+/// ```edition2018
+/// #[derive(Debug)]
+/// struct MySerError {...}
+///
+/// impl serde::ser::Error for MySerError {...}
+///
+/// impl std::fmt::Display for MySerError {...}
+///
+/// // We don't support no_std!
+/// impl std::error::Error for MySerError {}
+/// ```
+///
+/// Data formats that *do* support no\_std may either have a "std" feature of
+/// their own:
+///
+/// ```toml
+/// [features]
+/// std = ["serde/std"]
+/// ```
+///
+/// ```edition2018
+/// #[cfg(feature = "std")]
+/// impl std::error::Error for MySerError {}
+/// ```
+///
+/// ... or else provide the std Error impl unconditionally via Serde's
+/// re-export:
+///
+/// ```edition2018
+/// impl serde::ser::StdError for MySerError {}
+/// ```
+pub trait Error: Debug + Display {
+    /// The underlying cause of this error, if any.
+    fn source(&self) -> Option<&(Error + 'static)> {
+        None
+    }
+}


### PR DESCRIPTION
This PR adds `serde::ser::StdError` and `serde::de::StdError` which are either a re-export of `std::error::Error` (if "std" is enabled) or a new identical trait (otherwise).

```rust
#[cfg(feature = "std")]
pub use std::error::Error as StdError;

#[cfg(not(feature = "std"))]
pub trait StdError: Debug + Display {
    fn source(&self) -> Option<&(Error + 'static)> { None }
}
```

Serde's error traits `serde::ser::Error` and `serde::de::Error` require `std::error::Error` as a supertrait, but only when Serde is built with "std" enabled. Data formats that don't care about no\_std support should generally provide their error types with a `std::error::Error` impl directly:

```rust
#[derive(Debug)]
struct MySerError {...}

impl serde::ser::Error for MySerError {...}

impl std::fmt::Display for MySerError {...}

// We don't support no_std!
impl std::error::Error for MySerError {}
```

Data formats that *do* support no\_std may either have a "std" feature of their own:

```toml
[features]
std = ["serde/std"]
```

```rust
#[cfg(feature = "std")]
impl std::error::Error for MySerError {}
```

... or else provide the std Error impl unconditionally via Serde's re-export:

```rust
impl serde::ser::StdError for MySerError {}
```

---

<sup>FYI @oli-obk, @cbeck88</sup>