### PR TITLE
Improve `packed` repr matching and add tests.

### DIFF
--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -1893,4 +1893,16 @@ fn test_packed_struct_can_derive_serialize() {
     struct CPacked {
         t: f32,
     }
+
+    #[derive(Copy, Clone, Serialize)]
+    #[repr(C, packed(2))]
+    struct CPacked2 {
+        t: f32,
+    }
+
+    #[derive(Copy, Clone, Serialize)]
+    #[repr(packed(2), C)]
+    struct Packed2C {
+        t: f32,
+    }
 }

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -1878,3 +1878,19 @@ fn test_internally_tagged_newtype_variant_containing_unit_struct() {
         ],
     );
 }
+
+#[deny(safe_packed_borrows)]
+#[test]
+fn test_packed_struct_can_derive_serialize() {
+    #[derive(Copy, Clone, Serialize)]
+    #[repr(packed, C)]
+    struct PackedC {
+        t: f32,
+    }
+
+    #[derive(Copy, Clone, Serialize)]
+    #[repr(C, packed)]
+    struct CPacked {
+        t: f32,
+    }
+}


### PR DESCRIPTION
Further improves the patches related to #1747 which worked well as long as `packed` was the first attribute in the repr annotation. Now as long as the attribute exists it will behave appropriately.