### PR TITLE
Add prefix_all container attribute

### DIFF
--- a/serde_derive/src/internals/mod.rs
+++ b/serde_derive/src/internals/mod.rs
@@ -4,8 +4,8 @@ pub mod attr;
 mod ctxt;
 pub use self::ctxt::Ctxt;
 
-mod case;
 mod check;
+mod rename;
 mod symbol;
 
 #[derive(Copy, Clone)]

--- a/serde_derive/src/internals/symbol.rs
+++ b/serde_derive/src/internals/symbol.rs
@@ -19,6 +19,7 @@ pub const FROM: Symbol = Symbol("from");
 pub const GETTER: Symbol = Symbol("getter");
 pub const INTO: Symbol = Symbol("into");
 pub const OTHER: Symbol = Symbol("other");
+pub const PREFIX_ALL: Symbol = Symbol("prefix_all");
 pub const REMOTE: Symbol = Symbol("remote");
 pub const RENAME: Symbol = Symbol("rename");
 pub const RENAME_ALL: Symbol = Symbol("rename_all");

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -1734,6 +1734,64 @@ fn test_rename_all() {
         serialize_seq: bool,
     }
 
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    #[serde(prefix_all = "PREFIX_")]
+    struct Prefixed {
+        serialize: bool,
+        serialize_seq: bool,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    #[serde(prefix_all = "PREFIX_", rename_all = "camelCase")]
+    struct PrefixedCamelCase {
+        serialize: bool,
+        serialize_seq: bool,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    #[serde(
+        prefix_all(serialize = "SER_", deserialize = "DE_"),
+        rename_all = "camelCase"
+    )]
+    struct PrefixedSerAndDeCamelCase {
+        serialize: bool,
+        serialize_seq: bool,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    #[serde(prefix_all(serialize = "SER_"), rename_all = "camelCase")]
+    struct PrefixedSerOnlyCamelCase {
+        serialize: bool,
+        serialize_seq: bool,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    #[serde(prefix_all = "PREFIX_")]
+    enum PrefixedEnum {
+        TheVariant,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    #[serde(prefix_all = "PREFIX_", rename_all = "kebab-case")]
+    enum PrefixedKebabCaseEnum {
+        TheVariant,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    #[serde(
+        prefix_all(serialize = "SER_", deserialize = "DE_"),
+        rename_all = "kebab-case"
+    )]
+    enum PrefixedSerAndDeKebabCaseEnum {
+        TheVariant,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    #[serde(prefix_all(serialize = "SER_"), rename_all = "kebab-case")]
+    enum PrefixedSerOnlyKebabCaseEnum {
+        TheVariant,
+    }
+
     assert_tokens(
         &E::Serialize {
             serialize: true,
@@ -1822,6 +1880,154 @@ fn test_rename_all() {
             Token::Bool(true),
             Token::StructEnd,
         ],
+    );
+
+    assert_tokens(
+        &Prefixed {
+            serialize: true,
+            serialize_seq: true,
+        },
+        &[
+            Token::Struct {
+                name: "Prefixed",
+                len: 2,
+            },
+            Token::Str("PREFIX_serialize"),
+            Token::Bool(true),
+            Token::Str("PREFIX_serialize_seq"),
+            Token::Bool(true),
+            Token::StructEnd,
+        ],
+    );
+
+    assert_tokens(
+        &PrefixedCamelCase {
+            serialize: true,
+            serialize_seq: true,
+        },
+        &[
+            Token::Struct {
+                name: "PrefixedCamelCase",
+                len: 2,
+            },
+            Token::Str("PREFIX_serialize"),
+            Token::Bool(true),
+            Token::Str("PREFIX_serializeSeq"),
+            Token::Bool(true),
+            Token::StructEnd,
+        ],
+    );
+
+    assert_de_tokens(
+        &PrefixedSerAndDeCamelCase {
+            serialize: true,
+            serialize_seq: true,
+        },
+        &[
+            Token::Struct {
+                name: "PrefixedSerAndDeCamelCase",
+                len: 2,
+            },
+            Token::Str("DE_serialize"),
+            Token::Bool(true),
+            Token::Str("DE_serializeSeq"),
+            Token::Bool(true),
+            Token::StructEnd,
+        ],
+    );
+
+    assert_ser_tokens(
+        &PrefixedSerAndDeCamelCase {
+            serialize: true,
+            serialize_seq: true,
+        },
+        &[
+            Token::Struct {
+                name: "PrefixedSerAndDeCamelCase",
+                len: 2,
+            },
+            Token::Str("SER_serialize"),
+            Token::Bool(true),
+            Token::Str("SER_serializeSeq"),
+            Token::Bool(true),
+            Token::StructEnd,
+        ],
+    );
+
+    assert_de_tokens(
+        &PrefixedSerOnlyCamelCase {
+            serialize: true,
+            serialize_seq: true,
+        },
+        &[
+            Token::Struct {
+                name: "PrefixedSerOnlyCamelCase",
+                len: 2,
+            },
+            Token::Str("serialize"),
+            Token::Bool(true),
+            Token::Str("serializeSeq"),
+            Token::Bool(true),
+            Token::StructEnd,
+        ],
+    );
+
+    assert_ser_tokens(
+        &PrefixedSerOnlyCamelCase {
+            serialize: true,
+            serialize_seq: true,
+        },
+        &[
+            Token::Struct {
+                name: "PrefixedSerOnlyCamelCase",
+                len: 2,
+            },
+            Token::Str("SER_serialize"),
+            Token::Bool(true),
+            Token::Str("SER_serializeSeq"),
+            Token::Bool(true),
+            Token::StructEnd,
+        ],
+    );
+
+    assert_tokens(
+        &PrefixedEnum::TheVariant,
+        &[Token::UnitVariant {
+            name: "PrefixedEnum",
+            variant: "PREFIX_TheVariant",
+        }],
+    );
+
+    assert_tokens(
+        &PrefixedKebabCaseEnum::TheVariant,
+        &[Token::UnitVariant {
+            name: "PrefixedKebabCaseEnum",
+            variant: "PREFIX_the-variant",
+        }],
+    );
+
+    assert_de_tokens(
+        &PrefixedSerAndDeKebabCaseEnum::TheVariant,
+        &[Token::UnitVariant {
+            name: "PrefixedSerAndDeKebabCaseEnum",
+            variant: "DE_the-variant",
+        }],
+    );
+
+    assert_ser_tokens(
+        &PrefixedSerAndDeKebabCaseEnum::TheVariant,
+        &[Token::UnitVariant {
+            name: "PrefixedSerAndDeKebabCaseEnum",
+            variant: "SER_the-variant",
+        }],
+    );
+
+    assert_de_tokens(
+        &PrefixedSerOnlyKebabCaseEnum::TheVariant,
+        &[Token::UnitVariant {
+            name: "PrefixedSerOnlyKebabCaseEnum",
+            variant: "the-variant",
+        }],
     );
 }
 


### PR DESCRIPTION
Usage:

```
#[derive(Serialize, Deserialize, Debug, PartialEq)]
#[serde(prefix_all = "PREFIX_", rename_all = "camelCase")]
struct PrefixedCamelCase {
    serialize: bool,      // => "PREFIX_serialize"
    serialize_seq: bool,  // => "PREFIX_serializeSeq"
}
```

If used in combination with `rename_all`, as above, the prefix is applied after the case conversion. The rationale is that you could get the other behaviour by just writing the prefix in the desired case to begin with, and this way also allows for the additional flexibility of choosing the prefix to be a different case.

There is one weird edge case, however. If you want to add a prefix, and also rename all so that the final result is in camelCase, you actually need to use `rename_all = "PascalCase"`, so that the first letter of the field name is capitalised. I think the choice I made is the right one, but it seemed worth mentioning in case I didn't consider something.