### PR TITLE
Complete support for formats treating nulls as `None`

### DIFF
--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -30,6 +30,13 @@ impl<'de> Visitor<'de> for UnitVisitor {
     {
         Ok(())
     }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        Ok(())
+    }
 }
 
 impl<'de> Deserialize<'de> for () {

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -1267,6 +1267,7 @@ mod content {
         {
             match self.content {
                 Content::Unit => visitor.visit_unit(),
+                Content::None => visitor.visit_none(),
                 _ => Err(self.invalid_type(&visitor)),
             }
         }
@@ -1986,6 +1987,7 @@ mod content {
         {
             match *self.content {
                 Content::Unit => visitor.visit_unit(),
+                Content::None => visitor.visit_none(),
                 _ => Err(self.invalid_type(&visitor)),
             }
         }

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -821,7 +821,7 @@ fn test_internally_tagged_enum() {
             Token::Str("Z"),
             Token::MapEnd,
         ],
-        "unknown variant `Z`, expected one of `A`, `B`, `C`, `D`, `E`",
+        "unknown variant `Z`, expected one of `A`, `B`, `C`, `D`, `E`, `F`",
     );
 }
 

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -795,7 +795,7 @@ fn test_internally_tagged_enum() {
     // Serializes to unit, deserializes from either depending on format's
     // preference.
     assert_de_tokens(
-        &InternallyTagged::F { unit: () },
+        &InternallyTagged::F { f: () },
         &[
             Token::Struct {
                 name: "InternallyTagged",

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -690,6 +690,7 @@ fn test_internally_tagged_enum() {
         C(BTreeMap<String, String>),
         D(Newtype),
         E(Struct),
+        F { f: () },
     }
 
     assert_tokens(
@@ -788,6 +789,23 @@ fn test_internally_tagged_enum() {
             Token::Str("E"),
             Token::U8(6),
             Token::SeqEnd,
+        ],
+    );
+
+    // Serializes to unit, deserializes from either depending on format's
+    // preference.
+    assert_de_tokens(
+        &InternallyTagged::F { unit: () },
+        &[
+            Token::Struct {
+                name: "InternallyTagged",
+                len: 2,
+            },
+            Token::Str("type"),
+            Token::Str("F"),
+            Token::Str("f"),
+            Token::None,
+            Token::StructEnd,
         ],
     );
 
@@ -1029,6 +1047,7 @@ fn test_adjacently_tagged_enum() {
         Newtype(T),
         Tuple(u8, u8),
         Struct { f: u8 },
+        StructWithUnit { u: () },
     }
 
     // unit with no content
@@ -1223,6 +1242,30 @@ fn test_adjacently_tagged_enum() {
             Token::StructEnd,
             Token::Str("t"),
             Token::Str("Struct"),
+            Token::StructEnd,
+        ],
+    );
+
+    // Struct containing unit, with tag first.
+    // Serializes to unit, deserializes from either depending on format's
+    // preference.
+    assert_de_tokens(
+        &AdjacentlyTagged::StructWithUnit::<u8> { u: () },
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::Str("t"),
+            Token::Str("StructWithUnit"),
+            Token::Str("c"),
+            Token::Struct {
+                name: "StructWithUnit",
+                len: 1,
+            },
+            Token::Str("u"),
+            Token::None,
+            Token::StructEnd,
             Token::StructEnd,
         ],
     );


### PR DESCRIPTION
This is a follow-up to my previous PR about being able to treat `null` as `None`. I've noticed a couple more cases where an internally-tagged `enum` with a struct variant containing `()` wasn't able to be deserialized. This PR amends them.
