### PR TITLE
Simplify default Serializer::collect_str implementation

### DIFF
--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -1359,10 +1359,7 @@ pub trait Serializer: Sized {
     where
         T: Display,
     {
-        use lib::fmt::Write;
-        let mut string = String::new();
-        write!(string, "{}", value).unwrap();
-        self.serialize_str(&string)
+        self.serialize_str(&value.to_string())
     }
 
     /// Serialize a string produced by an implementation of `Display`.


### PR DESCRIPTION
According to https://github.com/serde-rs/serde/pull/789#pullrequestreview-24156711 this was implemented originally using `write!(...).unwrap()` due to https://github.com/rust-lang/rust/issues/40103, but that problem was later fixed in https://github.com/rust-lang/rust/pull/40117.