### PR TITLE
Add constructor function for all IntoDeserializer impls

### DIFF
--- a/serde/src/de/value.rs
+++ b/serde/src/de/value.rs
@@ -128,9 +128,7 @@ where
     type Deserializer = UnitDeserializer<E>;
 
     fn into_deserializer(self) -> UnitDeserializer<E> {
-        UnitDeserializer {
-            marker: PhantomData,
-        }
+        UnitDeserializer::new()
     }
 }
 
@@ -140,6 +138,15 @@ pub struct UnitDeserializer<E> {
 }
 
 impl_copy_clone!(UnitDeserializer);
+
+impl<E> UnitDeserializer<E> {
+    #[allow(missing_docs)]
+    pub fn new() -> Self {
+        UnitDeserializer {
+            marker: PhantomData,
+        }
+    }
+}
 
 impl<'de, E> de::Deserializer<'de> for UnitDeserializer<E>
 where
@@ -236,8 +243,15 @@ macro_rules! primitive_deserializer {
             type Deserializer = $name<E>;
 
             fn into_deserializer(self) -> $name<E> {
+                $name::new(self)
+            }
+        }
+
+        impl<E> $name<E> {
+            #[allow(missing_docs)]
+            pub fn new(value: $ty) -> Self {
                 $name {
-                    value: self,
+                    value: value,
                     marker: PhantomData,
                 }
             }
@@ -308,8 +322,15 @@ where
     type Deserializer = U32Deserializer<E>;
 
     fn into_deserializer(self) -> U32Deserializer<E> {
+        U32Deserializer::new(self)
+    }
+}
+
+impl<E> U32Deserializer<E> {
+    #[allow(missing_docs)]
+    pub fn new(value: u32) -> Self {
         U32Deserializer {
-            value: self,
+            value: value,
             marker: PhantomData,
         }
     }
@@ -390,8 +411,15 @@ where
     type Deserializer = StrDeserializer<'a, E>;
 
     fn into_deserializer(self) -> StrDeserializer<'a, E> {
+        StrDeserializer::new(self)
+    }
+}
+
+impl<'a, E> StrDeserializer<'a, E> {
+    #[allow(missing_docs)]
+    pub fn new(value: &'a str) -> Self {
         StrDeserializer {
-            value: self,
+            value: value,
             marker: PhantomData,
         }
     }
@@ -561,8 +589,16 @@ where
     type Deserializer = StringDeserializer<E>;
 
     fn into_deserializer(self) -> StringDeserializer<E> {
+        StringDeserializer::new(self)
+    }
+}
+
+#[cfg(any(feature = "std", feature = "alloc"))]
+impl<E> StringDeserializer<E> {
+    #[allow(missing_docs)]
+    pub fn new(value: String) -> Self {
         StringDeserializer {
-            value: self,
+            value: value,
             marker: PhantomData,
         }
     }
@@ -656,8 +692,16 @@ where
     type Deserializer = CowStrDeserializer<'a, E>;
 
     fn into_deserializer(self) -> CowStrDeserializer<'a, E> {
+        CowStrDeserializer::new(self)
+    }
+}
+
+#[cfg(any(feature = "std", feature = "alloc"))]
+impl<'a, E> CowStrDeserializer<'a, E> {
+    #[allow(missing_docs)]
+    pub fn new(value: Cow<'a, str>) -> Self {
         CowStrDeserializer {
-            value: self,
+            value: value,
             marker: PhantomData,
         }
     }


### PR DESCRIPTION
For example `StrDeserializer::<E>::new(str)` is significantly clearer than `IntoDeserializer::<E>::into_deserializer(str)`.