### PR TITLE
Enable 128-bit integers on emscripten post Rust 1.40

### DIFF
--- a/serde/build.rs
+++ b/serde/build.rs
@@ -53,9 +53,10 @@ fn main() {
     // 128-bit integers stabilized in Rust 1.26:
     // https://blog.rust-lang.org/2018/05/10/Rust-1.26.html
     //
-    // Disabled on Emscripten targets as Emscripten doesn't
-    // currently support integers larger than 64 bits.
-    if minor >= 26 && !emscripten {
+    // Disabled on Emscripten targets before Rust 1.40 since
+    // Emscripten did not support 128-bit integers until Rust 1.40
+    // (https://github.com/rust-lang/rust/pull/65251)
+    if minor >= 26 && (!emscripten || minor >= 40) {
         println!("cargo:rustc-cfg=integer128");
     }
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/65251 fixed the issue where Rust was unable to support 128-bit integers on emscripten targets, that has been in Rust since 1.40 (looking at the tags on https://github.com/rust-lang/rust/commit/2bf59bea481dd4b4365cafe2e94fa8bf330a6877)

Fixes https://github.com/serde-rs/serde/issues/1995, supersedes https://github.com/serde-rs/serde/pull/2049