### PR TITLE
spelling: implicitly

### DIFF
--- a/test_suite/tests/test_gen.rs
+++ b/test_suite/tests/test_gen.rs
@@ -641,7 +641,7 @@ fn test_gen() {
     assert::<SkippedVariant<X>>();
 
     #[derive(Deserialize)]
-    struct ImpliciltyBorrowedOption<'a> {
+    struct ImplicitlyBorrowedOption<'a> {
         option: std::option::Option<&'a str>,
     }
 


### PR DESCRIPTION
This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

The misspellings have been reported at https://github.com/jsoref/serde/commit/31ef747bf1e22a1279a097fb1c279d98ff549a1d#commitcomment-52641972

The action reports that the changes in this PR would make it happy: https://github.com/jsoref/serde/commit/171db514689a0f31bb05c4c55c55219c32f7e608

Note: this PR does not include the action. If you're interested in running a spell check on every PR and push, that can be offered separately.