### PR TITLE
Allow accessing internals for reexportable derives

### DIFF
--- a/serde_derive_internals/lib.rs
+++ b/serde_derive_internals/lib.rs
@@ -37,11 +37,29 @@
 #[macro_use]
 extern crate syn;
 
-extern crate proc_macro2;
+#[macro_use]
 extern crate quote;
 
-#[cfg_attr(serde_build_from_git, path = "../serde_derive/src/internals/mod.rs")]
-#[cfg_attr(not(serde_build_from_git), path = "src/mod.rs")]
-mod internals;
+extern crate proc_macro2;
 
-pub use internals::*;
+#[cfg_attr(serde_build_from_git, path = "../serde_derive/src/")]
+#[cfg_attr(not(serde_build_from_git), path = "./src/")]
+mod derive {
+    pub mod internals;
+
+    #[macro_use]
+    pub mod bound;
+
+    #[macro_use]
+    pub mod fragment;
+
+    pub mod de;
+    pub mod dummy;
+    pub mod pretend;
+    pub mod ser;
+    pub mod try;
+}
+
+pub use derive::internals::*;
+
+pub use derive::*;

--- a/serde_derive_internals/src
+++ b/serde_derive_internals/src
@@ -1,1 +1,1 @@
-../serde_derive/src/internals/
+../serde_derive/src


### PR DESCRIPTION
So. This one's a bit of a doozy.

Rocket is integrating `serde` as a core dependency. I'd like to reexport serde's derives (and other things) from `rocket::serde` so that, in the common case, a user can derive `Serialize` and `Deserialize` without depending directly on `serde`:

```rust
use rocket::serde::Serialize;

#[derive(Serialize)]
struct Foo { .. }
```

Of course, this doesn't work because there is no `serde` crate in the root:

```rust
error[E0463]: can't find crate for `serde`
   |
 3 | #[derive(Serialize)]
   |          ^^^^^^^^^ can't find crate
```

While a user can add `#[serde(crate = "rocket::serde")]` manually to fix this, I'd like for this to _just work_. So, the idea is for Rocket to define its own `Serialize` and `Deserialize` derives that work _exactly_ like `serde`'s. This commit makes this possible. With these changes, this can be done as:

```rust
#[macro_use] extern crate quote;
#[macro_use] extern crate syn;
extern crate proc_macro;
extern crate proc_macro2;

use syn::DeriveInput;
use proc_macro::TokenStream;

const SERDE_EXPORT_PATH: &'static str = "::rocket::serde";

#[proc_macro_derive(Serialize, attributes(serde))]
pub fn derive_serialize(input: TokenStream) -> TokenStream {
    let mut input = parse_macro_input!(input as DeriveInput);
    add_default_serde_export_path(&mut input);
    serde_derive_internals::ser::expand_derive_serialize(&mut input)
        .unwrap_or_else(to_compile_errors)
        .into()
}

#[proc_macro_derive(Deserialize, attributes(serde))]
pub fn derive_deserialize(input: TokenStream) -> TokenStream {
    let mut input = parse_macro_input!(input as DeriveInput);
    add_default_serde_export_path(&mut input);
    serde_derive_internals::de::expand_derive_deserialize(&mut input)
        .unwrap_or_else(to_compile_errors)
        .into()
}

fn add_default_serde_export_path(to: &mut DeriveInput) {
    let crate_override = to.attrs.iter()
        .filter_map(|attr| attr.parse_meta().ok())
        .filter_map(|meta| match meta {
            syn::Meta::List(list) if list.path.is_ident("serde") => Some(list.nested),
            _ => None
        })
        .flat_map(|list| list.into_iter())
        .filter(|nested| match nested {
            syn::NestedMeta::Meta(meta) => meta.path().is_ident("crate"),
            _ => false
        })
        .next();

    if crate_override.is_none() {
        to.attrs.insert(0, parse_quote!(#[serde(crate = #SERDE_EXPORT_PATH)]))
    }
}

fn to_compile_errors(errors: Vec<syn::Error>) -> proc_macro2::TokenStream {
    let compile_errors = errors.iter().map(syn::Error::to_compile_error);
    quote!(#(#compile_errors)*)
}
```

Then, the `derive` above _just works_, and the user can still override the external crate to use.

As an alternative, `serde` could export some kind of `bang!` macro that does exactly what the `Serialize`/`Deserialize` impls do. Then, instead of calling the internal methods in the new derives, they can simply emit a call to the `bang!` macro:

```rust
#[macro_use] extern crate quote;
extern crate proc_macro;
extern crate proc_macro2;

use proc_macro::TokenStream;

const SERDE_EXPORT_PATH: &'static str = "::rocket::serde";

#[proc_macro_derive(Serialize, attributes(serde))]
pub fn derive_serialize(input: TokenStream) -> TokenStream {
    let input: proc_macro2::TokenStream = input.into();
    quote!(::rocket::serde::serialize!(#SERDE_EXPORT_PATH, #input)).into()
}

#[proc_macro_derive(Deserialize, attributes(serde))]
pub fn derive_deserialize(input: TokenStream) -> TokenStream {
    let input: proc_macro2::TokenStream = input.into();
    quote!(::rocket::serde::deserialize!(#SERDE_EXPORT_PATH, #input)).into()
}
```

I'd be satisfied with either solution.