### PR TITLE
Add #[serde(rename_all_fields = "foo")] attribute

### DIFF
--- a/serde_derive/src/internals/ast.rs
+++ b/serde_derive/src/internals/ast.rs
@@ -89,7 +89,7 @@ impl<'a> Container<'a> {
                             has_flatten = true;
                         }
                         field.attrs.rename_by_rules(
-                            &variant
+                            variant
                                 .attrs
                                 .rename_all_rules()
                                 .or(attrs.rename_all_fields_rules()),

--- a/serde_derive/src/internals/ast.rs
+++ b/serde_derive/src/internals/ast.rs
@@ -88,9 +88,12 @@ impl<'a> Container<'a> {
                         if field.attrs.flatten() {
                             has_flatten = true;
                         }
-                        field
-                            .attrs
-                            .rename_by_rules(variant.attrs.rename_all_rules());
+                        field.attrs.rename_by_rules(
+                            &variant
+                                .attrs
+                                .rename_all_rules()
+                                .or(attrs.rename_all_fields_rules()),
+                        );
                     }
                 }
             }

--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -202,10 +202,10 @@ pub struct RenameAllRules {
 impl RenameAllRules {
     /// Returns a new `RenameAllRules` with the individual rules of `self` and
     /// `other_rules` joined by `RenameRules::or`.
-    pub fn or(&self, other_rules: &Self) -> Self {
+    pub fn or(self, other_rules: Self) -> Self {
         Self {
-            serialize: self.serialize.or(&other_rules.serialize),
-            deserialize: self.deserialize.or(&other_rules.deserialize),
+            serialize: self.serialize.or(other_rules.serialize),
+            deserialize: self.deserialize.or(other_rules.deserialize),
         }
     }
 }
@@ -604,12 +604,12 @@ impl Container {
         &self.name
     }
 
-    pub fn rename_all_rules(&self) -> &RenameAllRules {
-        &self.rename_all_rules
+    pub fn rename_all_rules(&self) -> RenameAllRules {
+        self.rename_all_rules
     }
 
-    pub fn rename_all_fields_rules(&self) -> &RenameAllRules {
-        &self.rename_all_fields_rules
+    pub fn rename_all_fields_rules(&self) -> RenameAllRules {
+        self.rename_all_fields_rules
     }
 
     pub fn transparent(&self) -> bool {
@@ -982,7 +982,7 @@ impl Variant {
         self.name.deserialize_aliases()
     }
 
-    pub fn rename_by_rules(&mut self, rules: &RenameAllRules) {
+    pub fn rename_by_rules(&mut self, rules: RenameAllRules) {
         if !self.name.serialize_renamed {
             self.name.serialize = rules.serialize.apply_to_variant(&self.name.serialize);
         }
@@ -991,8 +991,8 @@ impl Variant {
         }
     }
 
-    pub fn rename_all_rules(&self) -> &RenameAllRules {
-        &self.rename_all_rules
+    pub fn rename_all_rules(&self) -> RenameAllRules {
+        self.rename_all_rules
     }
 
     pub fn ser_bound(&self) -> Option<&[syn::WherePredicate]> {
@@ -1321,7 +1321,7 @@ impl Field {
         self.name.deserialize_aliases()
     }
 
-    pub fn rename_by_rules(&mut self, rules: &RenameAllRules) {
+    pub fn rename_by_rules(&mut self, rules: RenameAllRules) {
         if !self.name.serialize_renamed {
             self.name.serialize = rules.serialize.apply_to_field(&self.name.serialize);
         }

--- a/serde_derive/src/internals/case.rs
+++ b/serde_derive/src/internals/case.rs
@@ -112,6 +112,14 @@ impl RenameRule {
             ScreamingKebabCase => ScreamingSnakeCase.apply_to_field(field).replace('_', "-"),
         }
     }
+
+    /// Returns the `RenameRule` if it is not `None`, `rule_b` otherwise.
+    pub fn or(&self, rule_b: &Self) -> Self {
+        match self {
+            None => *rule_b,
+            _ => *self,
+        }
+    }
 }
 
 pub struct ParseError<'a> {

--- a/serde_derive/src/internals/case.rs
+++ b/serde_derive/src/internals/case.rs
@@ -59,8 +59,8 @@ impl RenameRule {
     }
 
     /// Apply a renaming rule to an enum variant, returning the version expected in the source.
-    pub fn apply_to_variant(&self, variant: &str) -> String {
-        match *self {
+    pub fn apply_to_variant(self, variant: &str) -> String {
+        match self {
             None | PascalCase => variant.to_owned(),
             LowerCase => variant.to_ascii_lowercase(),
             UpperCase => variant.to_ascii_uppercase(),
@@ -84,8 +84,8 @@ impl RenameRule {
     }
 
     /// Apply a renaming rule to a struct field, returning the version expected in the source.
-    pub fn apply_to_field(&self, field: &str) -> String {
-        match *self {
+    pub fn apply_to_field(self, field: &str) -> String {
+        match self {
             None | LowerCase | SnakeCase => field.to_owned(),
             UpperCase => field.to_ascii_uppercase(),
             PascalCase => {
@@ -114,10 +114,10 @@ impl RenameRule {
     }
 
     /// Returns the `RenameRule` if it is not `None`, `rule_b` otherwise.
-    pub fn or(&self, rule_b: &Self) -> Self {
+    pub fn or(self, rule_b: Self) -> Self {
         match self {
-            None => *rule_b,
-            _ => *self,
+            None => rule_b,
+            _ => self,
         }
     }
 }

--- a/serde_derive/src/internals/symbol.rs
+++ b/serde_derive/src/internals/symbol.rs
@@ -23,6 +23,7 @@ pub const OTHER: Symbol = Symbol("other");
 pub const REMOTE: Symbol = Symbol("remote");
 pub const RENAME: Symbol = Symbol("rename");
 pub const RENAME_ALL: Symbol = Symbol("rename_all");
+pub const RENAME_ALL_FIELDS: Symbol = Symbol("rename_all_fields");
 pub const REPR: Symbol = Symbol("repr");
 pub const SERDE: Symbol = Symbol("serde");
 pub const SERIALIZE: Symbol = Symbol("serialize");

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -1925,6 +1925,62 @@ fn test_rename_all() {
 }
 
 #[test]
+fn test_rename_all_fields() {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    #[serde(rename_all_fields = "kebab-case")]
+    enum E {
+        V1,
+        V2(bool),
+        V3 {
+            a_field: bool,
+            another_field: bool,
+            #[serde(rename = "last-field")]
+            yet_another_field: bool,
+        },
+        #[serde(rename_all = "snake_case")]
+        V4 {
+            a_field: bool,
+        },
+    }
+
+    assert_tokens(
+        &E::V3 {
+            a_field: true,
+            another_field: true,
+            yet_another_field: true,
+        },
+        &[
+            Token::StructVariant {
+                name: "E",
+                variant: "V3",
+                len: 3,
+            },
+            Token::Str("a-field"),
+            Token::Bool(true),
+            Token::Str("another-field"),
+            Token::Bool(true),
+            Token::Str("last-field"),
+            Token::Bool(true),
+            Token::StructVariantEnd,
+        ],
+    );
+
+    assert_tokens(
+        &E::V4 { a_field: true },
+        &[
+            Token::StructVariant {
+                name: "E",
+                variant: "V4",
+                len: 1,
+            },
+            Token::Str("a_field"),
+            Token::Bool(true),
+            Token::StructVariantEnd,
+        ],
+    );
+}
+
+#[test]
 fn test_untagged_newtype_variant_containing_unit_struct_not_map() {
     #[derive(Debug, PartialEq, Serialize, Deserialize)]
     struct Unit;


### PR DESCRIPTION
fixes #1061 

If you don't like the style change in the second commit, I can remove it from this PR (or you can just cherry-pick the first commit).