### PR TITLE
Hide generated dummy const in rustdoc

### DIFF
--- a/serde_derive/src/dummy.rs
+++ b/serde_derive/src/dummy.rs
@@ -29,6 +29,7 @@ pub fn wrap_in_const(
     };
 
     quote! {
+        #[doc(hidden)]
         #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
         const #dummy_const: () = {
             #use_serde


### PR DESCRIPTION
When creating a binary crate with a `src/main.rs` and `#[derive(Deserialize, Serialize)]`, running `cargo doc` on it will result in new doc items for generated constants:
```rust
use serde::{Deserialize, Serialize};

#[derive(Deserialize, Serialize)]
struct Dummy {
}

fn main() {
    println!("Hello, world!");
}
```
![rustdoc](https://user-images.githubusercontent.com/1538025/78402060-41891c80-75fa-11ea-8a2a-37af7ac72d19.png)

This is because Cargo runs with `--document-private-items` internally for `src/main.rs`. If you put the same code in a `src/lib.rs` the private items will not be documented by default, so you won't see them there for default `cargo doc`.
The items will be visible both for `src/lib.rs` and `src/main.rs` if the `struct` itself is `pub`.

I believe the generated `_IMPL_{}_FOR_{}` constants should not be visible in rustdoc and this merge request seems to fix the issue for me.
