### PR TITLE
Expose `RenameAllRules` fields for use in `serde_derive_internals`

### DIFF
--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -205,6 +205,18 @@ pub struct RenameAllRules {
     deserialize: RenameRule,
 }
 
+impl RenameAllRules {
+    #[allow(dead_code)]
+    pub fn serialize(&self) -> &RenameRule {
+        &self.serialize
+    }
+
+    #[allow(dead_code)]
+    pub fn deserialize(&self) -> &RenameRule {
+        &self.deserialize
+    }
+}
+
 /// Represents struct or enum attribute information.
 pub struct Container {
     name: Name,


### PR DESCRIPTION
One way to deal with #2237. Would this be okay?