### PR TITLE
Render 128-bit integer value into Visitor errors

### DIFF
--- a/serde/src/de/format.rs
+++ b/serde/src/de/format.rs
@@ -1,0 +1,30 @@
+use lib::fmt::{self, Write};
+use lib::str;
+
+pub struct Buf<'a> {
+    bytes: &'a mut [u8],
+    offset: usize,
+}
+
+impl<'a> Buf<'a> {
+    pub fn new(bytes: &'a mut [u8]) -> Self {
+        Buf { bytes, offset: 0 }
+    }
+
+    pub fn as_str(&self) -> &str {
+        let slice = &self.bytes[..self.offset];
+        unsafe { str::from_utf8_unchecked(slice) }
+    }
+}
+
+impl<'a> Write for Buf<'a> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        if self.offset + s.len() > self.bytes.len() {
+            Err(fmt::Error)
+        } else {
+            self.bytes[self.offset..self.offset + s.len()].copy_from_slice(s.as_bytes());
+            self.offset += s.len();
+            Ok(())
+        }
+    }
+}

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -118,6 +118,8 @@ use lib::*;
 
 pub mod value;
 
+#[cfg(not(no_integer128))]
+mod format;
 mod ignored_any;
 mod impls;
 mod utf8;
@@ -1366,8 +1368,10 @@ pub trait Visitor<'de>: Sized {
         where
             E: Error,
         {
-            let _ = v;
-            Err(Error::invalid_type(Unexpected::Other("i128"), &self))
+            let mut buf = [0u8; 58];
+            let mut writer = format::Buf::new(&mut buf);
+            fmt::Write::write_fmt(&mut writer, format_args!("integer `{}` as i128", v)).unwrap();
+            Err(Error::invalid_type(Unexpected::Other(writer.as_str()), &self))
         }
     }
 
@@ -1426,8 +1430,10 @@ pub trait Visitor<'de>: Sized {
         where
             E: Error,
         {
-            let _ = v;
-            Err(Error::invalid_type(Unexpected::Other("u128"), &self))
+            let mut buf = [0u8; 57];
+            let mut writer = format::Buf::new(&mut buf);
+            fmt::Write::write_fmt(&mut writer, format_args!("integer `{}` as u128", v)).unwrap();
+            Err(Error::invalid_type(Unexpected::Other(writer.as_str()), &self))
         }
     }
 

--- a/test_suite/tests/test_de_error.rs
+++ b/test_suite/tests/test_de_error.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::empty_enum, clippy::unreadable_literal)]
 #![cfg_attr(feature = "unstable", feature(never_type))]
 
+use serde::de::IntoDeserializer;
 use serde::Deserialize;
 use serde_test::{assert_de_tokens_error, Token};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
@@ -186,6 +187,16 @@ fn test_i64() {
 }
 
 #[test]
+fn test_i128() {
+    let deserializer = <i128 as IntoDeserializer>::into_deserializer(1);
+    let error = <&str>::deserialize(deserializer).unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "invalid type: i128, expected a borrowed string",
+    );
+}
+
+#[test]
 fn test_u8() {
     let test = assert_de_tokens_error::<u8>;
 
@@ -326,6 +337,13 @@ fn test_u64() {
         &[Token::I64(-1)],
         "invalid value: integer `-1`, expected u64",
     );
+
+    let deserializer = <u64 as IntoDeserializer>::into_deserializer(1);
+    let error = <&str>::deserialize(deserializer).unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "invalid type: integer `1`, expected a borrowed string",
+    );
 }
 
 #[test]
@@ -348,6 +366,13 @@ fn test_u128() {
     test(
         &[Token::I64(-1)],
         "invalid value: integer `-1`, expected u128",
+    );
+
+    let deserializer = <u128 as IntoDeserializer>::into_deserializer(1);
+    let error = <&str>::deserialize(deserializer).unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "invalid type: u128, expected a borrowed string",
     );
 }
 

--- a/test_suite/tests/test_de_error.rs
+++ b/test_suite/tests/test_de_error.rs
@@ -192,7 +192,7 @@ fn test_i128() {
     let error = <&str>::deserialize(deserializer).unwrap_err();
     assert_eq!(
         error.to_string(),
-        "invalid type: i128, expected a borrowed string",
+        "invalid type: integer `1` as i128, expected a borrowed string",
     );
 }
 
@@ -372,7 +372,7 @@ fn test_u128() {
     let error = <&str>::deserialize(deserializer).unwrap_err();
     assert_eq!(
         error.to_string(),
-        "invalid type: u128, expected a borrowed string",
+        "invalid type: integer `1` as u128, expected a borrowed string",
     );
 }
 


### PR DESCRIPTION
This makes the error produced by `serde::de::Visitor`'s default implementation of `visit_i128`/`visit_u128` match the format of the other integer methods' errors.