### PR TITLE
Add skip_serializing_if_default field attribute

### DIFF
--- a/serde_derive/src/internals/check.rs
+++ b/serde_derive/src/internals/check.rs
@@ -97,7 +97,7 @@ fn check_field_skip_if_default(cx: &Ctxt, cont: &Container) {
             if field.attrs.default().is_none() {
                 cx.error_spanned_by(
                     field.original,
-                    "#[serde(skip_serializing_if_default)] can only be used in fields that have #[serde(default = \"...\")]".to_string()
+                    "#[serde(skip_serializing_if_default)] can only be used in fields that have #[serde(default)]".to_string()
                 );
             }
         }

--- a/serde_derive/src/internals/check.rs
+++ b/serde_derive/src/internals/check.rs
@@ -90,18 +90,14 @@ fn check_field_skip_if_default(cx: &Ctxt, cont: &Container) {
             if field.attrs.skip_serializing_if().is_some() {
                 cx.error_spanned_by(
                     field.original,
-                    format!(
-                        "#[serde(skip_serializing_if_default)] and #[serde(skip_serializing_if)] conflict with each other"
-                    ),
+                    "#[serde(skip_serializing_if_default)] and #[serde(skip_serializing_if)] conflict with each other".to_string()
                 );
             }
 
             if field.attrs.default().is_none() {
                 cx.error_spanned_by(
                     field.original,
-                    format!(
-                        "#[serde(skip_serializing_if_default)] can only be used in fields that have #[serde(default = \"...\")]"
-                    ),
+                    "#[serde(skip_serializing_if_default)] can only be used in fields that have #[serde(default = \"...\")]".to_string()
                 );
             }
         }

--- a/serde_derive/src/internals/symbol.rs
+++ b/serde_derive/src/internals/symbol.rs
@@ -29,6 +29,7 @@ pub const SKIP: Symbol = Symbol("skip");
 pub const SKIP_DESERIALIZING: Symbol = Symbol("skip_deserializing");
 pub const SKIP_SERIALIZING: Symbol = Symbol("skip_serializing");
 pub const SKIP_SERIALIZING_IF: Symbol = Symbol("skip_serializing_if");
+pub const SKIP_SERIALIZING_IF_DEFAULT: Symbol = Symbol("skip_serializing_if_default");
 pub const TAG: Symbol = Symbol("tag");
 pub const TRANSPARENT: Symbol = Symbol("transparent");
 pub const TRY_FROM: Symbol = Symbol("try_from");

--- a/test_suite/tests/ui/default-attribute/skip_if_default.rs
+++ b/test_suite/tests/ui/default-attribute/skip_if_default.rs
@@ -1,0 +1,9 @@
+use serde_derive::Deserialize;
+
+#[derive(Deserialize)]
+struct T {
+    #[serde(skip_serializing_if = "always", skip_serializing_if_default)]
+    a: u8,
+}
+
+fn main() {}

--- a/test_suite/tests/ui/default-attribute/skip_if_default.stderr
+++ b/test_suite/tests/ui/default-attribute/skip_if_default.stderr
@@ -1,0 +1,13 @@
+error: #[serde(skip_serializing_if_default)] and #[serde(skip_serializing_if)] conflict with each other
+ --> tests/ui/default-attribute/skip_if_default.rs:5:5
+  |
+5 | /     #[serde(skip_serializing_if = "always", skip_serializing_if_default)]
+6 | |     a: u8,
+  | |_________^
+
+error: #[serde(skip_serializing_if_default)] can only be used in fields that have #[serde(default)]
+ --> tests/ui/default-attribute/skip_if_default.rs:5:5
+  |
+5 | /     #[serde(skip_serializing_if = "always", skip_serializing_if_default)]
+6 | |     a: u8,
+  | |_________^


### PR DESCRIPTION
This attribute skips field serialization if its value equals default.

### Motivation:
Imagine we have an application, where the config may be changed dynamically and needs to be saved. Or just be saved for some reason.
```
#[derive(Serialize, Deserialize, Debug)]
struct Config {
    #[serde(default = "default_version")]
    version: u32,
    #[serde(default = "default_author")]
    author: String,
}
```
Probably, if we have a lot of fields that just defaulted and saving them adds unnecessary noise to the config file.

We may use `skip_serializing_if` attribute and provide functions that check if the value is default:
 ```
#[derive(Serialize, Deserialize, Debug)]
struct Config {
    #[serde(default = "default_version", skip_serializing_if = "is_version_default")]
    version: u32,
    #[serde(default = "default_author", skip_serializing_if = "is_author_default")]
    author: String,
}

fn is_version_default(value: &u32) -> bool {
    *value == default_version()
}

fn is_author_default(value: &String) -> bool {
    *value == default_author()
}
```

This adds a lot of one-line functions and adds noise to the code.

### Solution:
Use `skip_serializing_if_default` attribute from this PR:
```
#[derive(Serialize, Deserialize, Debug)]
struct Config {
    #[serde(default = "default_version", skip_serializing_if_default)]
    version: u32,
    #[serde(default = "default_author", skip_serializing_if_default)]
    author: String,
}
```

It calls the field's default function, compares its current value, and if it matches with the value provided by the default function, skips serialization.