### PR TITLE
Remove len hint specialization

### DIFF
--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -89,7 +89,7 @@
 // discussion of these features please refer to this issue:
 //
 //    https://github.com/serde-rs/serde/issues/812
-#![cfg_attr(feature = "unstable", feature(specialization, never_type))]
+#![cfg_attr(feature = "unstable", feature(never_type))]
 #![allow(unknown_lints, bare_trait_objects, deprecated)]
 #![cfg_attr(feature = "cargo-clippy", allow(renamed_and_removed_lints))]
 #![cfg_attr(feature = "cargo-clippy", deny(clippy, clippy_pedantic))]

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -1278,7 +1278,7 @@ pub trait Serializer: Sized {
         <I as IntoIterator>::Item: Serialize,
     {
         let iter = iter.into_iter();
-        let mut serializer = try!(self.serialize_seq(iter.len_hint()));
+        let mut serializer = try!(self.serialize_seq(iterator_len_hint(&iter)));
         for item in iter {
             try!(serializer.serialize_element(&item));
         }
@@ -1318,7 +1318,7 @@ pub trait Serializer: Sized {
         I: IntoIterator<Item = (K, V)>,
     {
         let iter = iter.into_iter();
-        let mut serializer = try!(self.serialize_map(iter.len_hint()));
+        let mut serializer = try!(self.serialize_map(iterator_len_hint(&iter)));
         for (key, value) in iter {
             try!(serializer.serialize_entry(&key, &value));
         }
@@ -1951,35 +1951,6 @@ pub trait SerializeStructVariant {
 
     /// Finish serializing a struct variant.
     fn end(self) -> Result<Self::Ok, Self::Error>;
-}
-
-trait LenHint: Iterator {
-    fn len_hint(&self) -> Option<usize>;
-}
-
-impl<I> LenHint for I
-where
-    I: Iterator,
-{
-    #[cfg(not(feature = "unstable"))]
-    fn len_hint(&self) -> Option<usize> {
-        iterator_len_hint(self)
-    }
-
-    #[cfg(feature = "unstable")]
-    default fn len_hint(&self) -> Option<usize> {
-        iterator_len_hint(self)
-    }
-}
-
-#[cfg(feature = "unstable")]
-impl<I> LenHint for I
-where
-    I: ExactSizeIterator,
-{
-    fn len_hint(&self) -> Option<usize> {
-        Some(self.len())
-    }
 }
 
 fn iterator_len_hint<I>(iter: &I) -> Option<usize>


### PR DESCRIPTION
This started warning in the most recent nightly (2020-06-21).

```console
warning: the feature `specialization` is incomplete and may not be safe to use and/or cause compiler crashes
  --> serde/src/lib.rs:92:43
   |
92 | #![cfg_attr(feature = "unstable", feature(specialization, never_type))]
   |                                           ^^^^^^^^^^^^^^
   |
   = note: `#[warn(incomplete_features)]` on by default
   = note: see issue #31844 <https://github.com/rust-lang/rust/issues/31844> for more information
```

Originally from https://github.com/serde-rs/serde/pull/736.