### PR TITLE
serde_derive: require the same version as serde

### DIFF
--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde"
-version = "1.0.102" # remember to update html_root_url
+version = "1.0.102" # remember to update html_root_url and serde_derive dependency
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>", "David Tolnay <dtolnay@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "A generic serialization/deserialization framework"
@@ -18,7 +18,7 @@ travis-ci = { repository = "serde-rs/serde" }
 appveyor = { repository = "serde-rs/serde" }
 
 [dependencies]
-serde_derive = { version = "1.0", optional = true, path = "../serde_derive" }
+serde_derive = { version = "1.0.102", optional = true, path = "../serde_derive" }
 
 [dev-dependencies]
 serde_derive = { version = "1.0", path = "../serde_derive" }


### PR DESCRIPTION
This ensures that all features supported by serde are always available
through the derive macro provided through the feature flag.

Fixes: #1647

---
From discussion on https://github.com/dtolnay/trybuild/pull/37