### PR TITLE
Allow integer renames for struct fields

### DIFF
--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -262,7 +262,9 @@ macro_rules! declare_error_trait {
             /// Raised when a `Deserialize` struct type received a field with an
             /// unrecognized name.
             #[cold]
-            fn unknown_field(field: &str, expected: &'static [&'static str]) -> Self {
+            fn unknown_field<T>(field: T, expected: &'static [&'static str]) -> Self
+            where
+                T: Display {
                 if expected.is_empty() {
                     Error::custom(format_args!(
                         "unknown field `{}`, there are no fields",

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1934,6 +1934,7 @@ fn deserialize_generated_identifier(
         fallthrough,
         None,
         collect_other_fields,
+        cattrs.has_int_rename(),
         None,
     ));
 
@@ -2057,6 +2058,7 @@ fn deserialize_custom_identifier(
         fallthrough,
         fallthrough_borrowed,
         false,
+        cattrs.has_int_rename(),
         cattrs.expecting(),
     ));
 
@@ -2089,6 +2091,7 @@ fn deserialize_identifier(
     fallthrough: Option<TokenStream>,
     fallthrough_borrowed: Option<TokenStream>,
     collect_other_fields: bool,
+    has_int_rename: bool,
     expecting: Option<&str>,
 ) -> Fragment {
     let mut flat_fields = Vec::new();
@@ -2129,6 +2132,14 @@ fn deserialize_identifier(
         value_as_borrowed_str_content,
         value_as_bytes_content,
         value_as_borrowed_bytes_content,
+        value_as_i8_content,
+        value_as_i16_content,
+        value_as_i32_content,
+        value_as_i64_content,
+        value_as_u8_content,
+        value_as_u16_content,
+        value_as_u32_content,
+        value_as_u64_content,
     ) = if collect_other_fields {
         (
             Some(quote! {
@@ -2143,9 +2154,35 @@ fn deserialize_identifier(
             Some(quote! {
                 let __value = _serde::__private::de::Content::Bytes(__value);
             }),
+            Some(quote! {
+                let __value = _serde::__private::de::Content::I8(__value);
+            }),
+            Some(quote! {
+                let __value = _serde::__private::de::Content::I16(__value);
+            }),
+            Some(quote! {
+                let __value = _serde::__private::de::Content::I32(__value);
+            }),
+            Some(quote! {
+                let __value = _serde::__private::de::Content::I64(__value);
+            }),
+            Some(quote! {
+                let __value = _serde::__private::de::Content::U8(__value);
+            }),
+            Some(quote! {
+                let __value = _serde::__private::de::Content::U16(__value);
+            }),
+            Some(quote! {
+                let __value = _serde::__private::de::Content::U32(__value);
+            }),
+            Some(quote! {
+                let __value = _serde::__private::de::Content::U64(__value);
+            }),
         )
     } else {
-        (None, None, None, None)
+        (
+            None, None, None, None, None, None, None, None, None, None, None, None,
+        )
     };
 
     let fallthrough_arm_tokens;
@@ -2164,76 +2201,12 @@ fn deserialize_identifier(
     };
 
     let visit_other = if collect_other_fields {
-        quote! {
+        Some(quote! {
             fn visit_bool<__E>(self, __value: bool) -> _serde::__private::Result<Self::Value, __E>
             where
                 __E: _serde::de::Error,
             {
                 let __value = _serde::__private::de::Content::Bool(__value);
-                #fallthrough
-            }
-
-            fn visit_i8<__E>(self, __value: i8) -> _serde::__private::Result<Self::Value, __E>
-            where
-                __E: _serde::de::Error,
-            {
-                let __value = _serde::__private::de::Content::I8(__value);
-                #fallthrough
-            }
-
-            fn visit_i16<__E>(self, __value: i16) -> _serde::__private::Result<Self::Value, __E>
-            where
-                __E: _serde::de::Error,
-            {
-                let __value = _serde::__private::de::Content::I16(__value);
-                #fallthrough
-            }
-
-            fn visit_i32<__E>(self, __value: i32) -> _serde::__private::Result<Self::Value, __E>
-            where
-                __E: _serde::de::Error,
-            {
-                let __value = _serde::__private::de::Content::I32(__value);
-                #fallthrough
-            }
-
-            fn visit_i64<__E>(self, __value: i64) -> _serde::__private::Result<Self::Value, __E>
-            where
-                __E: _serde::de::Error,
-            {
-                let __value = _serde::__private::de::Content::I64(__value);
-                #fallthrough
-            }
-
-            fn visit_u8<__E>(self, __value: u8) -> _serde::__private::Result<Self::Value, __E>
-            where
-                __E: _serde::de::Error,
-            {
-                let __value = _serde::__private::de::Content::U8(__value);
-                #fallthrough
-            }
-
-            fn visit_u16<__E>(self, __value: u16) -> _serde::__private::Result<Self::Value, __E>
-            where
-                __E: _serde::de::Error,
-            {
-                let __value = _serde::__private::de::Content::U16(__value);
-                #fallthrough
-            }
-
-            fn visit_u32<__E>(self, __value: u32) -> _serde::__private::Result<Self::Value, __E>
-            where
-                __E: _serde::de::Error,
-            {
-                let __value = _serde::__private::de::Content::U32(__value);
-                #fallthrough
-            }
-
-            fn visit_u64<__E>(self, __value: u64) -> _serde::__private::Result<Self::Value, __E>
-            where
-                __E: _serde::de::Error,
-            {
-                let __value = _serde::__private::de::Content::U64(__value);
                 #fallthrough
             }
 
@@ -2267,6 +2240,76 @@ fn deserialize_identifier(
             {
                 let __value = _serde::__private::de::Content::Unit;
                 #fallthrough
+            }
+        })
+    } else {
+        None
+    };
+
+    let visit_int = if collect_other_fields || has_int_rename {
+        quote! {
+            fn visit_i8<__E>(self, __value: i8) -> _serde::__private::Result<Self::Value, __E>
+            where
+                __E: _serde::de::Error,
+            {
+                #value_as_i8_content
+                #fallthrough_arm
+            }
+
+            fn visit_i16<__E>(self, __value: i16) -> _serde::__private::Result<Self::Value, __E>
+            where
+                __E: _serde::de::Error,
+            {
+                #value_as_i16_content
+                #fallthrough_arm
+            }
+
+            fn visit_i32<__E>(self, __value: i32) -> _serde::__private::Result<Self::Value, __E>
+            where
+                __E: _serde::de::Error,
+            {
+                #value_as_i32_content
+                #fallthrough_arm
+            }
+
+            fn visit_i64<__E>(self, __value: i64) -> _serde::__private::Result<Self::Value, __E>
+            where
+                __E: _serde::de::Error,
+            {
+                #value_as_i64_content
+                #fallthrough_arm
+            }
+
+            fn visit_u8<__E>(self, __value: u8) -> _serde::__private::Result<Self::Value, __E>
+            where
+                __E: _serde::de::Error,
+            {
+                #value_as_u8_content
+                #fallthrough_arm
+            }
+
+            fn visit_u16<__E>(self, __value: u16) -> _serde::__private::Result<Self::Value, __E>
+            where
+                __E: _serde::de::Error,
+            {
+                #value_as_u16_content
+                #fallthrough_arm
+            }
+
+            fn visit_u32<__E>(self, __value: u32) -> _serde::__private::Result<Self::Value, __E>
+            where
+                __E: _serde::de::Error,
+            {
+                #value_as_u32_content
+                #fallthrough_arm
+            }
+
+            fn visit_u64<__E>(self, __value: u64) -> _serde::__private::Result<Self::Value, __E>
+            where
+                __E: _serde::de::Error,
+            {
+                #value_as_u64_content
+                #fallthrough_arm
             }
         }
     } else {
@@ -2350,6 +2393,7 @@ fn deserialize_identifier(
         }
 
         #visit_other
+        #visit_int
 
         fn visit_str<__E>(self, __value: &str) -> _serde::__private::Result<Self::Value, __E>
         where
@@ -2440,11 +2484,22 @@ fn deserialize_struct_as_map_visitor(
         })
         .collect();
 
+    let fields_stmt = if cattrs.deny_unknown_fields() {
+        let field_names = field_names_idents
+            .iter()
+            .map(|(name, _, _)| name.to_string());
+        Some(quote_block! {
+            const FIELDS: &'static [&'static str] = &[ #(#field_names),* ];
+        })
+    } else {
+        None
+    };
+
     let field_visitor = deserialize_generated_identifier(&field_names_idents, cattrs, false, None);
 
     let visit_map = deserialize_map(struct_path, params, fields, cattrs);
 
-    (field_visitor, None, visit_map)
+    (field_visitor, fields_stmt, visit_map)
 }
 
 fn deserialize_map(
@@ -2488,7 +2543,7 @@ fn deserialize_map(
         .iter()
         .filter(|&&(field, _)| !field.attrs.skip_deserializing() && !field.attrs.flatten())
         .map(|(field, name)| {
-            let deser_name = field.attrs.name().deserialize_name();
+            let deser_name = field.attrs.name().deserialize_name().to_string();
 
             let visit = match field.attrs.deserialize_with() {
                 None => {
@@ -2729,7 +2784,7 @@ fn deserialize_map_in_place(
         .iter()
         .filter(|&&(field, _)| !field.attrs.skip_deserializing())
         .map(|(field, name)| {
-            let deser_name = field.attrs.name().deserialize_name();
+            let deser_name = field.attrs.name().deserialize_name().to_string();
             let member = &field.member;
 
             let visit = match field.attrs.deserialize_with() {
@@ -2983,7 +3038,7 @@ fn expr_is_missing(field: &Field, cattrs: &attr::Container) -> Fragment {
         attr::Default::None => { /* below */ }
     }
 
-    let name = field.attrs.name().deserialize_name();
+    let name = field.attrs.name().deserialize_name().to_string();
     match field.attrs.deserialize_with() {
         None => {
             let span = field.original.span();

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1911,20 +1911,20 @@ fn deserialize_generated_identifier(
     let field_idents: &Vec<_> = &fields.iter().map(|(_, ident, _)| ident).collect();
     let collect_other_fields = !is_variant && cattrs.has_flatten();
 
-    let (ignore_variant, fallthrough) = if collect_other_fields {
-        let ignore_variant = quote!(__other(_serde::__private::de::Content<'de>),);
+    let (catchall_variant, fallthrough) = if collect_other_fields {
+        let catchall_variant = quote!(__other(_serde::__private::de::Content<'de>),);
         let fallthrough = quote!(_serde::__private::Ok(__Field::__other(__value)));
-        (Some(ignore_variant), Some(fallthrough))
+        (Some(catchall_variant), Some(fallthrough))
     } else if let Some(other_idx) = other_idx {
-        let ignore_variant = fields[other_idx].1.clone();
-        let fallthrough = quote!(_serde::__private::Ok(__Field::#ignore_variant));
+        let catchall_variant = fields[other_idx].1.clone();
+        let fallthrough = quote!(_serde::__private::Ok(__Field::#catchall_variant));
         (None, Some(fallthrough))
     } else if is_variant || cattrs.deny_unknown_fields() {
         (None, None)
     } else {
-        let ignore_variant = quote!(__ignore,);
+        let catchall_variant = quote!(__ignore,);
         let fallthrough = quote!(_serde::__private::Ok(__Field::__ignore));
-        (Some(ignore_variant), Some(fallthrough))
+        (Some(catchall_variant), Some(fallthrough))
     };
 
     let visitor_impl = Stmts(deserialize_identifier(
@@ -1947,7 +1947,7 @@ fn deserialize_generated_identifier(
         #[allow(non_camel_case_types)]
         enum __Field #lifetime {
             #(#field_idents,)*
-            #ignore_variant
+            #catchall_variant
         }
 
         struct __FieldVisitor;

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1902,7 +1902,7 @@ fn deserialize_untagged_newtype_variant(
 }
 
 fn deserialize_generated_identifier(
-    fields: &[(String, Ident, Vec<String>)],
+    fields: &[(attr::NameType, Ident, Vec<attr::NameType>)],
     cattrs: &attr::Container,
     is_variant: bool,
     other_idx: Option<usize>,
@@ -2084,7 +2084,7 @@ fn deserialize_custom_identifier(
 
 fn deserialize_identifier(
     this: &TokenStream,
-    fields: &[(String, Ident, Vec<String>)],
+    fields: &[(attr::NameType, Ident, Vec<attr::NameType>)],
     is_variant: bool,
     fallthrough: Option<TokenStream>,
     fallthrough_borrowed: Option<TokenStream>,
@@ -2096,10 +2096,13 @@ fn deserialize_identifier(
         flat_fields.extend(aliases.iter().map(|alias| (alias, ident)));
     }
 
-    let field_strs: &Vec<_> = &flat_fields.iter().map(|(name, _)| name).collect();
-    let field_bytes: &Vec<_> = &flat_fields
+    let field_strs: &Vec<_> = &flat_fields
         .iter()
-        .map(|(name, _)| Literal::byte_string(name.as_bytes()))
+        .filter_map(|(name, _)| name.as_str())
+        .collect();
+    let field_bytes: &Vec<_> = &field_strs
+        .iter()
+        .map(|name| Literal::byte_string(name.as_bytes()))
         .collect();
 
     let constructors: &Vec<_> = &flat_fields

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -2166,91 +2166,104 @@ fn deserialize_identifier(
             where
                 __E: _serde::de::Error,
             {
-                _serde::__private::Ok(__Field::__other(_serde::__private::de::Content::Bool(__value)))
+                let __value = _serde::__private::de::Content::Bool(__value);
+                #fallthrough
             }
 
             fn visit_i8<__E>(self, __value: i8) -> _serde::__private::Result<Self::Value, __E>
             where
                 __E: _serde::de::Error,
             {
-                _serde::__private::Ok(__Field::__other(_serde::__private::de::Content::I8(__value)))
+                let __value = _serde::__private::de::Content::I8(__value);
+                #fallthrough
             }
 
             fn visit_i16<__E>(self, __value: i16) -> _serde::__private::Result<Self::Value, __E>
             where
                 __E: _serde::de::Error,
             {
-                _serde::__private::Ok(__Field::__other(_serde::__private::de::Content::I16(__value)))
+                let __value = _serde::__private::de::Content::I16(__value);
+                #fallthrough
             }
 
             fn visit_i32<__E>(self, __value: i32) -> _serde::__private::Result<Self::Value, __E>
             where
                 __E: _serde::de::Error,
             {
-                _serde::__private::Ok(__Field::__other(_serde::__private::de::Content::I32(__value)))
+                let __value = _serde::__private::de::Content::I32(__value);
+                #fallthrough
             }
 
             fn visit_i64<__E>(self, __value: i64) -> _serde::__private::Result<Self::Value, __E>
             where
                 __E: _serde::de::Error,
             {
-                _serde::__private::Ok(__Field::__other(_serde::__private::de::Content::I64(__value)))
+                let __value = _serde::__private::de::Content::I64(__value);
+                #fallthrough
             }
 
             fn visit_u8<__E>(self, __value: u8) -> _serde::__private::Result<Self::Value, __E>
             where
                 __E: _serde::de::Error,
             {
-                _serde::__private::Ok(__Field::__other(_serde::__private::de::Content::U8(__value)))
+                let __value = _serde::__private::de::Content::U8(__value);
+                #fallthrough
             }
 
             fn visit_u16<__E>(self, __value: u16) -> _serde::__private::Result<Self::Value, __E>
             where
                 __E: _serde::de::Error,
             {
-                _serde::__private::Ok(__Field::__other(_serde::__private::de::Content::U16(__value)))
+                let __value = _serde::__private::de::Content::U16(__value);
+                #fallthrough
             }
 
             fn visit_u32<__E>(self, __value: u32) -> _serde::__private::Result<Self::Value, __E>
             where
                 __E: _serde::de::Error,
             {
-                _serde::__private::Ok(__Field::__other(_serde::__private::de::Content::U32(__value)))
+                let __value = _serde::__private::de::Content::U32(__value);
+                #fallthrough
             }
 
             fn visit_u64<__E>(self, __value: u64) -> _serde::__private::Result<Self::Value, __E>
             where
                 __E: _serde::de::Error,
             {
-                _serde::__private::Ok(__Field::__other(_serde::__private::de::Content::U64(__value)))
+                let __value = _serde::__private::de::Content::U64(__value);
+                #fallthrough
             }
 
             fn visit_f32<__E>(self, __value: f32) -> _serde::__private::Result<Self::Value, __E>
             where
                 __E: _serde::de::Error,
             {
-                _serde::__private::Ok(__Field::__other(_serde::__private::de::Content::F32(__value)))
+                let __value = _serde::__private::de::Content::F32(__value);
+                #fallthrough
             }
 
             fn visit_f64<__E>(self, __value: f64) -> _serde::__private::Result<Self::Value, __E>
             where
                 __E: _serde::de::Error,
             {
-                _serde::__private::Ok(__Field::__other(_serde::__private::de::Content::F64(__value)))
+                let __value = _serde::__private::de::Content::F64(__value);
+                #fallthrough
             }
 
             fn visit_char<__E>(self, __value: char) -> _serde::__private::Result<Self::Value, __E>
             where
                 __E: _serde::de::Error,
             {
-                _serde::__private::Ok(__Field::__other(_serde::__private::de::Content::Char(__value)))
+                let __value = _serde::__private::de::Content::Char(__value);
+                #fallthrough
             }
 
             fn visit_unit<__E>(self) -> _serde::__private::Result<Self::Value, __E>
             where
                 __E: _serde::de::Error,
             {
-                _serde::__private::Ok(__Field::__other(_serde::__private::de::Content::Unit))
+                let __value = _serde::__private::de::Content::Unit;
+                #fallthrough
             }
         }
     } else {

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1909,8 +1909,9 @@ fn deserialize_generated_identifier(
 ) -> Fragment {
     let this = quote!(__Field);
     let field_idents: &Vec<_> = &fields.iter().map(|(_, ident, _)| ident).collect();
+    let collect_other_fields = !is_variant && cattrs.has_flatten();
 
-    let (ignore_variant, fallthrough) = if !is_variant && cattrs.has_flatten() {
+    let (ignore_variant, fallthrough) = if collect_other_fields {
         let ignore_variant = quote!(__other(_serde::__private::de::Content<'de>),);
         let fallthrough = quote!(_serde::__private::Ok(__Field::__other(__value)));
         (Some(ignore_variant), Some(fallthrough))
@@ -1932,11 +1933,11 @@ fn deserialize_generated_identifier(
         is_variant,
         fallthrough,
         None,
-        !is_variant && cattrs.has_flatten(),
+        collect_other_fields,
         None,
     ));
 
-    let lifetime = if !is_variant && cattrs.has_flatten() {
+    let lifetime = if collect_other_fields {
         Some(quote!(<'de>))
     } else {
         None

--- a/serde_derive/src/internals/ast.rs
+++ b/serde_derive/src/internals/ast.rs
@@ -80,6 +80,7 @@ impl<'a> Container<'a> {
         };
 
         let mut has_flatten = false;
+        let mut has_int_rename = false;
         match &mut data {
             Data::Enum(variants) => {
                 for variant in variants {
@@ -100,12 +101,22 @@ impl<'a> Container<'a> {
                         has_flatten = true;
                     }
                     field.attrs.rename_by_rules(attrs.rename_all_rules());
+                    if field.attrs.name().serialize_name().is_int()
+                        || field.attrs.name().deserialize_name().is_int()
+                        || field.attrs.aliases().iter().any(|name| name.is_int())
+                    {
+                        has_int_rename = true;
+                    }
                 }
             }
         }
 
         if has_flatten {
             attrs.mark_has_flatten();
+        }
+
+        if has_int_rename {
+            attrs.mark_has_int_rename();
         }
 
         let mut item = Container {

--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -5,6 +5,7 @@ use proc_macro2::{Spacing, Span, TokenStream, TokenTree};
 use quote::ToTokens;
 use std::borrow::Cow;
 use std::collections::BTreeSet;
+use std::fmt;
 use syn;
 use syn::parse::{self, Parse, ParseStream};
 use syn::punctuated::Punctuated;
@@ -144,6 +145,14 @@ impl NameType {
         match self {
             Self::Str(s) => Some(s),
             _ => None,
+        }
+    }
+}
+
+impl fmt::Display for NameType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Str(s) => write!(f, "{}", s),
         }
     }
 }

--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -701,6 +701,10 @@ impl Container {
     pub fn expecting(&self) -> Option<&str> {
         self.expecting.as_ref().map(String::as_ref)
     }
+
+    pub fn struct_as_map(&self) -> bool {
+        self.has_flatten()
+    }
 }
 
 fn decide_tag(

--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -244,6 +244,7 @@ pub struct Container {
     remote: Option<syn::Path>,
     identifier: Identifier,
     has_flatten: bool,
+    has_int_rename: bool,
     serde_path: Option<syn::Path>,
     is_packed: bool,
     /// Error message generated when type can't be deserialized
@@ -640,6 +641,7 @@ impl Container {
             remote: remote.get(),
             identifier: decide_identifier(cx, item, field_identifier, variant_identifier),
             has_flatten: false,
+            has_int_rename: false,
             serde_path: serde_path.get(),
             is_packed,
             expecting: expecting.get(),
@@ -710,6 +712,14 @@ impl Container {
         self.has_flatten = true;
     }
 
+    pub fn has_int_rename(&self) -> bool {
+        self.has_int_rename
+    }
+
+    pub fn mark_has_int_rename(&mut self) {
+        self.has_int_rename = true
+    }
+
     pub fn custom_serde_path(&self) -> Option<&syn::Path> {
         self.serde_path.as_ref()
     }
@@ -726,7 +736,7 @@ impl Container {
     }
 
     pub fn struct_as_map(&self) -> bool {
-        self.has_flatten()
+        self.has_flatten() || self.has_int_rename()
     }
 }
 

--- a/serde_derive/src/internals/check.rs
+++ b/serde_derive/src/internals/check.rs
@@ -1,5 +1,5 @@
 use internals::ast::{Container, Data, Field, Style};
-use internals::attr::{Identifier, TagType};
+use internals::attr::{Identifier, NameType, TagType};
 use internals::{ungroup, Ctxt, Derive};
 use syn::{Member, Type};
 
@@ -270,17 +270,24 @@ fn check_internal_tag_field_name_conflict(cx: &Ctxt, cont: &Container) {
                     let check_ser = !field.attrs.skip_serializing();
                     let check_de = !field.attrs.skip_deserializing();
                     let name = field.attrs.name();
-                    let ser_name = name.serialize_name();
 
-                    if check_ser && ser_name == tag {
-                        diagnose_conflict();
-                        return;
+                    if check_ser {
+                        if let NameType::Str(ser_name) = name.serialize_name() {
+                            if ser_name == tag {
+                                diagnose_conflict();
+                                return;
+                            }
+                        }
                     }
 
-                    for de_name in field.attrs.aliases() {
-                        if check_de && de_name == tag {
-                            diagnose_conflict();
-                            return;
+                    if check_de {
+                        for de_name in field.attrs.aliases() {
+                            if let NameType::Str(de_name) = de_name {
+                                if de_name == tag {
+                                    diagnose_conflict();
+                                    return;
+                                }
+                            }
                         }
                     }
                 }

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -296,7 +296,7 @@ fn serialize_tuple_struct(
 fn serialize_struct(params: &Parameters, fields: &[Field], cattrs: &attr::Container) -> Fragment {
     assert!(fields.len() as u64 <= u64::from(u32::max_value()));
 
-    if cattrs.has_flatten() {
+    if cattrs.struct_as_map() {
         serialize_struct_as_map(params, fields, cattrs)
     } else {
         serialize_struct_as_struct(params, fields, cattrs)

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -1140,7 +1140,7 @@ fn serialize_struct_visitor(
             } else {
                 let func = struct_trait.serialize_field(span);
                 quote! {
-                    try!(#func(&mut __serde_state, #key_expr, #field_expr));
+                    try!(#func(&mut __serde_state, &#key_expr, #field_expr));
                 }
             };
 

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -500,8 +500,14 @@ fn serialize_externally_tagged_variant(
     variant_index: u32,
     cattrs: &attr::Container,
 ) -> Fragment {
-    let type_name = cattrs.name().serialize_name();
-    let variant_name = variant.attrs.name().serialize_name();
+    let type_name = cattrs.name().serialize_name().as_str().unwrap().to_string();
+    let variant_name = variant
+        .attrs
+        .name()
+        .serialize_name()
+        .as_str()
+        .unwrap()
+        .to_string();
 
     if let Some(path) = variant.attrs.serialize_with() {
         let ser = wrap_serialize_variant_with(params, path, variant);
@@ -573,8 +579,14 @@ fn serialize_internally_tagged_variant(
     cattrs: &attr::Container,
     tag: &str,
 ) -> Fragment {
-    let type_name = cattrs.name().serialize_name();
-    let variant_name = variant.attrs.name().serialize_name();
+    let type_name = cattrs.name().serialize_name().as_str().unwrap().to_string();
+    let variant_name = variant
+        .attrs
+        .name()
+        .serialize_name()
+        .as_str()
+        .unwrap()
+        .to_string();
 
     let enum_ident_str = params.type_name();
     let variant_ident_str = variant.ident.to_string();
@@ -641,8 +653,14 @@ fn serialize_adjacently_tagged_variant(
     content: &str,
 ) -> Fragment {
     let this = &params.this;
-    let type_name = cattrs.name().serialize_name();
-    let variant_name = variant.attrs.name().serialize_name();
+    let type_name = cattrs.name().serialize_name().as_str().unwrap().to_string();
+    let variant_name = variant
+        .attrs
+        .name()
+        .serialize_name()
+        .as_str()
+        .unwrap()
+        .to_string();
 
     let inner = Stmts(if let Some(path) = variant.attrs.serialize_with() {
         let ser = wrap_serialize_variant_with(params, path, variant);
@@ -780,7 +798,7 @@ fn serialize_untagged_variant(
         }
         Style::Tuple => serialize_tuple_variant(TupleVariant::Untagged, params, &variant.fields),
         Style::Struct => {
-            let type_name = cattrs.name().serialize_name();
+            let type_name = cattrs.name().serialize_name().as_str().unwrap().to_string();
             serialize_struct_variant(StructVariant::Untagged, params, &variant.fields, &type_name)
         }
     }

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -644,6 +644,352 @@ fn test_unknown_field_rename_struct() {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename = "IgnoredRename")]
+struct IntRenameStruct {
+    a1: i32,
+    #[serde(rename = 12i8)]
+    a2: i32,
+    #[serde(rename = -598i16)]
+    a3: i32,
+    #[serde(rename = 18435)]
+    a4: i32,
+    #[serde(rename = 592734i32)]
+    a5: i32,
+    #[serde(rename = 123123123123123123i64)]
+    a6: i32,
+    #[serde(rename = 73u8)]
+    a7: i32,
+    #[serde(rename = 598u16)]
+    a8: i32,
+    #[serde(rename = 26547u32)]
+    a9: i32,
+    #[serde(rename = 12312312312312312312u64)]
+    a10: i32,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename(serialize = "IgnoredSerRename", deserialize = "IgnoredDeRename"))]
+struct IntRenameStructSerializeDeserialize {
+    a1: i32,
+    #[serde(rename(serialize = -301, deserialize = 660u16))]
+    a2: i32,
+    #[serde(rename(serialize = 618, deserialize = "a12"))]
+    a3: i32,
+    #[serde(rename(serialize = "a13", deserialize = 320u16))]
+    a4: i32,
+}
+
+#[derive(Debug, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct IntAliasStruct {
+    a1: i32,
+    #[serde(alias = -50i64)]
+    a2: i32,
+    #[serde(alias = 77, rename = "a6")]
+    a4: i32,
+    #[serde(alias = "a7", rename = -8)]
+    a5: i32,
+}
+
+#[derive(Debug, PartialEq, Deserialize)]
+struct IntRenameDuplication {
+    #[serde(rename = 487i16)]
+    a1: i32,
+    #[serde(rename = 487u64)]
+    a2: i32,
+}
+
+#[test]
+fn test_int_rename_struct() {
+    assert_tokens(
+        &IntRenameStruct {
+            a1: 1,
+            a2: 2,
+            a3: 3,
+            a4: 4,
+            a5: 5,
+            a6: 6,
+            a7: 7,
+            a8: 8,
+            a9: 9,
+            a10: 10,
+        },
+        &[
+            Token::Map { len: Some(10) },
+            Token::Str("a1"),
+            Token::I32(1),
+            Token::I8(12),
+            Token::I32(2),
+            Token::I16(-598),
+            Token::I32(3),
+            Token::I32(18435),
+            Token::I32(4),
+            Token::I32(592734),
+            Token::I32(5),
+            Token::I64(123123123123123123),
+            Token::I32(6),
+            Token::U8(73),
+            Token::I32(7),
+            Token::U16(598),
+            Token::I32(8),
+            Token::U32(26547),
+            Token::I32(9),
+            Token::U64(12312312312312312312),
+            Token::I32(10),
+            Token::MapEnd,
+        ],
+    );
+
+    assert_de_tokens(
+        &IntRenameStruct {
+            a1: 1,
+            a2: 2,
+            a3: 3,
+            a4: 4,
+            a5: 5,
+            a6: 6,
+            a7: 7,
+            a8: 8,
+            a9: 9,
+            a10: 10,
+        },
+        &[
+            Token::Map { len: Some(10) },
+            Token::Str("a1"),
+            Token::I32(1),
+            Token::U64(12),
+            Token::I32(2),
+            Token::I32(-598),
+            Token::I32(3),
+            Token::U32(18435),
+            Token::I32(4),
+            Token::I64(592734),
+            Token::I32(5),
+            Token::U64(123123123123123123),
+            Token::I32(6),
+            Token::I8(73),
+            Token::I32(7),
+            Token::I16(598),
+            Token::I32(8),
+            Token::U64(26547),
+            Token::I32(9),
+            Token::U64(12312312312312312312),
+            Token::I32(10),
+            Token::MapEnd,
+        ],
+    );
+
+    assert_ser_tokens(
+        &IntRenameStructSerializeDeserialize {
+            a1: 1,
+            a2: 2,
+            a3: 3,
+            a4: 4,
+        },
+        &[
+            Token::Map { len: Some(4) },
+            Token::Str("a1"),
+            Token::I32(1),
+            Token::I32(-301),
+            Token::I32(2),
+            Token::I32(618),
+            Token::I32(3),
+            Token::Str("a13"),
+            Token::I32(4),
+            Token::MapEnd,
+        ],
+    );
+
+    assert_de_tokens(
+        &IntRenameStructSerializeDeserialize {
+            a1: 1,
+            a2: 2,
+            a3: 3,
+            a4: 4,
+        },
+        &[
+            Token::Map { len: Some(4) },
+            Token::Str("a1"),
+            Token::I32(1),
+            Token::U16(660),
+            Token::I32(2),
+            Token::Str("a12"),
+            Token::I32(3),
+            Token::U16(320),
+            Token::I32(4),
+            Token::MapEnd,
+        ],
+    );
+
+    assert_de_tokens(
+        &IntAliasStruct {
+            a1: 1,
+            a2: 2,
+            a4: 3,
+            a5: 4,
+        },
+        &[
+            Token::Map { len: Some(3) },
+            Token::Str("a1"),
+            Token::I32(1),
+            Token::I64(-50),
+            Token::I32(2),
+            Token::Str("a6"),
+            Token::I32(3),
+            Token::I32(-8),
+            Token::I32(4),
+            Token::MapEnd,
+        ],
+    );
+
+    assert_de_tokens(
+        &IntAliasStruct {
+            a1: 1,
+            a2: 2,
+            a4: 3,
+            a5: 4,
+        },
+        &[
+            Token::Map { len: Some(3) },
+            Token::Str("a1"),
+            Token::I32(1),
+            Token::Str("a2"),
+            Token::I32(2),
+            Token::I32(77),
+            Token::I32(3),
+            Token::Str("a7"),
+            Token::I32(4),
+            Token::MapEnd,
+        ],
+    );
+}
+
+#[test]
+fn test_unknown_field_int_rename_struct() {
+    assert_de_tokens_error::<IntAliasStruct>(
+        &[
+            Token::Map { len: Some(4) },
+            Token::Str("a1"),
+            Token::I32(1),
+            Token::I64(-50),
+            Token::I32(2),
+            Token::Str("a4"),
+            Token::I32(3),
+        ],
+        "unknown field `a4`, expected one of `a1`, `a2`, `a6`, `-8`",
+    );
+
+    assert_de_tokens_error::<IntAliasStruct>(
+        &[
+            Token::Map { len: Some(4) },
+            Token::Str("a1"),
+            Token::I32(1),
+            Token::I64(-50),
+            Token::I32(2),
+            Token::Str("a6"),
+            Token::I32(3),
+            Token::I32(120),
+            Token::I32(4),
+        ],
+        "unknown field `120`, expected one of `a1`, `a2`, `a6`, `-8`",
+    );
+}
+
+#[test]
+fn test_duplicate_field_int_rename_struct() {
+    assert_de_tokens_error::<IntRenameDuplication>(
+        &[
+            Token::Map { len: Some(2) },
+            Token::I16(487),
+            Token::I32(1),
+            Token::I64(487),
+            Token::I32(2),
+        ],
+        "duplicate field `487`",
+    );
+}
+
+#[test]
+fn test_missing_field_int_rename_struct() {
+    assert_de_tokens_error::<IntAliasStruct>(
+        &[
+            Token::Map { len: Some(1) },
+            Token::Str("a1"),
+            Token::I32(1),
+            Token::I64(-50),
+            Token::I32(2),
+            Token::Str("a6"),
+            Token::I32(3),
+            Token::MapEnd,
+        ],
+        "missing field `-8`",
+    );
+}
+
+#[test]
+fn test_flatten_with_int_rename_struct() {
+    #[derive(Debug, PartialEq, Deserialize)]
+    struct StructStringKeyMap {
+        #[serde(rename = 4)]
+        a1: i32,
+        #[serde(flatten)]
+        a2: BTreeMap<String, String>,
+    }
+
+    assert_de_tokens(
+        &StructStringKeyMap {
+            a1: 1,
+            a2: {
+                let mut a2 = BTreeMap::new();
+                a2.insert("x".to_owned(), "X".to_owned());
+                a2.insert("y".to_owned(), "Y".to_owned());
+                a2
+            },
+        },
+        &[
+            Token::Map { len: Some(4) },
+            Token::I32(4),
+            Token::I32(1),
+            Token::Str("x"),
+            Token::Str("X"),
+            Token::Str("y"),
+            Token::Str("Y"),
+            Token::MapEnd,
+        ],
+    );
+
+    #[derive(Debug, PartialEq, Deserialize)]
+    struct StructIntKeyMap {
+        #[serde(rename = 0)]
+        a1: String,
+        #[serde(flatten)]
+        a2: BTreeMap<i32, String>,
+    }
+
+    assert_de_tokens(
+        &StructIntKeyMap {
+            a1: "V".to_owned(),
+            a2: {
+                let mut a2 = BTreeMap::new();
+                a2.insert(14, "X".to_owned());
+                a2.insert(-12, "Y".to_owned());
+                a2
+            },
+        },
+        &[
+            Token::Map { len: Some(4) },
+            Token::I32(0),
+            Token::Str("V"),
+            Token::I32(14),
+            Token::Str("X"),
+            Token::I32(-12),
+            Token::Str("Y"),
+            Token::MapEnd,
+        ],
+    );
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename = "Superhero")]
 enum RenameEnum {
     #[serde(rename = "bruce_wayne")]

--- a/test_suite/tests/ui/expected-string/boolean.stderr
+++ b/test_suite/tests/ui/expected-string/boolean.stderr
@@ -1,4 +1,4 @@
-error: expected serde rename attribute to be a string: `rename = "..."`
+error: expected serde rename attribute to be a string or integer: `rename = ...`
  --> tests/ui/expected-string/boolean.rs:5:22
   |
 5 |     #[serde(rename = true)]

--- a/test_suite/tests/ui/expected-string/byte_character.stderr
+++ b/test_suite/tests/ui/expected-string/byte_character.stderr
@@ -1,4 +1,4 @@
-error: expected serde rename attribute to be a string: `rename = "..."`
+error: expected serde rename attribute to be a string or integer: `rename = ...`
  --> tests/ui/expected-string/byte_character.rs:5:22
   |
 5 |     #[serde(rename = b'a')]

--- a/test_suite/tests/ui/expected-string/byte_string.stderr
+++ b/test_suite/tests/ui/expected-string/byte_string.stderr
@@ -1,4 +1,4 @@
-error: expected serde rename attribute to be a string: `rename = "..."`
+error: expected serde rename attribute to be a string or integer: `rename = ...`
  --> tests/ui/expected-string/byte_string.rs:5:22
   |
 5 |     #[serde(rename = b"byte string")]

--- a/test_suite/tests/ui/expected-string/character.stderr
+++ b/test_suite/tests/ui/expected-string/character.stderr
@@ -1,4 +1,4 @@
-error: expected serde rename attribute to be a string: `rename = "..."`
+error: expected serde rename attribute to be a string or integer: `rename = ...`
  --> tests/ui/expected-string/character.rs:5:22
   |
 5 |     #[serde(rename = 'a')]

--- a/test_suite/tests/ui/expected-string/float.stderr
+++ b/test_suite/tests/ui/expected-string/float.stderr
@@ -1,4 +1,4 @@
-error: expected serde rename attribute to be a string: `rename = "..."`
+error: expected serde rename attribute to be a string or integer: `rename = ...`
  --> tests/ui/expected-string/float.rs:5:22
   |
 5 |     #[serde(rename = 3.14)]

--- a/test_suite/tests/ui/expected-string/integer.rs
+++ b/test_suite/tests/ui/expected-string/integer.rs
@@ -2,8 +2,12 @@ use serde_derive::Serialize;
 
 #[derive(Serialize)]
 struct S {
-    #[serde(rename = 100)]
-    integer: (),
+    #[serde(rename = 100i128)]
+    signed128: (),
+    #[serde(rename = 101u128)]
+    unsigned128: (),
+    #[serde(rename = 500u8)]
+    overflow: (),
 }
 
 fn main() {}

--- a/test_suite/tests/ui/expected-string/integer.stderr
+++ b/test_suite/tests/ui/expected-string/integer.stderr
@@ -1,5 +1,17 @@
-error: expected serde rename attribute to be a string: `rename = "..."`
+error: failed to parse integer serde rename attribute: `rename = 100i128`
  --> tests/ui/expected-string/integer.rs:5:22
   |
-5 |     #[serde(rename = 100)]
-  |                      ^^^
+5 |     #[serde(rename = 100i128)]
+  |                      ^^^^^^^
+
+error: failed to parse integer serde rename attribute: `rename = 101u128`
+ --> tests/ui/expected-string/integer.rs:7:22
+  |
+7 |     #[serde(rename = 101u128)]
+  |                      ^^^^^^^
+
+error: failed to parse integer serde rename attribute: `rename = 500u8`
+ --> tests/ui/expected-string/integer.rs:9:22
+  |
+9 |     #[serde(rename = 500u8)]
+  |                      ^^^^^


### PR DESCRIPTION
Closes #1773 and related to PR #2056.

Extends the serde_rename and alias annotations on struct fields to support integer names. Any struct with an integer name is serialized as a map, similarly to structs with any flattened fields, avoiding the need for changes in existing serializer implementations.

Integer names are typed and serialized based on that type, but deserialization is only based on the integer value because deserializers often don't know the exact type of integers.

There are a few unrelated refactors at the start of the series as I was learning the project, then the bulk of the changes are to represent non-string renames (similar to #2056) and to handle the cases of deserialization.