### PR TITLE
Fix hand-written enum variant deserializations to allow u64 discriminant

### DIFF
--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -1313,7 +1313,7 @@ macro_rules! variant_identifier {
                         formatter.write_str($expecting_message)
                     }
 
-                    fn visit_u32<E>(self, value: u32) -> Result<Self::Value, E>
+                    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
                     where
                         E: Error,
                     {
@@ -1321,7 +1321,7 @@ macro_rules! variant_identifier {
                             $(
                                 $index => Ok($name_kind :: $variant),
                             )*
-                            _ => Err(Error::invalid_value(Unexpected::Unsigned(value as u64), &self),),
+                            _ => Err(Error::invalid_value(Unexpected::Unsigned(value), &self),),
                         }
                     }
 
@@ -2326,7 +2326,7 @@ where
                         formatter.write_str("`Unbounded`, `Included` or `Excluded`")
                     }
 
-                    fn visit_u32<E>(self, value: u32) -> Result<Self::Value, E>
+                    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
                     where
                         E: Error,
                     {
@@ -2335,7 +2335,7 @@ where
                             1 => Ok(Field::Included),
                             2 => Ok(Field::Excluded),
                             _ => Err(Error::invalid_value(
-                                Unexpected::Unsigned(value as u64),
+                                Unexpected::Unsigned(value),
                                 &self,
                             )),
                         }
@@ -2492,7 +2492,7 @@ where
                         formatter.write_str("`Ok` or `Err`")
                     }
 
-                    fn visit_u32<E>(self, value: u32) -> Result<Self::Value, E>
+                    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
                     where
                         E: Error,
                     {
@@ -2500,7 +2500,7 @@ where
                             0 => Ok(Field::Ok),
                             1 => Ok(Field::Err),
                             _ => Err(Error::invalid_value(
-                                Unexpected::Unsigned(value as u64),
+                                Unexpected::Unsigned(value),
                                 &self,
                             )),
                         }


### PR DESCRIPTION
Automatically generated enum variant deserializers allowed any integer
type as the discriminant, but the hand-written ones for specific enum
types such as Result or IpAddr only allowed types up to u32. This broke
some non-human-readable deserializers for these enums, with
deserializers that emit any integer type as a u64. Switch the visit_u32
methods to visit_u64 methods to allow discriminants to have any size up
to a u64.