### PR TITLE
Add sequentially_adjacent_tag representation for enums.

### DIFF
--- a/serde_derive/src/internals/check.rs
+++ b/serde_derive/src/internals/check.rs
@@ -253,7 +253,9 @@ fn check_internal_tag_field_name_conflict(cx: &Ctxt, cont: &Container) {
 
     let tag = match cont.attrs.tag() {
         TagType::Internal { tag } => tag.as_str(),
-        TagType::External | TagType::Adjacent { .. } | TagType::None => return,
+        TagType::External | TagType::Adjacent { .. } | TagType::None | TagType::SeqAdjacent => {
+            return
+        }
     };
 
     let diagnose_conflict = || {
@@ -295,7 +297,9 @@ fn check_internal_tag_field_name_conflict(cx: &Ctxt, cont: &Container) {
 fn check_adjacent_tag_conflict(cx: &Ctxt, cont: &Container) {
     let (type_tag, content_tag) = match cont.attrs.tag() {
         TagType::Adjacent { tag, content } => (tag, content),
-        TagType::Internal { .. } | TagType::External | TagType::None => return,
+        TagType::Internal { .. } | TagType::External | TagType::None | TagType::SeqAdjacent => {
+            return
+        }
     };
 
     if type_tag == content_tag {

--- a/serde_derive/src/internals/symbol.rs
+++ b/serde_derive/src/internals/symbol.rs
@@ -33,6 +33,7 @@ pub const TAG: Symbol = Symbol("tag");
 pub const TRANSPARENT: Symbol = Symbol("transparent");
 pub const TRY_FROM: Symbol = Symbol("try_from");
 pub const UNTAGGED: Symbol = Symbol("untagged");
+pub const SEQ_ADJ_TAG: Symbol = Symbol("sequentially_adjacent_tag");
 pub const VARIANT_IDENTIFIER: Symbol = Symbol("variant_identifier");
 pub const WITH: Symbol = Symbol("with");
 pub const EXPECTING: Symbol = Symbol("expecting");


### PR DESCRIPTION
If present, this attribute will cause enums to be serialized and
deserialized into a sequence. The first element is the tag, and the
second the content. If the content is optional, then the sequence may
only be a single item.

Also, add a test to verify the functionality of this new feature.