### PR TITLE
Get rid of useless DeserializeWith wrapper in internally tagged enums

### DIFF
--- a/test_suite/tests/test_gen.rs
+++ b/test_suite/tests/test_gen.rs
@@ -821,3 +821,26 @@ where
 {
     vec.first().serialize(serializer)
 }
+
+//////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, PartialEq, Deserialize)]
+#[serde(tag = "tag")]
+enum InternallyTagged {
+    #[serde(deserialize_with = "deserialize_generic")]
+    Unit,
+
+    #[serde(deserialize_with = "deserialize_generic")]
+    Newtype(i32),
+
+    #[serde(deserialize_with = "deserialize_generic")]
+    Struct { f1: String, f2: u8 },
+}
+
+fn deserialize_generic<'de, T, D>(deserializer: D) -> StdResult<T, D::Error>
+where
+    T: Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    T::deserialize(deserializer)
+}


### PR DESCRIPTION
For 
```rust
#[derive(Deserialize)]
#[serde(tag = "tag")]
enum Enum {
  #[serde(deserialize_with = "de_x")]
  Struct { a: u32, b: bool },
}
```
replaces overcomplicated
```rust
Field::field1 => {
  struct DeserializeWith<'de> {
    value: (u32, bool),
    phantom: PhantomData<Enum2>,
    lifetime: PhantomData<&'de ()>,
  }
  impl<'de> Deserialize<'de> for DeserializeWith<'de> {
    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
    where
      D: Deserializer<'de>,
    {
      Ok(DeserializeWith {
        value: de_x(deserializer)?,
        phantom: PhantomData,
        lifetime: PhantomData,
      })
    }
  }
  Result::map(
    <DeserializeWith<'de> as Deserialize<'de>>::deserialize(deserializer),
    |wrap| Enum::WithStruct {
      a: wrap.value.0,
      b: wrap.value.1,
    },
  )
}
```
with much simple
```rust
Field::field1 => Result::map(de_x(deserializer), |wrap| Enum::WithStruct {
  a: wrap.0,
  b: wrap.1,
}),
```