### PR TITLE
Add new container attribute #[serde(expecting = "...")] for specifing custom expectation message

### DIFF
--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -824,15 +824,17 @@ mod content {
     /// Not public API.
     pub struct TaggedContentVisitor<'de, T> {
         tag_name: &'static str,
+        expecting: &'static str,
         value: PhantomData<TaggedContent<'de, T>>,
     }
 
     impl<'de, T> TaggedContentVisitor<'de, T> {
         /// Visitor for the content of an internally tagged enum with the given
         /// tag name.
-        pub fn new(name: &'static str) -> Self {
+        pub fn new(name: &'static str, expecting: &'static str) -> Self {
             TaggedContentVisitor {
                 tag_name: name,
+                expecting: expecting,
                 value: PhantomData,
             }
         }
@@ -861,7 +863,7 @@ mod content {
         type Value = TaggedContent<'de, T>;
 
         fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-            fmt.write_str("internally tagged enum")
+            fmt.write_str(self.expecting)
         }
 
         fn visit_seq<S>(self, mut seq: S) -> Result<Self::Value, S::Error>

--- a/serde_derive/src/internals/symbol.rs
+++ b/serde_derive/src/internals/symbol.rs
@@ -35,6 +35,7 @@ pub const TRY_FROM: Symbol = Symbol("try_from");
 pub const UNTAGGED: Symbol = Symbol("untagged");
 pub const VARIANT_IDENTIFIER: Symbol = Symbol("variant_identifier");
 pub const WITH: Symbol = Symbol("with");
+pub const EXPECTING: Symbol = Symbol("expecting");
 
 impl PartialEq<Symbol> for Ident {
     fn eq(&self, word: &Symbol) -> bool {

--- a/serde_test/src/de.rs
+++ b/serde_test/src/de.rs
@@ -250,9 +250,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             {
                 visitor.visit_enum(DeserializerEnumVisitor { de: self })
             }
-            _ => {
-                unexpected!(self.next_token());
-            }
+            _ => self.deserialize_any(visitor)
         }
     }
 

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -2633,3 +2633,200 @@ fn test_flatten_any_after_flatten_struct() {
         ],
     );
 }
+
+/// https://github.com/serde-rs/serde/issues/1883
+#[test]
+fn test_expecting_message() {
+    #[derive(Deserialize, PartialEq, Debug)]
+    #[serde(expecting = "something strange...")]
+    struct Unit;
+
+    #[derive(Deserialize)]
+    #[serde(expecting = "something strange...")]
+    struct Newtype(bool);
+
+    #[derive(Deserialize)]
+    #[serde(expecting = "something strange...")]
+    struct Tuple(u32, bool);
+
+    #[derive(Deserialize)]
+    #[serde(expecting = "something strange...")]
+    struct Struct {
+        question: String,
+        answer: u32,
+    }
+
+    assert_de_tokens_error::<Unit>(
+        &[Token::Str("Unit")],
+        r#"invalid type: string "Unit", expected something strange..."#
+    );
+
+    assert_de_tokens_error::<Newtype>(
+        &[Token::Str("Newtype")],
+        r#"invalid type: string "Newtype", expected something strange..."#
+    );
+
+    assert_de_tokens_error::<Tuple>(
+        &[Token::Str("Tuple")],
+        r#"invalid type: string "Tuple", expected something strange..."#
+    );
+
+    assert_de_tokens_error::<Struct>(
+        &[Token::Str("Struct")],
+        r#"invalid type: string "Struct", expected something strange..."#
+    );
+}
+
+#[test]
+fn test_expecting_message_externally_tagged_enum() {
+    #[derive(Deserialize)]
+    #[serde(expecting = "something strange...")]
+    enum Enum {
+        ExternallyTagged,
+    }
+
+    assert_de_tokens_error::<Enum>(
+        &[
+            Token::Str("ExternallyTagged"),
+        ],
+        r#"invalid type: string "ExternallyTagged", expected something strange..."#
+    );
+
+    // Check that #[serde(expecting = "...")] doesn't affect variant identifier error message
+    assert_de_tokens_error::<Enum>(
+        &[
+            Token::Enum { name: "Enum" },
+            Token::Unit,
+        ],
+        r#"invalid type: unit value, expected variant identifier"#
+    );
+}
+
+#[test]
+fn test_expecting_message_internally_tagged_enum() {
+    #[derive(Deserialize)]
+    #[serde(tag = "tag")]
+    #[serde(expecting = "something strange...")]
+    enum Enum {
+        InternallyTagged,
+    }
+
+    assert_de_tokens_error::<Enum>(
+        &[
+            Token::Str("InternallyTagged"),
+        ],
+        r#"invalid type: string "InternallyTagged", expected something strange..."#
+    );
+
+    // Check that #[serde(expecting = "...")] doesn't affect variant identifier error message
+    assert_de_tokens_error::<Enum>(
+        &[
+            Token::Map { len: None },
+            Token::Str("tag"),
+            Token::Unit,
+        ],
+        r#"invalid type: unit value, expected variant identifier"#
+    );
+}
+
+#[test]
+fn test_expecting_message_adjacently_tagged_enum() {
+    #[derive(Deserialize)]
+    #[serde(tag = "tag", content = "content")]
+    #[serde(expecting = "something strange...")]
+    enum Enum {
+        AdjacentlyTagged,
+    }
+
+    assert_de_tokens_error::<Enum>(
+        &[
+            Token::Str("AdjacentlyTagged"),
+        ],
+        r#"invalid type: string "AdjacentlyTagged", expected something strange..."#
+    );
+
+    assert_de_tokens_error::<Enum>(
+        &[
+            Token::Map { len: None },
+            Token::Unit,
+        ],
+        r#"invalid type: unit value, expected "tag", "content", or other ignored fields"#
+    );
+
+    // Check that #[serde(expecting = "...")] doesn't affect variant identifier error message
+    assert_de_tokens_error::<Enum>(
+        &[
+            Token::Map { len: None },
+            Token::Str("tag"),
+            Token::Unit,
+        ],
+        r#"invalid type: unit value, expected variant identifier"#
+    );
+}
+
+#[test]
+fn test_expecting_message_untagged_tagged_enum() {
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    #[serde(expecting = "something strange...")]
+    enum Enum {
+        Untagged,
+    }
+
+    assert_de_tokens_error::<Enum>(
+        &[
+            Token::Str("Untagged"),
+        ],
+        r#"something strange..."#
+    );
+}
+
+#[test]
+fn test_expecting_message_identifier_enum() {
+    #[derive(Deserialize)]
+    #[serde(field_identifier)]
+    #[serde(expecting = "something strange...")]
+    enum FieldEnum {
+        Field,
+    }
+
+    #[derive(Deserialize)]
+    #[serde(variant_identifier)]
+    #[serde(expecting = "something strange...")]
+    enum VariantEnum {
+        Variant,
+    }
+
+    assert_de_tokens_error::<FieldEnum>(
+        &[
+            Token::Unit,
+        ],
+        r#"invalid type: unit value, expected something strange..."#
+    );
+
+    assert_de_tokens_error::<FieldEnum>(
+        &[
+            Token::Enum { name: "FieldEnum" },
+            Token::Str("Unknown"),
+            Token::None,
+        ],
+        r#"invalid type: map, expected something strange..."#
+    );
+
+
+    assert_de_tokens_error::<VariantEnum>(
+        &[
+            Token::Unit,
+        ],
+        r#"invalid type: unit value, expected something strange..."#
+    );
+
+    assert_de_tokens_error::<VariantEnum>(
+        &[
+            Token::Enum { name: "VariantEnum" },
+            Token::Str("Unknown"),
+            Token::None,
+        ],
+        r#"invalid type: map, expected something strange..."#
+    );
+}

--- a/test_suite/tests/test_gen.rs
+++ b/test_suite/tests/test_gen.rs
@@ -723,6 +723,55 @@ fn test_gen() {
     }
 
     deriving!(&'a str);
+
+    // https://github.com/serde-rs/serde/issues/1883
+    #[derive(Deserialize)]
+    #[serde(expecting = "a message")]
+    struct CustomMessageUnit;
+
+    #[derive(Deserialize)]
+    #[serde(expecting = "a message")]
+    struct CustomMessageNewtype(bool);
+
+    #[derive(Deserialize)]
+    #[serde(expecting = "a message")]
+    struct CustomMessageTuple(u32, bool);
+
+    #[derive(Deserialize)]
+    #[serde(expecting = "a message")]
+    struct CustomMessageStruct {
+        question: String,
+        answer: u32,
+    }
+
+    #[derive(Deserialize)]
+    #[serde(expecting = "a message")]
+    enum CustomMessageExternallyTaggedEnum {}
+
+    #[derive(Deserialize)]
+    #[serde(tag = "tag")]
+    #[serde(expecting = "a message")]
+    enum CustomMessageInternallyTaggedEnum {}
+
+    #[derive(Deserialize)]
+    #[serde(tag = "tag", content = "content")]
+    #[serde(expecting = "a message")]
+    enum CustomMessageAdjacentlyTaggedEnum {}
+
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    #[serde(expecting = "a message")]
+    enum CustomMessageUntaggedEnum {}
+
+    #[derive(Deserialize)]
+    #[serde(field_identifier)]
+    #[serde(expecting = "a message")]
+    enum CustomMessageFieldIdentifierEnum {}
+
+    #[derive(Deserialize)]
+    #[serde(variant_identifier)]
+    #[serde(expecting = "a message")]
+    enum CustomMessageVariantIdentifierEnum {}
 }
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This can be especially useful together with
- `#[serde(field_identifier)]`
- `#[serde(variant_identifier)]`
- `#[serde(untagged)]` -- for that case attribute completely replaces error message

because by default they all have very generic messages.

New attribute usage:
```rust
// default message would be 
// `data did not match any variant of untagged enum OneOrMany`
#[derive(Deserialize)]
#[serde(untagged, expecting = "expected single element or array of elements")]
struct OneOrMany<T> {
  One(T),
  Many(Vec<T>),
}
```

As two side-effects, first commit fixes panic in `assert_de_tokens_error` for enums when token stream doesn't represent an enum, so we can actually test implementation of `Deserialize`d type instead of implementation of test deserializer.

The second small improvement is adding enum name to default message for internally tagged enums:
`expected internally tagged enum`
replaced by
`expected internally tagged enum {}`

Closes #1883