### PR TITLE
Fix `unused_results` complaining rustc lint in codegen for adjacently tagged enum

### DIFF
--- a/serde/src/private/mod.rs
+++ b/serde/src/private/mod.rs
@@ -13,6 +13,7 @@ pub use lib::convert::{From, Into};
 pub use lib::default::Default;
 pub use lib::fmt::{self, Formatter};
 pub use lib::marker::PhantomData;
+pub use lib::mem;
 pub use lib::option::Option::{self, None, Some};
 pub use lib::ptr;
 pub use lib::result::Result::{self, Err, Ok};

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1458,7 +1458,7 @@ fn deserialize_adjacently_tagged_enum(
             while let _serde::__private::Some(__k) = #next_key {
                 match __k {
                     _serde::__private::de::TagContentOtherField::Other => {
-                        try!(_serde::de::MapAccess::next_value::<_serde::de::IgnoredAny>(&mut __map));
+                        _serde::__private::mem::drop(try!(_serde::de::MapAccess::next_value::<_serde::de::IgnoredAny>(&mut __map)));
                         continue;
                     },
                     _serde::__private::de::TagContentOtherField::Tag => {


### PR DESCRIPTION
## MRE

```rust
#![allow(dead_code)]
#![deny(unused_results)]

use serde::Deserialize; // =1.0.130

#[derive(Deserialize)]
#[serde(tag = "msg", content = "data")]
enum ServerMsg {
    Ping(u32),
    Event {
        room_id: u32,
    },
}
```

[Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&code=%23!%5Ballow(dead_code)%5D%0A%23!%5Bdeny(unused_results)%5D%0A%0Ause%20serde%3A%3ADeserialize%3B%20%2F%2F%20%3D1.0.130%0A%0A%23%5Bderive(Deserialize)%5D%0A%23%5Bserde(tag%20%3D%20%22msg%22%2C%20content%20%3D%20%22data%22)%5D%0Aenum%20ServerMsg%20%7B%0A%20%20%20%20Ping(u32)%2C%0A%20%20%20%20Event%20%7B%0A%20%20%20%20%20%20%20%20room_id%3A%20u32%2C%0A%20%20%20%20%7D%2C%0A%7D)