### PR TITLE
Optimize few string allocations

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1902,7 +1902,7 @@ fn deserialize_untagged_newtype_variant(
 }
 
 fn deserialize_generated_identifier(
-    fields: &[(String, Ident, Vec<String>)],
+    fields: &[(&str, Ident, Vec<String>)],
     cattrs: &attr::Container,
     is_variant: bool,
     other_idx: Option<usize>,
@@ -2083,7 +2083,7 @@ fn deserialize_custom_identifier(
 
 fn deserialize_identifier(
     this: &TokenStream,
-    fields: &[(String, Ident, Vec<String>)],
+    fields: &[(&str, Ident, Vec<String>)],
     is_variant: bool,
     fallthrough: Option<TokenStream>,
     fallthrough_borrowed: Option<TokenStream>,

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -11,6 +11,7 @@ use internals::ast::{Container, Data, Field, Style, Variant};
 use internals::{attr, replace_receiver, ungroup, Ctxt, Derive};
 use pretend;
 
+use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::ptr;
 
@@ -1902,7 +1903,7 @@ fn deserialize_untagged_newtype_variant(
 }
 
 fn deserialize_generated_identifier(
-    fields: &[(&str, Ident, Vec<String>)],
+    fields: &[(&str, Ident, Cow<[String]>)],
     cattrs: &attr::Container,
     is_variant: bool,
     other_idx: Option<usize>,
@@ -2083,7 +2084,7 @@ fn deserialize_custom_identifier(
 
 fn deserialize_identifier(
     this: &TokenStream,
-    fields: &[(&str, Ident, Vec<String>)],
+    fields: &[(&str, Ident, Cow<[String]>)],
     is_variant: bool,
     fallthrough: Option<TokenStream>,
     fallthrough_borrowed: Option<TokenStream>,

--- a/serde_derive/src/dummy.rs
+++ b/serde_derive/src/dummy.rs
@@ -4,6 +4,8 @@ use quote::format_ident;
 use syn;
 use try;
 
+use internals::attr::unraw;
+
 pub fn wrap_in_const(
     serde_path: Option<&syn::Path>,
     trait_: &str,
@@ -37,12 +39,4 @@ pub fn wrap_in_const(
             #code
         };
     }
-}
-
-#[allow(deprecated)]
-fn unraw(ident: &Ident) -> String {
-    // str::trim_start_matches was added in 1.30, trim_left_matches deprecated
-    // in 1.33. We currently support rustc back to 1.15 so we need to continue
-    // to use the deprecated one.
-    ident.to_string().trim_left_matches("r#").to_owned()
 }

--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -185,15 +185,15 @@ impl Name {
     }
 
     /// Return the container name for the container when deserializing.
-    pub fn deserialize_name(&self) -> String {
-        self.deserialize.clone()
+    pub fn deserialize_name(&self) -> &str {
+        self.deserialize.as_str()
     }
 
     fn deserialize_aliases(&self) -> Vec<String> {
         let mut aliases = self.deserialize_aliases.clone();
         let main_name = self.deserialize_name();
-        if !aliases.contains(&main_name) {
-            aliases.push(main_name);
+        if !aliases.iter().any(|s| s == main_name) {
+            aliases.push(main_name.to_owned());
         }
         aliases
     }

--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -1061,8 +1061,8 @@ impl Variant {
         &self.name
     }
 
-    pub fn aliases(&self) -> Vec<String> {
-        self.name.deserialize_aliases().into()
+    pub fn aliases(&self) -> Cow<[String]> {
+        self.name.deserialize_aliases()
     }
 
     pub fn rename_by_rules(&mut self, rules: &RenameAllRules) {
@@ -1443,8 +1443,8 @@ impl Field {
         &self.name
     }
 
-    pub fn aliases(&self) -> Vec<String> {
-        self.name.deserialize_aliases().into()
+    pub fn aliases(&self) -> Cow<[String]> {
+        self.name.deserialize_aliases()
     }
 
     pub fn rename_by_rules(&mut self, rules: &RenameAllRules) {

--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -189,13 +189,15 @@ impl Name {
         self.deserialize.as_str()
     }
 
-    fn deserialize_aliases(&self) -> Vec<String> {
-        let mut aliases = self.deserialize_aliases.clone();
+    fn deserialize_aliases(&self) -> Cow<[String]> {
         let main_name = self.deserialize_name();
-        if !aliases.iter().any(|s| s == main_name) {
+        if !self.deserialize_aliases.iter().any(|s| s == main_name) {
+            let mut aliases = self.deserialize_aliases.clone();
             aliases.push(main_name.to_owned());
+            Cow::Owned(aliases)
+        } else {
+            Cow::Borrowed(&self.deserialize_aliases)
         }
-        aliases
     }
 }
 
@@ -1060,7 +1062,7 @@ impl Variant {
     }
 
     pub fn aliases(&self) -> Vec<String> {
-        self.name.deserialize_aliases()
+        self.name.deserialize_aliases().into()
     }
 
     pub fn rename_by_rules(&mut self, rules: &RenameAllRules) {
@@ -1442,7 +1444,7 @@ impl Field {
     }
 
     pub fn aliases(&self) -> Vec<String> {
-        self.name.deserialize_aliases()
+        self.name.deserialize_aliases().into()
     }
 
     pub fn rename_by_rules(&mut self, rules: &RenameAllRules) {

--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -180,8 +180,8 @@ impl Name {
     }
 
     /// Return the container name for the container when serializing.
-    pub fn serialize_name(&self) -> String {
-        self.serialize.clone()
+    pub fn serialize_name(&self) -> &str {
+        self.serialize.as_str()
     }
 
     /// Return the container name for the container when deserializing.

--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -315,8 +315,9 @@ impl Container {
                 // Parse `#[serde(rename = "foo")]`
                 Meta(NameValue(m)) if m.path == RENAME => {
                     if let Ok(s) = get_lit_str(cx, RENAME, &m.lit) {
-                        ser_name.set(&m.path, s.value());
-                        de_name.set(&m.path, s.value());
+                        let s_value = s.value();
+                        ser_name.set(&m.path, s_value.clone());
+                        de_name.set(&m.path, s_value);
                     }
                 }
 
@@ -877,9 +878,10 @@ impl Variant {
                 // Parse `#[serde(rename = "foo")]`
                 Meta(NameValue(m)) if m.path == RENAME => {
                     if let Ok(s) = get_lit_str(cx, RENAME, &m.lit) {
-                        ser_name.set(&m.path, s.value());
-                        de_name.set_if_none(s.value());
-                        de_aliases.insert(&m.path, s.value());
+                        let s_value = s.value();
+                        ser_name.set(&m.path, s_value.clone());
+                        de_name.set_if_none(s_value.clone());
+                        de_aliases.insert(&m.path, s_value);
                     }
                 }
 
@@ -888,8 +890,9 @@ impl Variant {
                     if let Ok((ser, de)) = get_multiple_renames(cx, &m.nested) {
                         ser_name.set_opt(&m.path, ser.map(syn::LitStr::value));
                         for de_value in de {
-                            de_name.set_if_none(de_value.value());
-                            de_aliases.insert(&m.path, de_value.value());
+                            let de_value_str = de_value.value();
+                            de_name.set_if_none(de_value_str.clone());
+                            de_aliases.insert(&m.path, de_value_str);
                         }
                     }
                 }
@@ -1179,9 +1182,10 @@ impl Field {
                 // Parse `#[serde(rename = "foo")]`
                 Meta(NameValue(m)) if m.path == RENAME => {
                     if let Ok(s) = get_lit_str(cx, RENAME, &m.lit) {
-                        ser_name.set(&m.path, s.value());
-                        de_name.set_if_none(s.value());
-                        de_aliases.insert(&m.path, s.value());
+                        let s_value = s.value();
+                        ser_name.set(&m.path, s_value.clone());
+                        de_name.set_if_none(s_value.clone());
+                        de_aliases.insert(&m.path, s_value);
                     }
                 }
 
@@ -1190,8 +1194,9 @@ impl Field {
                     if let Ok((ser, de)) = get_multiple_renames(cx, &m.nested) {
                         ser_name.set_opt(&m.path, ser.map(syn::LitStr::value));
                         for de_value in de {
-                            de_name.set_if_none(de_value.value());
-                            de_aliases.insert(&m.path, de_value.value());
+                            let de_value_str = de_value.value();
+                            de_name.set_if_none(de_value_str.clone());
+                            de_aliases.insert(&m.path, de_value_str);
                         }
                     }
                 }
@@ -1627,11 +1632,12 @@ fn parse_lit_into_where(
     lit: &syn::Lit,
 ) -> Result<Vec<syn::WherePredicate>, ()> {
     let string = get_lit_str2(cx, attr_name, meta_item_name, lit)?;
-    if string.value().is_empty() {
+    let string_value = string.value();
+    if string_value.is_empty() {
         return Ok(Vec::new());
     }
 
-    let where_string = syn::LitStr::new(&format!("where {}", string.value()), string.span());
+    let where_string = syn::LitStr::new(&format!("where {}", string_value), string.span());
 
     parse_lit_str::<syn::WhereClause>(&where_string)
         .map(|wh| wh.predicates.into_iter().collect())

--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -141,12 +141,8 @@ pub struct Name {
     deserialize_aliases: Vec<String>,
 }
 
-#[allow(deprecated)]
-fn unraw(ident: &Ident) -> String {
-    // str::trim_start_matches was added in 1.30, trim_left_matches deprecated
-    // in 1.33. We currently support rustc back to 1.15 so we need to continue
-    // to use the deprecated one.
-    ident.to_string().trim_left_matches("r#").to_owned()
+pub(crate) fn unraw(ident: &Ident) -> String {
+    ident.to_string().trim_start_matches("r#").to_owned()
 }
 
 impl Name {

--- a/serde_derive/src/internals/check.rs
+++ b/serde_derive/src/internals/check.rs
@@ -277,7 +277,7 @@ fn check_internal_tag_field_name_conflict(cx: &Ctxt, cont: &Container) {
                         return;
                     }
 
-                    for de_name in field.attrs.aliases() {
+                    for de_name in field.attrs.aliases().iter() {
                         if check_de && de_name == tag {
                             diagnose_conflict();
                             return;

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -562,7 +562,7 @@ fn serialize_externally_tagged_variant(
             },
             params,
             &variant.fields,
-            &type_name,
+            type_name,
         ),
     }
 }
@@ -627,7 +627,7 @@ fn serialize_internally_tagged_variant(
             StructVariant::InternallyTagged { tag, variant_name },
             params,
             &variant.fields,
-            &type_name,
+            type_name,
         ),
         Style::Tuple => unreachable!("checked in serde_derive_internals"),
     }
@@ -686,7 +686,7 @@ fn serialize_adjacently_tagged_variant(
                 StructVariant::Untagged,
                 params,
                 &variant.fields,
-                &variant_name,
+                variant_name,
             ),
         }
     });
@@ -781,7 +781,7 @@ fn serialize_untagged_variant(
         Style::Tuple => serialize_tuple_variant(TupleVariant::Untagged, params, &variant.fields),
         Style::Struct => {
             let type_name = cattrs.name().serialize_name();
-            serialize_struct_variant(StructVariant::Untagged, params, &variant.fields, &type_name)
+            serialize_struct_variant(StructVariant::Untagged, params, &variant.fields, type_name)
         }
     }
 }

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -786,11 +786,11 @@ fn serialize_untagged_variant(
     }
 }
 
-enum TupleVariant {
+enum TupleVariant<'a> {
     ExternallyTagged {
-        type_name: String,
+        type_name: &'a str,
         variant_index: u32,
-        variant_name: String,
+        variant_name: &'a str,
     },
     Untagged,
 }
@@ -857,11 +857,11 @@ fn serialize_tuple_variant(
 enum StructVariant<'a> {
     ExternallyTagged {
         variant_index: u32,
-        variant_name: String,
+        variant_name: &'a str,
     },
     InternallyTagged {
         tag: &'a str,
-        variant_name: String,
+        variant_name: &'a str,
     },
     Untagged,
 }


### PR DESCRIPTION
Few string allocating optimizations and replacing of deprecated `trim_left_matches`.