### PR TITLE
allow user control on has_atomic32 and has_atomic64

### DIFF
--- a/serde/build.rs
+++ b/serde/build.rs
@@ -110,6 +110,11 @@ fn has_atomic(n: u8, default: bool) -> bool {
         None => return default,
     };
 
+    let explicit_value = match explicit_value.into_string() {
+        Ok(explicit_value) => explicit_value,
+        Err(_) => return default,
+    };
+
     /* needs setting to 0 or empty to disable atomicN, everything else means has_atomicN */
     explicit_value != "0" && explicit_value != ""
 }


### PR DESCRIPTION
on OpenBSD, for i386 architecture, we use a slightly different specification that the one in `src/librustc_target/spec/i686_unknown_openbsd.rs`. we are targeting olders CPUs, possibly without atomic64.

this PR adds a user configurable way to specify if the target has atomic32 and atomic64.

it uses environment variables `SERDE_HAS_ATOMIC32_targetname` and `SERDE_HAS_ATOMIC64_targetname` to force a specific value, and fallback to hardcoded definition.