### PR TITLE
Remove non_ascii_idents feature gate from test suite

### DIFF
--- a/test_suite/tests/test_gen.rs
+++ b/test_suite/tests/test_gen.rs
@@ -3,7 +3,6 @@
 // types involved.
 
 #![deny(warnings)]
-#![cfg_attr(feature = "unstable", feature(non_ascii_idents))]
 #![allow(
     unknown_lints,
     mixed_script_confusables,
@@ -267,7 +266,6 @@ fn test_gen() {
     }
     assert::<EmptyEnumVariant>();
 
-    #[cfg(feature = "unstable")]
     #[derive(Serialize, Deserialize)]
     struct NonAsciiIdents {
         σ: f64,


### PR DESCRIPTION
This feature was just stabilized in https://github.com/rust-lang/rust/pull/83799.

```console
error: the feature `non_ascii_idents` has been stable since 1.53.0 and no longer requires an attribute to enable
 --> test_suite/tests/test_gen.rs:6:43
  |
6 | #![cfg_attr(feature = "unstable", feature(non_ascii_idents))]
  |                                           ^^^^^^^^^^^^^^^^
  |
note: the lint level is defined here
 --> test_suite/tests/test_gen.rs:5:9
  |
5 | #![deny(warnings)]
  |         ^^^^^^^^
  = note: `#[deny(stable_features)]` implied by `#[deny(warnings)]`
```