### PR TITLE
Preserve is_human_readable flag on delegating (de)serializers

### DIFF
--- a/serde/src/de/value.rs
+++ b/serde/src/de/value.rs
@@ -1000,16 +1000,40 @@ where
 
 ////////////////////////////////////////////////////////////////////////////////
 
-/// A deserializer holding a `SeqAccess`.
+/// Represents [seq accessor] as a [deserializer], that forwards all calls
+/// to [`Visitor::visit_seq`].
+///
+/// Contains seq accessor and human readable capability of the deserializer.
+///
+/// [seq accessor]: ../trait.SeqAccess.html
+/// [deserializer]: ../trait.Deserializer.html
+/// [`Visitor::visit_seq`]: ../trait.Visitor.html#method.visit_seq
 #[derive(Clone, Debug)]
 pub struct SeqAccessDeserializer<A> {
+    /// Sequence assessor represented as a deserializer. Deserializer will forward
+    /// all calls to [`visit_seq()`] with this sequence as an argument.
+    ///
+    /// [`visit_seq()`]: ../trait.Visitor.html#method.visit_seq
     seq: A,
+
+    /// [`is_human_readable()`] attribute of the original deserializer, that
+    /// creates `seq` accessor.
+    ///
+    /// [`is_human_readable()`]: ../trait.Deserializer.html#method.is_human_readable
+    is_human_readable: bool,
 }
 
 impl<A> SeqAccessDeserializer<A> {
-    /// Construct a new `SeqAccessDeserializer<A>`.
+    /// Construct a new `SeqAccessDeserializer<A>` with readable representation
+    /// (`self.is_human_readable() == true`).
     pub fn new(seq: A) -> Self {
-        SeqAccessDeserializer { seq: seq }
+        SeqAccessDeserializer { seq: seq, is_human_readable: true }
+    }
+
+    /// Construct a new `SeqAccessDeserializer<A>` with specified representation
+    /// (`self.is_human_readable()`).
+    pub fn with_representation(seq: A, is_human_readable: bool) -> Self {
+        SeqAccessDeserializer { seq: seq, is_human_readable: is_human_readable }
     }
 }
 
@@ -1030,6 +1054,11 @@ where
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
         bytes byte_buf option unit unit_struct newtype_struct seq tuple
         tuple_struct map struct enum identifier ignored_any
+    }
+
+    #[inline]
+    fn is_human_readable(&self) -> bool {
+        self.is_human_readable
     }
 }
 
@@ -1401,16 +1430,43 @@ where
 
 ////////////////////////////////////////////////////////////////////////////////
 
-/// A deserializer holding a `MapAccess`.
+/// Represents [map accessor] as a [deserializer], that forward almost all calls
+/// to [`Visitor::visit_map`]. Exception is a [`deserialize_enum`], which is forwarded
+/// to [`Visitor::visit_enum`].
+///
+/// Contains map accessor and human readable capability of the deserializer.
+///
+/// [map accessor]: ../trait.MapAccess.html
+/// [deserializer]: ../trait.Deserializer.html
+/// [`deserialize_enum`]: ../trait.Deserializer.html#method.deserialize_enum
+/// [`Visitor::visit_map`]: ../trait.Visitor.html#method.visit_map
+/// [`Visitor::visit_enum`]: ../trait.Visitor.html#method.visit_enum
 #[derive(Clone, Debug)]
 pub struct MapAccessDeserializer<A> {
+    /// Map assessor represented as a deserializer. Deserializer will forward
+    /// all calls to [`visit_map()`] with this map as an argument.
+    ///
+    /// [`visit_map()`]: ../trait.Visitor.html#method.visit_map
     map: A,
+
+    /// [`is_human_readable()`] attribute of the original deserializer, that
+    /// creates `map` accessor.
+    ///
+    /// [`is_human_readable()`]: ../trait.Deserializer.html#method.is_human_readable
+    is_human_readable: bool,
 }
 
 impl<A> MapAccessDeserializer<A> {
-    /// Construct a new `MapAccessDeserializer<A>`.
+    /// Construct a new `MapAccessDeserializer<A>` with readable representation
+    /// (`self.is_human_readable() == true`).
     pub fn new(map: A) -> Self {
-        MapAccessDeserializer { map: map }
+        MapAccessDeserializer { map: map, is_human_readable: true }
+    }
+
+    /// Construct a new `MapAccessDeserializer<A>` with specified representation
+    /// (`self.is_human_readable()`).
+    pub fn with_representation(map: A, is_human_readable: bool) -> Self {
+        MapAccessDeserializer { map: map, is_human_readable: is_human_readable }
     }
 }
 
@@ -1443,6 +1499,11 @@ where
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
         bytes byte_buf option unit unit_struct newtype_struct seq tuple
         tuple_struct map struct identifier ignored_any
+    }
+
+    #[inline]
+    fn is_human_readable(&self) -> bool {
+        self.is_human_readable
     }
 }
 

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -829,6 +829,7 @@ mod content {
     /// Not public API.
     pub struct TaggedContentVisitor<'de, T> {
         tag_name: &'static str,
+        is_human_readable: bool,
         expecting: &'static str,
         value: PhantomData<TaggedContent<'de, T>>,
     }
@@ -836,9 +837,10 @@ mod content {
     impl<'de, T> TaggedContentVisitor<'de, T> {
         /// Visitor for the content of an internally tagged enum with the given
         /// tag name.
-        pub fn new(name: &'static str, expecting: &'static str) -> Self {
+        pub fn new(name: &'static str, is_human_readable: bool, expecting: &'static str) -> Self {
             TaggedContentVisitor {
                 tag_name: name,
+                is_human_readable: is_human_readable,
                 expecting: expecting,
                 value: PhantomData,
             }
@@ -881,7 +883,7 @@ mod content {
                     return Err(de::Error::missing_field(self.tag_name));
                 }
             };
-            let rest = de::value::SeqAccessDeserializer::new(seq);
+            let rest = de::value::SeqAccessDeserializer::with_representation(seq, self.is_human_readable);
             Ok(TaggedContent {
                 tag: tag,
                 content: try!(Content::deserialize(rest)),

--- a/serde/src/private/ser.rs
+++ b/serde/src/private/ser.rs
@@ -35,6 +35,15 @@ where
     })
 }
 
+/// Used to serialize tagged newtype, such as:
+///
+/// ```ignore
+/// #[derive(Serialize)]
+/// #[serde(tag = "tag")]
+/// enum Enum {
+///     A(String),
+/// }
+/// ```
 struct TaggedSerializer<S> {
     type_ident: &'static str,
     variant_ident: &'static str,
@@ -332,6 +341,10 @@ where
         T: Display,
     {
         Err(self.bad_type(Unsupported::String))
+    }
+
+    fn is_human_readable(&self) -> bool {
+        self.delegate.is_human_readable()
     }
 }
 

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1351,7 +1351,7 @@ fn deserialize_internally_tagged_enum(
         let __form = _serde::Deserializer::is_human_readable(&__deserializer);
         let __tagged = try!(_serde::Deserializer::deserialize_any(
             __deserializer,
-            _serde::__private::de::TaggedContentVisitor::<__Field>::new(#tag, #expecting)));
+            _serde::__private::de::TaggedContentVisitor::<__Field>::new(#tag, __form, #expecting)));
 
         match __tagged.tag {
             #(#variant_arms)*

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -935,31 +935,31 @@ fn deserialize_struct(
     let visit_map = Stmts(visit_map);
 
     let visitor_expr = quote! {
-        __Visitor {
+        let __visitor = __Visitor {
             marker: _serde::__private::PhantomData::<#this #ty_generics>,
             lifetime: _serde::__private::PhantomData,
-        }
+        };
     };
     let dispatch = if let Some(deserializer) = deserializer {
         quote! {
-            _serde::Deserializer::deserialize_any(#deserializer, #visitor_expr)
+            _serde::Deserializer::deserialize_any(#deserializer, __visitor)
         }
     } else if is_enum && cattrs.has_flatten() {
         quote! {
-            _serde::de::VariantAccess::newtype_variant_seed(__variant, #visitor_expr)
+            _serde::de::VariantAccess::newtype_variant_seed(__variant, __visitor)
         }
     } else if is_enum {
         quote! {
-            _serde::de::VariantAccess::struct_variant(__variant, FIELDS, #visitor_expr)
+            _serde::de::VariantAccess::struct_variant(__variant, FIELDS, __visitor)
         }
     } else if cattrs.has_flatten() {
         quote! {
-            _serde::Deserializer::deserialize_map(__deserializer, #visitor_expr)
+            _serde::Deserializer::deserialize_map(__deserializer, __visitor)
         }
     } else {
         let type_name = cattrs.name().deserialize_name();
         quote! {
-            _serde::Deserializer::deserialize_struct(__deserializer, #type_name, FIELDS, #visitor_expr)
+            _serde::Deserializer::deserialize_struct(__deserializer, #type_name, FIELDS, __visitor)
         }
     };
 
@@ -1031,6 +1031,8 @@ fn deserialize_struct(
         #visitor_seed
 
         #fields_stmt
+
+        #visitor_expr
 
         #dispatch
     }

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -931,10 +931,6 @@ fn deserialize_struct(
     };
     let expecting = cattrs.expecting().unwrap_or(&expecting);
 
-    let visit_seq = Stmts(deserialize_seq(
-        &type_path, params, fields, true, cattrs, &expecting,
-    ));
-
     let (field_visitor, fields_stmt, visit_map) = if cattrs.has_flatten() {
         deserialize_struct_as_map_visitor(&type_path, params, fields, cattrs)
     } else {
@@ -951,25 +947,30 @@ fn deserialize_struct(
         };
     };
 
-    let all_skipped = fields.iter().all(|field| field.attrs.skip_deserializing());
-    let visitor_var = if all_skipped {
-        quote!(_)
-    } else {
-        quote!(mut __seq)
-    };
-
     // untagged struct variants do not get a visit_seq method. The same applies to
     // structs that only have a map representation.
     let visit_seq = match *untagged {
-        Untagged::No if !cattrs.has_flatten() => Some(quote! {
-            #[inline]
-            fn visit_seq<__A>(self, #visitor_var: __A) -> _serde::__private::Result<Self::Value, __A::Error>
-            where
-                __A: _serde::de::SeqAccess<#delife>,
-            {
-                #visit_seq
-            }
-        }),
+        Untagged::No if !cattrs.has_flatten() => {
+            let visit_seq = Stmts(deserialize_seq(
+                &type_path, params, fields, true, cattrs, &expecting,
+            ));
+            let all_skipped = fields.iter().all(|field| field.attrs.skip_deserializing());
+            let visitor_var = if all_skipped {
+                quote!(_)
+            } else {
+                quote!(mut __seq)
+            };
+
+            Some(quote! {
+                #[inline]
+                fn visit_seq<__A>(self, #visitor_var: __A) -> _serde::__private::Result<Self::Value, __A::Error>
+                where
+                    __A: _serde::de::SeqAccess<#delife>,
+                {
+                    #visit_seq
+                }
+            })
+        },
         _ => None,
     };
 

--- a/test_suite/tests/test_representation.rs
+++ b/test_suite/tests/test_representation.rs
@@ -1,0 +1,550 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_test::{assert_tokens, Configure, Token};
+
+/// Readable representation of the test subject
+#[derive(Serialize, Deserialize)]
+struct Readable {
+    mode: String,
+}
+
+/// Compact representation of the test subject
+#[derive(Serialize, Deserialize)]
+struct Compact {
+    mode: u32,
+}
+
+/// Test subject, have the different representations in readable and compact formats
+#[derive(Debug, PartialEq)]
+struct Subject;
+impl Serialize for Subject {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer
+    {
+        if serializer.is_human_readable() {
+            Readable { mode: "readable".to_string() }.serialize(serializer)
+        } else {
+            Compact { mode: 42 }.serialize(serializer)
+        }
+    }
+}
+impl<'de> Deserialize<'de> for Subject {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>
+    {
+        if deserializer.is_human_readable() {
+            <Readable as Deserialize<'de>>::deserialize(deserializer)?;
+        } else {
+            <Compact as Deserialize<'de>>::deserialize(deserializer)?;
+        }
+        Ok(Subject)
+    }
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct Newtype(Subject);
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct Tuple((), Subject);
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct Struct {
+    subject: Subject,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct Flatten {
+    dummy: (),
+    #[serde(flatten)]
+    subject: Subject,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+enum ExternallyTagged {
+    Newtype(Subject),
+    Tuple((), Subject),
+    Struct { subject: Subject },
+}
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "tag")]
+enum InternallyTagged {
+    Newtype(Subject),
+    Struct { subject: Subject },
+}
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "tag", content = "content")]
+enum AdjacentlyTagged {
+    Newtype(Subject),
+    Tuple((), Subject),
+    Struct { subject: Subject },
+}
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+enum Untagged {
+    Newtype(Subject),
+    Tuple((), Subject),
+    Struct { subject: Subject },
+}
+
+mod readable {
+    use super::*;
+
+    #[test]
+    fn bare() {
+        assert_tokens(&Subject.readable(), &[
+            Token::Struct { name: "Readable", len: 1 },
+                Token::Str("mode"),
+                Token::Str("readable"),
+            Token::StructEnd,
+        ]);
+    }
+
+    #[test]
+    fn tuple() {
+        assert_tokens(&((), Subject).readable(), &[
+            Token::Tuple { len: 2 },
+                Token::Unit,
+                Token::Struct { name: "Readable", len: 1 },
+                    Token::Str("mode"),
+                    Token::Str("readable"),
+                Token::StructEnd,
+            Token::TupleEnd,
+        ]);
+    }
+
+    #[test]
+    fn newtype() {
+        assert_tokens(&Newtype(Subject).readable(), &[
+            Token::NewtypeStruct { name: "Newtype" },
+            Token::Struct { name: "Readable", len: 1 },
+                Token::Str("mode"),
+                Token::Str("readable"),
+            Token::StructEnd,
+        ]);
+    }
+
+    #[test]
+    fn named_tuple() {
+        assert_tokens(&Tuple((), Subject).readable(), &[
+            Token::TupleStruct { name: "Tuple", len: 2 },
+                Token::Unit,
+                Token::Struct { name: "Readable", len: 1 },
+                    Token::Str("mode"),
+                    Token::Str("readable"),
+                Token::StructEnd,
+            Token::TupleStructEnd,
+        ]);
+    }
+
+    #[test]
+    fn struct_() {
+        assert_tokens(&Struct { subject: Subject }.readable(), &[
+            Token::Struct { name: "Struct", len: 1 },
+                Token::Str("subject"),
+                Token::Struct { name: "Readable", len: 1 },
+                    Token::Str("mode"),
+                    Token::Str("readable"),
+                Token::StructEnd,
+            Token::StructEnd,
+        ]);
+    }
+
+    mod externally_tagged_enum {
+        use super::*;
+
+        #[test]
+        fn newtype() {
+            assert_tokens(&ExternallyTagged::Newtype(Subject).readable(), &[
+                Token::NewtypeVariant { name: "ExternallyTagged", variant: "Newtype" },
+                Token::Struct { name: "Readable", len: 1 },
+                    Token::Str("mode"),
+                    Token::Str("readable"),
+                Token::StructEnd,
+            ]);
+        }
+
+        #[test]
+        fn tuple() {
+            assert_tokens(&ExternallyTagged::Tuple((), Subject).readable(), &[
+                Token::TupleVariant { name: "ExternallyTagged", variant: "Tuple", len: 2 },
+                    Token::Unit,
+                    Token::Struct { name: "Readable", len: 1 },
+                        Token::Str("mode"),
+                        Token::Str("readable"),
+                    Token::StructEnd,
+                Token::TupleVariantEnd,
+            ]);
+        }
+
+        #[test]
+        fn struct_() {
+            assert_tokens(&ExternallyTagged::Struct { subject: Subject }.readable(), &[
+                Token::StructVariant { name: "ExternallyTagged", variant: "Struct", len: 1 },
+                    Token::Str("subject"),
+                    Token::Struct { name: "Readable", len: 1 },
+                        Token::Str("mode"),
+                        Token::Str("readable"),
+                    Token::StructEnd,
+                Token::StructVariantEnd,
+            ]);
+        }
+    }
+
+    mod internally_tagged_enum {
+        use super::*;
+
+        #[test]
+        fn newtype() {
+            assert_tokens(&InternallyTagged::Newtype(Subject).readable(), &[
+                Token::Struct { name: "Readable", len: 2 },
+                    Token::Str("tag"),
+                    Token::Str("Newtype"),
+                    Token::Str("mode"),
+                    Token::Str("readable"),
+                Token::StructEnd,
+            ]);
+        }
+
+        #[test]
+        fn struct_() {
+            assert_tokens(&InternallyTagged::Struct { subject: Subject }.readable(), &[
+                Token::Struct { name: "InternallyTagged", len: 2 },
+                    Token::Str("tag"),
+                    Token::Str("Struct"),
+                    Token::Str("subject"),
+                    Token::Struct { name: "Readable", len: 1 },
+                        Token::Str("mode"),
+                        Token::Str("readable"),
+                    Token::StructEnd,
+                Token::StructEnd,
+            ]);
+        }
+    }
+
+    mod adjacently_tagged_enum {
+        use super::*;
+
+        #[test]
+        fn newtype() {
+            assert_tokens(&AdjacentlyTagged::Newtype(Subject).readable(), &[
+                Token::Struct { name: "AdjacentlyTagged", len: 2 },
+                    Token::Str("tag"),
+                    Token::Str("Newtype"),
+                    Token::Str("content"),
+                    Token::Struct { name: "Readable", len: 1 },
+                        Token::Str("mode"),
+                        Token::Str("readable"),
+                    Token::StructEnd,
+                Token::StructEnd,
+            ]);
+        }
+
+        #[test]
+        fn tuple() {
+            assert_tokens(&AdjacentlyTagged::Tuple((), Subject).readable(), &[
+                Token::Struct { name: "AdjacentlyTagged", len: 2 },
+                    Token::Str("tag"),
+                    Token::Str("Tuple"),
+                    Token::Str("content"),
+                    Token::Tuple { len: 2 },
+                        Token::Unit,
+                        Token::Struct { name: "Readable", len: 1 },
+                            Token::Str("mode"),
+                            Token::Str("readable"),
+                        Token::StructEnd,
+                    Token::TupleEnd,
+                Token::StructEnd,
+            ]);
+        }
+
+        #[test]
+        fn struct_() {
+            assert_tokens(&AdjacentlyTagged::Struct { subject: Subject }.readable(), &[
+                Token::Struct { name: "AdjacentlyTagged", len: 2 },
+                    Token::Str("tag"),
+                    Token::Str("Struct"),
+                    Token::Str("content"),
+                    Token::Struct { name: "Struct", len: 1 },
+                        Token::Str("subject"),
+                        Token::Struct { name: "Readable", len: 1 },
+                            Token::Str("mode"),
+                            Token::Str("readable"),
+                        Token::StructEnd,
+                    Token::StructEnd,
+                Token::StructEnd,
+            ]);
+        }
+    }
+
+    mod untagged_enum {
+        use super::*;
+
+        #[test]
+        fn newtype() {
+            assert_tokens(&Untagged::Newtype(Subject).readable(), &[
+                Token::Struct { name: "Readable", len: 1 },
+                    Token::Str("mode"),
+                    Token::Str("readable"),
+                Token::StructEnd,
+            ]);
+        }
+
+        #[test]
+        fn tuple() {
+            assert_tokens(&Untagged::Tuple((), Subject).readable(), &[
+                Token::Tuple { len: 2 },
+                    Token::Unit,
+                    Token::Struct { name: "Readable", len: 1 },
+                        Token::Str("mode"),
+                        Token::Str("readable"),
+                    Token::StructEnd,
+                Token::TupleEnd,
+            ]);
+        }
+
+        #[test]
+        fn struct_() {
+            assert_tokens(&Untagged::Struct { subject: Subject }.readable(), &[
+                Token::Struct { name: "Untagged", len: 1 },
+                    Token::Str("subject"),
+                    Token::Struct { name: "Readable", len: 1 },
+                        Token::Str("mode"),
+                        Token::Str("readable"),
+                    Token::StructEnd,
+                Token::StructEnd,
+            ]);
+        }
+    }
+}
+
+mod compact {
+    use super::*;
+
+    #[test]
+    fn bare() {
+        assert_tokens(&Subject.compact(), &[
+            Token::Struct { name: "Compact", len: 1 },
+                Token::Str("mode"),
+                Token::U32(42),
+            Token::StructEnd,
+        ]);
+    }
+
+    #[test]
+    fn tuple() {
+        assert_tokens(&((), Subject).compact(), &[
+            Token::Tuple { len: 2 },
+                Token::Unit,
+                Token::Struct { name: "Compact", len: 1 },
+                    Token::Str("mode"),
+                    Token::U32(42),
+                Token::StructEnd,
+            Token::TupleEnd,
+        ]);
+    }
+
+    #[test]
+    fn newtype() {
+        assert_tokens(&Newtype(Subject).compact(), &[
+            Token::NewtypeStruct { name: "Newtype" },
+            Token::Struct { name: "Compact", len: 1 },
+                Token::Str("mode"),
+                Token::U32(42),
+            Token::StructEnd,
+        ]);
+    }
+
+    #[test]
+    fn named_tuple() {
+        assert_tokens(&Tuple((), Subject).compact(), &[
+            Token::TupleStruct { name: "Tuple", len: 2 },
+                Token::Unit,
+                Token::Struct { name: "Compact", len: 1 },
+                    Token::Str("mode"),
+                    Token::U32(42),
+                Token::StructEnd,
+            Token::TupleStructEnd,
+        ]);
+    }
+
+    #[test]
+    fn struct_() {
+        assert_tokens(&Struct { subject: Subject }.compact(), &[
+            Token::Struct { name: "Struct", len: 1 },
+                Token::Str("subject"),
+                Token::Struct { name: "Compact", len: 1 },
+                    Token::Str("mode"),
+                    Token::U32(42),
+                Token::StructEnd,
+            Token::StructEnd,
+        ]);
+    }
+
+    mod externally_tagged_enum {
+        use super::*;
+
+        #[test]
+        fn newtype() {
+            assert_tokens(&ExternallyTagged::Newtype(Subject).compact(), &[
+                Token::NewtypeVariant { name: "ExternallyTagged", variant: "Newtype" },
+                Token::Struct { name: "Compact", len: 1 },
+                    Token::Str("mode"),
+                    Token::U32(42),
+                Token::StructEnd,
+            ]);
+        }
+
+        #[test]
+        fn tuple() {
+            assert_tokens(&ExternallyTagged::Tuple((), Subject).compact(), &[
+                Token::TupleVariant { name: "ExternallyTagged", variant: "Tuple", len: 2 },
+                    Token::Unit,
+                    Token::Struct { name: "Compact", len: 1 },
+                        Token::Str("mode"),
+                        Token::U32(42),
+                    Token::StructEnd,
+                Token::TupleVariantEnd,
+            ]);
+        }
+
+        #[test]
+        fn struct_() {
+            assert_tokens(&ExternallyTagged::Struct { subject: Subject }.compact(), &[
+                Token::StructVariant { name: "ExternallyTagged", variant: "Struct", len: 1 },
+                    Token::Str("subject"),
+                    Token::Struct { name: "Compact", len: 1 },
+                        Token::Str("mode"),
+                        Token::U32(42),
+                    Token::StructEnd,
+                Token::StructVariantEnd,
+            ]);
+        }
+    }
+
+    mod internally_tagged_enum {
+        use super::*;
+
+        #[test]
+        fn newtype() {
+            assert_tokens(&InternallyTagged::Newtype(Subject).compact(), &[
+                Token::Struct { name: "Compact", len: 2 },
+                    Token::Str("tag"),
+                    Token::Str("Newtype"),
+                    Token::Str("mode"),
+                    Token::U32(42),
+                Token::StructEnd,
+            ]);
+        }
+
+        #[test]
+        fn struct_() {
+            assert_tokens(&InternallyTagged::Struct { subject: Subject }.compact(), &[
+                Token::Struct { name: "InternallyTagged", len: 2 },
+                    Token::Str("tag"),
+                    Token::Str("Struct"),
+                    Token::Str("subject"),
+                    Token::Struct { name: "Compact", len: 1 },
+                        Token::Str("mode"),
+                        Token::U32(42),
+                    Token::StructEnd,
+                Token::StructEnd,
+            ]);
+        }
+    }
+
+    mod adjacently_tagged_enum {
+        use super::*;
+
+        #[test]
+        fn newtype() {
+            assert_tokens(&AdjacentlyTagged::Newtype(Subject).compact(), &[
+                Token::Struct { name: "AdjacentlyTagged", len: 2 },
+                    Token::Str("tag"),
+                    Token::Str("Newtype"),
+                    Token::Str("content"),
+                    Token::Struct { name: "Compact", len: 1 },
+                        Token::Str("mode"),
+                        Token::U32(42),
+                    Token::StructEnd,
+                Token::StructEnd,
+            ]);
+        }
+
+        #[test]
+        fn tuple() {
+            assert_tokens(&AdjacentlyTagged::Tuple((), Subject).compact(), &[
+                Token::Struct { name: "AdjacentlyTagged", len: 2 },
+                    Token::Str("tag"),
+                    Token::Str("Tuple"),
+                    Token::Str("content"),
+                    Token::Tuple { len: 2 },
+                        Token::Unit,
+                        Token::Struct { name: "Compact", len: 1 },
+                            Token::Str("mode"),
+                            Token::U32(42),
+                        Token::StructEnd,
+                    Token::TupleEnd,
+                Token::StructEnd,
+            ]);
+        }
+
+        #[test]
+        fn struct_() {
+            assert_tokens(&AdjacentlyTagged::Struct { subject: Subject }.compact(), &[
+                Token::Struct { name: "AdjacentlyTagged", len: 2 },
+                    Token::Str("tag"),
+                    Token::Str("Struct"),
+                    Token::Str("content"),
+                    Token::Struct { name: "Struct", len: 1 },
+                        Token::Str("subject"),
+                        Token::Struct { name: "Compact", len: 1 },
+                            Token::Str("mode"),
+                            Token::U32(42),
+                        Token::StructEnd,
+                    Token::StructEnd,
+                Token::StructEnd,
+            ]);
+        }
+    }
+
+    mod untagged_enum {
+        use super::*;
+
+        #[test]
+        fn newtype() {
+            assert_tokens(&Untagged::Newtype(Subject).compact(), &[
+                Token::Struct { name: "Compact", len: 1 },
+                    Token::Str("mode"),
+                    Token::U32(42),
+                Token::StructEnd,
+            ]);
+        }
+
+        #[test]
+        fn tuple() {
+            assert_tokens(&Untagged::Tuple((), Subject).compact(), &[
+                Token::Tuple { len: 2 },
+                    Token::Unit,
+                    Token::Struct { name: "Compact", len: 1 },
+                        Token::Str("mode"),
+                        Token::U32(42),
+                    Token::StructEnd,
+                Token::TupleEnd,
+            ]);
+        }
+
+        #[test]
+        fn struct_() {
+            assert_tokens(&Untagged::Struct { subject: Subject }.compact(), &[
+                Token::Struct { name: "Untagged", len: 1 },
+                    Token::Str("subject"),
+                    Token::Struct { name: "Compact", len: 1 },
+                        Token::Str("mode"),
+                        Token::U32(42),
+                    Token::StructEnd,
+                Token::StructEnd,
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
Added tests asserting that deserializer correctly reports readable/compact format sign and fix them.