### PR TITLE
Allow untagged unit variants to deserialize from `Visitor::visit_none()`

### DIFF
--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -2510,6 +2510,13 @@ mod content {
         {
             Ok(())
         }
+
+        fn visit_none<E>(self) -> Result<(), E>
+        where
+            E: de::Error,
+        {
+            Ok(())
+        }
     }
 }
 

--- a/test_suite/tests/test_de.rs
+++ b/test_suite/tests/test_de.rs
@@ -137,12 +137,6 @@ enum EnumOther {
     Other,
 }
 
-#[derive(PartialEq, Debug, Deserialize)]
-#[serde(untagged)]
-enum EnumUntaggedUnit {
-    Unit,
-}
-
 #[derive(PartialEq, Debug)]
 struct IgnoredAny;
 
@@ -793,9 +787,6 @@ declare_tests! {
             Token::Str("Foo"),
             Token::Unit,
         ],
-    }
-    test_enum_untagged_unit_from_none {
-        EnumUntaggedUnit::Unit => &[Token::None],
     }
     test_box {
         Box::new(0i32) => &[Token::I32(0)],

--- a/test_suite/tests/test_de.rs
+++ b/test_suite/tests/test_de.rs
@@ -795,7 +795,7 @@ declare_tests! {
         ],
     }
     test_enum_untagged_unit_from_none {
-        UntaggedUnit::Unit => &[Token::None],
+        EnumUntaggedUnit::Unit => &[Token::None],
     }
     test_box {
         Box::new(0i32) => &[Token::I32(0)],

--- a/test_suite/tests/test_de.rs
+++ b/test_suite/tests/test_de.rs
@@ -137,6 +137,12 @@ enum EnumOther {
     Other,
 }
 
+#[derive(PartialEq, Debug, Deserialize)]
+#[serde(untagged)]
+enum EnumUntaggedUnit {
+    Unit,
+}
+
 #[derive(PartialEq, Debug)]
 struct IgnoredAny;
 
@@ -787,6 +793,9 @@ declare_tests! {
             Token::Str("Foo"),
             Token::Unit,
         ],
+    }
+    test_enum_untagged_unit_from_none {
+        UntaggedUnit::Unit => &[Token::None],
     }
     test_box {
         Box::new(0i32) => &[Token::I32(0)],

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -638,6 +638,7 @@ fn test_untagged_enum() {
     );
 
     assert_tokens(&Untagged::C, &[Token::Unit]);
+    assert_tokens(&Untagged::C, &[Token::None]);
 
     assert_tokens(&Untagged::D(4), &[Token::U8(4)]);
     assert_tokens(&Untagged::E("e".to_owned()), &[Token::Str("e")]);
@@ -650,11 +651,6 @@ fn test_untagged_enum() {
             Token::U8(2),
             Token::TupleEnd,
         ],
-    );
-
-    assert_de_tokens_error::<Untagged>(
-        &[Token::None],
-        "data did not match any variant of untagged enum Untagged",
     );
 
     assert_de_tokens_error::<Untagged>(

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -637,8 +637,10 @@ fn test_untagged_enum() {
         ],
     );
 
+    // Serializes to unit, deserializes from either depending on format's
+    // preference.
     assert_tokens(&Untagged::C, &[Token::Unit]);
-    assert_tokens(&Untagged::C, &[Token::None]);
+    assert_de_tokens(&Untagged::C, &[Token::None]);
 
     assert_tokens(&Untagged::D(4), &[Token::U8(4)]);
     assert_tokens(&Untagged::E("e".to_owned()), &[Token::Str("e")]);


### PR DESCRIPTION
Fixes https://github.com/serde-rs/serde/issues/1668.

Note: the test suite fails to compile on my machine for some reason. I still added a test verifying the expected behavior nevertheless – could you please check if it's correct?
