### PR TITLE
Show correct location in error messages by tracking caller of utility `assert_tokens` functions

### DIFF
--- a/serde_test/build.rs
+++ b/serde_test/build.rs
@@ -1,0 +1,33 @@
+use std::env;
+use std::process::Command;
+use std::str;
+
+// The rustc-cfg strings below are *not* public API. Please let us know by
+// opening a GitHub issue if your build environment requires some way to enable
+// these cfgs other than by executing our build script.
+fn main() {
+    let minor = match rustc_minor_version() {
+        Some(minor) => minor,
+        None => return,
+    };
+
+    // Check ability to use #[track_caller]:
+    // https://doc.rust-lang.org/reference/attributes/codegen.html#the-track_caller-attribute
+    //
+    // Perhaps sometime it will be possible to replace by built-in `version` attribute:
+    // https://github.com/rust-lang/rust/issues/64796
+    if minor >= 46 {
+        println!("cargo:rustc-cfg=has_track_caller");
+    }
+}
+
+fn rustc_minor_version() -> Option<u32> {
+    let rustc = env::var_os("RUSTC")?;
+    let output = Command::new(rustc).arg("--version").output().ok()?;
+    let version = str::from_utf8(&output.stdout).ok()?;
+    let mut pieces = version.split('.');
+    if pieces.next() != Some("rustc 1") {
+        return None;
+    }
+    pieces.next()?.parse().ok()
+}

--- a/serde_test/src/assert.rs
+++ b/serde_test/src/assert.rs
@@ -28,6 +28,7 @@ use std::fmt::Debug;
 ///     Token::StructEnd,
 /// ]);
 /// ```
+#[cfg_attr(has_track_caller, track_caller)]
 pub fn assert_tokens<'de, T>(value: &T, tokens: &'de [Token])
 where
     T: Serialize + Deserialize<'de> + PartialEq + Debug,
@@ -58,6 +59,7 @@ where
 ///     Token::StructEnd,
 /// ]);
 /// ```
+#[cfg_attr(has_track_caller, track_caller)]
 pub fn assert_ser_tokens<T>(value: &T, tokens: &[Token])
 where
     T: Serialize,
@@ -110,6 +112,7 @@ where
 ///     assert_ser_tokens_error(&example, expected, error);
 /// }
 /// ```
+#[cfg_attr(has_track_caller, track_caller)]
 pub fn assert_ser_tokens_error<T>(value: &T, tokens: &[Token], error: &str)
 where
     T: Serialize,
@@ -147,6 +150,7 @@ where
 ///     Token::StructEnd,
 /// ]);
 /// ```
+#[cfg_attr(has_track_caller, track_caller)]
 pub fn assert_de_tokens<'de, T>(value: &T, tokens: &'de [Token])
 where
     T: Deserialize<'de> + PartialEq + Debug,
@@ -199,6 +203,7 @@ where
 ///     "unknown field `x`, expected `a` or `b`",
 /// );
 /// ```
+#[cfg_attr(has_track_caller, track_caller)]
 pub fn assert_de_tokens_error<'de, T>(tokens: &'de [Token], error: &str)
 where
     T: Deserialize<'de>,


### PR DESCRIPTION
Currently when error originates in the `assert_tokens` and similar functions error position pointed to location inside that helper function, which is not much helpful. This PR improves the situation is some cases. There still have cases where error location points to inside of, for example, `serde_test::ser::Serializer`, because of too many levels of calls, generated by derive macro. I don't know how to improve situation here -- maybe not panic inside of (de)serializer but to return an error?