### PR TITLE
Consistently handle numeric and string/bytes keys of field names

### DIFF
--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -2542,11 +2542,11 @@ pub trait IdentifierDeserializer<'de, E: Error> {
     fn from(self) -> Self::Deserializer;
 }
 
-impl<'de, E> IdentifierDeserializer<'de, E> for u32
+impl<'de, E> IdentifierDeserializer<'de, E> for u64
 where
     E: Error,
 {
-    type Deserializer = <u32 as IntoDeserializer<'de, E>>::Deserializer;
+    type Deserializer = <u64 as IntoDeserializer<'de, E>>::Deserializer;
 
     fn from(self) -> Self::Deserializer {
         self.into_deserializer()

--- a/serde_test/src/de.rs
+++ b/serde_test/src/de.rs
@@ -168,13 +168,41 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
                         self.next_token();
                         visitor.visit_str(variant)
                     }
+                    (Token::BorrowedStr(variant), Token::Unit) => {
+                        self.next_token();
+                        visitor.visit_borrowed_str(variant)
+                    }
+                    (Token::String(variant), Token::Unit) => {
+                        self.next_token();
+                        visitor.visit_string(variant.to_string())
+                    }
                     (Token::Bytes(variant), Token::Unit) => {
                         self.next_token();
                         visitor.visit_bytes(variant)
                     }
+                    (Token::BorrowedBytes(variant), Token::Unit) => {
+                        self.next_token();
+                        visitor.visit_borrowed_bytes(variant)
+                    }
+                    (Token::ByteBuf(variant), Token::Unit) => {
+                        self.next_token();
+                        visitor.visit_byte_buf(variant.to_vec())
+                    }
+                    (Token::U8(variant), Token::Unit) => {
+                        self.next_token();
+                        visitor.visit_u8(variant)
+                    }
+                    (Token::U16(variant), Token::Unit) => {
+                        self.next_token();
+                        visitor.visit_u16(variant)
+                    }
                     (Token::U32(variant), Token::Unit) => {
                         self.next_token();
                         visitor.visit_u32(variant)
+                    }
+                    (Token::U64(variant), Token::Unit) => {
+                        self.next_token();
+                        visitor.visit_u64(variant)
                     }
                     (variant, Token::Unit) => unexpected!(variant),
                     (variant, _) => {

--- a/test_suite/tests/expand/de_enum.expanded.rs
+++ b/test_suite/tests/expand/de_enum.expanded.rs
@@ -563,10 +563,7 @@ const _: () = {
                                         1u64 => _serde::export::Ok(__Field::__field1),
                                         2u64 => _serde::export::Ok(__Field::__field2),
                                         3u64 => _serde::export::Ok(__Field::__field3),
-                                        _ => _serde::export::Err(_serde::de::Error::invalid_value(
-                                            _serde::de::Unexpected::Unsigned(__value),
-                                            &"field index 0 <= i < 4",
-                                        )),
+                                        _ => _serde::export::Ok(__Field::__ignore),
                                     }
                                 }
                                 fn visit_str<__E>(
@@ -1066,10 +1063,7 @@ const _: () = {
                                         1u64 => _serde::export::Ok(__Field::__field1),
                                         2u64 => _serde::export::Ok(__Field::__field2),
                                         3u64 => _serde::export::Ok(__Field::__field3),
-                                        _ => _serde::export::Err(_serde::de::Error::invalid_value(
-                                            _serde::de::Unexpected::Unsigned(__value),
-                                            &"field index 0 <= i < 4",
-                                        )),
+                                        _ => _serde::export::Ok(__Field::__ignore),
                                     }
                                 }
                                 fn visit_str<__E>(

--- a/test_suite/tests/expand/default_ty_param.expanded.rs
+++ b/test_suite/tests/expand/default_ty_param.expanded.rs
@@ -74,10 +74,7 @@ const _: () = {
                 {
                     match __value {
                         0u64 => _serde::export::Ok(__Field::__field0),
-                        _ => _serde::export::Err(_serde::de::Error::invalid_value(
-                            _serde::de::Unexpected::Unsigned(__value),
-                            &"field index 0 <= i < 1",
-                        )),
+                        _ => _serde::export::Ok(__Field::__ignore),
                     }
                 }
                 fn visit_str<__E>(self, __value: &str) -> _serde::export::Result<Self::Value, __E>
@@ -250,10 +247,7 @@ const _: () = {
                 {
                     match __value {
                         0u64 => _serde::export::Ok(__Field::__field0),
-                        _ => _serde::export::Err(_serde::de::Error::invalid_value(
-                            _serde::de::Unexpected::Unsigned(__value),
-                            &"field index 0 <= i < 1",
-                        )),
+                        _ => _serde::export::Ok(__Field::__ignore),
                     }
                 }
                 fn visit_str<__E>(self, __value: &str) -> _serde::export::Result<Self::Value, __E>

--- a/test_suite/tests/expand/generic_enum.expanded.rs
+++ b/test_suite/tests/expand/generic_enum.expanded.rs
@@ -347,10 +347,7 @@ const _: () = {
                                     match __value {
                                         0u64 => _serde::export::Ok(__Field::__field0),
                                         1u64 => _serde::export::Ok(__Field::__field1),
-                                        _ => _serde::export::Err(_serde::de::Error::invalid_value(
-                                            _serde::de::Unexpected::Unsigned(__value),
-                                            &"field index 0 <= i < 2",
-                                        )),
+                                        _ => _serde::export::Ok(__Field::__ignore),
                                     }
                                 }
                                 fn visit_str<__E>(

--- a/test_suite/tests/expand/generic_struct.expanded.rs
+++ b/test_suite/tests/expand/generic_struct.expanded.rs
@@ -70,10 +70,7 @@ const _: () = {
                 {
                     match __value {
                         0u64 => _serde::export::Ok(__Field::__field0),
-                        _ => _serde::export::Err(_serde::de::Error::invalid_value(
-                            _serde::de::Unexpected::Unsigned(__value),
-                            &"field index 0 <= i < 1",
-                        )),
+                        _ => _serde::export::Ok(__Field::__ignore),
                     }
                 }
                 fn visit_str<__E>(self, __value: &str) -> _serde::export::Result<Self::Value, __E>
@@ -246,10 +243,7 @@ const _: () = {
                 {
                     match __value {
                         0u64 => _serde::export::Ok(__Field::__field0),
-                        _ => _serde::export::Err(_serde::de::Error::invalid_value(
-                            _serde::de::Unexpected::Unsigned(__value),
-                            &"field index 0 <= i < 1",
-                        )),
+                        _ => _serde::export::Ok(__Field::__ignore),
                     }
                 }
                 fn visit_str<__E>(self, __value: &str) -> _serde::export::Result<Self::Value, __E>

--- a/test_suite/tests/expand/lifetimes.expanded.rs
+++ b/test_suite/tests/expand/lifetimes.expanded.rs
@@ -235,10 +235,7 @@ const _: () = {
                                 {
                                     match __value {
                                         0u64 => _serde::export::Ok(__Field::__field0),
-                                        _ => _serde::export::Err(_serde::de::Error::invalid_value(
-                                            _serde::de::Unexpected::Unsigned(__value),
-                                            &"field index 0 <= i < 1",
-                                        )),
+                                        _ => _serde::export::Ok(__Field::__ignore),
                                     }
                                 }
                                 fn visit_str<__E>(
@@ -420,10 +417,7 @@ const _: () = {
                                 {
                                     match __value {
                                         0u64 => _serde::export::Ok(__Field::__field0),
-                                        _ => _serde::export::Err(_serde::de::Error::invalid_value(
-                                            _serde::de::Unexpected::Unsigned(__value),
-                                            &"field index 0 <= i < 1",
-                                        )),
+                                        _ => _serde::export::Ok(__Field::__ignore),
                                     }
                                 }
                                 fn visit_str<__E>(

--- a/test_suite/tests/expand/named_map.expanded.rs
+++ b/test_suite/tests/expand/named_map.expanded.rs
@@ -97,10 +97,7 @@ const _: () = {
                         0u64 => _serde::export::Ok(__Field::__field0),
                         1u64 => _serde::export::Ok(__Field::__field1),
                         2u64 => _serde::export::Ok(__Field::__field2),
-                        _ => _serde::export::Err(_serde::de::Error::invalid_value(
-                            _serde::de::Unexpected::Unsigned(__value),
-                            &"field index 0 <= i < 3",
-                        )),
+                        _ => _serde::export::Ok(__Field::__ignore),
                     }
                 }
                 fn visit_str<__E>(self, __value: &str) -> _serde::export::Result<Self::Value, __E>
@@ -373,10 +370,7 @@ const _: () = {
                         0u64 => _serde::export::Ok(__Field::__field0),
                         1u64 => _serde::export::Ok(__Field::__field1),
                         2u64 => _serde::export::Ok(__Field::__field2),
-                        _ => _serde::export::Err(_serde::de::Error::invalid_value(
-                            _serde::de::Unexpected::Unsigned(__value),
-                            &"field index 0 <= i < 3",
-                        )),
+                        _ => _serde::export::Ok(__Field::__ignore),
                     }
                 }
                 fn visit_str<__E>(self, __value: &str) -> _serde::export::Result<Self::Value, __E>

--- a/test_suite/tests/test_de.rs
+++ b/test_suite/tests/test_de.rs
@@ -693,6 +693,46 @@ declare_tests! {
             Token::SeqEnd,
         ],
     }
+    test_struct_borrowed_keys {
+        Struct { a: 1, b: 2, c: 0 } => &[
+            Token::Map { len: Some(3) },
+                Token::BorrowedStr("a"),
+                Token::I32(1),
+
+                Token::BorrowedStr("b"),
+                Token::I32(2),
+            Token::MapEnd,
+        ],
+        Struct { a: 1, b: 2, c: 0 } => &[
+            Token::Struct { name: "Struct", len: 2 },
+                Token::BorrowedStr("a"),
+                Token::I32(1),
+
+                Token::BorrowedStr("b"),
+                Token::I32(2),
+            Token::StructEnd,
+        ],
+    }
+    test_struct_owned_keys {
+        Struct { a: 1, b: 2, c: 0 } => &[
+            Token::Map { len: Some(3) },
+                Token::String("a"),
+                Token::I32(1),
+
+                Token::String("b"),
+                Token::I32(2),
+            Token::MapEnd,
+        ],
+        Struct { a: 1, b: 2, c: 0 } => &[
+            Token::Struct { name: "Struct", len: 2 },
+                Token::String("a"),
+                Token::I32(1),
+
+                Token::String("b"),
+                Token::I32(2),
+            Token::StructEnd,
+        ],
+    }
     test_struct_with_skip {
         Struct { a: 1, b: 2, c: 0 } => &[
             Token::Map { len: Some(3) },

--- a/test_suite/tests/test_de.rs
+++ b/test_suite/tests/test_de.rs
@@ -624,10 +624,56 @@ declare_tests! {
         ],
         Struct { a: 1, b: 2, c: 0 } => &[
             Token::Map { len: Some(3) },
+                Token::U8(0),
+                Token::I32(1),
+
+                Token::U8(1),
+                Token::I32(2),
+            Token::MapEnd,
+        ],
+        Struct { a: 1, b: 2, c: 0 } => &[
+            Token::Map { len: Some(3) },
+                Token::U16(0),
+                Token::I32(1),
+
+                Token::U16(1),
+                Token::I32(2),
+            Token::MapEnd,
+        ],
+        Struct { a: 1, b: 2, c: 0 } => &[
+            Token::Map { len: Some(3) },
                 Token::U32(0),
                 Token::I32(1),
 
                 Token::U32(1),
+                Token::I32(2),
+            Token::MapEnd,
+        ],
+        Struct { a: 1, b: 2, c: 0 } => &[
+            Token::Map { len: Some(3) },
+                Token::U64(0),
+                Token::I32(1),
+
+                Token::U64(1),
+                Token::I32(2),
+            Token::MapEnd,
+        ],
+        // Mixed key types
+        Struct { a: 1, b: 2, c: 0 } => &[
+            Token::Map { len: Some(3) },
+                Token::U8(0),
+                Token::I32(1),
+
+                Token::U64(1),
+                Token::I32(2),
+            Token::MapEnd,
+        ],
+        Struct { a: 1, b: 2, c: 0 } => &[
+            Token::Map { len: Some(3) },
+                Token::U8(0),
+                Token::I32(1),
+
+                Token::Str("b"),
                 Token::I32(2),
             Token::MapEnd,
         ],
@@ -660,6 +706,21 @@ declare_tests! {
                 Token::I32(3),
 
                 Token::Str("d"),
+                Token::I32(4),
+            Token::MapEnd,
+        ],
+        Struct { a: 1, b: 2, c: 0 } => &[
+            Token::Map { len: Some(3) },
+                Token::U8(0),
+                Token::I32(1),
+
+                Token::U16(1),
+                Token::I32(2),
+
+                Token::U32(2),
+                Token::I32(3),
+
+                Token::U64(3),
                 Token::I32(4),
             Token::MapEnd,
         ],
@@ -780,11 +841,51 @@ declare_tests! {
             Token::Str("Unit"),
             Token::Unit,
         ],
+        EnumOther::Unit => &[
+            Token::Enum { name: "EnumOther" },
+            Token::U8(0),
+            Token::Unit,
+        ],
+        EnumOther::Unit => &[
+            Token::Enum { name: "EnumOther" },
+            Token::U16(0),
+            Token::Unit,
+        ],
+        EnumOther::Unit => &[
+            Token::Enum { name: "EnumOther" },
+            Token::U32(0),
+            Token::Unit,
+        ],
+        EnumOther::Unit => &[
+            Token::Enum { name: "EnumOther" },
+            Token::U64(0),
+            Token::Unit,
+        ],
     }
     test_enum_other {
         EnumOther::Other => &[
             Token::Enum { name: "EnumOther" },
             Token::Str("Foo"),
+            Token::Unit,
+        ],
+        EnumOther::Other => &[
+            Token::Enum { name: "EnumOther" },
+            Token::U8(42),
+            Token::Unit,
+        ],
+        EnumOther::Other => &[
+            Token::Enum { name: "EnumOther" },
+            Token::U16(42),
+            Token::Unit,
+        ],
+        EnumOther::Other => &[
+            Token::Enum { name: "EnumOther" },
+            Token::U32(42),
+            Token::Unit,
+        ],
+        EnumOther::Other => &[
+            Token::Enum { name: "EnumOther" },
+            Token::U64(42),
             Token::Unit,
         ],
     }

--- a/test_suite/tests/test_identifier.rs
+++ b/test_suite/tests/test_identifier.rs
@@ -1,3 +1,4 @@
+//! Tests for `#[serde(field_identifier)]` and `#[serde(variant_identifier)]`
 use serde::Deserialize;
 use serde_test::{assert_de_tokens, Token};
 
@@ -27,6 +28,10 @@ fn test_field_identifier() {
         Bbb,
     }
 
+    assert_de_tokens(&F::Aaa, &[Token::U8(0)]);
+    assert_de_tokens(&F::Aaa, &[Token::U16(0)]);
+    assert_de_tokens(&F::Aaa, &[Token::U32(0)]);
+    assert_de_tokens(&F::Aaa, &[Token::U64(0)]);
     assert_de_tokens(&F::Aaa, &[Token::Str("aaa")]);
     assert_de_tokens(&F::Aaa, &[Token::Bytes(b"aaa")]);
 }
@@ -42,6 +47,10 @@ fn test_unit_fallthrough() {
         Other,
     }
 
+    assert_de_tokens(&F::Other, &[Token::U8(42)]);
+    assert_de_tokens(&F::Other, &[Token::U16(42)]);
+    assert_de_tokens(&F::Other, &[Token::U32(42)]);
+    assert_de_tokens(&F::Other, &[Token::U64(42)]);
     assert_de_tokens(&F::Other, &[Token::Str("x")]);
 }
 
@@ -68,5 +77,9 @@ fn test_newtype_fallthrough_generic() {
         Other(T),
     }
 
+    assert_de_tokens(&F::Other(42u8), &[Token::U8(42)]);
+    assert_de_tokens(&F::Other(42u16), &[Token::U16(42)]);
+    assert_de_tokens(&F::Other(42u32), &[Token::U32(42)]);
+    assert_de_tokens(&F::Other(42u64), &[Token::U64(42)]);
     assert_de_tokens(&F::Other("x".to_owned()), &[Token::Str("x")]);
 }


### PR DESCRIPTION
Consider following structure:
```rust
use serde::private::de::Content;

#[derive(Deserialize)]
#[serde(field_identifier)]
enum Field<'de> {
  tag,
  other(Content<'de>),
}
```
(This enum can be used as used field identifier of internally tagged enums)
Currently it generates following `Visitor` implementation for extracting value of the `Field`:
```rust
impl<'de> de::Visitor<'de> for FieldVisitor<'de> {
  ...
  fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
  where
    E: Error,
  {
    match value {
      0u64 => Ok(Field::tag),
      _ => Err(Error::invalid_value(Unexpected::Unsigned(value), &"field index 0 <= i < 1")),
    }
  }
  fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
  where
    E: Error,
  {
    match value {
      "tag" => Ok(Field::tag),
      _ => Deserialize::deserialize(IdentifierDeserializer::from(value)).map(Field::other),
      // or that for Unit other variant
      // _ => Ok(Field::other),
    }
  }
  ...
}
```
As you can see, whenever as `visit_str` and `visit_bytes` allows any unknown tag to be mapped to `other` element, `visit_u64` doesn't do that. That means that compact formats that used integer tags can't be deserialized. I consider that as a bug. This PR fixes that and in the end fallthrough arm is the same, as for `visit_str`/`visit_bytes`. The same fix also applied to generated identifiers.

Also, when developing new tests I realized, that assertion deserializer didn't allow to use `Borrowed*`, owned and `Uxx` (except `U32`) variants to act as field identifiers. I had to fix this too, although `Field` still does not able to borrow data. I can fix that in follow-up PR or in this PR, but I not know how to check that data is borrowed and not copied. Any suggestions?