### PR TITLE
Use try_fold in default implementation of collect_seq, collect_map

### DIFF
--- a/serde/build.rs
+++ b/serde/build.rs
@@ -62,8 +62,11 @@ fn main() {
 
     // Inclusive ranges methods stabilized in Rust 1.27:
     // https://github.com/rust-lang/rust/pull/50758
+    // Also Iterator::try_for_each:
+    // https://blog.rust-lang.org/2018/06/21/Rust-1.27.html#library-stabilizations
     if minor >= 27 {
         println!("cargo:rustc-cfg=range_inclusive");
+        println!("cargo:rustc-cfg=iterator_try_fold");
     }
 
     // Non-zero integers stabilized in Rust 1.28:

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -1279,9 +1279,20 @@ pub trait Serializer: Sized {
     {
         let iter = iter.into_iter();
         let mut serializer = try!(self.serialize_seq(iterator_len_hint(&iter)));
-        for item in iter {
-            try!(serializer.serialize_element(&item));
+
+        #[cfg(iterator_try_fold)]
+        {
+            let mut iter = iter;
+            try!(iter.try_for_each(|item| serializer.serialize_element(&item)));
         }
+
+        #[cfg(not(iterator_try_fold))]
+        {
+            for item in iter {
+                try!(serializer.serialize_element(&item));
+            }
+        }
+
         serializer.end()
     }
 
@@ -1319,9 +1330,20 @@ pub trait Serializer: Sized {
     {
         let iter = iter.into_iter();
         let mut serializer = try!(self.serialize_map(iterator_len_hint(&iter)));
-        for (key, value) in iter {
-            try!(serializer.serialize_entry(&key, &value));
+
+        #[cfg(iterator_try_fold)]
+        {
+            let mut iter = iter;
+            try!(iter.try_for_each(|(key, value)| serializer.serialize_entry(&key, &value)));
         }
+
+        #[cfg(not(iterator_try_fold))]
+        {
+            for (key, value) in iter {
+                try!(serializer.serialize_entry(&key, &value));
+            }
+        }
+
         serializer.end()
     }
 


### PR DESCRIPTION
I noticed this in https://github.com/jonasbb/serde_with/blob/c578069eab2f64fd672b6dbd40068b36dd256f84/src/rust.rs#L1174 and it seems like a good idea because some iterator adapters, like `Chain`, are able to perform more efficiently in internal iteration than external iteration. See https://doc.rust-lang.org/1.54.0/std/iter/trait.Iterator.html#method.for_each.