### PR TITLE
Support packed remote struct without destructuring

### DIFF
--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -157,7 +157,7 @@ mod lib {
         pub use std::*;
     }
 
-    pub use self::core::{cmp, iter, mem, num, slice, str};
+    pub use self::core::{cmp, iter, mem, num, ptr, slice, str};
     pub use self::core::{f32, f64};
     pub use self::core::{i16, i32, i64, i8, isize};
     pub use self::core::{u16, u32, u64, u8, usize};

--- a/serde/src/private/mod.rs
+++ b/serde/src/private/mod.rs
@@ -14,6 +14,7 @@ pub use lib::default::Default;
 pub use lib::fmt::{self, Formatter};
 pub use lib::marker::PhantomData;
 pub use lib::option::Option::{self, None, Some};
+pub use lib::ptr;
 pub use lib::result::Result::{self, Err, Ok};
 
 pub use self::string::from_utf8_lossy;

--- a/serde_derive/build.rs
+++ b/serde_derive/build.rs
@@ -16,6 +16,12 @@ fn main() {
     if minor >= 37 {
         println!("cargo:rustc-cfg=underscore_consts");
     }
+
+    // The ptr::addr_of! macro stabilized in Rust 1.51:
+    // https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html#stabilized-apis
+    if minor >= 51 {
+        println!("cargo:rustc-cfg=ptr_addr_of");
+    }
 }
 
 fn rustc_minor_version() -> Option<u32> {

--- a/test_suite/tests/test_gen.rs
+++ b/test_suite/tests/test_gen.rs
@@ -851,14 +851,36 @@ where
 
 #[repr(packed)]
 pub struct RemotePacked {
-    pub a: u8,
-    pub b: u16,
+    pub a: u16,
+    pub b: u32,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize)]
 #[repr(packed)]
 #[serde(remote = "RemotePacked")]
 pub struct RemotePackedDef {
-    a: u8,
-    b: u16,
+    a: u16,
+    b: u32,
+}
+
+impl Drop for RemotePackedDef {
+    fn drop(&mut self) {}
+}
+
+#[repr(packed)]
+pub struct RemotePackedNonCopy {
+    pub a: u16,
+    pub b: String,
+}
+
+#[derive(Deserialize)]
+#[repr(packed)]
+#[serde(remote = "RemotePackedNonCopy")]
+pub struct RemotePackedNonCopyDef {
+    a: u16,
+    b: String,
+}
+
+impl Drop for RemotePackedNonCopyDef {
+    fn drop(&mut self) {}
 }


### PR DESCRIPTION
The destructuring-based implementation from #2079 is potentially problematic because not all objects can be destructured by value. For example:

```rust
#[repr(packed)]
pub struct RemotePackedNonCopy {
    pub a: u16,
    pub b: String,
}

#[derive(Deserialize)]
#[repr(packed)]
#[serde(remote = "RemotePackedNonCopy")]
pub struct RemotePackedNonCopyDef {
    a: u16,
    b: String,
}

impl Drop for RemotePackedNonCopyDef {
    fn drop(&mut self) {}
}
```

```console
error[E0509]: cannot move out of type `RemotePackedNonCopyDef`, which implements the `Drop` trait
   --> test_suite/tests/test_gen.rs:876:10
    |
876 | #[derive(Deserialize)]
    |          ^^^^^^^^^^^
    |          |
    |          cannot move out of here
    |          data moved here
    |          move occurs because `__v1` has type `std::string::String`, which does not implement the `Copy` trait
    |
    = note: this error originates in the derive macro `Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)
```