### PR TITLE
Omit derive helpers in versions older than serde_derive msrv

### DIFF
--- a/serde/build.rs
+++ b/serde/build.rs
@@ -71,6 +71,11 @@ fn main() {
         println!("cargo:rustc-cfg=num_nonzero");
     }
 
+    // Current minimum supported version of serde_derive crate is Rust 1.31.
+    if minor >= 31 {
+        println!("cargo:rustc-cfg=serde_derive");
+    }
+
     // TryFrom, Atomic types, and non-zero signed integers stabilized in Rust 1.34:
     // https://blog.rust-lang.org/2019/04/11/Rust-1.34.0.html#tryfrom-and-tryinto
     // https://blog.rust-lang.org/2019/04/11/Rust-1.34.0.html#library-stabilizations

--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -10,7 +10,7 @@ use de::MapAccess;
 use seed::InPlaceSeed;
 
 #[cfg(any(feature = "std", feature = "alloc"))]
-use __private::de::size_hint;
+use __private::size_hint;
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -7,7 +7,7 @@ use de::{
 #[cfg(any(core_duration, feature = "std", feature = "alloc"))]
 use de::MapAccess;
 
-use __private::de::InPlaceSeed;
+use seed::InPlaceSeed;
 
 #[cfg(any(feature = "std", feature = "alloc"))]
 use __private::de::size_hint;

--- a/serde/src/de/seed.rs
+++ b/serde/src/de/seed.rs
@@ -1,0 +1,19 @@
+use de::{Deserialize, DeserializeSeed, Deserializer};
+
+/// A DeserializeSeed helper for implementing deserialize_in_place Visitors.
+///
+/// Wraps a mutable reference and calls deserialize_in_place on it.
+pub struct InPlaceSeed<'a, T: 'a>(pub &'a mut T);
+
+impl<'a, 'de, T> DeserializeSeed<'de> for InPlaceSeed<'a, T>
+where
+    T: Deserialize<'de>,
+{
+    type Value = ();
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        T::deserialize_in_place(deserializer, self.0)
+    }
+}

--- a/serde/src/de/value.rs
+++ b/serde/src/de/value.rs
@@ -24,7 +24,7 @@
 use lib::*;
 
 use self::private::{First, Second};
-use __private::de::size_hint;
+use __private::size_hint;
 use de::{self, Deserializer, Expected, IntoDeserializer, SeqAccess, Visitor};
 use ser;
 

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -276,6 +276,9 @@ use self::__private as export;
 #[allow(unused_imports)]
 use self::__private as private;
 
+#[path = "de/seed.rs"]
+mod seed;
+
 #[cfg(not(feature = "std"))]
 mod std_error;
 

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -191,29 +191,6 @@ where
         .map(From::from)
 }
 
-pub mod size_hint {
-    use lib::*;
-
-    pub fn from_bounds<I>(iter: &I) -> Option<usize>
-    where
-        I: Iterator,
-    {
-        helper(iter.size_hint())
-    }
-
-    #[inline]
-    pub fn cautious(hint: Option<usize>) -> usize {
-        cmp::min(hint.unwrap_or(0), 4096)
-    }
-
-    fn helper(bounds: (usize, Option<usize>)) -> Option<usize> {
-        match bounds {
-            (lower, Some(upper)) if lower == upper => Some(upper),
-            _ => None,
-        }
-    }
-}
-
 #[cfg(any(feature = "std", feature = "alloc"))]
 mod content {
     // This module is private and nothing here should be used outside of
@@ -228,7 +205,7 @@ mod content {
 
     use lib::*;
 
-    use super::size_hint;
+    use __private::size_hint;
     use de::{
         self, Deserialize, DeserializeSeed, Deserializer, EnumAccess, Expected, IgnoredAny,
         MapAccess, SeqAccess, Unexpected, Visitor,

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -1,10 +1,10 @@
 use lib::*;
 
 use de::value::{BorrowedBytesDeserializer, BytesDeserializer};
-use de::{Deserialize, DeserializeSeed, Deserializer, Error, IntoDeserializer, Visitor};
+use de::{Deserialize, Deserializer, Error, IntoDeserializer, Visitor};
 
 #[cfg(any(feature = "std", feature = "alloc"))]
-use de::{MapAccess, Unexpected};
+use de::{DeserializeSeed, MapAccess, Unexpected};
 
 #[cfg(any(feature = "std", feature = "alloc"))]
 pub use self::content::{
@@ -12,6 +12,8 @@ pub use self::content::{
     InternallyTaggedUnitVisitor, TagContentOtherField, TagContentOtherFieldVisitor,
     TagOrContentField, TagOrContentFieldVisitor, TaggedContentVisitor, UntaggedUnitVisitor,
 };
+
+pub use seed::InPlaceSeed;
 
 /// If the missing field is of type `Option<T>` then treat is as `None`,
 /// otherwise it is an error.
@@ -2663,24 +2665,6 @@ where
 
     fn from(self) -> Self::Deserializer {
         BorrowedBytesDeserializer::new(self.0)
-    }
-}
-
-/// A DeserializeSeed helper for implementing deserialize_in_place Visitors.
-///
-/// Wraps a mutable reference and calls deserialize_in_place on it.
-pub struct InPlaceSeed<'a, T: 'a>(pub &'a mut T);
-
-impl<'a, 'de, T> DeserializeSeed<'de> for InPlaceSeed<'a, T>
-where
-    T: Deserialize<'de>,
-{
-    type Value = ();
-    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        T::deserialize_in_place(deserializer, self.0)
     }
 }
 

--- a/serde/src/private/mod.rs
+++ b/serde/src/private/mod.rs
@@ -1,5 +1,8 @@
+#[cfg(serde_derive)]
 pub mod de;
+#[cfg(serde_derive)]
 pub mod ser;
+
 pub mod size_hint;
 
 // FIXME: #[cfg(doctest)] once https://github.com/rust-lang/rust/issues/67295 is fixed.

--- a/serde/src/private/mod.rs
+++ b/serde/src/private/mod.rs
@@ -1,5 +1,6 @@
 pub mod de;
 pub mod ser;
+pub mod size_hint;
 
 // FIXME: #[cfg(doctest)] once https://github.com/rust-lang/rust/issues/67295 is fixed.
 pub mod doc;

--- a/serde/src/private/size_hint.rs
+++ b/serde/src/private/size_hint.rs
@@ -7,6 +7,7 @@ where
     helper(iter.size_hint())
 }
 
+#[cfg(any(feature = "std", feature = "alloc"))]
 #[inline]
 pub fn cautious(hint: Option<usize>) -> usize {
     cmp::min(hint.unwrap_or(0), 4096)

--- a/serde/src/private/size_hint.rs
+++ b/serde/src/private/size_hint.rs
@@ -1,0 +1,20 @@
+use lib::*;
+
+pub fn from_bounds<I>(iter: &I) -> Option<usize>
+where
+    I: Iterator,
+{
+    helper(iter.size_hint())
+}
+
+#[inline]
+pub fn cautious(hint: Option<usize>) -> usize {
+    cmp::min(hint.unwrap_or(0), 4096)
+}
+
+fn helper(bounds: (usize, Option<usize>)) -> Option<usize> {
+    match bounds {
+        (lower, Some(upper)) if lower == upper => Some(upper),
+        _ => None,
+    }
+}


### PR DESCRIPTION
On rustc versions between 1.13 and 1.30, the `serde` crate does not need to compile `__private::de` and `__private::ser` which are only helpers intended for the derive generated code to call. The most important effect of this is it unblocks using newer Rust features in those modules, such as `pub(crate)` syntax.