### PR TITLE
Add #[serde(allow_duplicates)] attribute

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -2427,11 +2427,18 @@ fn deserialize_map(
                     })
                 }
             };
-            quote! {
-                __Field::#name => {
+            let duplicate_field_check = if field.attrs.allow_duplicates() {
+                quote! { }
+            } else {
+                quote! {
                     if _serde::export::Option::is_some(&#name) {
                         return _serde::export::Err(<__A::Error as _serde::de::Error>::duplicate_field(#deser_name));
                     }
+                }
+            };
+            quote! {
+                __Field::#name => {
+                    #duplicate_field_check
                     #name = _serde::export::Some(#visit);
                 }
             }
@@ -2665,11 +2672,18 @@ fn deserialize_map_in_place(
                     })
                 }
             };
-            quote! {
-                __Field::#name => {
+            let duplicate_field_check = if field.attrs.allow_duplicates() {
+                quote! { }
+            } else {
+                quote! {
                     if #name {
                         return _serde::export::Err(<__A::Error as _serde::de::Error>::duplicate_field(#deser_name));
                     }
+                }
+            };
+            quote! {
+                __Field::#name => {
+                    #duplicate_field_check
                     #visit;
                     #name = true;
                 }

--- a/serde_derive/src/internals/ast.rs
+++ b/serde_derive/src/internals/ast.rs
@@ -91,6 +91,9 @@ impl<'a> Container<'a> {
                         field
                             .attrs
                             .rename_by_rules(variant.attrs.rename_all_rules());
+                        if attrs.allow_duplicates() || variant.attrs.allow_duplicates() {
+                            field.attrs.mark_allow_duplicates();
+                        }
                     }
                 }
             }
@@ -100,6 +103,9 @@ impl<'a> Container<'a> {
                         has_flatten = true;
                     }
                     field.attrs.rename_by_rules(attrs.rename_all_rules());
+                    if attrs.allow_duplicates() {
+                        field.attrs.mark_allow_duplicates();
+                    }
                 }
             }
         }

--- a/serde_derive/src/internals/symbol.rs
+++ b/serde_derive/src/internals/symbol.rs
@@ -5,6 +5,7 @@ use syn::{Ident, Path};
 pub struct Symbol(&'static str);
 
 pub const ALIAS: Symbol = Symbol("alias");
+pub const ALLOW_DUPLICATES: Symbol = Symbol("allow_duplicates");
 pub const BORROW: Symbol = Symbol("borrow");
 pub const BOUND: Symbol = Symbol("bound");
 pub const CONTENT: Symbol = Symbol("content");

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -952,6 +952,36 @@ fn test_skip_struct() {
     );
 }
 
+#[derive(Debug, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AllowDuplicatesStruct {
+    a: i32,
+    #[serde(allow_duplicates)]
+    b: i32,
+}
+
+#[test]
+fn test_allow_duplicates_struct() {
+    assert_de_tokens(
+        &AllowDuplicatesStruct { a: 1, b: 3 },
+        &[
+            Token::Struct {
+                name: "AllowDuplicatesStruct",
+                len: 4,
+            },
+            Token::Str("a"),
+            Token::I8(1),
+            Token::Str("b"),
+            Token::I8(1),
+            Token::Str("b"),
+            Token::I8(2),
+            Token::Str("b"),
+            Token::I8(3),
+            Token::StructEnd,
+        ],
+    );
+}
+
 #[derive(Debug, PartialEq, Serialize)]
 enum SkipSerializingEnum<'a, B, C>
 where


### PR DESCRIPTION
This attribute causes deserialization to ignore duplicated struct fields, as this is allowed in some data formats. When this happens, the last instance of the field is used. The attribute can be used either on a field itself (in which case, it applies only to that field), or to a whole container/variant (in which case, it applies to all fields in the container).

I don't know if this is the correct implementation or not, it could be argued that this should be a property of the data format similar to `is_human_readable`.