### PR TITLE
Add new field attributes: from/try_from/from_str/into

### DIFF
--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -184,6 +184,28 @@ where
     deserializer.deserialize_bytes(CowBytesVisitor)
 }
 
+#[cfg(any(feature = "std", feature = "alloc"))]
+pub fn deserialize_type_from<'de: 'a, 'a, D, U, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: From<U>,
+    U: Deserialize<'de>
+{
+    Ok(T::from(U::deserialize(deserializer)?))
+}
+
+#[cfg(any(feature = "std", feature = "alloc"))]
+pub fn deserialize_type_try_from<'de: 'a, 'a, D, U, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: std::convert::TryFrom<U>,
+    T::Error: std::fmt::Display,
+    U: Deserialize<'de>
+{
+    T::try_from(U::deserialize(deserializer)?)
+        .map_err(::de::Error::custom)
+}
+
 pub mod size_hint {
     use lib::*;
 

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -206,6 +206,17 @@ where
         .map_err(::de::Error::custom)
 }
 
+#[cfg(any(feature = "std", feature = "alloc"))]
+pub fn deserialize_type_from_str<'de: 'a, 'a, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    T::from_str(&<String as Deserialize>::deserialize(deserializer)?)
+        .map_err(::de::Error::custom)
+}
+
 pub mod size_hint {
     use lib::*;
 

--- a/serde/src/private/ser.rs
+++ b/serde/src/private/ser.rs
@@ -1324,3 +1324,13 @@ where
         Ok(())
     }
 }
+
+#[cfg(any(feature = "std", feature = "alloc"))]
+pub fn serialize_type_into<S, U, T>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: Clone + Into<U>,
+    U: Serialize,
+{
+    U::serialize(&value.clone().into(), serializer)
+}

--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -73,6 +73,10 @@ impl<'c, T> Attr<'c, T> {
             None => None,
         }
     }
+
+    fn is_some(&self) -> bool {
+        self.value.is_some()
+    }
 }
 
 struct BoolAttr<'c>(Attr<'c, ()>);
@@ -1219,6 +1223,10 @@ impl Field {
         let mut getter = Attr::none(cx, GETTER);
         let mut flatten = BoolAttr::none(cx, FLATTEN);
 
+        let mut type_from = Attr::none(cx, FROM);
+        let mut type_try_from = Attr::none(cx, TRY_FROM);
+        let mut type_into = Attr::none(cx, INTO);
+
         let ident = match field.ident {
             Some(ref ident) => unraw(ident),
             None => index.to_string(),
@@ -1387,6 +1395,27 @@ impl Field {
                         flatten.set_true(word);
                     }
 
+                    // Parse `#[serde(from = "Type")]
+                    Meta(NameValue(ref m)) if m.path == FROM => {
+                        if let Ok(from_ty) = parse_lit_into_ty(cx, FROM, &m.lit) {
+                            type_from.set_opt(&m.path, Some(from_ty));
+                        }
+                    }
+
+                    // Parse `#[serde(try_from = "Type")]
+                    Meta(NameValue(ref m)) if m.path == TRY_FROM => {
+                        if let Ok(try_from_ty) = parse_lit_into_ty(cx, TRY_FROM, &m.lit) {
+                            type_try_from.set_opt(&m.path, Some(try_from_ty));
+                        }
+                    }
+
+                    // Parse `#[serde(into = "Type")]
+                    Meta(NameValue(ref m)) if m.path == INTO => {
+                        if let Ok(into_ty) = parse_lit_into_ty(cx, INTO, &m.lit) {
+                            type_into.set_opt(&m.path, Some(into_ty));
+                        }
+                    }
+
                     Meta(ref meta_item) => {
                         let path = meta_item
                             .path()
@@ -1413,6 +1442,69 @@ impl Field {
             if skip_deserializing.0.value.is_some() {
                 default.set_if_none(Default::Default);
             }
+        }
+
+        let type_from = type_from.get();
+        let type_try_from = type_try_from.get();
+        let type_into = type_into.get();
+
+        if type_from.is_some() && type_try_from.is_some() {
+            cx.error_spanned_by(
+                field,
+                "#[serde(from = \"...\")] and #[serde(try_from = \"...\")] conflict with each other",
+            );
+        }
+        if type_from.is_some() && deserialize_with.is_some() {
+            cx.error_spanned_by(
+                field,
+                "#[serde(from = \"...\")] and #[serde(deserialize_with = \"...\")] conflict with each other",
+            );
+        }
+        if type_try_from.is_some() && deserialize_with.is_some() {
+            cx.error_spanned_by(
+                field,
+                "#[serde(try_from = \"...\")] and #[serde(deserialize_with = \"...\")] conflict with each other",
+            );
+        }
+
+        if type_into.is_some() && serialize_with.is_some() {
+            cx.error_spanned_by(
+                field,
+                "#[serde(into = \"...\")] and #[serde(serialize_with = \"...\")] conflict with each other",
+            );
+        }
+
+        if let Some(type_from) = type_from {
+            let mut generics = Punctuated::<_, Token![,]>::new();
+            let underscore: syn::Type = syn::TypeInfer{underscore_token: Token![_](Span::call_site())}.into();
+            generics.push(syn::GenericArgument::Type(underscore.clone()));
+            generics.push(syn::GenericArgument::Type(type_from));
+            generics.push(syn::GenericArgument::Type(underscore));
+
+            let expr = get_generic_function_path(&["_serde", "private", "de", "deserialize_type_from"], generics);
+            deserialize_with.set_if_none(expr);
+        }
+
+        if let Some(type_try_from) = type_try_from {
+            let mut generics = Punctuated::new();
+            let underscore: syn::Type = syn::TypeInfer{underscore_token: Token![_](Span::call_site())}.into();
+            generics.push(syn::GenericArgument::Type(underscore.clone()));
+            generics.push(syn::GenericArgument::Type(type_try_from));
+            generics.push(syn::GenericArgument::Type(underscore));
+
+            let expr = get_generic_function_path(&["_serde", "private", "de", "deserialize_type_try_from"], generics);
+            deserialize_with.set_if_none(expr);
+        }
+
+        if let Some(type_into) = type_into {
+            let mut generics = Punctuated::new();
+            let underscore: syn::Type = syn::TypeInfer{underscore_token: Token![_](Span::call_site())}.into();
+            generics.push(syn::GenericArgument::Type(underscore.clone()));
+            generics.push(syn::GenericArgument::Type(type_into));
+            generics.push(syn::GenericArgument::Type(underscore));
+
+            let expr = get_generic_function_path(&["_serde", "private", "ser", "serialize_type_into"], generics);
+            serialize_with.set_if_none(expr);
         }
 
         let mut borrowed_lifetimes = borrowed_lifetimes.get().unwrap_or_default();
@@ -2000,3 +2092,31 @@ fn respan_token_tree(mut token: TokenTree, span: Span) -> TokenTree {
     token.set_span(span);
     token
 }
+
+fn get_generic_function_path(segments: &[&str], args: Punctuated<syn::GenericArgument, Token![,]>) -> syn::ExprPath {
+    let mut path = syn::Path {
+        leading_colon: None,
+        segments: segments[..segments.len()-1]
+            .iter()
+            .map(|name| Ident::new(name, Span::call_site()))
+            .map(syn::PathSegment::from)
+            .collect(),
+    };
+    path.segments
+        .push(syn::PathSegment {
+            ident: Ident::new(segments[segments.len()-1], Span::call_site()),
+            arguments: syn::PathArguments::AngleBracketed(syn::AngleBracketedGenericArguments {
+                colon2_token: Some(Token![::](Span::call_site())),
+                lt_token: Token![<](Span::call_site()),
+                args: args,
+                gt_token: Token![>](Span::call_site())
+            })
+        });
+
+    syn::ExprPath {
+        attrs: Vec::new(),
+        qself: None,
+        path: path,
+    }
+}
+

--- a/serde_derive/src/internals/check.rs
+++ b/serde_derive/src/internals/check.rs
@@ -427,3 +427,4 @@ fn check_from_and_try_from(cx: &Ctxt, cont: &mut Container) {
         );
     }
 }
+

--- a/serde_derive/src/internals/symbol.rs
+++ b/serde_derive/src/internals/symbol.rs
@@ -16,6 +16,7 @@ pub const DESERIALIZE_WITH: Symbol = Symbol("deserialize_with");
 pub const FIELD_IDENTIFIER: Symbol = Symbol("field_identifier");
 pub const FLATTEN: Symbol = Symbol("flatten");
 pub const FROM: Symbol = Symbol("from");
+pub const FROM_STR: Symbol = Symbol("from_str");
 pub const GETTER: Symbol = Symbol("getter");
 pub const INTO: Symbol = Symbol("into");
 pub const OTHER: Symbol = Symbol("other");

--- a/test_suite/tests/ui/conflict/field-from-try-from.rs
+++ b/test_suite/tests/ui/conflict/field-from-try-from.rs
@@ -1,0 +1,9 @@
+use serde_derive::Serialize;
+
+#[derive(Serialize)]
+struct S {
+    #[serde(from = "u64", try_from = "u64", deserialize_with = "de_unit")]
+    a: u8,
+}
+
+fn main() {}

--- a/test_suite/tests/ui/conflict/field-from-try-from.rs
+++ b/test_suite/tests/ui/conflict/field-from-try-from.rs
@@ -2,7 +2,7 @@ use serde_derive::Serialize;
 
 #[derive(Serialize)]
 struct S {
-    #[serde(from = "u64", try_from = "u64", deserialize_with = "de_unit")]
+    #[serde(from = "u64", try_from = "u64", from_str, deserialize_with = "de_unit")]
     a: u8,
 }
 

--- a/test_suite/tests/ui/conflict/field-from-try-from.stderr
+++ b/test_suite/tests/ui/conflict/field-from-try-from.stderr
@@ -1,20 +1,41 @@
 error: #[serde(from = "...")] and #[serde(try_from = "...")] conflict with each other
  --> $DIR/field-from-try-from.rs:5:5
   |
-5 | /     #[serde(from = "u64", try_from = "u64", deserialize_with = "de_unit")]
+5 | /     #[serde(from = "u64", try_from = "u64", from_str, deserialize_with = "de_unit")]
+6 | |     a: u8,
+  | |_________^
+
+error: #[serde(from = "...")] and #[serde(from_str)] conflict with each other
+ --> $DIR/field-from-try-from.rs:5:5
+  |
+5 | /     #[serde(from = "u64", try_from = "u64", from_str, deserialize_with = "de_unit")]
+6 | |     a: u8,
+  | |_________^
+
+error: #[serde(try_from = "...")] and #[serde(from_str)] conflict with each other
+ --> $DIR/field-from-try-from.rs:5:5
+  |
+5 | /     #[serde(from = "u64", try_from = "u64", from_str, deserialize_with = "de_unit")]
 6 | |     a: u8,
   | |_________^
 
 error: #[serde(from = "...")] and #[serde(deserialize_with = "...")] conflict with each other
  --> $DIR/field-from-try-from.rs:5:5
   |
-5 | /     #[serde(from = "u64", try_from = "u64", deserialize_with = "de_unit")]
+5 | /     #[serde(from = "u64", try_from = "u64", from_str, deserialize_with = "de_unit")]
 6 | |     a: u8,
   | |_________^
 
 error: #[serde(try_from = "...")] and #[serde(deserialize_with = "...")] conflict with each other
  --> $DIR/field-from-try-from.rs:5:5
   |
-5 | /     #[serde(from = "u64", try_from = "u64", deserialize_with = "de_unit")]
+5 | /     #[serde(from = "u64", try_from = "u64", from_str, deserialize_with = "de_unit")]
+6 | |     a: u8,
+  | |_________^
+
+error: #[serde(from_str)] and #[serde(deserialize_with = "...")] conflict with each other
+ --> $DIR/field-from-try-from.rs:5:5
+  |
+5 | /     #[serde(from = "u64", try_from = "u64", from_str, deserialize_with = "de_unit")]
 6 | |     a: u8,
   | |_________^

--- a/test_suite/tests/ui/conflict/field-from-try-from.stderr
+++ b/test_suite/tests/ui/conflict/field-from-try-from.stderr
@@ -1,0 +1,20 @@
+error: #[serde(from = "...")] and #[serde(try_from = "...")] conflict with each other
+ --> $DIR/field-from-try-from.rs:5:5
+  |
+5 | /     #[serde(from = "u64", try_from = "u64", deserialize_with = "de_unit")]
+6 | |     a: u8,
+  | |_________^
+
+error: #[serde(from = "...")] and #[serde(deserialize_with = "...")] conflict with each other
+ --> $DIR/field-from-try-from.rs:5:5
+  |
+5 | /     #[serde(from = "u64", try_from = "u64", deserialize_with = "de_unit")]
+6 | |     a: u8,
+  | |_________^
+
+error: #[serde(try_from = "...")] and #[serde(deserialize_with = "...")] conflict with each other
+ --> $DIR/field-from-try-from.rs:5:5
+  |
+5 | /     #[serde(from = "u64", try_from = "u64", deserialize_with = "de_unit")]
+6 | |     a: u8,
+  | |_________^

--- a/test_suite/tests/ui/conflict/field-into-serialize-with.rs
+++ b/test_suite/tests/ui/conflict/field-into-serialize-with.rs
@@ -1,0 +1,9 @@
+use serde_derive::Serialize;
+
+#[derive(Serialize)]
+struct S {
+    #[serde(into = "u64", serialize_with = "ser_unit")]
+    a: u8,
+}
+
+fn main() {}

--- a/test_suite/tests/ui/conflict/field-into-serialize-with.stderr
+++ b/test_suite/tests/ui/conflict/field-into-serialize-with.stderr
@@ -1,0 +1,6 @@
+error: #[serde(into = "...")] and #[serde(serialize_with = "...")] conflict with each other
+ --> $DIR/field-into-serialize-with.rs:5:5
+  |
+5 | /     #[serde(into = "u64", serialize_with = "ser_unit")]
+6 | |     a: u8,
+  | |_________^


### PR DESCRIPTION
Addresses #1550.

The new field attributes `from`, `try_from`, `from_str` and `into` act as a shorthand for the `deserialize_with` and `serialize_with`. They mirror the functionality found in the container attributes with the same names. This PR adds a new kind of field attribute: `from_str`. If set, it first deserializes the field as a string and then attempts to convert it into the correct type by calling `FromStr::from_str`.

## Example

```rust
#[derive(Debug, Deserialize)]
struct Foo {
    #[serde(from = "i32")]
    sign: Sign,
    #[serde(from_str)]
    number: u32,
}

#[derive(Debug, PartialEq)]
enum Sign {
    Negative,
    Zero,
    Positive,
}

impl From<i32> for Sign {
    fn from(v: i32) -> Sign {
        match v {
            _ if v < 0 => Sign::Negative,
            _ if v == 0 => Sign::Zero,
            _ => Sign::Positive
        }
    }
}

fn main() {
    let json = r#"{ "sign": -1, "number": "14" }"#;

    let foo: Foo = serde_json::from_str(json).unwrap();

    assert_eq!(foo.sign, Sign::Negative);
    assert_eq!(foo.number, 14);
}
```