### PR TITLE
Add a CI builder on 1.31.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,14 @@ jobs:
       - run: cd serde && cargo build --no-default-features
       - run: cd serde && cargo build
 
+  derive:
+    name: Rust 1.31.0
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dtolnay/rust-toolchain@1.31.0
+      - run: cd serde_derive && cargo check
+
   alloc:
     name: Rust 1.36.0
     runs-on: ubuntu-latest


### PR DESCRIPTION
We have a gap in coverage of pre-NLL-on-2015-edition compilers (the 1.31 through 1.35 range) which resulted in CI failing to catch dda070f45cb02b26186d2579efaefd838022a26c.