### PR TITLE
Provide serialisation context to data structures

### DIFF
--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -163,6 +163,7 @@ mod lib {
     pub use self::core::{i16, i32, i64, i8, isize};
     pub use self::core::{u16, u32, u64, u8, usize};
 
+    pub use self::core::any::Any;
     pub use self::core::cell::{Cell, RefCell};
     pub use self::core::clone::{self, Clone};
     pub use self::core::convert::{self, From, Into};

--- a/serde_test/src/de.rs
+++ b/serde_test/src/de.rs
@@ -1,3 +1,4 @@
+use std::any::Any;
 use serde::de::value::{MapAccessDeserializer, SeqAccessDeserializer};
 use serde::de::{
     self, Deserialize, DeserializeSeed, EnumAccess, IntoDeserializer, MapAccess, SeqAccess,
@@ -397,6 +398,14 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         panic!(
             "Types which have different human-readable and compact representations \
              must explicitly mark their test cases with `serde_test::Configure`"
+        );
+    }
+
+    #[allow(bare_trait_objects)] // to support rustc < 1.27
+    fn get_context<T: ?Sized + Any>(&self) -> &Any {
+        panic!(
+            "Types which have different representations must explicitly mark their \
+            test cases with `serde_test::Configure`"
         );
     }
 }

--- a/serde_test/src/lib.rs
+++ b/serde_test/src/lib.rs
@@ -182,7 +182,7 @@ pub use assert::{
 };
 pub use token::Token;
 
-pub use configure::{Compact, Configure, Readable};
+pub use configure::{Compact, Configure, Context, Readable};
 
 // Not public API.
 #[doc(hidden)]

--- a/serde_test/src/ser.rs
+++ b/serde_test/src/ser.rs
@@ -1,3 +1,4 @@
+use std::any::Any;
 use serde::{ser, Serialize};
 
 use error::Error;
@@ -310,6 +311,14 @@ impl<'s, 'a> ser::Serializer for &'s mut Serializer<'a> {
         panic!(
             "Types which have different human-readable and compact representations \
              must explicitly mark their test cases with `serde_test::Configure`"
+        );
+    }
+
+    #[allow(bare_trait_objects)] // to support rustc < 1.27
+    fn get_context<T: ?Sized + Any>(&self) -> &Any {
+        panic!(
+            "Types which have different representations must explicitly mark their \
+            test cases with `serde_test::Configure`"
         );
     }
 }


### PR DESCRIPTION
In order for representations in the serde data model to be adaptable to
particular requirements from different serialisation formats, we provide
means for the de/serializer to be queried for additional context.

This is an escape hatch for niche situations, that increases coupling
between the data structure and the de/serializer and should therefore be
avoided wherever possible.  Neither serialisation format nor data
structure should assume/require that the other supports any particular
context, but should instead adopt sensible defaults whenever an expected
context is unsupported.

Closes #2003