### PR TITLE
Build using relative path in repo if Windows lost the symlink

### DIFF
--- a/serde_derive_internals/build.rs
+++ b/serde_derive_internals/build.rs
@@ -1,0 +1,12 @@
+use std::path::Path;
+
+fn main() {
+    // Sometimes on Windows the git checkout does not correctly wire up the
+    // symlink from serde_derive_internals/src to serde_derive/src/internals.
+    // When this happens we'll just build based on relative paths within the git
+    // repo.
+    let mod_behind_symlink = Path::new("src/mod.rs");
+    if !mod_behind_symlink.exists() {
+        println!("cargo:rustc-cfg=serde_build_from_git");
+    }
+}

--- a/serde_derive_internals/lib.rs
+++ b/serde_derive_internals/lib.rs
@@ -40,7 +40,8 @@ extern crate syn;
 extern crate proc_macro2;
 extern crate quote;
 
-#[path = "src/mod.rs"]
+#[cfg_attr(serde_build_from_git, path = "../serde_derive/src/internals/mod.rs")]
+#[cfg_attr(not(serde_build_from_git), path = "src/mod.rs")]
 mod internals;
 
 pub use internals::*;


### PR DESCRIPTION
Closes #2014. Closes #1987.