### PR TITLE
Added #[serde(case_insensitive)] container attribute for case-insensitive identifier deserialization

### DIFF
--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -223,6 +223,7 @@ pub struct Container {
     has_flatten: bool,
     serde_path: Option<syn::Path>,
     is_packed: bool,
+    case_insensitive: bool,
 }
 
 /// Styles of representing an enum.
@@ -305,6 +306,7 @@ impl Container {
         let mut field_identifier = BoolAttr::none(cx, FIELD_IDENTIFIER);
         let mut variant_identifier = BoolAttr::none(cx, VARIANT_IDENTIFIER);
         let mut serde_path = Attr::none(cx, CRATE);
+        let mut case_insensitive = BoolAttr::none(cx, CASE_INSENSITIVE);
 
         for meta_item in item
             .attrs
@@ -575,6 +577,11 @@ impl Container {
                     }
                 }
 
+                // Parse `#[serde(case_insensitive)]`
+                Meta(Path(word)) if word == CASE_INSENSITIVE => {
+                    case_insensitive.set_true(word);
+                }
+
                 Meta(meta_item) => {
                     let path = meta_item
                         .path()
@@ -627,6 +634,7 @@ impl Container {
             has_flatten: false,
             serde_path: serde_path.get(),
             is_packed,
+            case_insensitive: case_insensitive.get(),
         }
     }
 
@@ -701,6 +709,10 @@ impl Container {
     pub fn serde_path(&self) -> Cow<syn::Path> {
         self.custom_serde_path()
             .map_or_else(|| Cow::Owned(parse_quote!(_serde)), Cow::Borrowed)
+    }
+
+    pub fn case_insensitive(&self) -> bool {
+        self.case_insensitive
     }
 }
 

--- a/serde_derive/src/internals/symbol.rs
+++ b/serde_derive/src/internals/symbol.rs
@@ -35,6 +35,7 @@ pub const TRY_FROM: Symbol = Symbol("try_from");
 pub const UNTAGGED: Symbol = Symbol("untagged");
 pub const VARIANT_IDENTIFIER: Symbol = Symbol("variant_identifier");
 pub const WITH: Symbol = Symbol("with");
+pub const CASE_INSENSITIVE: Symbol = Symbol("case_insensitive");
 
 impl PartialEq<Symbol> for Ident {
     fn eq(&self, word: &Symbol) -> bool {


### PR DESCRIPTION
Added an attritube that enables case-insensitive container field/variant identifier deserialization.

A similar attribute been requested in #586, which was closed because case-insensitive parsing was provided by the serde-aux crate.
The case insensitive implementation there however seems to first parse the data into a map, convert all keys into lowercase and then deserialize the map into the target type.
This is definitely slower than having the code generated by derive compare the field names using case-insensitive comparison.
The serde_aux implementation also depends on serde_json::Value and might not work for other data formats.

This PR uses eq_ignore_ascii_case() for case-insensitive comparison, which limits it to ASCII characters. This should be sufficient for most use cases, and the standard library currently doesn't have a case insensitive comparsion function that supports any characters.

Also added tests test_case_insensitive_struct, test_case_insensitive_enum and test_case_insensitive_bytes.