### PR TITLE
Implement Deserialize for &[u8; N], as with &[u8]

### DIFF
--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -160,7 +160,7 @@ mod lib {
 
     pub use self::core::cell::{Cell, RefCell};
     pub use self::core::clone::{self, Clone};
-    pub use self::core::convert::{self, From, Into};
+    pub use self::core::convert::{self, From, Into, TryInto};
     pub use self::core::default::{self, Default};
     pub use self::core::fmt::{self, Debug, Display};
     pub use self::core::marker::{self, PhantomData};


### PR DESCRIPTION
This change adds implementations of `Deserialize` for `&[u8; 0..=32]`, with the same byte-array semantics as `&[u8]`, by threading in existing `TryFrom` implementations in `core`.

This also doesn't work on older Rust versions, unfortunately, so it needs to be conditioned by that, or we can just use the same pointer casts that `core` does.

Unfortunately, I worry that this may break round-tripping. I'm not familiar enough with Serde's test suite to be able to add the appropriate tests, so guidance would be appreciated there.

Fixes #1857, at any rate.