### PR TITLE
Change cbor link to new repo

### DIFF
--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -60,7 +60,7 @@
 //!
 //! [JSON]: https://github.com/serde-rs/json
 //! [Bincode]: https://github.com/servo/bincode
-//! [CBOR]: https://github.com/pyfisch/cbor
+//! [CBOR]: https://github.com/enarx/ciborium
 //! [YAML]: https://github.com/dtolnay/serde-yaml
 //! [MessagePack]: https://github.com/3Hren/msgpack-rust
 //! [TOML]: https://github.com/alexcrichton/toml-rs


### PR DESCRIPTION
Mirrored from https://github.com/serde-rs/serde-rs.github.io/pull/131.

> The [`serde_cbor`](https://github.com/pyfisch/cbor) crate [is no longer maintained](https://github.com/pyfisch/cbor/issues/179) and points to [`ciborium`](https://github.com/enarx/ciborium) as worthy successor.