### PR TITLE
Point to type instead of field for missing traits

### DIFF
--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -201,7 +201,7 @@ fn serialize_transparent(cont: &Container, params: &Parameters) -> Fragment {
     let path = match transparent_field.attrs.serialize_with() {
         Some(path) => quote!(#path),
         None => {
-            let span = transparent_field.original.span();
+            let span = transparent_field.original.ty.span();
             quote_spanned!(span=> _serde::Serialize::serialize)
         }
     };
@@ -247,7 +247,7 @@ fn serialize_newtype_struct(
         field_expr = wrap_serialize_field_with(params, field.ty, path, &field_expr);
     }
 
-    let span = field.original.span();
+    let span = field.original.ty.span();
     let func = quote_spanned!(span=> _serde::Serializer::serialize_newtype_struct);
     quote_expr! {
         #func(__serializer, #type_name, #field_expr)
@@ -534,7 +534,7 @@ fn serialize_externally_tagged_variant(
                 field_expr = wrap_serialize_field_with(params, field.ty, path, &field_expr);
             }
 
-            let span = field.original.span();
+            let span = field.original.ty.span();
             let func = quote_spanned!(span=> _serde::Serializer::serialize_newtype_variant);
             quote_expr! {
                 #func(
@@ -610,7 +610,7 @@ fn serialize_internally_tagged_variant(
                 field_expr = wrap_serialize_field_with(params, field.ty, path, &field_expr);
             }
 
-            let span = field.original.span();
+            let span = field.original.ty.span();
             let func = quote_spanned!(span=> _serde::__private::ser::serialize_tagged_newtype);
             quote_expr! {
                 #func(
@@ -667,7 +667,7 @@ fn serialize_adjacently_tagged_variant(
                     field_expr = wrap_serialize_field_with(params, field.ty, path, &field_expr);
                 }
 
-                let span = field.original.span();
+                let span = field.original.ty.span();
                 let func = quote_spanned!(span=> _serde::ser::SerializeStruct::serialize_field);
                 return quote_block! {
                     let mut __struct = try!(_serde::Serializer::serialize_struct(
@@ -772,7 +772,7 @@ fn serialize_untagged_variant(
                 field_expr = wrap_serialize_field_with(params, field.ty, path, &field_expr);
             }
 
-            let span = field.original.span();
+            let span = field.original.ty.span();
             let func = quote_spanned!(span=> _serde::Serialize::serialize);
             quote_expr! {
                 #func(#field_expr, __serializer)
@@ -1070,7 +1070,7 @@ fn serialize_tuple_struct_visitor(
                 field_expr = wrap_serialize_field_with(params, field.ty, path, &field_expr);
             }
 
-            let span = field.original.span();
+            let span = field.original.ty.span();
             let func = tuple_trait.serialize_element(span);
             let ser = quote! {
                 try!(#func(&mut __serde_state, #field_expr));
@@ -1113,7 +1113,7 @@ fn serialize_struct_visitor(
                 field_expr = wrap_serialize_field_with(params, field.ty, path, &field_expr);
             }
 
-            let span = field.original.span();
+            let span = field.original.ty.span();
             let ser = if field.attrs.flatten() {
                 let func = quote_spanned!(span=> _serde::Serialize::serialize);
                 quote! {


### PR DESCRIPTION
In issue #2103 it was noted that spans for missing `Deserialize`
implementations include the doc comment. This commit changes it to
explicitly use the type of each field, as this is the behavior nightly
rust has.
This is done for both `Deserialize` and `Serialize`.

At the same time this fixes two places where no span was used, thus the
error message would point at the derive attribute instead of the
problematic field. Both cases concern the ude of `Default::default()`.

Compiletests currently only run on nightly, which does not have this issue. Therefore I'm not sure if this can be tested or needs a test.

Closes #2103