### PR TITLE
New internally tagged tests

### DIFF
--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -1287,8 +1287,9 @@ mod content {
                 //     }
                 //
                 // We want {"topic":"Info"} to deserialize even though
-                // ordinarily unit structs do not deserialize from empty map.
+                // ordinarily unit structs do not deserialize from empty map/seq.
                 Content::Map(ref v) if v.is_empty() => visitor.visit_unit(),
+                Content::Seq(ref v) if v.is_empty() => visitor.visit_unit(),
                 _ => self.deserialize_any(visitor),
             }
         }

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -1899,6 +1899,25 @@ fn test_internally_tagged_newtype_variant_containing_unit_struct() {
             Token::MapEnd,
         ],
     );
+
+    assert_de_tokens(
+        &Message::Info(Info),
+        &[
+            Token::Struct { name: "Message", len: 1 },
+            Token::Str("topic"),
+            Token::Str("Info"),
+            Token::StructEnd,
+        ],
+    );
+
+    assert_de_tokens(
+        &Message::Info(Info),
+        &[
+            Token::Seq { len: Some(1) },
+            Token::Str("Info"),
+            Token::SeqEnd,
+        ],
+    );
 }
 
 #[deny(safe_packed_borrows)]

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -994,6 +994,28 @@ fn test_internally_tagged_struct_variant_containing_unit_variant() {
             Token::StructEnd,
         ],
     );
+
+    assert_de_tokens(
+        &Message::Log { level: Level::Info },
+        &[
+            Token::Map { len: Some(2) },
+            Token::Str("action"),
+            Token::Str("Log"),
+            Token::Str("level"),
+            Token::BorrowedStr("Info"),
+            Token::MapEnd,
+        ],
+    );
+
+    assert_de_tokens(
+        &Message::Log { level: Level::Info },
+        &[
+            Token::Seq { len: Some(2) },
+            Token::Str("Log"),
+            Token::BorrowedStr("Info"),
+            Token::SeqEnd,
+        ],
+    );
 }
 
 #[test]


### PR DESCRIPTION
Added missing tests that proves that internally tagged enums can be deserialized from all serialized forms:
- Struct representation (named list of key-value pairs)
- Map representation (unnamed list of key-value pairs)
- Seq representation (unnamed list of values)