### PR TITLE
Support std::lazy::OnceCell (unstable: RFC 2788)

### DIFF
--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -50,6 +50,32 @@ impl<'de> Deserialize<'de> for ! {
     }
 }
 
+#[cfg(feature = "unstable")]
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for core::lazy::OnceCell<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(match Option::<T>::deserialize(deserializer)? {
+            Some(value) => core::lazy::OnceCell::from(value),
+            None => core::lazy::OnceCell::new(),
+        })
+    }
+}
+
+#[cfg(all(feature = "unstable", feature = "std"))]
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for std::lazy::SyncOnceCell<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(match Option::<T>::deserialize(deserializer)? {
+            Some(value) => std::lazy::SyncOnceCell::from(value),
+            None => std::lazy::SyncOnceCell::new(),
+        })
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 struct BoolVisitor;

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -92,6 +92,8 @@
 //
 //    https://github.com/serde-rs/serde/issues/812
 #![cfg_attr(feature = "unstable", feature(never_type))]
+// Support OnceCell in RFC #2788
+#![cfg_attr(feature = "unstable", feature(once_cell))]
 #![allow(unknown_lints, bare_trait_objects, deprecated)]
 #![cfg_attr(feature = "cargo-clippy", allow(renamed_and_removed_lints))]
 #![cfg_attr(feature = "cargo-clippy", deny(clippy, clippy_pedantic))]

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -301,6 +301,32 @@ impl Serialize for ! {
     }
 }
 
+#[cfg(feature = "unstable")]
+impl<T: Serialize> Serialize for core::lazy::OnceCell<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self.get() {
+            Some(value) => serializer.serialize_some(value),
+            None => serializer.serialize_none(),
+        }
+    }
+}
+
+#[cfg(all(feature = "unstable", feature = "std"))]
+impl<T: Serialize> Serialize for std::lazy::SyncOnceCell<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self.get() {
+            Some(value) => serializer.serialize_some(value),
+            None => serializer.serialize_none(),
+        }
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 macro_rules! tuple_impls {


### PR DESCRIPTION
Let me know if anything needs fixing or if this should have a dedicated feature flag.

Fixes #1952