### PR TITLE
Eliminate duplicated borrowed and non-borrowed identifier deserialization

### DIFF
--- a/test_suite/tests/expand/de_enum.expanded.rs
+++ b/test_suite/tests/expand/de_enum.expanded.rs
@@ -332,50 +332,9 @@ const _: () = {
                         )),
                     }
                 }
-                fn visit_borrowed_str<__E>(
-                    self,
-                    __value: &'de str,
-                ) -> _serde::__private::Result<Self::Value, __E>
-                where
-                    __E: _serde::de::Error,
-                {
-                    match __value {
-                        "Unit" => _serde::__private::Ok(__Field::__field0),
-                        "Seq" => _serde::__private::Ok(__Field::__field1),
-                        "Map" => _serde::__private::Ok(__Field::__field2),
-                        "_Unit2" => _serde::__private::Ok(__Field::__field3),
-                        "_Seq2" => _serde::__private::Ok(__Field::__field4),
-                        "_Map2" => _serde::__private::Ok(__Field::__field5),
-                        _ => _serde::__private::Err(_serde::de::Error::unknown_variant(
-                            __value, VARIANTS,
-                        )),
-                    }
-                }
                 fn visit_bytes<__E>(
                     self,
                     __value: &[u8],
-                ) -> _serde::__private::Result<Self::Value, __E>
-                where
-                    __E: _serde::de::Error,
-                {
-                    match __value {
-                        b"Unit" => _serde::__private::Ok(__Field::__field0),
-                        b"Seq" => _serde::__private::Ok(__Field::__field1),
-                        b"Map" => _serde::__private::Ok(__Field::__field2),
-                        b"_Unit2" => _serde::__private::Ok(__Field::__field3),
-                        b"_Seq2" => _serde::__private::Ok(__Field::__field4),
-                        b"_Map2" => _serde::__private::Ok(__Field::__field5),
-                        _ => {
-                            let __value = &_serde::__private::from_utf8_lossy(__value);
-                            _serde::__private::Err(_serde::de::Error::unknown_variant(
-                                __value, VARIANTS,
-                            ))
-                        }
-                    }
-                }
-                fn visit_borrowed_bytes<__E>(
-                    self,
-                    __value: &'de [u8],
                 ) -> _serde::__private::Result<Self::Value, __E>
                 where
                     __E: _serde::de::Error,
@@ -632,39 +591,9 @@ const _: () = {
                                         _ => _serde::__private::Ok(__Field::__ignore),
                                     }
                                 }
-                                fn visit_borrowed_str<__E>(
-                                    self,
-                                    __value: &'de str,
-                                ) -> _serde::__private::Result<Self::Value, __E>
-                                where
-                                    __E: _serde::de::Error,
-                                {
-                                    match __value {
-                                        "a" => _serde::__private::Ok(__Field::__field0),
-                                        "b" => _serde::__private::Ok(__Field::__field1),
-                                        "c" => _serde::__private::Ok(__Field::__field2),
-                                        "d" => _serde::__private::Ok(__Field::__field3),
-                                        _ => _serde::__private::Ok(__Field::__ignore),
-                                    }
-                                }
                                 fn visit_bytes<__E>(
                                     self,
                                     __value: &[u8],
-                                ) -> _serde::__private::Result<Self::Value, __E>
-                                where
-                                    __E: _serde::de::Error,
-                                {
-                                    match __value {
-                                        b"a" => _serde::__private::Ok(__Field::__field0),
-                                        b"b" => _serde::__private::Ok(__Field::__field1),
-                                        b"c" => _serde::__private::Ok(__Field::__field2),
-                                        b"d" => _serde::__private::Ok(__Field::__field3),
-                                        _ => _serde::__private::Ok(__Field::__ignore),
-                                    }
-                                }
-                                fn visit_borrowed_bytes<__E>(
-                                    self,
-                                    __value: &'de [u8],
                                 ) -> _serde::__private::Result<Self::Value, __E>
                                 where
                                     __E: _serde::de::Error,
@@ -1165,39 +1094,9 @@ const _: () = {
                                         _ => _serde::__private::Ok(__Field::__ignore),
                                     }
                                 }
-                                fn visit_borrowed_str<__E>(
-                                    self,
-                                    __value: &'de str,
-                                ) -> _serde::__private::Result<Self::Value, __E>
-                                where
-                                    __E: _serde::de::Error,
-                                {
-                                    match __value {
-                                        "a" => _serde::__private::Ok(__Field::__field0),
-                                        "b" => _serde::__private::Ok(__Field::__field1),
-                                        "c" => _serde::__private::Ok(__Field::__field2),
-                                        "d" => _serde::__private::Ok(__Field::__field3),
-                                        _ => _serde::__private::Ok(__Field::__ignore),
-                                    }
-                                }
                                 fn visit_bytes<__E>(
                                     self,
                                     __value: &[u8],
-                                ) -> _serde::__private::Result<Self::Value, __E>
-                                where
-                                    __E: _serde::de::Error,
-                                {
-                                    match __value {
-                                        b"a" => _serde::__private::Ok(__Field::__field0),
-                                        b"b" => _serde::__private::Ok(__Field::__field1),
-                                        b"c" => _serde::__private::Ok(__Field::__field2),
-                                        b"d" => _serde::__private::Ok(__Field::__field3),
-                                        _ => _serde::__private::Ok(__Field::__ignore),
-                                    }
-                                }
-                                fn visit_borrowed_bytes<__E>(
-                                    self,
-                                    __value: &'de [u8],
                                 ) -> _serde::__private::Result<Self::Value, __E>
                                 where
                                     __E: _serde::de::Error,

--- a/test_suite/tests/expand/default_ty_param.expanded.rs
+++ b/test_suite/tests/expand/default_ty_param.expanded.rs
@@ -92,33 +92,9 @@ const _: () = {
                         _ => _serde::__private::Ok(__Field::__ignore),
                     }
                 }
-                fn visit_borrowed_str<__E>(
-                    self,
-                    __value: &'de str,
-                ) -> _serde::__private::Result<Self::Value, __E>
-                where
-                    __E: _serde::de::Error,
-                {
-                    match __value {
-                        "phantom" => _serde::__private::Ok(__Field::__field0),
-                        _ => _serde::__private::Ok(__Field::__ignore),
-                    }
-                }
                 fn visit_bytes<__E>(
                     self,
                     __value: &[u8],
-                ) -> _serde::__private::Result<Self::Value, __E>
-                where
-                    __E: _serde::de::Error,
-                {
-                    match __value {
-                        b"phantom" => _serde::__private::Ok(__Field::__field0),
-                        _ => _serde::__private::Ok(__Field::__ignore),
-                    }
-                }
-                fn visit_borrowed_bytes<__E>(
-                    self,
-                    __value: &'de [u8],
                 ) -> _serde::__private::Result<Self::Value, __E>
                 where
                     __E: _serde::de::Error,
@@ -296,33 +272,9 @@ const _: () = {
                         _ => _serde::__private::Ok(__Field::__ignore),
                     }
                 }
-                fn visit_borrowed_str<__E>(
-                    self,
-                    __value: &'de str,
-                ) -> _serde::__private::Result<Self::Value, __E>
-                where
-                    __E: _serde::de::Error,
-                {
-                    match __value {
-                        "phantom" => _serde::__private::Ok(__Field::__field0),
-                        _ => _serde::__private::Ok(__Field::__ignore),
-                    }
-                }
                 fn visit_bytes<__E>(
                     self,
                     __value: &[u8],
-                ) -> _serde::__private::Result<Self::Value, __E>
-                where
-                    __E: _serde::de::Error,
-                {
-                    match __value {
-                        b"phantom" => _serde::__private::Ok(__Field::__field0),
-                        _ => _serde::__private::Ok(__Field::__ignore),
-                    }
-                }
-                fn visit_borrowed_bytes<__E>(
-                    self,
-                    __value: &'de [u8],
                 ) -> _serde::__private::Result<Self::Value, __E>
                 where
                     __E: _serde::de::Error,

--- a/test_suite/tests/expand/generic_enum.expanded.rs
+++ b/test_suite/tests/expand/generic_enum.expanded.rs
@@ -174,46 +174,9 @@ const _: () = {
                         )),
                     }
                 }
-                fn visit_borrowed_str<__E>(
-                    self,
-                    __value: &'de str,
-                ) -> _serde::__private::Result<Self::Value, __E>
-                where
-                    __E: _serde::de::Error,
-                {
-                    match __value {
-                        "Unit" => _serde::__private::Ok(__Field::__field0),
-                        "NewType" => _serde::__private::Ok(__Field::__field1),
-                        "Seq" => _serde::__private::Ok(__Field::__field2),
-                        "Map" => _serde::__private::Ok(__Field::__field3),
-                        _ => _serde::__private::Err(_serde::de::Error::unknown_variant(
-                            __value, VARIANTS,
-                        )),
-                    }
-                }
                 fn visit_bytes<__E>(
                     self,
                     __value: &[u8],
-                ) -> _serde::__private::Result<Self::Value, __E>
-                where
-                    __E: _serde::de::Error,
-                {
-                    match __value {
-                        b"Unit" => _serde::__private::Ok(__Field::__field0),
-                        b"NewType" => _serde::__private::Ok(__Field::__field1),
-                        b"Seq" => _serde::__private::Ok(__Field::__field2),
-                        b"Map" => _serde::__private::Ok(__Field::__field3),
-                        _ => {
-                            let __value = &_serde::__private::from_utf8_lossy(__value);
-                            _serde::__private::Err(_serde::de::Error::unknown_variant(
-                                __value, VARIANTS,
-                            ))
-                        }
-                    }
-                }
-                fn visit_borrowed_bytes<__E>(
-                    self,
-                    __value: &'de [u8],
                 ) -> _serde::__private::Result<Self::Value, __E>
                 where
                     __E: _serde::de::Error,
@@ -410,35 +373,9 @@ const _: () = {
                                         _ => _serde::__private::Ok(__Field::__ignore),
                                     }
                                 }
-                                fn visit_borrowed_str<__E>(
-                                    self,
-                                    __value: &'de str,
-                                ) -> _serde::__private::Result<Self::Value, __E>
-                                where
-                                    __E: _serde::de::Error,
-                                {
-                                    match __value {
-                                        "x" => _serde::__private::Ok(__Field::__field0),
-                                        "y" => _serde::__private::Ok(__Field::__field1),
-                                        _ => _serde::__private::Ok(__Field::__ignore),
-                                    }
-                                }
                                 fn visit_bytes<__E>(
                                     self,
                                     __value: &[u8],
-                                ) -> _serde::__private::Result<Self::Value, __E>
-                                where
-                                    __E: _serde::de::Error,
-                                {
-                                    match __value {
-                                        b"x" => _serde::__private::Ok(__Field::__field0),
-                                        b"y" => _serde::__private::Ok(__Field::__field1),
-                                        _ => _serde::__private::Ok(__Field::__ignore),
-                                    }
-                                }
-                                fn visit_borrowed_bytes<__E>(
-                                    self,
-                                    __value: &'de [u8],
                                 ) -> _serde::__private::Result<Self::Value, __E>
                                 where
                                     __E: _serde::de::Error,

--- a/test_suite/tests/expand/generic_struct.expanded.rs
+++ b/test_suite/tests/expand/generic_struct.expanded.rs
@@ -88,33 +88,9 @@ const _: () = {
                         _ => _serde::__private::Ok(__Field::__ignore),
                     }
                 }
-                fn visit_borrowed_str<__E>(
-                    self,
-                    __value: &'de str,
-                ) -> _serde::__private::Result<Self::Value, __E>
-                where
-                    __E: _serde::de::Error,
-                {
-                    match __value {
-                        "x" => _serde::__private::Ok(__Field::__field0),
-                        _ => _serde::__private::Ok(__Field::__ignore),
-                    }
-                }
                 fn visit_bytes<__E>(
                     self,
                     __value: &[u8],
-                ) -> _serde::__private::Result<Self::Value, __E>
-                where
-                    __E: _serde::de::Error,
-                {
-                    match __value {
-                        b"x" => _serde::__private::Ok(__Field::__field0),
-                        _ => _serde::__private::Ok(__Field::__ignore),
-                    }
-                }
-                fn visit_borrowed_bytes<__E>(
-                    self,
-                    __value: &'de [u8],
                 ) -> _serde::__private::Result<Self::Value, __E>
                 where
                     __E: _serde::de::Error,
@@ -292,33 +268,9 @@ const _: () = {
                         _ => _serde::__private::Ok(__Field::__ignore),
                     }
                 }
-                fn visit_borrowed_str<__E>(
-                    self,
-                    __value: &'de str,
-                ) -> _serde::__private::Result<Self::Value, __E>
-                where
-                    __E: _serde::de::Error,
-                {
-                    match __value {
-                        "x" => _serde::__private::Ok(__Field::__field0),
-                        _ => _serde::__private::Ok(__Field::__ignore),
-                    }
-                }
                 fn visit_bytes<__E>(
                     self,
                     __value: &[u8],
-                ) -> _serde::__private::Result<Self::Value, __E>
-                where
-                    __E: _serde::de::Error,
-                {
-                    match __value {
-                        b"x" => _serde::__private::Ok(__Field::__field0),
-                        _ => _serde::__private::Ok(__Field::__ignore),
-                    }
-                }
-                fn visit_borrowed_bytes<__E>(
-                    self,
-                    __value: &'de [u8],
                 ) -> _serde::__private::Result<Self::Value, __E>
                 where
                     __E: _serde::de::Error,

--- a/test_suite/tests/expand/lifetimes.expanded.rs
+++ b/test_suite/tests/expand/lifetimes.expanded.rs
@@ -151,46 +151,9 @@ const _: () = {
                         )),
                     }
                 }
-                fn visit_borrowed_str<__E>(
-                    self,
-                    __value: &'de str,
-                ) -> _serde::__private::Result<Self::Value, __E>
-                where
-                    __E: _serde::de::Error,
-                {
-                    match __value {
-                        "LifetimeSeq" => _serde::__private::Ok(__Field::__field0),
-                        "NoLifetimeSeq" => _serde::__private::Ok(__Field::__field1),
-                        "LifetimeMap" => _serde::__private::Ok(__Field::__field2),
-                        "NoLifetimeMap" => _serde::__private::Ok(__Field::__field3),
-                        _ => _serde::__private::Err(_serde::de::Error::unknown_variant(
-                            __value, VARIANTS,
-                        )),
-                    }
-                }
                 fn visit_bytes<__E>(
                     self,
                     __value: &[u8],
-                ) -> _serde::__private::Result<Self::Value, __E>
-                where
-                    __E: _serde::de::Error,
-                {
-                    match __value {
-                        b"LifetimeSeq" => _serde::__private::Ok(__Field::__field0),
-                        b"NoLifetimeSeq" => _serde::__private::Ok(__Field::__field1),
-                        b"LifetimeMap" => _serde::__private::Ok(__Field::__field2),
-                        b"NoLifetimeMap" => _serde::__private::Ok(__Field::__field3),
-                        _ => {
-                            let __value = &_serde::__private::from_utf8_lossy(__value);
-                            _serde::__private::Err(_serde::de::Error::unknown_variant(
-                                __value, VARIANTS,
-                            ))
-                        }
-                    }
-                }
-                fn visit_borrowed_bytes<__E>(
-                    self,
-                    __value: &'de [u8],
                 ) -> _serde::__private::Result<Self::Value, __E>
                 where
                     __E: _serde::de::Error,
@@ -296,33 +259,9 @@ const _: () = {
                                         _ => _serde::__private::Ok(__Field::__ignore),
                                     }
                                 }
-                                fn visit_borrowed_str<__E>(
-                                    self,
-                                    __value: &'de str,
-                                ) -> _serde::__private::Result<Self::Value, __E>
-                                where
-                                    __E: _serde::de::Error,
-                                {
-                                    match __value {
-                                        "a" => _serde::__private::Ok(__Field::__field0),
-                                        _ => _serde::__private::Ok(__Field::__ignore),
-                                    }
-                                }
                                 fn visit_bytes<__E>(
                                     self,
                                     __value: &[u8],
-                                ) -> _serde::__private::Result<Self::Value, __E>
-                                where
-                                    __E: _serde::de::Error,
-                                {
-                                    match __value {
-                                        b"a" => _serde::__private::Ok(__Field::__field0),
-                                        _ => _serde::__private::Ok(__Field::__ignore),
-                                    }
-                                }
-                                fn visit_borrowed_bytes<__E>(
-                                    self,
-                                    __value: &'de [u8],
                                 ) -> _serde::__private::Result<Self::Value, __E>
                                 where
                                     __E: _serde::de::Error,
@@ -504,33 +443,9 @@ const _: () = {
                                         _ => _serde::__private::Ok(__Field::__ignore),
                                     }
                                 }
-                                fn visit_borrowed_str<__E>(
-                                    self,
-                                    __value: &'de str,
-                                ) -> _serde::__private::Result<Self::Value, __E>
-                                where
-                                    __E: _serde::de::Error,
-                                {
-                                    match __value {
-                                        "a" => _serde::__private::Ok(__Field::__field0),
-                                        _ => _serde::__private::Ok(__Field::__ignore),
-                                    }
-                                }
                                 fn visit_bytes<__E>(
                                     self,
                                     __value: &[u8],
-                                ) -> _serde::__private::Result<Self::Value, __E>
-                                where
-                                    __E: _serde::de::Error,
-                                {
-                                    match __value {
-                                        b"a" => _serde::__private::Ok(__Field::__field0),
-                                        _ => _serde::__private::Ok(__Field::__ignore),
-                                    }
-                                }
-                                fn visit_borrowed_bytes<__E>(
-                                    self,
-                                    __value: &'de [u8],
                                 ) -> _serde::__private::Result<Self::Value, __E>
                                 where
                                     __E: _serde::de::Error,

--- a/test_suite/tests/expand/named_map.expanded.rs
+++ b/test_suite/tests/expand/named_map.expanded.rs
@@ -117,37 +117,9 @@ const _: () = {
                         _ => _serde::__private::Ok(__Field::__ignore),
                     }
                 }
-                fn visit_borrowed_str<__E>(
-                    self,
-                    __value: &'de str,
-                ) -> _serde::__private::Result<Self::Value, __E>
-                where
-                    __E: _serde::de::Error,
-                {
-                    match __value {
-                        "a" => _serde::__private::Ok(__Field::__field0),
-                        "b" => _serde::__private::Ok(__Field::__field1),
-                        "c" => _serde::__private::Ok(__Field::__field2),
-                        _ => _serde::__private::Ok(__Field::__ignore),
-                    }
-                }
                 fn visit_bytes<__E>(
                     self,
                     __value: &[u8],
-                ) -> _serde::__private::Result<Self::Value, __E>
-                where
-                    __E: _serde::de::Error,
-                {
-                    match __value {
-                        b"a" => _serde::__private::Ok(__Field::__field0),
-                        b"b" => _serde::__private::Ok(__Field::__field1),
-                        b"c" => _serde::__private::Ok(__Field::__field2),
-                        _ => _serde::__private::Ok(__Field::__ignore),
-                    }
-                }
-                fn visit_borrowed_bytes<__E>(
-                    self,
-                    __value: &'de [u8],
                 ) -> _serde::__private::Result<Self::Value, __E>
                 where
                     __E: _serde::de::Error,
@@ -429,37 +401,9 @@ const _: () = {
                         _ => _serde::__private::Ok(__Field::__ignore),
                     }
                 }
-                fn visit_borrowed_str<__E>(
-                    self,
-                    __value: &'de str,
-                ) -> _serde::__private::Result<Self::Value, __E>
-                where
-                    __E: _serde::de::Error,
-                {
-                    match __value {
-                        "a" => _serde::__private::Ok(__Field::__field0),
-                        "b" => _serde::__private::Ok(__Field::__field1),
-                        "c" => _serde::__private::Ok(__Field::__field2),
-                        _ => _serde::__private::Ok(__Field::__ignore),
-                    }
-                }
                 fn visit_bytes<__E>(
                     self,
                     __value: &[u8],
-                ) -> _serde::__private::Result<Self::Value, __E>
-                where
-                    __E: _serde::de::Error,
-                {
-                    match __value {
-                        b"a" => _serde::__private::Ok(__Field::__field0),
-                        b"b" => _serde::__private::Ok(__Field::__field1),
-                        b"c" => _serde::__private::Ok(__Field::__field2),
-                        _ => _serde::__private::Ok(__Field::__ignore),
-                    }
-                }
-                fn visit_borrowed_bytes<__E>(
-                    self,
-                    __value: &'de [u8],
                 ) -> _serde::__private::Result<Self::Value, __E>
                 where
                     __E: _serde::de::Error,

--- a/test_suite/tests/expand/void.expanded.rs
+++ b/test_suite/tests/expand/void.expanded.rs
@@ -64,38 +64,9 @@ const _: () = {
                         )),
                     }
                 }
-                fn visit_borrowed_str<__E>(
-                    self,
-                    __value: &'de str,
-                ) -> _serde::__private::Result<Self::Value, __E>
-                where
-                    __E: _serde::de::Error,
-                {
-                    match __value {
-                        _ => _serde::__private::Err(_serde::de::Error::unknown_variant(
-                            __value, VARIANTS,
-                        )),
-                    }
-                }
                 fn visit_bytes<__E>(
                     self,
                     __value: &[u8],
-                ) -> _serde::__private::Result<Self::Value, __E>
-                where
-                    __E: _serde::de::Error,
-                {
-                    match __value {
-                        _ => {
-                            let __value = &_serde::__private::from_utf8_lossy(__value);
-                            _serde::__private::Err(_serde::de::Error::unknown_variant(
-                                __value, VARIANTS,
-                            ))
-                        }
-                    }
-                }
-                fn visit_borrowed_bytes<__E>(
-                    self,
-                    __value: &'de [u8],
                 ) -> _serde::__private::Result<Self::Value, __E>
                 where
                     __E: _serde::de::Error,


### PR DESCRIPTION
This fixes bloat introduced by #1917, as seen in https://github.com/serde-rs/serde/commit/999b94d6aee46262b883b26c9008b44bc699eedb. When the non-borrowed and borrowed fallthrough are identical, emitting them both only makes things compile slower, since the borrowed case would automatically forward to the non-borrowed case using the Visitor trait's default impl of the method.

@Mingun