### PR TITLE
Use underscore consts on Rust 1.37+

### DIFF
--- a/serde_derive/Cargo.toml
+++ b/serde_derive/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/serde-rs/serde"
 documentation = "https://serde.rs/derive.html"
 keywords = ["serde", "serialization", "no_std"]
 readme = "crates-io.md"
-include = ["src/**/*.rs", "crates-io.md", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
+include = ["build.rs", "src/**/*.rs", "crates-io.md", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 
 [features]
 default = []

--- a/serde_derive/build.rs
+++ b/serde_derive/build.rs
@@ -1,0 +1,30 @@
+use std::env;
+use std::process::Command;
+use std::str;
+
+// The rustc-cfg strings below are *not* public API. Please let us know by
+// opening a GitHub issue if your build environment requires some way to enable
+// these cfgs other than by executing our build script.
+fn main() {
+    let minor = match rustc_minor_version() {
+        Some(minor) => minor,
+        None => return,
+    };
+
+    // Underscore const names stabilized in Rust 1.37:
+    // https://github.com/rust-lang/rust/pull/61347
+    if minor >= 37 {
+        println!("cargo:rustc-cfg=underscore_consts");
+    }
+}
+
+fn rustc_minor_version() -> Option<u32> {
+    let rustc = env::var_os("RUSTC")?;
+    let output = Command::new(rustc).arg("--version").output().ok()?;
+    let version = str::from_utf8(&output.stdout).ok()?;
+    let mut pieces = version.split('.');
+    if pieces.next() != Some("rustc 1") {
+        return None;
+    }
+    pieces.next()?.parse().ok()
+}

--- a/serde_derive/src/dummy.rs
+++ b/serde_derive/src/dummy.rs
@@ -1,4 +1,5 @@
-use proc_macro2::{Ident, Span, TokenStream};
+use proc_macro2::{Ident, TokenStream};
+use quote::format_ident;
 
 use syn;
 use try;
@@ -11,10 +12,11 @@ pub fn wrap_in_const(
 ) -> TokenStream {
     let try_replacement = try::replacement();
 
-    let dummy_const = Ident::new(
-        &format!("_IMPL_{}_FOR_{}", trait_, unraw(ty)),
-        Span::call_site(),
-    );
+    let dummy_const = if cfg!(underscore_consts) {
+        format_ident!("_")
+    } else {
+        format_ident!("_IMPL_{}_FOR_{}", trait_, unraw(ty))
+    };
 
     let use_serde = match serde_path {
         Some(path) => quote! {

--- a/test_suite/tests/expand/de_enum.expanded.rs
+++ b/test_suite/tests/expand/de_enum.expanded.rs
@@ -9,7 +9,7 @@ enum DeEnum<B, C, D> {
 }
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
-const _IMPL_SERIALIZE_FOR_DeEnum: () = {
+const _: () = {
     #[allow(rust_2018_idioms, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
@@ -261,7 +261,7 @@ const _IMPL_SERIALIZE_FOR_DeEnum: () = {
 };
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
-const _IMPL_DESERIALIZE_FOR_DeEnum: () = {
+const _: () = {
     #[allow(rust_2018_idioms, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]

--- a/test_suite/tests/expand/default_ty_param.expanded.rs
+++ b/test_suite/tests/expand/default_ty_param.expanded.rs
@@ -10,7 +10,7 @@ struct DefaultTyParam<T: AssociatedType<X = i32> = i32> {
 }
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
-const _IMPL_SERIALIZE_FOR_DefaultTyParam: () = {
+const _: () = {
     #[allow(rust_2018_idioms, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
@@ -45,7 +45,7 @@ const _IMPL_SERIALIZE_FOR_DefaultTyParam: () = {
 };
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
-const _IMPL_DESERIALIZE_FOR_DefaultTyParam: () = {
+const _: () = {
     #[allow(rust_2018_idioms, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]

--- a/test_suite/tests/expand/generic_enum.expanded.rs
+++ b/test_suite/tests/expand/generic_enum.expanded.rs
@@ -7,7 +7,7 @@ pub enum GenericEnum<T, U> {
 }
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
-const _IMPL_SERIALIZE_FOR_GenericEnum: () = {
+const _: () = {
     #[allow(rust_2018_idioms, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
@@ -110,7 +110,7 @@ const _IMPL_SERIALIZE_FOR_GenericEnum: () = {
 };
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
-const _IMPL_DESERIALIZE_FOR_GenericEnum: () = {
+const _: () = {
     #[allow(rust_2018_idioms, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]

--- a/test_suite/tests/expand/generic_struct.expanded.rs
+++ b/test_suite/tests/expand/generic_struct.expanded.rs
@@ -4,7 +4,7 @@ pub struct GenericStruct<T> {
 }
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
-const _IMPL_SERIALIZE_FOR_GenericStruct: () = {
+const _: () = {
     #[allow(rust_2018_idioms, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
@@ -38,7 +38,7 @@ const _IMPL_SERIALIZE_FOR_GenericStruct: () = {
 };
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
-const _IMPL_DESERIALIZE_FOR_GenericStruct: () = {
+const _: () = {
     #[allow(rust_2018_idioms, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
@@ -400,7 +400,7 @@ const _IMPL_DESERIALIZE_FOR_GenericStruct: () = {
 pub struct GenericNewTypeStruct<T>(T);
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
-const _IMPL_SERIALIZE_FOR_GenericNewTypeStruct: () = {
+const _: () = {
     #[allow(rust_2018_idioms, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
@@ -422,7 +422,7 @@ const _IMPL_SERIALIZE_FOR_GenericNewTypeStruct: () = {
 };
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
-const _IMPL_DESERIALIZE_FOR_GenericNewTypeStruct: () = {
+const _: () = {
     #[allow(rust_2018_idioms, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]

--- a/test_suite/tests/expand/generic_tuple_struct.expanded.rs
+++ b/test_suite/tests/expand/generic_tuple_struct.expanded.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 pub struct GenericTupleStruct<T, U>(T, U);
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
-const _IMPL_DESERIALIZE_FOR_GenericTupleStruct: () = {
+const _: () = {
     #[allow(rust_2018_idioms, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]

--- a/test_suite/tests/expand/lifetimes.expanded.rs
+++ b/test_suite/tests/expand/lifetimes.expanded.rs
@@ -7,7 +7,7 @@ enum Lifetimes<'a> {
 }
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
-const _IMPL_SERIALIZE_FOR_Lifetimes: () = {
+const _: () = {
     #[allow(rust_2018_idioms, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
@@ -91,7 +91,7 @@ const _IMPL_SERIALIZE_FOR_Lifetimes: () = {
 };
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
-const _IMPL_DESERIALIZE_FOR_Lifetimes: () = {
+const _: () = {
     #[allow(rust_2018_idioms, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]

--- a/test_suite/tests/expand/named_map.expanded.rs
+++ b/test_suite/tests/expand/named_map.expanded.rs
@@ -6,7 +6,7 @@ struct SerNamedMap<'a, 'b, A: 'a, B: 'b, C> {
 }
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
-const _IMPL_SERIALIZE_FOR_SerNamedMap: () = {
+const _: () = {
     #[allow(rust_2018_idioms, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
@@ -59,7 +59,7 @@ struct DeNamedMap<A, B, C> {
 }
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
-const _IMPL_DESERIALIZE_FOR_DeNamedMap: () = {
+const _: () = {
     #[allow(rust_2018_idioms, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]

--- a/test_suite/tests/expand/named_tuple.expanded.rs
+++ b/test_suite/tests/expand/named_tuple.expanded.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 struct SerNamedTuple<'a, 'b, A: 'a, B: 'b, C>(&'a A, &'b mut B, C);
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
-const _IMPL_SERIALIZE_FOR_SerNamedTuple: () = {
+const _: () = {
     #[allow(rust_2018_idioms, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
@@ -51,7 +51,7 @@ const _IMPL_SERIALIZE_FOR_SerNamedTuple: () = {
 struct DeNamedTuple<A, B, C>(A, B, C);
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
-const _IMPL_DESERIALIZE_FOR_DeNamedTuple: () = {
+const _: () = {
     #[allow(rust_2018_idioms, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]

--- a/test_suite/tests/expand/named_unit.expanded.rs
+++ b/test_suite/tests/expand/named_unit.expanded.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 struct NamedUnit;
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
-const _IMPL_SERIALIZE_FOR_NamedUnit: () = {
+const _: () = {
     #[allow(rust_2018_idioms, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
@@ -17,7 +17,7 @@ const _IMPL_SERIALIZE_FOR_NamedUnit: () = {
 };
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
-const _IMPL_DESERIALIZE_FOR_NamedUnit: () = {
+const _: () = {
     #[allow(rust_2018_idioms, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]

--- a/test_suite/tests/expand/ser_enum.expanded.rs
+++ b/test_suite/tests/expand/ser_enum.expanded.rs
@@ -12,7 +12,7 @@ where
 }
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
-const _IMPL_SERIALIZE_FOR_SerEnum: () = {
+const _: () = {
     #[allow(rust_2018_idioms, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]

--- a/test_suite/tests/expand/void.expanded.rs
+++ b/test_suite/tests/expand/void.expanded.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 enum Void {}
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
-const _IMPL_SERIALIZE_FOR_Void: () = {
+const _: () = {
     #[allow(rust_2018_idioms, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
@@ -17,7 +17,7 @@ const _IMPL_SERIALIZE_FOR_Void: () = {
 };
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
-const _IMPL_DESERIALIZE_FOR_Void: () = {
+const _: () = {
     #[allow(rust_2018_idioms, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]


### PR DESCRIPTION
Fixes #1683

The error message for the code mentioned in https://github.com/rust-lang/rust/issues/46991 is now as follows:

```text
error[E0277]: the trait bound `S: _::_serde::Serialize` is not satisfied
  --> src/main.rs:14:5
     |
14   |     serde_json::to_string(&S);
     |                           ^^ the trait `_::_serde::Serialize` is not implemented for `S`
     | 
```