### PR TITLE
`lean_strings` feature to eliminate some auto-generated strings

### DIFF
--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -20,7 +20,7 @@ serde_derive = { version = "=1.0.111", optional = true, path = "../serde_derive"
 serde_derive = { version = "1.0", path = "../serde_derive" }
 
 [package.metadata.playground]
-features = ["derive", "rc"]
+features = ["derive", "lean_strings", "rc"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -33,6 +33,9 @@ default = ["std"]
 
 # Provide derive(Serialize, Deserialize) macros.
 derive = ["serde_derive"]
+
+# Remove optional diagnostic strings that may contain source code identifiers.
+lean_strings = ["serde_derive/lean_strings"]
 
 # Provide impls for common standard library types like Vec<T> and HashMap<K, V>.
 # Requires a dependency on the Rust standard library.

--- a/serde_derive/Cargo.toml
+++ b/serde_derive/Cargo.toml
@@ -14,6 +14,7 @@ include = ["Cargo.toml", "src/**/*.rs", "crates-io.md", "README.md", "LICENSE-AP
 [features]
 default = []
 deserialize_in_place = []
+lean_strings = []
 
 [lib]
 name = "serde_derive"


### PR DESCRIPTION
Hi,

This pull request implements the `lean_strings` Cargo feature to eliminate some strings generated by `serde_derive`.  There is a growing interest in reducing the footprint of Rust programs as well as in removing automatically generated strings that embed portions of the source code into executable (e.g., reduction of panic strings as shown in https://github.com/johnthagen/min-sized-rust#remove-panic-string-formatting-with-panic_immediate_abort).

Currently `serde_derive` converts source-code identifiers into strings both for use as keys in some data format (e.g., JSON) as well as for generating error messages to help diagnose corrupt serialized data.  With binary data formats like `bincode` (https://github.com/servo/bincode) that don't use the strings for keys, link-time optimization removes many of the strings; but the strings embedded within the error messages remain.

The feature `lean_strings` provided by this pull request aims to eliminate such source-code snippets from these error messages.

A separate pull request documenting this feature is at https://github.com/serde-rs/serde-rs.github.io/pull/116.

Let me know of any adjustments you'd like to see.

Thanks,
Michael Henry
