### PR TITLE
Integer/boolean tags for internally/adjacently tagged enums

### DIFF
--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -2654,6 +2654,28 @@ where
     }
 }
 
+impl<'de, E> IdentifierDeserializer<'de, E> for i64
+where
+    E: Error
+{
+    type Deserializer = <i64 as IntoDeserializer<'de, E>>::Deserializer;
+
+    fn from(self) -> Self::Deserializer {
+        self.into_deserializer()
+    }
+}
+
+impl<'de, E> IdentifierDeserializer<'de, E> for bool
+where
+    E: Error
+{
+    type Deserializer = <bool as IntoDeserializer<'de, E>>::Deserializer;
+
+    fn from(self) -> Self::Deserializer {
+        self.into_deserializer()
+    }
+}
+
 #[cfg(any(feature = "std", feature = "alloc"))]
 pub struct FlatMapDeserializer<'a, 'de: 'a, E>(
     pub &'a mut Vec<Option<(Content<'de>, Content<'de>)>>,

--- a/serde/src/private/ser.rs
+++ b/serde/src/private/ser.rs
@@ -19,7 +19,7 @@ pub fn serialize_tagged_newtype<S, T>(
     type_ident: &'static str,
     variant_ident: &'static str,
     tag: &'static str,
-    variant_name: &'static str,
+    variant_name: &'static VariantName,
     value: &T,
 ) -> Result<S::Ok, S::Error>
 where
@@ -39,7 +39,7 @@ struct TaggedSerializer<S> {
     type_ident: &'static str,
     variant_ident: &'static str,
     tag: &'static str,
-    variant_name: &'static str,
+    variant_name: &'static VariantName,
     delegate: S,
 }
 
@@ -1306,5 +1306,24 @@ where
             .map
             .serialize_value(&Content::Struct(self.name, self.fields)));
         Ok(())
+    }
+}
+
+pub enum VariantName {
+    String(&'static str),
+    Integer(i64),
+    Boolean(bool),
+}
+
+impl Serialize for VariantName {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer
+    {
+        match self {
+            Self::String(s) => serializer.serialize_str(s),
+            Self::Integer(i) => serializer.serialize_i64(*i),
+            Self::Boolean(b) => serializer.serialize_bool(*b),
+        }
     }
 }

--- a/serde/src/private/ser.rs
+++ b/serde/src/private/ser.rs
@@ -1321,9 +1321,9 @@ impl Serialize for VariantName {
         S: Serializer
     {
         match self {
-            Self::String(s) => serializer.serialize_str(s),
-            Self::Integer(i) => serializer.serialize_i64(*i),
-            Self::Boolean(b) => serializer.serialize_bool(*b),
+            VariantName::String(s) => serializer.serialize_str(s),
+            VariantName::Integer(i) => serializer.serialize_i64(*i),
+            VariantName::Boolean(b) => serializer.serialize_bool(*b),
         }
     }
 }

--- a/serde/src/private/ser.rs
+++ b/serde/src/private/ser.rs
@@ -19,7 +19,7 @@ pub fn serialize_tagged_newtype<S, T>(
     type_ident: &'static str,
     variant_ident: &'static str,
     tag: &'static str,
-    variant_name: &'static VariantName,
+    variant_name: VariantName,
     value: &T,
 ) -> Result<S::Ok, S::Error>
 where
@@ -39,7 +39,7 @@ struct TaggedSerializer<S> {
     type_ident: &'static str,
     variant_ident: &'static str,
     tag: &'static str,
-    variant_name: &'static VariantName,
+    variant_name: VariantName,
     delegate: S,
 }
 
@@ -189,7 +189,7 @@ where
 
     fn serialize_unit_struct(self, _: &'static str) -> Result<Self::Ok, Self::Error> {
         let mut map = try!(self.delegate.serialize_map(Some(1)));
-        try!(map.serialize_entry(self.tag, self.variant_name));
+        try!(map.serialize_entry(self.tag, &self.variant_name));
         map.end()
     }
 
@@ -200,7 +200,7 @@ where
         inner_variant: &'static str,
     ) -> Result<Self::Ok, Self::Error> {
         let mut map = try!(self.delegate.serialize_map(Some(2)));
-        try!(map.serialize_entry(self.tag, self.variant_name));
+        try!(map.serialize_entry(self.tag, &self.variant_name));
         try!(map.serialize_entry(inner_variant, &()));
         map.end()
     }
@@ -227,7 +227,7 @@ where
         T: Serialize,
     {
         let mut map = try!(self.delegate.serialize_map(Some(2)));
-        try!(map.serialize_entry(self.tag, self.variant_name));
+        try!(map.serialize_entry(self.tag, &self.variant_name));
         try!(map.serialize_entry(inner_variant, inner_value));
         map.end()
     }
@@ -270,7 +270,7 @@ where
         len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
         let mut map = try!(self.delegate.serialize_map(Some(2)));
-        try!(map.serialize_entry(self.tag, self.variant_name));
+        try!(map.serialize_entry(self.tag, &self.variant_name));
         try!(map.serialize_key(inner_variant));
         Ok(SerializeTupleVariantAsMapValue::new(
             map,
@@ -281,7 +281,7 @@ where
 
     fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
         let mut map = try!(self.delegate.serialize_map(len.map(|len| len + 1)));
-        try!(map.serialize_entry(self.tag, self.variant_name));
+        try!(map.serialize_entry(self.tag, &self.variant_name));
         Ok(map)
     }
 
@@ -291,7 +291,7 @@ where
         len: usize,
     ) -> Result<Self::SerializeStruct, Self::Error> {
         let mut state = try!(self.delegate.serialize_struct(name, len + 1));
-        try!(state.serialize_field(self.tag, self.variant_name));
+        try!(state.serialize_field(self.tag, &self.variant_name));
         Ok(state)
     }
 
@@ -317,7 +317,7 @@ where
         len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
         let mut map = try!(self.delegate.serialize_map(Some(2)));
-        try!(map.serialize_entry(self.tag, self.variant_name));
+        try!(map.serialize_entry(self.tag, &self.variant_name));
         try!(map.serialize_key(inner_variant));
         Ok(SerializeStructVariantAsMapValue::new(
             map,

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -2304,7 +2304,7 @@ fn deserialize_identifier(
                     )*
                     _ => {
                         let __value_bytes = __value.to_le_bytes();
-                        let __value = &_serde::__private::from_utf8_lossy(&bytes);
+                        let __value = &_serde::__private::from_utf8_lossy(&__value_bytes);
                         #fallthrough_arm
                     },
                 }
@@ -2321,7 +2321,7 @@ fn deserialize_identifier(
                     )*
                     _ => {
                         let __value_bytes = __value.to_le_bytes();
-                        let __value = &_serde::__private::from_utf8_lossy(&bytes);
+                        let __value = &_serde::__private::from_utf8_lossy(&__value_bytes);
                         #fallthrough_arm
                     },
                 }

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -2226,7 +2226,7 @@ fn deserialize_identifier(
 
     // TODO: handle collect_other_fields here
     let visit_bool = if constructor_bools.len() > 0 {
-        let missing_true_arm = !field_bools.iter().all(|b| !**b);
+        let missing_true_arm = field_bools.iter().all(|b| !**b);
         let missing_false_arm = field_bools.iter().all(|b| **b);
 
         let fallthrough_true_arm = if missing_true_arm {

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -2276,7 +2276,7 @@ fn deserialize_identifier(
     let visit_int = if constructor_ints.is_empty() {
         let variant_indices = 0_u64..;
 
-        Some(quote! {
+        quote! {
             fn visit_u64<__E>(self, __value: u64) -> _serde::__private::Result<Self::Value, __E>
             where
                 __E: _serde::de::Error,
@@ -2288,11 +2288,18 @@ fn deserialize_identifier(
                     _ => #u64_fallthrough_arm,
                 }
             }
-        })
+        }
     } else if collect_other_fields {
-        None
+        quote! {
+            fn visit_u64<__E>(self, __value: u64) -> _serde::__private::Result<Self::Value, __E>
+            where
+                __E: _serde::de::Error,
+            {
+                _serde::__private::Ok(__Field::__other(_serde::__private::de::Content::U64(__value)))
+            }
+        }
     } else {
-        Some(quote! {
+        quote! {
             fn visit_i64<__E>(self, __value: i64) -> _serde::__private::Result<Self::Value, __E>
             where
                 __E: _serde::de::Error,
@@ -2326,7 +2333,7 @@ fn deserialize_identifier(
                     },
                 }
             }
-        })
+        }
     };
 
     let visit_str_and_bytes = if constructor_strs.is_empty() {
@@ -2498,13 +2505,6 @@ fn deserialize_identifier(
                 __E: _serde::de::Error,
             {
                 _serde::__private::Ok(__Field::__other(_serde::__private::de::Content::U32(__value)))
-            }
-
-            fn visit_u64<__E>(self, __value: u64) -> _serde::__private::Result<Self::Value, __E>
-            where
-                __E: _serde::de::Error,
-            {
-                _serde::__private::Ok(__Field::__other(_serde::__private::de::Content::U64(__value)))
             }
 
             fn visit_f32<__E>(self, __value: f32) -> _serde::__private::Result<Self::Value, __E>

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -2233,7 +2233,7 @@ fn deserialize_identifier(
             // it is safe to use VARIANTS unconditionally here, as bool variants 
             // only appear in enums, which means is_variant is always true.
             Some(quote! {
-                true => #fallthrough_arm
+                true => #fallthrough_arm,
             })
         } else {
             None
@@ -2241,7 +2241,7 @@ fn deserialize_identifier(
 
         let fallthrough_false_arm = if missing_false_arm {
             Some(quote! {
-                false => #fallthrough_arm
+                false => #fallthrough_arm,
             })
         } else {
             None
@@ -2257,8 +2257,8 @@ fn deserialize_identifier(
                     #(
                         #field_bools => _serde::__private::Ok(#constructor_bools),
                     )*
-                    #fallthrough_true_arm,
-                    #fallthrough_false_arm,
+                    #fallthrough_true_arm
+                    #fallthrough_false_arm
                 }
             }
         })

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -2200,7 +2200,7 @@ fn deserialize_identifier(
         fallthrough
     } else if is_variant {
         fallthrough_arm_tokens = quote! {
-            _serde::__private::Err(_serde::de::Error::unknown_variant(&__value.to_string(), VARIANTS))
+            _serde::__private::Err(_serde::de::Error::unknown_variant(__value, VARIANTS))
         };
         &fallthrough_arm_tokens
     } else {
@@ -2233,7 +2233,10 @@ fn deserialize_identifier(
             // it is safe to use VARIANTS unconditionally here, as bool variants 
             // only appear in enums, which means is_variant is always true.
             Some(quote! {
-                true => #fallthrough_arm,
+                true => {
+                    let __value = "true";
+                    #fallthrough_arm
+                },
             })
         } else {
             None
@@ -2241,7 +2244,10 @@ fn deserialize_identifier(
 
         let fallthrough_false_arm = if missing_false_arm {
             Some(quote! {
-                false => #fallthrough_arm,
+                false => {
+                    let __value = "false";
+                    #fallthrough_arm
+                },
             })
         } else {
             None
@@ -2278,7 +2284,11 @@ fn deserialize_identifier(
                     #(
                         #field_ints => _serde::__private::Ok(#constructor_ints),
                     )*
-                    _ => #fallthrough_arm,
+                    _ => {
+                        let __value_bytes = __value.to_le_bytes();
+                        let __value = &_serde::__private::from_utf8_lossy(&bytes);
+                        #fallthrough_arm
+                    },
                 }
             }
 
@@ -2291,7 +2301,11 @@ fn deserialize_identifier(
                     #(
                         #field_ints => _serde::__private::Ok(#constructor_ints),
                     )*
-                    _ => #fallthrough_arm,
+                    _ => {
+                        let __value_bytes = __value.to_le_bytes();
+                        let __value = &_serde::__private::from_utf8_lossy(&bytes);
+                        #fallthrough_arm
+                    },
                 }
             }
         })

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -2150,18 +2150,11 @@ fn deserialize_identifier(
         .map(|(_, ident)| quote!(#this::#ident))
         .collect();
 
-    let main_constructors: &Vec<_> = &fields
-        .iter()
-        .map(|(_, ident, _)| quote!(#this::#ident))
-        .collect();
-
     let expecting = expecting.unwrap_or(if is_variant {
         "variant identifier"
     } else {
         "field identifier"
     });
-
-    let index_expecting = if is_variant { "variant" } else { "field" };
 
     let bytes_to_str = if fallthrough.is_some() || collect_other_fields {
         None
@@ -2210,30 +2203,40 @@ fn deserialize_identifier(
         &fallthrough_arm_tokens
     };
 
-    let u64_fallthrough_arm_tokens;
-    let u64_fallthrough_arm = if let Some(fallthrough) = &fallthrough {
-        fallthrough
-    } else {
-        let fallthrough_msg = format!("{} index 0 <= i < {}", index_expecting, fields.len());
-        u64_fallthrough_arm_tokens = quote! {
-            _serde::__private::Err(_serde::de::Error::invalid_value(
-                _serde::de::Unexpected::Unsigned(__value),
-                &#fallthrough_msg,
-            ))
-        };
-        &u64_fallthrough_arm_tokens
-    };
-
-    // TODO: handle collect_other_fields here
-    let visit_bool = if constructor_bools.is_empty() {
+    let visit_bool = if constructor_bools.is_empty() && collect_other_fields {
+        Some(quote! {
+            fn visit_bool<__E>(self, __value: bool) -> _serde::__private::Result<Self::Value, __E>
+            where
+                __E: _serde::de::Error,
+            {
+                _serde::__private::Ok(__Field::__other(_serde::__private::de::Content::Bool(__value)))
+            }
+        })
+    } else if collect_other_fields {
+        // We are collecting other fields and we have bool constructors.
+        Some(quote! {
+            fn visit_bool<__E>(self, __value: bool) -> _serde::__private::Result<Self::Value, __E>
+            where
+                __E: _serde::de::Error,
+            {
+                match __value {
+                    #(
+                        #field_bools => _serde::__private::Ok(#constructor_bools),
+                    )*
+                    _ => _serde::__private::Ok(__Field::__other(_serde::__private::de::Content::Bool(__value)))
+                }
+            }
+        })
+    } else if constructor_bools.is_empty() {
+        // We are not collecting unknown fields, and there are no bool constructors.
+        // We want to error upon visiting a bool.
         None
     } else {
+        // We are not collecting unknown fields, but there are bool constructors.
         let missing_true_arm = field_bools.iter().all(|b| !**b);
         let missing_false_arm = field_bools.iter().all(|b| **b);
 
         let fallthrough_true_arm = if missing_true_arm {
-            // it is safe to use VARIANTS unconditionally here, as bool variants 
-            // only appear in enums, which means is_variant is always true.
             Some(quote! {
                 true => {
                     let __value = "true";
@@ -2272,9 +2275,73 @@ fn deserialize_identifier(
         })
     };
 
-    // TODO: handle collect_other_fields here
-    let visit_int = if constructor_ints.is_empty() {
+    let visit_int = if constructor_ints.is_empty() && collect_other_fields {
+        quote! {
+            fn visit_u64<__E>(self, __value: u64) -> _serde::__private::Result<Self::Value, __E>
+            where
+                __E: _serde::de::Error,
+            {
+                _serde::__private::Ok(__Field::__other(_serde::__private::de::Content::U64(__value)))
+            }
+
+            fn visit_i64<__E>(self, __value: i64) -> _serde::__private::Result<Self::Value, __E>
+            where
+                __E: _serde::de::Error,
+            {
+                _serde::__private::Ok(__Field::__other(_serde::__private::de::Content::I64(__value)))
+            }
+        }
+    } else if collect_other_fields {
+        // We are collecting other fields and we have int constructors.
+        quote! {
+            fn visit_i64<__E>(self, __value: i64) -> _serde::__private::Result<Self::Value, __E>
+            where
+                __E: _serde::de::Error,
+            {
+                match __value {
+                    #(
+                        #field_ints => _serde::__private::Ok(#constructor_ints),
+                    )*
+                    _ => _serde::__private::Ok(__Field::__other(_serde::__private::de::Content::I64(__value)))
+                }
+            }
+
+            fn visit_u64<__E>(self, __value: u64) -> _serde::__private::Result<Self::Value, __E>
+            where
+                __E: _serde::de::Error,
+            {
+                match __value {
+                    #(
+                        #field_ints => _serde::__private::Ok(#constructor_ints),
+                    )*
+                    _ => _serde::__private::Ok(__Field::__other(_serde::__private::de::Content::U64(__value)))
+                }
+            }
+        }
+    } else if constructor_ints.is_empty() {
+        // We are not collecting unknown fields, and there are no int constructors.
+        // We want to error upon visiting an i64. For u64, we want to construct variants
+        // based on their indices.
         let variant_indices = 0_u64..;
+        let u64_fallthrough_arm_tokens;
+        let u64_fallthrough_arm = if let Some(fallthrough) = &fallthrough {
+            fallthrough
+        } else {
+            let index_expecting = if is_variant { "variant" } else { "field" };
+            let fallthrough_msg = format!("{} index 0 <= i < {}", index_expecting, fields.len());
+            u64_fallthrough_arm_tokens = quote! {
+                _serde::__private::Err(_serde::de::Error::invalid_value(
+                    _serde::de::Unexpected::Unsigned(__value),
+                    &#fallthrough_msg,
+                ))
+            };
+            &u64_fallthrough_arm_tokens
+        };
+
+        let main_constructors: &Vec<_> = &fields
+            .iter()
+            .map(|(_, ident, _)| quote!(#this::#ident))
+            .collect();
 
         quote! {
             fn visit_u64<__E>(self, __value: u64) -> _serde::__private::Result<Self::Value, __E>
@@ -2289,16 +2356,8 @@ fn deserialize_identifier(
                 }
             }
         }
-    } else if collect_other_fields {
-        quote! {
-            fn visit_u64<__E>(self, __value: u64) -> _serde::__private::Result<Self::Value, __E>
-            where
-                __E: _serde::de::Error,
-            {
-                _serde::__private::Ok(__Field::__other(_serde::__private::de::Content::U64(__value)))
-            }
-        }
     } else {
+        // We are not collecting unknown fields, but there are int constructors.
         quote! {
             fn visit_i64<__E>(self, __value: i64) -> _serde::__private::Result<Self::Value, __E>
             where
@@ -2336,32 +2395,47 @@ fn deserialize_identifier(
         }
     };
 
-    let visit_str_and_bytes = if constructor_strs.is_empty() {
-        let visit_borrowed = if fallthrough_borrowed.is_some() || collect_other_fields {
-            let fallthrough_borrowed_arm = fallthrough_borrowed.as_ref().unwrap_or(fallthrough_arm);
-            Some(quote! {
-                fn visit_borrowed_str<__E>(self, __value: &'de str) -> _serde::__private::Result<Self::Value, __E>
-                where
-                    __E: _serde::de::Error,
-                {
-                    #value_as_borrowed_str_content
-                    #fallthrough_borrowed_arm
-                }
+    let visit_borrowed = if fallthrough_borrowed.is_some() || collect_other_fields {
+        let fallthrough_borrowed_arm = fallthrough_borrowed.as_ref().unwrap_or(fallthrough_arm);
 
-                fn visit_borrowed_bytes<__E>(self, __value: &'de [u8]) -> _serde::__private::Result<Self::Value, __E>
-                where
-                    __E: _serde::de::Error,
-                {
-                    #bytes_to_str
-                    #value_as_borrowed_bytes_content
-                    #fallthrough_borrowed_arm
+        Some(quote! {
+            fn visit_borrowed_str<__E>(self, __value: &'de str) -> _serde::__private::Result<Self::Value, __E>
+            where
+                __E: _serde::de::Error,
+            {
+                match __value {
+                    #(
+                        #field_strs => _serde::__private::Ok(#constructor_strs),
+                    )*
+                    _ => {
+                        #value_as_borrowed_str_content
+                        #fallthrough_borrowed_arm
+                    }
                 }
-            })
-        } else {
-            None
-        };
+            }
 
-        quote! {
+            fn visit_borrowed_bytes<__E>(self, __value: &'de [u8]) -> _serde::__private::Result<Self::Value, __E>
+            where
+                __E: _serde::de::Error,
+            {
+                match __value {
+                    #(
+                        #field_bytes => _serde::__private::Ok(#constructor_strs),
+                    )*
+                    _ => {
+                        #bytes_to_str
+                        #value_as_borrowed_bytes_content
+                        #fallthrough_borrowed_arm
+                    }
+                }
+            }
+        })
+    } else {
+        None
+    };
+
+    let visit_str_and_bytes = if constructor_strs.is_empty() && collect_other_fields {
+        Some(quote! {
             fn visit_str<__E>(self, __value: &str) -> _serde::__private::Result<Self::Value, __E>
             where
                 __E: _serde::de::Error,
@@ -2378,49 +2452,10 @@ fn deserialize_identifier(
                 #value_as_bytes_content
                 #fallthrough_arm
             }
-
-            #visit_borrowed
-        }
-    } else {
-        let visit_borrowed = if fallthrough_borrowed.is_some() || collect_other_fields {
-            let fallthrough_borrowed_arm = fallthrough_borrowed.as_ref().unwrap_or(fallthrough_arm);
-            Some(quote! {
-                fn visit_borrowed_str<__E>(self, __value: &'de str) -> _serde::__private::Result<Self::Value, __E>
-                where
-                    __E: _serde::de::Error,
-                {
-                    match __value {
-                        #(
-                            #field_strs => _serde::__private::Ok(#constructor_strs),
-                        )*
-                        _ => {
-                            #value_as_borrowed_str_content
-                            #fallthrough_borrowed_arm
-                        }
-                    }
-                }
-
-                fn visit_borrowed_bytes<__E>(self, __value: &'de [u8]) -> _serde::__private::Result<Self::Value, __E>
-                where
-                    __E: _serde::de::Error,
-                {
-                    match __value {
-                        #(
-                            #field_bytes => _serde::__private::Ok(#constructor_strs),
-                        )*
-                        _ => {
-                            #bytes_to_str
-                            #value_as_borrowed_bytes_content
-                            #fallthrough_borrowed_arm
-                        }
-                    }
-                }
-            })
-        } else {
-            None
-        };
-
-        quote! {
+        })
+    } else if collect_other_fields {
+        // We have string constructors and we are collecting other fields.
+        Some(quote! {
             fn visit_str<__E>(self, __value: &str) -> _serde::__private::Result<Self::Value, __E>
             where
                 __E: _serde::de::Error,
@@ -2451,20 +2486,48 @@ fn deserialize_identifier(
                     }
                 }
             }
+        })
+    } else if constructor_strs.is_empty() {
+        // We have no string constructors and we are not collecting other fields.
+        None
+    } else {
+        // We have string constructors, but we are not collecting other fields.
+        Some(quote! {
+            fn visit_str<__E>(self, __value: &str) -> _serde::__private::Result<Self::Value, __E>
+            where
+                __E: _serde::de::Error,
+            {
+                match __value {
+                    #(
+                        #field_strs => _serde::__private::Ok(#constructor_strs),
+                    )*
+                    _ => {
+                        #value_as_str_content
+                        #fallthrough_arm
+                    }
+                }
+            }
 
-            #visit_borrowed
-        }
+            fn visit_bytes<__E>(self, __value: &[u8]) -> _serde::__private::Result<Self::Value, __E>
+            where
+                __E: _serde::de::Error,
+            {
+                match __value {
+                    #(
+                        #field_bytes => _serde::__private::Ok(#constructor_strs),
+                    )*
+                    _ => {
+                        #bytes_to_str
+                        #value_as_bytes_content
+                        #fallthrough_arm
+                    }
+                }
+            }
+        })
     };
 
     let visit_other = if collect_other_fields {
         Some(quote! {
-            fn visit_bool<__E>(self, __value: bool) -> _serde::__private::Result<Self::Value, __E>
-            where
-                __E: _serde::de::Error,
-            {
-                _serde::__private::Ok(__Field::__other(_serde::__private::de::Content::Bool(__value)))
-            }
-
             fn visit_i8<__E>(self, __value: i8) -> _serde::__private::Result<Self::Value, __E>
             where
                 __E: _serde::de::Error,
@@ -2551,6 +2614,8 @@ fn deserialize_identifier(
         #visit_int
 
         #visit_str_and_bytes
+
+        #visit_borrowed
     }
 }
 

--- a/serde_derive/src/internals/case.rs
+++ b/serde_derive/src/internals/case.rs
@@ -9,6 +9,8 @@ use std::fmt::{self, Debug, Display};
 
 use self::RenameRule::*;
 
+use super::attr::VariantName;
+
 /// The different possible ways to change case of fields in a struct, or variants in an enum.
 #[derive(Copy, Clone, PartialEq)]
 pub enum RenameRule {
@@ -58,8 +60,7 @@ impl RenameRule {
         })
     }
 
-    /// Apply a renaming rule to an enum variant, returning the version expected in the source.
-    pub fn apply_to_variant(&self, variant: &str) -> String {
+    fn apply_to_variant_str(&self, variant: &str) -> String {
         match *self {
             None | PascalCase => variant.to_owned(),
             LowerCase => variant.to_ascii_lowercase(),
@@ -75,15 +76,22 @@ impl RenameRule {
                 }
                 snake
             }
-            ScreamingSnakeCase => SnakeCase.apply_to_variant(variant).to_ascii_uppercase(),
-            KebabCase => SnakeCase.apply_to_variant(variant).replace('_', "-"),
+            ScreamingSnakeCase => SnakeCase.apply_to_variant_str(variant).to_ascii_uppercase(),
+            KebabCase => SnakeCase.apply_to_variant_str(variant).replace('_', "-"),
             ScreamingKebabCase => ScreamingSnakeCase
-                .apply_to_variant(variant)
+                .apply_to_variant_str(variant)
                 .replace('_', "-"),
         }
     }
 
-    /// Apply a renaming rule to a struct field, returning the version expected in the source.
+    /// Apply a renaming rule to an enum variant, returning the version expected in the source.
+    pub fn apply_to_variant(&self, variant: &VariantName) -> VariantName {
+        match variant {
+            VariantName::String(variant) => VariantName::String(self.apply_to_variant_str(&variant)),
+            _ => variant.clone(),
+        }
+    }
+
     pub fn apply_to_field(&self, field: &str) -> String {
         match *self {
             None | LowerCase | SnakeCase => field.to_owned(),
@@ -152,16 +160,16 @@ fn rename_variants() {
         ("A", "a", "A", "a", "a", "A", "a", "A"),
         ("Z42", "z42", "Z42", "z42", "z42", "Z42", "z42", "Z42"),
     ] {
-        assert_eq!(None.apply_to_variant(original), original);
-        assert_eq!(LowerCase.apply_to_variant(original), lower);
-        assert_eq!(UpperCase.apply_to_variant(original), upper);
-        assert_eq!(PascalCase.apply_to_variant(original), original);
-        assert_eq!(CamelCase.apply_to_variant(original), camel);
-        assert_eq!(SnakeCase.apply_to_variant(original), snake);
-        assert_eq!(ScreamingSnakeCase.apply_to_variant(original), screaming);
-        assert_eq!(KebabCase.apply_to_variant(original), kebab);
+        assert_eq!(None.apply_to_variant_str(original), original);
+        assert_eq!(LowerCase.apply_to_variant_str(original), lower);
+        assert_eq!(UpperCase.apply_to_variant_str(original), upper);
+        assert_eq!(PascalCase.apply_to_variant_str(original), original);
+        assert_eq!(CamelCase.apply_to_variant_str(original), camel);
+        assert_eq!(SnakeCase.apply_to_variant_str(original), snake);
+        assert_eq!(ScreamingSnakeCase.apply_to_variant_str(original), screaming);
+        assert_eq!(KebabCase.apply_to_variant_str(original), kebab);
         assert_eq!(
-            ScreamingKebabCase.apply_to_variant(original),
+            ScreamingKebabCase.apply_to_variant_str(original),
             screaming_kebab
         );
     }

--- a/serde_derive/src/internals/check.rs
+++ b/serde_derive/src/internals/check.rs
@@ -400,26 +400,23 @@ fn check_non_string_renames(cx: &Ctxt, cont: &mut Container) {
         Data::Struct(_, _) => return,
     };
 
-    match &cont.data {
-        Data::Enum(variants) => {
-            for v in variants {
-                let name = v.attrs.name();
-                let ser_name = name.serialize_name();
+    if let Data::Enum(variants) = &cont.data {
+        for v in variants {
+            let name = v.attrs.name();
+            let ser_name = name.serialize_name();
 
-                match ser_name {
+            match ser_name {
+                VariantName::String(_) => {},
+                _ => cx.error_spanned_by(v.original, format!("#[serde(rename)] must use a string name in {}", details)),
+            }
+
+            for alias in v.attrs.aliases() {
+                match alias {
                     VariantName::String(_) => {},
                     _ => cx.error_spanned_by(v.original, format!("#[serde(rename)] must use a string name in {}", details)),
                 }
-
-                for alias in v.attrs.aliases() {
-                    match alias {
-                        VariantName::String(_) => {},
-                        _ => cx.error_spanned_by(v.original, format!("#[serde(rename)] must use a string name in {}", details)),
-                    }
-                }
             }
-        },
-        _ => {},
+        }
     }
 }
 

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -667,7 +667,7 @@ fn serialize_adjacently_tagged_variant(
                     let mut __struct = try!(_serde::Serializer::serialize_struct(
                         __serializer, #type_name, 1));
                     try!(_serde::ser::SerializeStruct::serialize_field(
-                        &mut __struct, #tag, #variant_name));
+                        &mut __struct, #tag, &#variant_name));
                     _serde::ser::SerializeStruct::end(__struct)
                 };
             }
@@ -684,7 +684,7 @@ fn serialize_adjacently_tagged_variant(
                     let mut __struct = try!(_serde::Serializer::serialize_struct(
                         __serializer, #type_name, 2));
                     try!(_serde::ser::SerializeStruct::serialize_field(
-                        &mut __struct, #tag, #variant_name));
+                        &mut __struct, #tag, &#variant_name));
                     try!(#func(
                         &mut __struct, #content, #field_expr));
                     _serde::ser::SerializeStruct::end(__struct)
@@ -748,7 +748,7 @@ fn serialize_adjacently_tagged_variant(
         let mut __struct = try!(_serde::Serializer::serialize_struct(
             __serializer, #type_name, 2));
         try!(_serde::ser::SerializeStruct::serialize_field(
-            &mut __struct, #tag, #variant_name));
+            &mut __struct, #tag, &#variant_name));
         try!(_serde::ser::SerializeStruct::serialize_field(
             &mut __struct, #content, &__AdjacentlyTagged {
                 data: (#(#fields_ident,)*),

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -596,7 +596,7 @@ fn serialize_internally_tagged_variant(
                 #enum_ident_str,
                 #variant_ident_str,
                 #tag,
-                &#variant_name,
+                #variant_name,
                 #ser,
             )
         };
@@ -629,7 +629,7 @@ fn serialize_internally_tagged_variant(
                     #enum_ident_str,
                     #variant_ident_str,
                     #tag,
-                    &#variant_name,
+                    #variant_name,
                     #field_expr,
                 )
             }

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -697,7 +697,6 @@ fn serialize_adjacently_tagged_variant(
                 StructVariant::Untagged,
                 params,
                 &variant.fields,
-                // TODO: Is this correct?
                 &variant_name.to_string(),
             ),
         }
@@ -941,8 +940,6 @@ fn serialize_struct_variant<'a>(
                     #name,
                     #len + 1,
                 ));
-
-                // MARKER: is-problematic-borrow?
 
                 try!(_serde::ser::SerializeStruct::serialize_field(
                     &mut __serde_state,

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -2918,3 +2918,75 @@ fn test_non_string_renames() {
         ],
     )
 }
+
+#[test]
+fn test_non_string_aliases() {
+    #[derive(Deserialize, Serialize, PartialEq, Eq, Debug)]
+    #[serde(tag = "op")]
+    enum AliasedEnum {
+        #[serde(rename = 1, alias = 2, alias = "foo")]
+        A,
+        #[serde(rename = 3, alias = "bar", alias = false)]
+        B,
+    }
+
+    assert_de_tokens(
+        &AliasedEnum::A,
+        &[
+            Token::Map { len: None },
+            Token::Str("op"),
+            Token::I64(1),
+            Token::MapEnd,
+        ]
+    );
+
+    assert_de_tokens(
+        &AliasedEnum::A,
+        &[
+            Token::Map { len: None },
+            Token::Str("op"),
+            Token::I64(2),
+            Token::MapEnd,
+        ]
+    );
+
+    assert_de_tokens(
+        &AliasedEnum::A,
+        &[
+            Token::Map { len: None },
+            Token::Str("op"),
+            Token::Str("foo"),
+            Token::MapEnd,
+        ]
+    );
+
+    assert_de_tokens(
+        &AliasedEnum::B,
+        &[
+            Token::Map { len: None },
+            Token::Str("op"),
+            Token::I64(3),
+            Token::MapEnd,
+        ]
+    );
+
+    assert_de_tokens(
+        &AliasedEnum::B,
+        &[
+            Token::Map { len: None },
+            Token::Str("op"),
+            Token::Str("bar"),
+            Token::MapEnd,
+        ]
+    );
+
+    assert_de_tokens(
+        &AliasedEnum::B,
+        &[
+            Token::Map { len: None },
+            Token::Str("op"),
+            Token::Bool(false),
+            Token::MapEnd,
+        ]
+    );
+}

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -2807,3 +2807,45 @@ fn test_expecting_message_identifier_enum() {
         r#"invalid type: map, expected something strange..."#,
     );
 }
+
+#[test]
+fn test_non_string_renames() {
+    #[derive(Deserialize, Serialize, PartialEq, Eq, Debug)]
+    #[serde(tag = "op")]
+    enum SpecialEnum {
+        #[serde(rename = 1)]
+        A,
+        #[serde(rename = true)]
+        B,
+    }
+
+    assert_de_tokens(
+        &SpecialEnum::A,
+        &[
+            Token::Map { len: None },
+            Token::Str("op"),
+            Token::I32(1),
+            Token::MapEnd,
+        ],
+    );
+
+    assert_de_tokens(
+        &SpecialEnum::B,
+        &[
+            Token::Map { len: None },
+            Token::Str("op"),
+            Token::Bool(true),
+            Token::MapEnd,
+        ]
+    );
+
+    assert_ser_tokens(
+        &SpecialEnum::A,
+        &[
+            Token::Struct { name: "SpecialEnum", len: 1 },
+            Token::Str("op"),
+            Token::I64(1),
+            Token::StructEnd,
+        ],
+    );
+}

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -2848,4 +2848,73 @@ fn test_non_string_renames() {
             Token::StructEnd,
         ],
     );
+
+    assert_ser_tokens(
+        &SpecialEnum::B,
+        &[
+            Token::Struct { name: "SpecialEnum", len: 1 },
+            Token::Str("op"),
+            Token::Bool(true),
+            Token::StructEnd,
+        ],
+    );
+
+    #[derive(Deserialize, Serialize, PartialEq, Eq, Debug)]
+    #[serde(tag = "op", content = "d")]
+    enum AdjacentEnum {
+        #[serde(rename = 1)]
+        A { a: u64 },
+        #[serde(rename = true)]
+        B,
+    }
+
+    assert_de_tokens(
+        &AdjacentEnum::A { a: 1 },
+        &[
+            Token::Map { len: None },
+            Token::Str("op"),
+            Token::I32(1),
+            Token::Str("d"),
+            Token::Map { len: Some(1) },
+            Token::Str("a"),
+            Token::U64(1),
+            Token::MapEnd,
+            Token::MapEnd,
+        ],
+    );
+
+    assert_de_tokens(
+        &AdjacentEnum::B,
+        &[
+            Token::Map { len: None },
+            Token::Str("op"),
+            Token::Bool(true),
+            Token::MapEnd,
+        ]
+    );
+
+    assert_ser_tokens(
+        &AdjacentEnum::A { a: 1 },
+        &[
+            Token::Struct { name: "AdjacentEnum", len: 2 },
+            Token::Str("op"),
+            Token::I64(1),
+            Token::Str("d"),
+            Token::Struct { name: "1", len: 1 },
+            Token::Str("a"),
+            Token::U64(1),
+            Token::StructEnd,
+            Token::StructEnd,
+        ],
+    );
+
+    assert_ser_tokens(
+        &AdjacentEnum::B,
+        &[
+            Token::Struct { name: "AdjacentEnum", len: 1 },
+            Token::Str("op"),
+            Token::Bool(true),
+            Token::StructEnd,
+        ],
+    )
 }

--- a/test_suite/tests/ui/rename/non_string_on_externally_tagged.rs
+++ b/test_suite/tests/ui/rename/non_string_on_externally_tagged.rs
@@ -1,0 +1,9 @@
+use serde_derive::Serialize;
+
+#[derive(Serialize)]
+enum S {
+    #[serde(rename = 1)]
+    A,
+}
+
+fn main() {}

--- a/test_suite/tests/ui/rename/non_string_on_externally_tagged.stderr
+++ b/test_suite/tests/ui/rename/non_string_on_externally_tagged.stderr
@@ -1,0 +1,6 @@
+error: #[serde(rename)] must use a string name in externally tagged enums
+ --> $DIR/non_string_on_externally_tagged.rs:5:5
+  |
+5 | /     #[serde(rename = 1)]
+6 | |     A,
+  | |_____^

--- a/test_suite/tests/ui/rename/non_string_on_untagged_enum.rs
+++ b/test_suite/tests/ui/rename/non_string_on_untagged_enum.rs
@@ -1,0 +1,10 @@
+use serde_derive::Serialize;
+
+#[derive(Serialize)]
+#[serde(untagged)]
+enum S {
+    #[serde(rename = 1)]
+    A,
+}
+
+fn main() {}

--- a/test_suite/tests/ui/rename/non_string_on_untagged_enum.stderr
+++ b/test_suite/tests/ui/rename/non_string_on_untagged_enum.stderr
@@ -1,0 +1,6 @@
+error: #[serde(rename)] must use a string name in untagged enums
+ --> $DIR/non_string_on_untagged_enum.rs:6:5
+  |
+6 | /     #[serde(rename = 1)]
+7 | |     A,
+  | |_____^


### PR DESCRIPTION
Closes #745.

Implements integer/boolean renames / aliases for internally and adjacently tagged enum variants:
```rust
#[derive(Serialize, Deserialize, Debug)]
#[serde(tag = "op")]
enum Something {
    #[serde(rename = 1)]
    A { a: i32 },
    #[serde(rename = 2)]
    B(u64),
    #[serde(rename = true)]
    C,
}

#[derive(Serialize, Deserialize, Debug)]
#[serde(tag = "op", content = "d")]
enum Adjacent {
    #[serde(rename = 1)]
    A { a: i32 },
    #[serde(rename = 2)]
    B(u64),
    #[serde(rename = true)]
    C,
}
```

## UI
In `attr.rs`, I introduced a new `Name` variant, `VariantName`. To cut down on code duplication, I made `Name` generic over its internal name representation; `Name` is now `Names<String>`. I added a step to `check.rs` to ensure that non-string renames are only used on internally/adjacently tagged enums. It's not necessary to check this for structs or the container name; the types of those names are still `String`.

## Deserialization
Deserialization was relatively straightforward to implement: rather than unconditionally generating constructors/fields for strings/bytes, we only do this if there are string-named variants. We do the same for ints/bools. One concern is that `VARIANTS` is still `&'static [&'static str]`, but I think this is pretty low-impact, as it's used only for stringifying error messages. Changing it would be a breaking change as it would be visible in the signatures of `Error::unknown_variant` and `Error::unknown_field`.

## Serialization
For serialization, I had to add a `VariantName` enum to `serde` itself, to be used in places where an integer/boolean can appear where previously only a `String` existed. We generate code in `serde_derive` for this enum wherever we invoke these methods.

The one part of this change that I'm not happy about is here:
https://github.com/AmaranthineCodices/serde/blob/37b4c68c0a9aa7aba8c6ee148c9c5e64c6f3f28c/serde_derive/src/ser.rs#L700
I am not fond of this `to_string` call, but getting rid of it would be a breaking change as far as I can tell - the change would be visible in the public-facing signatures of `Serializer::serialize_struct` and `Serializer::serialize_struct_variant`. This would be a good change to include in a new major serde version, though.

## TODO

- [x] Make sure we handle `collect_other_fields` in deserialization
- [x] Revisit `deserialize_generated_identifier` and see if I can remove the code duplication between it and `deserialize_identifier`
- [x] Add unit test for integer/boolean aliases
- [x] Revisit `main_constructors` in `deserialize_identifier`