### PR TITLE
Allow `#[serde(flatten)]` on seq represented structures

### DIFF
--- a/serde_derive/src/internals/check.rs
+++ b/serde_derive/src/internals/check.rs
@@ -62,12 +62,6 @@ fn check_flatten_field(cx: &Ctxt, style: Style, field: &Field) {
         return;
     }
     match style {
-        Style::Tuple => {
-            cx.error_spanned_by(
-                field.original,
-                "#[serde(flatten)] cannot be used on tuple structs",
-            );
-        }
         Style::Newtype => {
             cx.error_spanned_by(
                 field.original,

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -2610,3 +2610,67 @@ fn test_flatten_any_after_flatten_struct() {
         ],
     );
 }
+
+#[test]
+fn test_flatten_on_tuple_struct() {
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct FirstTwo(i32, i32);
+
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct Outer(
+        #[serde(flatten)]
+        FirstTwo,
+        #[serde(flatten)]
+        Vec<i32>,
+    );
+
+    let s = Outer(
+        FirstTwo(1, 2),
+        vec![3, 4, 5],
+    );
+
+    assert_de_tokens(
+        &s,
+        &[
+            Token::Seq { len: Some(5) },
+            Token::I32(1),
+            Token::I32(2),
+            Token::I32(3),
+            Token::I32(4),
+            Token::I32(5),
+            Token::SeqEnd,
+        ],
+    );
+}
+
+#[test]
+fn test_flatten_on_named_struct_deserialized_from_seq() {
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct FirstTwo(i32, i32);
+
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct Outer {
+        #[serde(flatten)]
+        first_two: FirstTwo,
+        #[serde(flatten)]
+        rest: Vec<i32>,
+    }
+
+    let s = Outer {
+        first_two: FirstTwo(1, 2),
+        rest: vec![3, 4, 5],
+    };
+
+    assert_de_tokens(
+        &s,
+        &[
+            Token::Seq { len: Some(5) },
+            Token::I32(1),
+            Token::I32(2),
+            Token::I32(3),
+            Token::I32(4),
+            Token::I32(5),
+            Token::SeqEnd,
+        ],
+    );
+}


### PR DESCRIPTION
This commit allows `#[serde(flatten)]` for tuple structs, and generates
seq deserialization code for named structs containing
`#[serde(flatten)]`. There's no fundamental reason we can't allow this,
and in fact we can do this much more efficiently for sequences than we
can for maps.

My use case for this is the need to deserialize a structure in the form:

```
["string_content", (TStringContent | StringEmbexpr | StringDVar)*]
```

There's no way to deserialize this structure with a derive in Serde
prior to this commit. The struct representation would be

```rust
struct StringContent(string_content_tag, Vec<StringContentPart>);
```

The manual deserialize impl for this would look roughly like:

```rust
fn visit_seq<A>(seq: A) -> Result<Self::Item, A::Error> {
    let tag = seq.next_element()?
        .ok_or_else(|| Error::invalid_length(0, &self))?;
    let parts = Deserialize::deserialize(
        SeqAccessDeserializer::new(&mut seq),
    )?;
    Ok(Self(tag, parts))
}
```

With this commit, this struct can now be written as:

```rust
 #[derive(Deserialize)]
struct StringContent(string_content_tag, #[serde(flatten)] Vec<StringContentPart>);
```

or

```rust
 #[derive(Deserialize)]
struct StringContent {
    tag: string_content_tag,
    #[serde(flatten)]
    parts: Vec<StringContentPart>,
}
```