### PR TITLE
Allow #[serde(borrow)] for non-std Cow

### DIFF
--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -53,9 +53,10 @@ where
 }
 
 #[cfg(any(feature = "std", feature = "alloc"))]
-pub fn borrow_cow_str<'de: 'a, 'a, D>(deserializer: D) -> Result<Cow<'a, str>, D::Error>
+pub fn borrow_cow_str<'de: 'a, 'a, D, R>(deserializer: D) -> Result<R, D::Error>
 where
     D: Deserializer<'de>,
+    R: From<Cow<'a, str>>,
 {
     struct CowStrVisitor;
 
@@ -121,13 +122,14 @@ where
         }
     }
 
-    deserializer.deserialize_str(CowStrVisitor)
+    deserializer.deserialize_str(CowStrVisitor).map(From::from)
 }
 
 #[cfg(any(feature = "std", feature = "alloc"))]
-pub fn borrow_cow_bytes<'de: 'a, 'a, D>(deserializer: D) -> Result<Cow<'a, [u8]>, D::Error>
+pub fn borrow_cow_bytes<'de: 'a, 'a, D, R>(deserializer: D) -> Result<R, D::Error>
 where
     D: Deserializer<'de>,
+    R: From<Cow<'a, [u8]>>,
 {
     struct CowBytesVisitor;
 
@@ -181,7 +183,7 @@ where
         }
     }
 
-    deserializer.deserialize_bytes(CowBytesVisitor)
+    deserializer.deserialize_bytes(CowBytesVisitor).map(From::from)
 }
 
 pub mod size_hint {


### PR DESCRIPTION
I've written a [custom `Cow` implementation](https://github.com/maciejhirsz/beef/) that's meant to be (mostly) a drop-in replacement for `std::borrow::Cow`.

The `#[derive(Deserialize)]` macro currently does specialization for `Cow` by ident name when using `#[serde(borrow)]`, which is smart, but it also means [we get the false positives](https://github.com/serde-rs/serde/blob/078e88b2235992282c3fe72a6e7365db9508f46b/serde_derive/src/internals/attr.rs#L1704-L1725), as it is in this case:

```rust
use beef::Cow;

#[derive(Deserialize)]
struct Foo<'a> {
    #[serde(borrow)]
    foo: Cow<'a, str>,
}
```

Will produce following compile error:
```
#[derive(Deserialize)]
         ^^^^^^^^^^^
         |
         expected struct `beef::generic::Cow`, found enum `std::borrow::Cow`
         in this macro invocation
```

This PR modifies `serde::private::de::borrow_cow_*` functions to return a generic type `R` with a bound `R: From<std::borrow::Cow>`. It would allow *any* custom type named `Cow` that also implements `From<std::borrow::Cow<T>>` (which it probably should) to be consistent with `std::borrow::Cow` in deserializing behavior. This should obviously just add a no-op for std `Cow`.

# Breakage?

All the usage of the function within the derive macros should continue working since types will be always easily inferred. Given this function is not part of public documentation I reckon this should be fine even though it's technically a breaking change. Thoughts?