### PR TITLE
Allow only `unused_extern_crates` instead of the whole `rust_2018_idioms` lint group in `serde_derive`-generated code

### DIFF
--- a/serde_derive/src/dummy.rs
+++ b/serde_derive/src/dummy.rs
@@ -23,7 +23,7 @@ pub fn wrap_in_const(
             use #path as _serde;
         },
         None => quote! {
-            #[allow(rust_2018_idioms, clippy::useless_attribute)]
+            #[allow(unused_extern_crates, clippy::useless_attribute)]
             extern crate serde as _serde;
         },
     };

--- a/test_suite/tests/expand/de_enum.expanded.rs
+++ b/test_suite/tests/expand/de_enum.expanded.rs
@@ -10,7 +10,7 @@ enum DeEnum<B, C, D> {
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
 const _: () = {
-    #[allow(rust_2018_idioms, clippy::useless_attribute)]
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
     impl<B, C, D> _serde::Serialize for DeEnum<B, C, D>
@@ -265,7 +265,7 @@ const _: () = {
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
 const _: () = {
-    #[allow(rust_2018_idioms, clippy::useless_attribute)]
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
     impl<'de, B, C, D> _serde::Deserialize<'de> for DeEnum<B, C, D>

--- a/test_suite/tests/expand/default_ty_param.expanded.rs
+++ b/test_suite/tests/expand/default_ty_param.expanded.rs
@@ -11,7 +11,7 @@ struct DefaultTyParam<T: AssociatedType<X = i32> = i32> {
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
 const _: () = {
-    #[allow(rust_2018_idioms, clippy::useless_attribute)]
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
     impl<T: AssociatedType<X = i32>> _serde::Serialize for DefaultTyParam<T> {
@@ -49,7 +49,7 @@ const _: () = {
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
 const _: () = {
-    #[allow(rust_2018_idioms, clippy::useless_attribute)]
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
     impl<'de, T: AssociatedType<X = i32>> _serde::Deserialize<'de> for DefaultTyParam<T> {

--- a/test_suite/tests/expand/generic_enum.expanded.rs
+++ b/test_suite/tests/expand/generic_enum.expanded.rs
@@ -8,7 +8,7 @@ pub enum GenericEnum<T, U> {
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
 const _: () = {
-    #[allow(rust_2018_idioms, clippy::useless_attribute)]
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
     impl<T, U> _serde::Serialize for GenericEnum<T, U>
@@ -114,7 +114,7 @@ const _: () = {
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
 const _: () = {
-    #[allow(rust_2018_idioms, clippy::useless_attribute)]
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
     impl<'de, T, U> _serde::Deserialize<'de> for GenericEnum<T, U>

--- a/test_suite/tests/expand/generic_struct.expanded.rs
+++ b/test_suite/tests/expand/generic_struct.expanded.rs
@@ -5,7 +5,7 @@ pub struct GenericStruct<T> {
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
 const _: () = {
-    #[allow(rust_2018_idioms, clippy::useless_attribute)]
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
     impl<T> _serde::Serialize for GenericStruct<T>
@@ -42,7 +42,7 @@ const _: () = {
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
 const _: () = {
-    #[allow(rust_2018_idioms, clippy::useless_attribute)]
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
     impl<'de, T> _serde::Deserialize<'de> for GenericStruct<T>
@@ -410,7 +410,7 @@ pub struct GenericNewTypeStruct<T>(T);
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
 const _: () = {
-    #[allow(rust_2018_idioms, clippy::useless_attribute)]
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
     impl<T> _serde::Serialize for GenericNewTypeStruct<T>
@@ -435,7 +435,7 @@ const _: () = {
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
 const _: () = {
-    #[allow(rust_2018_idioms, clippy::useless_attribute)]
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
     impl<'de, T> _serde::Deserialize<'de> for GenericNewTypeStruct<T>

--- a/test_suite/tests/expand/generic_tuple_struct.expanded.rs
+++ b/test_suite/tests/expand/generic_tuple_struct.expanded.rs
@@ -3,7 +3,7 @@ pub struct GenericTupleStruct<T, U>(T, U);
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
 const _: () = {
-    #[allow(rust_2018_idioms, clippy::useless_attribute)]
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
     impl<'de, T, U> _serde::Deserialize<'de> for GenericTupleStruct<T, U>

--- a/test_suite/tests/expand/lifetimes.expanded.rs
+++ b/test_suite/tests/expand/lifetimes.expanded.rs
@@ -8,7 +8,7 @@ enum Lifetimes<'a> {
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
 const _: () = {
-    #[allow(rust_2018_idioms, clippy::useless_attribute)]
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
     impl<'a> _serde::Serialize for Lifetimes<'a> {
@@ -95,7 +95,7 @@ const _: () = {
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
 const _: () = {
-    #[allow(rust_2018_idioms, clippy::useless_attribute)]
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
     impl<'de, 'a> _serde::Deserialize<'de> for Lifetimes<'a> {

--- a/test_suite/tests/expand/named_map.expanded.rs
+++ b/test_suite/tests/expand/named_map.expanded.rs
@@ -7,7 +7,7 @@ struct SerNamedMap<'a, 'b, A: 'a, B: 'b, C> {
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
 const _: () = {
-    #[allow(rust_2018_idioms, clippy::useless_attribute)]
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
     impl<'a, 'b, A: 'a, B: 'b, C> _serde::Serialize for SerNamedMap<'a, 'b, A, B, C>
@@ -63,7 +63,7 @@ struct DeNamedMap<A, B, C> {
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
 const _: () = {
-    #[allow(rust_2018_idioms, clippy::useless_attribute)]
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
     impl<'de, A, B, C> _serde::Deserialize<'de> for DeNamedMap<A, B, C>

--- a/test_suite/tests/expand/named_tuple.expanded.rs
+++ b/test_suite/tests/expand/named_tuple.expanded.rs
@@ -3,7 +3,7 @@ struct SerNamedTuple<'a, 'b, A: 'a, B: 'b, C>(&'a A, &'b mut B, C);
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
 const _: () = {
-    #[allow(rust_2018_idioms, clippy::useless_attribute)]
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
     impl<'a, 'b, A: 'a, B: 'b, C> _serde::Serialize for SerNamedTuple<'a, 'b, A, B, C>
@@ -55,7 +55,7 @@ struct DeNamedTuple<A, B, C>(A, B, C);
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
 const _: () = {
-    #[allow(rust_2018_idioms, clippy::useless_attribute)]
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
     impl<'de, A, B, C> _serde::Deserialize<'de> for DeNamedTuple<A, B, C>

--- a/test_suite/tests/expand/named_unit.expanded.rs
+++ b/test_suite/tests/expand/named_unit.expanded.rs
@@ -3,7 +3,7 @@ struct NamedUnit;
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
 const _: () = {
-    #[allow(rust_2018_idioms, clippy::useless_attribute)]
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
     impl _serde::Serialize for NamedUnit {
@@ -21,7 +21,7 @@ const _: () = {
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
 const _: () = {
-    #[allow(rust_2018_idioms, clippy::useless_attribute)]
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
     impl<'de> _serde::Deserialize<'de> for NamedUnit {

--- a/test_suite/tests/expand/ser_enum.expanded.rs
+++ b/test_suite/tests/expand/ser_enum.expanded.rs
@@ -13,7 +13,7 @@ where
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
 const _: () = {
-    #[allow(rust_2018_idioms, clippy::useless_attribute)]
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
     impl<'a, B: 'a, C: 'a, D> _serde::Serialize for SerEnum<'a, B, C, D>

--- a/test_suite/tests/expand/void.expanded.rs
+++ b/test_suite/tests/expand/void.expanded.rs
@@ -3,7 +3,7 @@ enum Void {}
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
 const _: () = {
-    #[allow(rust_2018_idioms, clippy::useless_attribute)]
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
     impl _serde::Serialize for Void {
@@ -21,7 +21,7 @@ const _: () = {
 #[doc(hidden)]
 #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
 const _: () = {
-    #[allow(rust_2018_idioms, clippy::useless_attribute)]
+    #[allow(unused_extern_crates, clippy::useless_attribute)]
     extern crate serde as _serde;
     #[automatically_derived]
     impl<'de> _serde::Deserialize<'de> for Void {


### PR DESCRIPTION
I found that this kind of `extern` only triggers `unused_extern_crates` warning: https://godbolt.org/z/bMxP8vGE9
Therefore, I think it's unnecessary to `#[allow]` the *whole* `rust_2018_idioms` lint group.

(It's causing some problems for me since I'm also using `#[forbid(future_incompatible)]`, and rust-lang/rust#83213 added some of the lints in `rust_2018_idioms` to `future_incompatible`, causing my program [fails to compile](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2018&gist=60284f31914d92f2fc512885f0573b66).)