### PR TITLE
Add 128-bit integer support to de::IgnoredAny

### DIFF
--- a/serde/src/de/ignored_any.rs
+++ b/serde/src/de/ignored_any.rs
@@ -130,10 +130,26 @@ impl<'de> Visitor<'de> for IgnoredAny {
         Ok(IgnoredAny)
     }
 
+    serde_if_integer128! {
+        #[inline]
+        fn visit_i128<E>(self, x: i128) -> Result<Self::Value, E> {
+            let _ = x;
+            Ok(IgnoredAny)
+        }
+    }
+
     #[inline]
     fn visit_u64<E>(self, x: u64) -> Result<Self::Value, E> {
         let _ = x;
         Ok(IgnoredAny)
+    }
+
+    serde_if_integer128! {
+        #[inline]
+        fn visit_u128<E>(self, x: u128) -> Result<Self::Value, E> {
+            let _ = x;
+            Ok(IgnoredAny)
+        }
     }
 
     #[inline]


### PR DESCRIPTION
This fixes the errors that occur when `IgnoredAny` is deserialized from anything containing a 128-bit integer somewhere.
As `IgnoredAny` is used in `serde_derive` to skip ignored fields in structs, these errors currently prevent deserializing structs with an ignored field containing a 128-bit integer in the input.

There's a second bug I encountered related to 128-bit integer support for untagged enums, but that one already has an issue (#1717) and a draft PR (#1719).