### PR TITLE
Implemented 'and_then' struct field attribute, fixing #939

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -2482,10 +2482,14 @@ fn deserialize_map(
         .filter(|&&(field, _)| !field.attrs.skip_deserializing() && !field.attrs.flatten())
         .map(|(field, name)| {
             let missing_expr = Match(expr_is_missing(field, cattrs));
-
+            let and_then = match field.attrs.and_then() {
+                Some(and_then) => quote! { try!(#and_then(#name)) },
+                None => quote! { #name }
+            };
+            
             quote! {
                 let #name = match #name {
-                    _serde::export::Some(#name) => #name,
+                    _serde::export::Some(#name) => #and_then,
                     _serde::export::None => #missing_expr
                 };
             }

--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -1137,6 +1137,7 @@ pub struct Field {
     getter: Option<syn::ExprPath>,
     flatten: bool,
     transparent: bool,
+    and_then: Option<syn::ExprPath>
 }
 
 /// Represents the default to use for a field when deserializing.
@@ -1181,6 +1182,7 @@ impl Field {
         let mut borrowed_lifetimes = Attr::none(cx, BORROW);
         let mut getter = Attr::none(cx, GETTER);
         let mut flatten = BoolAttr::none(cx, FLATTEN);
+        let mut and_then = Attr::none(cx, AND_THEN);
 
         let ident = match &field.ident {
             Some(ident) => unraw(ident),
@@ -1347,6 +1349,12 @@ impl Field {
                 Meta(Path(word)) if word == FLATTEN => {
                     flatten.set_true(word);
                 }
+                
+                Meta(NameValue(m)) if m.path == AND_THEN => {
+                    if let Ok(path) = parse_lit_into_expr_path(cx, AND_THEN, &m.lit) {
+                        and_then.set(&m.path, path);
+                    }
+                }
 
                 Meta(meta_item) => {
                     let path = meta_item
@@ -1441,6 +1449,7 @@ impl Field {
             getter: getter.get(),
             flatten: flatten.get(),
             transparent: false,
+            and_then: and_then.get()
         }
     }
 
@@ -1511,6 +1520,10 @@ impl Field {
 
     pub fn mark_transparent(&mut self) {
         self.transparent = true;
+    }
+    
+    pub fn and_then(&self) -> Option<&syn::ExprPath> {
+        self.and_then.as_ref()
     }
 }
 

--- a/serde_derive/src/internals/symbol.rs
+++ b/serde_derive/src/internals/symbol.rs
@@ -35,6 +35,7 @@ pub const TRY_FROM: Symbol = Symbol("try_from");
 pub const UNTAGGED: Symbol = Symbol("untagged");
 pub const VARIANT_IDENTIFIER: Symbol = Symbol("variant_identifier");
 pub const WITH: Symbol = Symbol("with");
+pub const AND_THEN: Symbol = Symbol("and_then");
 
 impl PartialEq<Symbol> for Ident {
     fn eq(&self, word: &Symbol) -> bool {


### PR DESCRIPTION
Implements the 'and_then' struct field attribute. It can be used for validation but also for post-processing.
Example:

```Rust
fn check_above_2<E>(v: u32) -> Result<u32, E> where E: serde::de::Error {
    if v > 2 {
        Ok(v)
    } else {
        Err(serde::de::Error::invalid_value(
            serde::de::Unexpected::Unsigned(v as u64), &"a value above 2")
        )
    }
}

fn check_vec_not_empty<E>(v: Vec<u32>) -> Result<Vec<u32>, E> where E: serde::de::Error {
    match v.is_empty() {
        false => Ok(v),
        true => Err(serde::de::Error::invalid_value(
            serde::de::Unexpected::Seq, &"a non-empty vector'")
        ),
    }
}

#[derive(Debug, PartialEq, Serialize, Deserialize)]
struct Struct {
    #[serde(and_then="check_above_2")]
    field_above_2: u32,
    #[serde(and_then="check_vec_not_empty")]
    vec_non_empty: Vec<u32>,
    field_unconditional: u32
}
```

This addresses Issue #939.