### PR TITLE
Implement the serialization of tagged values

### DIFF
--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -1247,6 +1247,27 @@ pub trait Serializer: Sized {
         len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error>;
 
+    /// Serialize a value with a semantic tag for the given format.
+    ///
+    /// Tagged values are a mechanism supported by some data formats
+    /// to add additional information to serialized values and to
+    /// introduce user-defined subtypes.
+    ///
+    /// The default behavior is to ignore the tag and to serialize
+    /// just the value.
+    fn serialize_tagged_value<T: ?Sized, U: ?Sized>(
+        self,
+        _format: &'static str,
+        _tag: &U,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+        U: Serialize,
+    {
+        value.serialize(self)
+    }
+
     /// Collect an iterator as a sequence.
     ///
     /// The default implementation serializes each item yielded by the iterator


### PR DESCRIPTION
Add a new method called serialize_tagged_value to the Serializer trait.
The method has a default implementation serializing just the value for all
formats without tags.

[Tagged values are the most requested feature](https://github.com/pyfisch/cbor/issues/157) of the `serde_cbor` crate and they are an important part of working with CBOR documents. But tagged values do not fit neatly into serde's data model therefore this small change to serde is required to enable serialization of tagged values in CBOR and possibly other data formats.

Simple CBOR serialization with a string tagged as an URL (tag 32):

```rust
let mut ser = serde_cbor::Serializer::new(&mut buf);
assert!(ser.serialize_tagged_value("cbor", &32u64, "http://example.org/").is_ok());
```

To support tagged values in a serializer for a data format it is necessary to implement `serialize_tagged_value` and write a custom serializer as I have done for CBOR: https://github.com/pyfisch/cbor/blob/6ad5ea3ade62ceadc20c5bcc832ac85f6c1d3901/src/ser.rs#L511-L695

This PR deliberately only includes serialization and not deserialization as both parts can be discussed and used independently from each other.

What do you think about this extension to serde?
