### PR TITLE
Allow serializing of Wrapping without std

### DIFF
--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -2570,7 +2570,6 @@ where
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#[cfg(feature = "std")]
 impl<'de, T> Deserialize<'de> for Wrapping<T>
 where
     T: Deserialize<'de>,

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -166,6 +166,7 @@ mod lib {
     pub use self::core::default::{self, Default};
     pub use self::core::fmt::{self, Debug, Display};
     pub use self::core::marker::{self, PhantomData};
+    pub use self::core::num::Wrapping;
     pub use self::core::ops::Range;
     pub use self::core::option::{self, Option};
     pub use self::core::result::{self, Result};
@@ -216,8 +217,6 @@ mod lib {
     pub use std::hash::{BuildHasher, Hash};
     #[cfg(feature = "std")]
     pub use std::io::Write;
-    #[cfg(feature = "std")]
-    pub use std::num::Wrapping;
     #[cfg(feature = "std")]
     pub use std::path::{Path, PathBuf};
     #[cfg(feature = "std")]

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -824,7 +824,6 @@ impl Serialize for OsString {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#[cfg(feature = "std")]
 impl<T> Serialize for Wrapping<T>
 where
     T: Serialize,


### PR DESCRIPTION
I'm not sure why, but `std::num::Wrapping` implements `Serialize` and `Deserialize`, but only when `std` is enabled. This change allows it in the `no-std` case as well.