### PR TITLE
Shrink derive output size

### DIFF
--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -1732,6 +1732,25 @@ pub trait SeqAccess<'de> {
         self.next_element_seed(PhantomData)
     }
 
+    /// Equivalent to calling `next_element`, and then if there are no more remaining items,
+    /// calling `Error::invalid_length`.
+    ///
+    /// This method exists purely to reduce the size of the generated code,
+    /// reducing compile times. `SeqAccess` implementations should not override
+    /// the default behavior.
+    #[doc(hidden)]
+    #[inline]
+    fn next_element_checked<T>(&mut self, len: usize, exp: &Expected) -> Result<T, Self::Error>
+    where
+        T: Deserialize<'de>,
+    {
+        match self.next_element() {
+            Ok(Some(val)) => Ok(val),
+            Ok(None) => Err(Error::invalid_length(len, exp)),
+            Err(err) => Err(err),
+        }
+    }
+
     /// Returns the number of elements remaining in the sequence, if known.
     #[inline]
     fn size_hint(&self) -> Option<usize> {

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -1890,6 +1890,28 @@ pub trait MapAccess<'de> {
         self.next_value_seed(PhantomData)
     }
 
+    /// Equivalent to calling `Error::duplicate_field` if the field has already
+    /// been deserialized, and to calling `next_value` otherwise.
+    ///
+    /// This method exists purely to reduce the size of the generated code,
+    /// reducing compile times. `MapAccess` implementations should not override
+    /// the default behavior.
+    #[doc(hidden)]
+    #[inline]
+    fn next_value_checked<V>(
+        &mut self,
+        field: &Option<V>,
+        field_name: &'static str,
+    ) -> Result<V, Self::Error>
+    where
+        V: Deserialize<'de>,
+    {
+        if field.is_some() {
+            return Err(Error::duplicate_field(field_name));
+        }
+        self.next_value()
+    }
+
     /// This returns `Ok(Some((key, value)))` for the next (key-value) pair in
     /// the map, or `Ok(None)` if there are no more remaining items.
     ///

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -15,7 +15,7 @@ pub use self::content::{
 
 pub use seed::InPlaceSeed;
 
-/// If the missing field is of type `Option<T>` then treat is as `None`,
+/// If the missing field is of type `Option<T>` then treat it as `None`,
 /// otherwise it is an error.
 pub fn missing_field<'de, V, E>(field: &'static str) -> Result<V, E>
 where
@@ -53,6 +53,23 @@ where
 
     let deserializer = MissingFieldDeserializer(field, PhantomData);
     Deserialize::deserialize(deserializer)
+}
+
+/// Equivalent to calling `missing_field` if the field has been missed, and
+/// returning its value otherwise.
+///
+/// This method exists purely to reduce the size of the generated code,
+/// reducing compile times.
+#[inline]
+pub fn missing_field_checked<'de, V, E>(value: Option<V>, name: &'static str) -> Result<V, E>
+where
+    V: Deserialize<'de>,
+    E: Error,
+{
+    match value {
+        Some(value) => Ok(value),
+        None => missing_field(name),
+    }
 }
 
 #[cfg(any(feature = "std", feature = "alloc"))]

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -677,7 +677,7 @@ fn deserialize_seq(
                 attr::Default::Default => quote!(_serde::__private::Default::default()),
                 attr::Default::Path(path) => quote!(#path()),
                 attr::Default::None => quote!(
-                    return _serde::__private::Err(_serde::de::Error::invalid_length(#index_in_seq, &#expecting));
+                    return _serde::__private::Err(_serde::de::Error::invalid_length(#index_in_seq, &expecting));
                 ),
             };
             let assign = quote! {
@@ -727,6 +727,7 @@ fn deserialize_seq(
 
     quote_block! {
         #let_default
+        let expecting = #expecting;
         #(#let_values)*
         _serde::__private::Ok(#result)
     }
@@ -768,7 +769,7 @@ fn deserialize_seq_in_place(
                     self.place.#member = #path();
                 ),
                 attr::Default::None => quote!(
-                    return _serde::__private::Err(_serde::de::Error::invalid_length(#index_in_seq, &#expecting));
+                    return _serde::__private::Err(_serde::de::Error::invalid_length(#index_in_seq, &expecting));
                 ),
             };
             let write = match field.attrs.deserialize_with() {
@@ -819,6 +820,7 @@ fn deserialize_seq_in_place(
 
     quote_block! {
         #let_default
+        let expecting = #expecting;
         #(#write_values)*
         _serde::__private::Ok(())
     }

--- a/test_suite/tests/expand/de_enum.expanded.rs
+++ b/test_suite/tests/expand/de_enum.expanded.rs
@@ -464,6 +464,7 @@ const _: () = {
                                 where
                                     __A: _serde::de::SeqAccess<'de>,
                                 {
+                                    let expecting = "tuple variant DeEnum::Seq with 4 elements";
                                     let __field0 = match match _serde::de::SeqAccess::next_element::<
                                         i8,
                                     >(&mut __seq) {
@@ -475,10 +476,7 @@ const _: () = {
                                         _serde::__private::Some(__value) => __value,
                                         _serde::__private::None => {
                                             return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(
-                                                    0usize,
-                                                    &"tuple variant DeEnum::Seq with 4 elements",
-                                                ),
+                                                _serde::de::Error::invalid_length(0usize, &expecting),
                                             );
                                         }
                                     };
@@ -493,10 +491,7 @@ const _: () = {
                                         _serde::__private::Some(__value) => __value,
                                         _serde::__private::None => {
                                             return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(
-                                                    1usize,
-                                                    &"tuple variant DeEnum::Seq with 4 elements",
-                                                ),
+                                                _serde::de::Error::invalid_length(1usize, &expecting),
                                             );
                                         }
                                     };
@@ -511,10 +506,7 @@ const _: () = {
                                         _serde::__private::Some(__value) => __value,
                                         _serde::__private::None => {
                                             return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(
-                                                    2usize,
-                                                    &"tuple variant DeEnum::Seq with 4 elements",
-                                                ),
+                                                _serde::de::Error::invalid_length(2usize, &expecting),
                                             );
                                         }
                                     };
@@ -529,10 +521,7 @@ const _: () = {
                                         _serde::__private::Some(__value) => __value,
                                         _serde::__private::None => {
                                             return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(
-                                                    3usize,
-                                                    &"tuple variant DeEnum::Seq with 4 elements",
-                                                ),
+                                                _serde::de::Error::invalid_length(3usize, &expecting),
                                             );
                                         }
                                     };
@@ -665,6 +654,7 @@ const _: () = {
                                 where
                                     __A: _serde::de::SeqAccess<'de>,
                                 {
+                                    let expecting = "struct variant DeEnum::Map with 4 elements";
                                     let __field0 = match match _serde::de::SeqAccess::next_element::<
                                         i8,
                                     >(&mut __seq) {
@@ -676,10 +666,7 @@ const _: () = {
                                         _serde::__private::Some(__value) => __value,
                                         _serde::__private::None => {
                                             return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(
-                                                    0usize,
-                                                    &"struct variant DeEnum::Map with 4 elements",
-                                                ),
+                                                _serde::de::Error::invalid_length(0usize, &expecting),
                                             );
                                         }
                                     };
@@ -694,10 +681,7 @@ const _: () = {
                                         _serde::__private::Some(__value) => __value,
                                         _serde::__private::None => {
                                             return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(
-                                                    1usize,
-                                                    &"struct variant DeEnum::Map with 4 elements",
-                                                ),
+                                                _serde::de::Error::invalid_length(1usize, &expecting),
                                             );
                                         }
                                     };
@@ -712,10 +696,7 @@ const _: () = {
                                         _serde::__private::Some(__value) => __value,
                                         _serde::__private::None => {
                                             return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(
-                                                    2usize,
-                                                    &"struct variant DeEnum::Map with 4 elements",
-                                                ),
+                                                _serde::de::Error::invalid_length(2usize, &expecting),
                                             );
                                         }
                                     };
@@ -730,10 +711,7 @@ const _: () = {
                                         _serde::__private::Some(__value) => __value,
                                         _serde::__private::None => {
                                             return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(
-                                                    3usize,
-                                                    &"struct variant DeEnum::Map with 4 elements",
-                                                ),
+                                                _serde::de::Error::invalid_length(3usize, &expecting),
                                             );
                                         }
                                     };
@@ -949,6 +927,7 @@ const _: () = {
                                 where
                                     __A: _serde::de::SeqAccess<'de>,
                                 {
+                                    let expecting = "tuple variant DeEnum::_Seq2 with 4 elements";
                                     let __field0 = match match _serde::de::SeqAccess::next_element::<
                                         i8,
                                     >(&mut __seq) {
@@ -960,10 +939,7 @@ const _: () = {
                                         _serde::__private::Some(__value) => __value,
                                         _serde::__private::None => {
                                             return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(
-                                                    0usize,
-                                                    &"tuple variant DeEnum::_Seq2 with 4 elements",
-                                                ),
+                                                _serde::de::Error::invalid_length(0usize, &expecting),
                                             );
                                         }
                                     };
@@ -978,10 +954,7 @@ const _: () = {
                                         _serde::__private::Some(__value) => __value,
                                         _serde::__private::None => {
                                             return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(
-                                                    1usize,
-                                                    &"tuple variant DeEnum::_Seq2 with 4 elements",
-                                                ),
+                                                _serde::de::Error::invalid_length(1usize, &expecting),
                                             );
                                         }
                                     };
@@ -996,10 +969,7 @@ const _: () = {
                                         _serde::__private::Some(__value) => __value,
                                         _serde::__private::None => {
                                             return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(
-                                                    2usize,
-                                                    &"tuple variant DeEnum::_Seq2 with 4 elements",
-                                                ),
+                                                _serde::de::Error::invalid_length(2usize, &expecting),
                                             );
                                         }
                                     };
@@ -1014,10 +984,7 @@ const _: () = {
                                         _serde::__private::Some(__value) => __value,
                                         _serde::__private::None => {
                                             return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(
-                                                    3usize,
-                                                    &"tuple variant DeEnum::_Seq2 with 4 elements",
-                                                ),
+                                                _serde::de::Error::invalid_length(3usize, &expecting),
                                             );
                                         }
                                     };
@@ -1150,6 +1117,7 @@ const _: () = {
                                 where
                                     __A: _serde::de::SeqAccess<'de>,
                                 {
+                                    let expecting = "struct variant DeEnum::_Map2 with 4 elements";
                                     let __field0 = match match _serde::de::SeqAccess::next_element::<
                                         i8,
                                     >(&mut __seq) {
@@ -1161,10 +1129,7 @@ const _: () = {
                                         _serde::__private::Some(__value) => __value,
                                         _serde::__private::None => {
                                             return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(
-                                                    0usize,
-                                                    &"struct variant DeEnum::_Map2 with 4 elements",
-                                                ),
+                                                _serde::de::Error::invalid_length(0usize, &expecting),
                                             );
                                         }
                                     };
@@ -1179,10 +1144,7 @@ const _: () = {
                                         _serde::__private::Some(__value) => __value,
                                         _serde::__private::None => {
                                             return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(
-                                                    1usize,
-                                                    &"struct variant DeEnum::_Map2 with 4 elements",
-                                                ),
+                                                _serde::de::Error::invalid_length(1usize, &expecting),
                                             );
                                         }
                                     };
@@ -1197,10 +1159,7 @@ const _: () = {
                                         _serde::__private::Some(__value) => __value,
                                         _serde::__private::None => {
                                             return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(
-                                                    2usize,
-                                                    &"struct variant DeEnum::_Map2 with 4 elements",
-                                                ),
+                                                _serde::de::Error::invalid_length(2usize, &expecting),
                                             );
                                         }
                                     };
@@ -1215,10 +1174,7 @@ const _: () = {
                                         _serde::__private::Some(__value) => __value,
                                         _serde::__private::None => {
                                             return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(
-                                                    3usize,
-                                                    &"struct variant DeEnum::_Map2 with 4 elements",
-                                                ),
+                                                _serde::de::Error::invalid_length(3usize, &expecting),
                                             );
                                         }
                                     };

--- a/test_suite/tests/expand/de_enum.expanded.rs
+++ b/test_suite/tests/expand/de_enum.expanded.rs
@@ -748,48 +748,40 @@ const _: () = {
                                             }
                                         }
                                     }
-                                    let __field0 = match __field0 {
-                                        _serde::__private::Some(__field0) => __field0,
-                                        _serde::__private::None => {
-                                            match _serde::__private::de::missing_field("a") {
-                                                _serde::__private::Ok(__val) => __val,
-                                                _serde::__private::Err(__err) => {
-                                                    return _serde::__private::Err(__err);
-                                                }
-                                            }
+                                    let __field0 = match _serde::__private::de::missing_field_checked(
+                                        __field0,
+                                        "a",
+                                    ) {
+                                        _serde::__private::Ok(__val) => __val,
+                                        _serde::__private::Err(__err) => {
+                                            return _serde::__private::Err(__err);
                                         }
                                     };
-                                    let __field1 = match __field1 {
-                                        _serde::__private::Some(__field1) => __field1,
-                                        _serde::__private::None => {
-                                            match _serde::__private::de::missing_field("b") {
-                                                _serde::__private::Ok(__val) => __val,
-                                                _serde::__private::Err(__err) => {
-                                                    return _serde::__private::Err(__err);
-                                                }
-                                            }
+                                    let __field1 = match _serde::__private::de::missing_field_checked(
+                                        __field1,
+                                        "b",
+                                    ) {
+                                        _serde::__private::Ok(__val) => __val,
+                                        _serde::__private::Err(__err) => {
+                                            return _serde::__private::Err(__err);
                                         }
                                     };
-                                    let __field2 = match __field2 {
-                                        _serde::__private::Some(__field2) => __field2,
-                                        _serde::__private::None => {
-                                            match _serde::__private::de::missing_field("c") {
-                                                _serde::__private::Ok(__val) => __val,
-                                                _serde::__private::Err(__err) => {
-                                                    return _serde::__private::Err(__err);
-                                                }
-                                            }
+                                    let __field2 = match _serde::__private::de::missing_field_checked(
+                                        __field2,
+                                        "c",
+                                    ) {
+                                        _serde::__private::Ok(__val) => __val,
+                                        _serde::__private::Err(__err) => {
+                                            return _serde::__private::Err(__err);
                                         }
                                     };
-                                    let __field3 = match __field3 {
-                                        _serde::__private::Some(__field3) => __field3,
-                                        _serde::__private::None => {
-                                            match _serde::__private::de::missing_field("d") {
-                                                _serde::__private::Ok(__val) => __val,
-                                                _serde::__private::Err(__err) => {
-                                                    return _serde::__private::Err(__err);
-                                                }
-                                            }
+                                    let __field3 = match _serde::__private::de::missing_field_checked(
+                                        __field3,
+                                        "d",
+                                    ) {
+                                        _serde::__private::Ok(__val) => __val,
+                                        _serde::__private::Err(__err) => {
+                                            return _serde::__private::Err(__err);
                                         }
                                     };
                                     _serde::__private::Ok(DeEnum::Map {
@@ -1143,48 +1135,40 @@ const _: () = {
                                             }
                                         }
                                     }
-                                    let __field0 = match __field0 {
-                                        _serde::__private::Some(__field0) => __field0,
-                                        _serde::__private::None => {
-                                            match _serde::__private::de::missing_field("a") {
-                                                _serde::__private::Ok(__val) => __val,
-                                                _serde::__private::Err(__err) => {
-                                                    return _serde::__private::Err(__err);
-                                                }
-                                            }
+                                    let __field0 = match _serde::__private::de::missing_field_checked(
+                                        __field0,
+                                        "a",
+                                    ) {
+                                        _serde::__private::Ok(__val) => __val,
+                                        _serde::__private::Err(__err) => {
+                                            return _serde::__private::Err(__err);
                                         }
                                     };
-                                    let __field1 = match __field1 {
-                                        _serde::__private::Some(__field1) => __field1,
-                                        _serde::__private::None => {
-                                            match _serde::__private::de::missing_field("b") {
-                                                _serde::__private::Ok(__val) => __val,
-                                                _serde::__private::Err(__err) => {
-                                                    return _serde::__private::Err(__err);
-                                                }
-                                            }
+                                    let __field1 = match _serde::__private::de::missing_field_checked(
+                                        __field1,
+                                        "b",
+                                    ) {
+                                        _serde::__private::Ok(__val) => __val,
+                                        _serde::__private::Err(__err) => {
+                                            return _serde::__private::Err(__err);
                                         }
                                     };
-                                    let __field2 = match __field2 {
-                                        _serde::__private::Some(__field2) => __field2,
-                                        _serde::__private::None => {
-                                            match _serde::__private::de::missing_field("c") {
-                                                _serde::__private::Ok(__val) => __val,
-                                                _serde::__private::Err(__err) => {
-                                                    return _serde::__private::Err(__err);
-                                                }
-                                            }
+                                    let __field2 = match _serde::__private::de::missing_field_checked(
+                                        __field2,
+                                        "c",
+                                    ) {
+                                        _serde::__private::Ok(__val) => __val,
+                                        _serde::__private::Err(__err) => {
+                                            return _serde::__private::Err(__err);
                                         }
                                     };
-                                    let __field3 = match __field3 {
-                                        _serde::__private::Some(__field3) => __field3,
-                                        _serde::__private::None => {
-                                            match _serde::__private::de::missing_field("d") {
-                                                _serde::__private::Ok(__val) => __val,
-                                                _serde::__private::Err(__err) => {
-                                                    return _serde::__private::Err(__err);
-                                                }
-                                            }
+                                    let __field3 = match _serde::__private::de::missing_field_checked(
+                                        __field3,
+                                        "d",
+                                    ) {
+                                        _serde::__private::Ok(__val) => __val,
+                                        _serde::__private::Err(__err) => {
+                                            return _serde::__private::Err(__err);
                                         }
                                     };
                                     _serde::__private::Ok(DeEnum::_Map2 {

--- a/test_suite/tests/expand/de_enum.expanded.rs
+++ b/test_suite/tests/expand/de_enum.expanded.rs
@@ -689,13 +689,10 @@ const _: () = {
                                         } {
                                         match __key {
                                             __Field::__field0 => {
-                                                if _serde::__private::Option::is_some(&__field0) {
-                                                    return _serde::__private::Err(
-                                                        <__A::Error as _serde::de::Error>::duplicate_field("a"),
-                                                    );
-                                                }
                                                 __field0 = _serde::__private::Some(
-                                                    match _serde::de::MapAccess::next_value::<i8>(&mut __map) {
+                                                    match _serde::de::MapAccess::next_value_checked::<
+                                                        i8,
+                                                    >(&mut __map, &__field0, "a") {
                                                         _serde::__private::Ok(__val) => __val,
                                                         _serde::__private::Err(__err) => {
                                                             return _serde::__private::Err(__err);
@@ -704,13 +701,10 @@ const _: () = {
                                                 );
                                             }
                                             __Field::__field1 => {
-                                                if _serde::__private::Option::is_some(&__field1) {
-                                                    return _serde::__private::Err(
-                                                        <__A::Error as _serde::de::Error>::duplicate_field("b"),
-                                                    );
-                                                }
                                                 __field1 = _serde::__private::Some(
-                                                    match _serde::de::MapAccess::next_value::<B>(&mut __map) {
+                                                    match _serde::de::MapAccess::next_value_checked::<
+                                                        B,
+                                                    >(&mut __map, &__field1, "b") {
                                                         _serde::__private::Ok(__val) => __val,
                                                         _serde::__private::Err(__err) => {
                                                             return _serde::__private::Err(__err);
@@ -719,13 +713,10 @@ const _: () = {
                                                 );
                                             }
                                             __Field::__field2 => {
-                                                if _serde::__private::Option::is_some(&__field2) {
-                                                    return _serde::__private::Err(
-                                                        <__A::Error as _serde::de::Error>::duplicate_field("c"),
-                                                    );
-                                                }
                                                 __field2 = _serde::__private::Some(
-                                                    match _serde::de::MapAccess::next_value::<C>(&mut __map) {
+                                                    match _serde::de::MapAccess::next_value_checked::<
+                                                        C,
+                                                    >(&mut __map, &__field2, "c") {
                                                         _serde::__private::Ok(__val) => __val,
                                                         _serde::__private::Err(__err) => {
                                                             return _serde::__private::Err(__err);
@@ -734,13 +725,10 @@ const _: () = {
                                                 );
                                             }
                                             __Field::__field3 => {
-                                                if _serde::__private::Option::is_some(&__field3) {
-                                                    return _serde::__private::Err(
-                                                        <__A::Error as _serde::de::Error>::duplicate_field("d"),
-                                                    );
-                                                }
                                                 __field3 = _serde::__private::Some(
-                                                    match _serde::de::MapAccess::next_value::<D>(&mut __map) {
+                                                    match _serde::de::MapAccess::next_value_checked::<
+                                                        D,
+                                                    >(&mut __map, &__field3, "d") {
                                                         _serde::__private::Ok(__val) => __val,
                                                         _serde::__private::Err(__err) => {
                                                             return _serde::__private::Err(__err);
@@ -1096,13 +1084,10 @@ const _: () = {
                                         } {
                                         match __key {
                                             __Field::__field0 => {
-                                                if _serde::__private::Option::is_some(&__field0) {
-                                                    return _serde::__private::Err(
-                                                        <__A::Error as _serde::de::Error>::duplicate_field("a"),
-                                                    );
-                                                }
                                                 __field0 = _serde::__private::Some(
-                                                    match _serde::de::MapAccess::next_value::<i8>(&mut __map) {
+                                                    match _serde::de::MapAccess::next_value_checked::<
+                                                        i8,
+                                                    >(&mut __map, &__field0, "a") {
                                                         _serde::__private::Ok(__val) => __val,
                                                         _serde::__private::Err(__err) => {
                                                             return _serde::__private::Err(__err);
@@ -1111,13 +1096,10 @@ const _: () = {
                                                 );
                                             }
                                             __Field::__field1 => {
-                                                if _serde::__private::Option::is_some(&__field1) {
-                                                    return _serde::__private::Err(
-                                                        <__A::Error as _serde::de::Error>::duplicate_field("b"),
-                                                    );
-                                                }
                                                 __field1 = _serde::__private::Some(
-                                                    match _serde::de::MapAccess::next_value::<B>(&mut __map) {
+                                                    match _serde::de::MapAccess::next_value_checked::<
+                                                        B,
+                                                    >(&mut __map, &__field1, "b") {
                                                         _serde::__private::Ok(__val) => __val,
                                                         _serde::__private::Err(__err) => {
                                                             return _serde::__private::Err(__err);
@@ -1126,13 +1108,10 @@ const _: () = {
                                                 );
                                             }
                                             __Field::__field2 => {
-                                                if _serde::__private::Option::is_some(&__field2) {
-                                                    return _serde::__private::Err(
-                                                        <__A::Error as _serde::de::Error>::duplicate_field("c"),
-                                                    );
-                                                }
                                                 __field2 = _serde::__private::Some(
-                                                    match _serde::de::MapAccess::next_value::<C>(&mut __map) {
+                                                    match _serde::de::MapAccess::next_value_checked::<
+                                                        C,
+                                                    >(&mut __map, &__field2, "c") {
                                                         _serde::__private::Ok(__val) => __val,
                                                         _serde::__private::Err(__err) => {
                                                             return _serde::__private::Err(__err);
@@ -1141,13 +1120,10 @@ const _: () = {
                                                 );
                                             }
                                             __Field::__field3 => {
-                                                if _serde::__private::Option::is_some(&__field3) {
-                                                    return _serde::__private::Err(
-                                                        <__A::Error as _serde::de::Error>::duplicate_field("d"),
-                                                    );
-                                                }
                                                 __field3 = _serde::__private::Some(
-                                                    match _serde::de::MapAccess::next_value::<D>(&mut __map) {
+                                                    match _serde::de::MapAccess::next_value_checked::<
+                                                        D,
+                                                    >(&mut __map, &__field3, "d") {
                                                         _serde::__private::Ok(__val) => __val,
                                                         _serde::__private::Err(__err) => {
                                                             return _serde::__private::Err(__err);

--- a/test_suite/tests/expand/de_enum.expanded.rs
+++ b/test_suite/tests/expand/de_enum.expanded.rs
@@ -465,64 +465,36 @@ const _: () = {
                                     __A: _serde::de::SeqAccess<'de>,
                                 {
                                     let expecting = "tuple variant DeEnum::Seq with 4 elements";
-                                    let __field0 = match match _serde::de::SeqAccess::next_element::<
+                                    let __field0 = match _serde::de::SeqAccess::next_element_checked::<
                                         i8,
-                                    >(&mut __seq) {
+                                    >(&mut __seq, 0usize, &expecting) {
                                         _serde::__private::Ok(__val) => __val,
                                         _serde::__private::Err(__err) => {
                                             return _serde::__private::Err(__err);
                                         }
-                                    } {
-                                        _serde::__private::Some(__value) => __value,
-                                        _serde::__private::None => {
-                                            return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(0usize, &expecting),
-                                            );
-                                        }
                                     };
-                                    let __field1 = match match _serde::de::SeqAccess::next_element::<
+                                    let __field1 = match _serde::de::SeqAccess::next_element_checked::<
                                         B,
-                                    >(&mut __seq) {
+                                    >(&mut __seq, 1usize, &expecting) {
                                         _serde::__private::Ok(__val) => __val,
                                         _serde::__private::Err(__err) => {
                                             return _serde::__private::Err(__err);
                                         }
-                                    } {
-                                        _serde::__private::Some(__value) => __value,
-                                        _serde::__private::None => {
-                                            return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(1usize, &expecting),
-                                            );
-                                        }
                                     };
-                                    let __field2 = match match _serde::de::SeqAccess::next_element::<
+                                    let __field2 = match _serde::de::SeqAccess::next_element_checked::<
                                         C,
-                                    >(&mut __seq) {
+                                    >(&mut __seq, 2usize, &expecting) {
                                         _serde::__private::Ok(__val) => __val,
                                         _serde::__private::Err(__err) => {
                                             return _serde::__private::Err(__err);
-                                        }
-                                    } {
-                                        _serde::__private::Some(__value) => __value,
-                                        _serde::__private::None => {
-                                            return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(2usize, &expecting),
-                                            );
                                         }
                                     };
-                                    let __field3 = match match _serde::de::SeqAccess::next_element::<
+                                    let __field3 = match _serde::de::SeqAccess::next_element_checked::<
                                         D,
-                                    >(&mut __seq) {
+                                    >(&mut __seq, 3usize, &expecting) {
                                         _serde::__private::Ok(__val) => __val,
                                         _serde::__private::Err(__err) => {
                                             return _serde::__private::Err(__err);
-                                        }
-                                    } {
-                                        _serde::__private::Some(__value) => __value,
-                                        _serde::__private::None => {
-                                            return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(3usize, &expecting),
-                                            );
                                         }
                                     };
                                     _serde::__private::Ok(
@@ -655,64 +627,36 @@ const _: () = {
                                     __A: _serde::de::SeqAccess<'de>,
                                 {
                                     let expecting = "struct variant DeEnum::Map with 4 elements";
-                                    let __field0 = match match _serde::de::SeqAccess::next_element::<
+                                    let __field0 = match _serde::de::SeqAccess::next_element_checked::<
                                         i8,
-                                    >(&mut __seq) {
+                                    >(&mut __seq, 0usize, &expecting) {
                                         _serde::__private::Ok(__val) => __val,
                                         _serde::__private::Err(__err) => {
                                             return _serde::__private::Err(__err);
                                         }
-                                    } {
-                                        _serde::__private::Some(__value) => __value,
-                                        _serde::__private::None => {
-                                            return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(0usize, &expecting),
-                                            );
-                                        }
                                     };
-                                    let __field1 = match match _serde::de::SeqAccess::next_element::<
+                                    let __field1 = match _serde::de::SeqAccess::next_element_checked::<
                                         B,
-                                    >(&mut __seq) {
+                                    >(&mut __seq, 1usize, &expecting) {
                                         _serde::__private::Ok(__val) => __val,
                                         _serde::__private::Err(__err) => {
                                             return _serde::__private::Err(__err);
                                         }
-                                    } {
-                                        _serde::__private::Some(__value) => __value,
-                                        _serde::__private::None => {
-                                            return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(1usize, &expecting),
-                                            );
-                                        }
                                     };
-                                    let __field2 = match match _serde::de::SeqAccess::next_element::<
+                                    let __field2 = match _serde::de::SeqAccess::next_element_checked::<
                                         C,
-                                    >(&mut __seq) {
+                                    >(&mut __seq, 2usize, &expecting) {
                                         _serde::__private::Ok(__val) => __val,
                                         _serde::__private::Err(__err) => {
                                             return _serde::__private::Err(__err);
-                                        }
-                                    } {
-                                        _serde::__private::Some(__value) => __value,
-                                        _serde::__private::None => {
-                                            return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(2usize, &expecting),
-                                            );
                                         }
                                     };
-                                    let __field3 = match match _serde::de::SeqAccess::next_element::<
+                                    let __field3 = match _serde::de::SeqAccess::next_element_checked::<
                                         D,
-                                    >(&mut __seq) {
+                                    >(&mut __seq, 3usize, &expecting) {
                                         _serde::__private::Ok(__val) => __val,
                                         _serde::__private::Err(__err) => {
                                             return _serde::__private::Err(__err);
-                                        }
-                                    } {
-                                        _serde::__private::Some(__value) => __value,
-                                        _serde::__private::None => {
-                                            return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(3usize, &expecting),
-                                            );
                                         }
                                     };
                                     _serde::__private::Ok(DeEnum::Map {
@@ -928,64 +872,36 @@ const _: () = {
                                     __A: _serde::de::SeqAccess<'de>,
                                 {
                                     let expecting = "tuple variant DeEnum::_Seq2 with 4 elements";
-                                    let __field0 = match match _serde::de::SeqAccess::next_element::<
+                                    let __field0 = match _serde::de::SeqAccess::next_element_checked::<
                                         i8,
-                                    >(&mut __seq) {
+                                    >(&mut __seq, 0usize, &expecting) {
                                         _serde::__private::Ok(__val) => __val,
                                         _serde::__private::Err(__err) => {
                                             return _serde::__private::Err(__err);
                                         }
-                                    } {
-                                        _serde::__private::Some(__value) => __value,
-                                        _serde::__private::None => {
-                                            return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(0usize, &expecting),
-                                            );
-                                        }
                                     };
-                                    let __field1 = match match _serde::de::SeqAccess::next_element::<
+                                    let __field1 = match _serde::de::SeqAccess::next_element_checked::<
                                         B,
-                                    >(&mut __seq) {
+                                    >(&mut __seq, 1usize, &expecting) {
                                         _serde::__private::Ok(__val) => __val,
                                         _serde::__private::Err(__err) => {
                                             return _serde::__private::Err(__err);
                                         }
-                                    } {
-                                        _serde::__private::Some(__value) => __value,
-                                        _serde::__private::None => {
-                                            return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(1usize, &expecting),
-                                            );
-                                        }
                                     };
-                                    let __field2 = match match _serde::de::SeqAccess::next_element::<
+                                    let __field2 = match _serde::de::SeqAccess::next_element_checked::<
                                         C,
-                                    >(&mut __seq) {
+                                    >(&mut __seq, 2usize, &expecting) {
                                         _serde::__private::Ok(__val) => __val,
                                         _serde::__private::Err(__err) => {
                                             return _serde::__private::Err(__err);
-                                        }
-                                    } {
-                                        _serde::__private::Some(__value) => __value,
-                                        _serde::__private::None => {
-                                            return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(2usize, &expecting),
-                                            );
                                         }
                                     };
-                                    let __field3 = match match _serde::de::SeqAccess::next_element::<
+                                    let __field3 = match _serde::de::SeqAccess::next_element_checked::<
                                         D,
-                                    >(&mut __seq) {
+                                    >(&mut __seq, 3usize, &expecting) {
                                         _serde::__private::Ok(__val) => __val,
                                         _serde::__private::Err(__err) => {
                                             return _serde::__private::Err(__err);
-                                        }
-                                    } {
-                                        _serde::__private::Some(__value) => __value,
-                                        _serde::__private::None => {
-                                            return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(3usize, &expecting),
-                                            );
                                         }
                                     };
                                     _serde::__private::Ok(
@@ -1118,64 +1034,36 @@ const _: () = {
                                     __A: _serde::de::SeqAccess<'de>,
                                 {
                                     let expecting = "struct variant DeEnum::_Map2 with 4 elements";
-                                    let __field0 = match match _serde::de::SeqAccess::next_element::<
+                                    let __field0 = match _serde::de::SeqAccess::next_element_checked::<
                                         i8,
-                                    >(&mut __seq) {
+                                    >(&mut __seq, 0usize, &expecting) {
                                         _serde::__private::Ok(__val) => __val,
                                         _serde::__private::Err(__err) => {
                                             return _serde::__private::Err(__err);
                                         }
-                                    } {
-                                        _serde::__private::Some(__value) => __value,
-                                        _serde::__private::None => {
-                                            return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(0usize, &expecting),
-                                            );
-                                        }
                                     };
-                                    let __field1 = match match _serde::de::SeqAccess::next_element::<
+                                    let __field1 = match _serde::de::SeqAccess::next_element_checked::<
                                         B,
-                                    >(&mut __seq) {
+                                    >(&mut __seq, 1usize, &expecting) {
                                         _serde::__private::Ok(__val) => __val,
                                         _serde::__private::Err(__err) => {
                                             return _serde::__private::Err(__err);
                                         }
-                                    } {
-                                        _serde::__private::Some(__value) => __value,
-                                        _serde::__private::None => {
-                                            return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(1usize, &expecting),
-                                            );
-                                        }
                                     };
-                                    let __field2 = match match _serde::de::SeqAccess::next_element::<
+                                    let __field2 = match _serde::de::SeqAccess::next_element_checked::<
                                         C,
-                                    >(&mut __seq) {
+                                    >(&mut __seq, 2usize, &expecting) {
                                         _serde::__private::Ok(__val) => __val,
                                         _serde::__private::Err(__err) => {
                                             return _serde::__private::Err(__err);
-                                        }
-                                    } {
-                                        _serde::__private::Some(__value) => __value,
-                                        _serde::__private::None => {
-                                            return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(2usize, &expecting),
-                                            );
                                         }
                                     };
-                                    let __field3 = match match _serde::de::SeqAccess::next_element::<
+                                    let __field3 = match _serde::de::SeqAccess::next_element_checked::<
                                         D,
-                                    >(&mut __seq) {
+                                    >(&mut __seq, 3usize, &expecting) {
                                         _serde::__private::Ok(__val) => __val,
                                         _serde::__private::Err(__err) => {
                                             return _serde::__private::Err(__err);
-                                        }
-                                    } {
-                                        _serde::__private::Some(__value) => __value,
-                                        _serde::__private::None => {
-                                            return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(3usize, &expecting),
-                                            );
                                         }
                                     };
                                     _serde::__private::Ok(DeEnum::_Map2 {

--- a/test_suite/tests/expand/default_ty_param.expanded.rs
+++ b/test_suite/tests/expand/default_ty_param.expanded.rs
@@ -183,17 +183,10 @@ const _: () = {
                         } {
                         match __key {
                             __Field::__field0 => {
-                                if _serde::__private::Option::is_some(&__field0) {
-                                    return _serde::__private::Err(
-                                        <__A::Error as _serde::de::Error>::duplicate_field(
-                                            "phantom",
-                                        ),
-                                    );
-                                }
                                 __field0 = _serde::__private::Some(
-                                    match _serde::de::MapAccess::next_value::<
+                                    match _serde::de::MapAccess::next_value_checked::<
                                         PhantomData<T>,
-                                    >(&mut __map) {
+                                    >(&mut __map, &__field0, "phantom") {
                                         _serde::__private::Ok(__val) => __val,
                                         _serde::__private::Err(__err) => {
                                             return _serde::__private::Err(__err);

--- a/test_suite/tests/expand/default_ty_param.expanded.rs
+++ b/test_suite/tests/expand/default_ty_param.expanded.rs
@@ -152,6 +152,7 @@ const _: () = {
                 where
                     __A: _serde::de::SeqAccess<'de>,
                 {
+                    let expecting = "struct DefaultTyParam with 1 element";
                     let __field0 = match match _serde::de::SeqAccess::next_element::<
                         PhantomData<T>,
                     >(&mut __seq) {
@@ -163,10 +164,7 @@ const _: () = {
                         _serde::__private::Some(__value) => __value,
                         _serde::__private::None => {
                             return _serde::__private::Err(
-                                _serde::de::Error::invalid_length(
-                                    0usize,
-                                    &"struct DefaultTyParam with 1 element",
-                                ),
+                                _serde::de::Error::invalid_length(0usize, &expecting),
                             );
                         }
                     };
@@ -351,6 +349,7 @@ const _: () = {
                 where
                     __A: _serde::de::SeqAccess<'de>,
                 {
+                    let expecting = "struct DefaultTyParam with 1 element";
                     if let _serde::__private::None
                         = match _serde::de::SeqAccess::next_element_seed(
                             &mut __seq,
@@ -362,10 +361,7 @@ const _: () = {
                             }
                         } {
                         return _serde::__private::Err(
-                            _serde::de::Error::invalid_length(
-                                0usize,
-                                &"struct DefaultTyParam with 1 element",
-                            ),
+                            _serde::de::Error::invalid_length(0usize, &expecting),
                         );
                     }
                     _serde::__private::Ok(())

--- a/test_suite/tests/expand/default_ty_param.expanded.rs
+++ b/test_suite/tests/expand/default_ty_param.expanded.rs
@@ -153,19 +153,12 @@ const _: () = {
                     __A: _serde::de::SeqAccess<'de>,
                 {
                     let expecting = "struct DefaultTyParam with 1 element";
-                    let __field0 = match match _serde::de::SeqAccess::next_element::<
+                    let __field0 = match _serde::de::SeqAccess::next_element_checked::<
                         PhantomData<T>,
-                    >(&mut __seq) {
+                    >(&mut __seq, 0usize, &expecting) {
                         _serde::__private::Ok(__val) => __val,
                         _serde::__private::Err(__err) => {
                             return _serde::__private::Err(__err);
-                        }
-                    } {
-                        _serde::__private::Some(__value) => __value,
-                        _serde::__private::None => {
-                            return _serde::__private::Err(
-                                _serde::de::Error::invalid_length(0usize, &expecting),
-                            );
                         }
                     };
                     _serde::__private::Ok(DefaultTyParam {

--- a/test_suite/tests/expand/default_ty_param.expanded.rs
+++ b/test_suite/tests/expand/default_ty_param.expanded.rs
@@ -25,7 +25,7 @@ const _: () = {
             let mut __serde_state = match _serde::Serializer::serialize_struct(
                 __serializer,
                 "DefaultTyParam",
-                false as usize + 1,
+                1usize,
             ) {
                 _serde::__private::Ok(__val) => __val,
                 _serde::__private::Err(__err) => {

--- a/test_suite/tests/expand/default_ty_param.expanded.rs
+++ b/test_suite/tests/expand/default_ty_param.expanded.rs
@@ -206,15 +206,13 @@ const _: () = {
                             }
                         }
                     }
-                    let __field0 = match __field0 {
-                        _serde::__private::Some(__field0) => __field0,
-                        _serde::__private::None => {
-                            match _serde::__private::de::missing_field("phantom") {
-                                _serde::__private::Ok(__val) => __val,
-                                _serde::__private::Err(__err) => {
-                                    return _serde::__private::Err(__err);
-                                }
-                            }
+                    let __field0 = match _serde::__private::de::missing_field_checked(
+                        __field0,
+                        "phantom",
+                    ) {
+                        _serde::__private::Ok(__val) => __val,
+                        _serde::__private::Err(__err) => {
+                            return _serde::__private::Err(__err);
                         }
                     };
                     _serde::__private::Ok(DefaultTyParam {

--- a/test_suite/tests/expand/generic_enum.expanded.rs
+++ b/test_suite/tests/expand/generic_enum.expanded.rs
@@ -521,26 +521,22 @@ const _: () = {
                                             }
                                         }
                                     }
-                                    let __field0 = match __field0 {
-                                        _serde::__private::Some(__field0) => __field0,
-                                        _serde::__private::None => {
-                                            match _serde::__private::de::missing_field("x") {
-                                                _serde::__private::Ok(__val) => __val,
-                                                _serde::__private::Err(__err) => {
-                                                    return _serde::__private::Err(__err);
-                                                }
-                                            }
+                                    let __field0 = match _serde::__private::de::missing_field_checked(
+                                        __field0,
+                                        "x",
+                                    ) {
+                                        _serde::__private::Ok(__val) => __val,
+                                        _serde::__private::Err(__err) => {
+                                            return _serde::__private::Err(__err);
                                         }
                                     };
-                                    let __field1 = match __field1 {
-                                        _serde::__private::Some(__field1) => __field1,
-                                        _serde::__private::None => {
-                                            match _serde::__private::de::missing_field("y") {
-                                                _serde::__private::Ok(__val) => __val,
-                                                _serde::__private::Err(__err) => {
-                                                    return _serde::__private::Err(__err);
-                                                }
-                                            }
+                                    let __field1 = match _serde::__private::de::missing_field_checked(
+                                        __field1,
+                                        "y",
+                                    ) {
+                                        _serde::__private::Ok(__val) => __val,
+                                        _serde::__private::Err(__err) => {
+                                            return _serde::__private::Err(__err);
                                         }
                                     };
                                     _serde::__private::Ok(GenericEnum::Map {

--- a/test_suite/tests/expand/generic_enum.expanded.rs
+++ b/test_suite/tests/expand/generic_enum.expanded.rs
@@ -486,13 +486,10 @@ const _: () = {
                                         } {
                                         match __key {
                                             __Field::__field0 => {
-                                                if _serde::__private::Option::is_some(&__field0) {
-                                                    return _serde::__private::Err(
-                                                        <__A::Error as _serde::de::Error>::duplicate_field("x"),
-                                                    );
-                                                }
                                                 __field0 = _serde::__private::Some(
-                                                    match _serde::de::MapAccess::next_value::<T>(&mut __map) {
+                                                    match _serde::de::MapAccess::next_value_checked::<
+                                                        T,
+                                                    >(&mut __map, &__field0, "x") {
                                                         _serde::__private::Ok(__val) => __val,
                                                         _serde::__private::Err(__err) => {
                                                             return _serde::__private::Err(__err);
@@ -501,13 +498,10 @@ const _: () = {
                                                 );
                                             }
                                             __Field::__field1 => {
-                                                if _serde::__private::Option::is_some(&__field1) {
-                                                    return _serde::__private::Err(
-                                                        <__A::Error as _serde::de::Error>::duplicate_field("y"),
-                                                    );
-                                                }
                                                 __field1 = _serde::__private::Some(
-                                                    match _serde::de::MapAccess::next_value::<U>(&mut __map) {
+                                                    match _serde::de::MapAccess::next_value_checked::<
+                                                        U,
+                                                    >(&mut __map, &__field1, "y") {
                                                         _serde::__private::Ok(__val) => __val,
                                                         _serde::__private::Err(__err) => {
                                                             return _serde::__private::Err(__err);

--- a/test_suite/tests/expand/generic_enum.expanded.rs
+++ b/test_suite/tests/expand/generic_enum.expanded.rs
@@ -310,34 +310,20 @@ const _: () = {
                                     __A: _serde::de::SeqAccess<'de>,
                                 {
                                     let expecting = "tuple variant GenericEnum::Seq with 2 elements";
-                                    let __field0 = match match _serde::de::SeqAccess::next_element::<
+                                    let __field0 = match _serde::de::SeqAccess::next_element_checked::<
                                         T,
-                                    >(&mut __seq) {
+                                    >(&mut __seq, 0usize, &expecting) {
                                         _serde::__private::Ok(__val) => __val,
                                         _serde::__private::Err(__err) => {
                                             return _serde::__private::Err(__err);
-                                        }
-                                    } {
-                                        _serde::__private::Some(__value) => __value,
-                                        _serde::__private::None => {
-                                            return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(0usize, &expecting),
-                                            );
                                         }
                                     };
-                                    let __field1 = match match _serde::de::SeqAccess::next_element::<
+                                    let __field1 = match _serde::de::SeqAccess::next_element_checked::<
                                         U,
-                                    >(&mut __seq) {
+                                    >(&mut __seq, 1usize, &expecting) {
                                         _serde::__private::Ok(__val) => __val,
                                         _serde::__private::Err(__err) => {
                                             return _serde::__private::Err(__err);
-                                        }
-                                    } {
-                                        _serde::__private::Some(__value) => __value,
-                                        _serde::__private::None => {
-                                            return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(1usize, &expecting),
-                                            );
                                         }
                                     };
                                     _serde::__private::Ok(GenericEnum::Seq(__field0, __field1))
@@ -458,34 +444,20 @@ const _: () = {
                                     __A: _serde::de::SeqAccess<'de>,
                                 {
                                     let expecting = "struct variant GenericEnum::Map with 2 elements";
-                                    let __field0 = match match _serde::de::SeqAccess::next_element::<
+                                    let __field0 = match _serde::de::SeqAccess::next_element_checked::<
                                         T,
-                                    >(&mut __seq) {
+                                    >(&mut __seq, 0usize, &expecting) {
                                         _serde::__private::Ok(__val) => __val,
                                         _serde::__private::Err(__err) => {
                                             return _serde::__private::Err(__err);
-                                        }
-                                    } {
-                                        _serde::__private::Some(__value) => __value,
-                                        _serde::__private::None => {
-                                            return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(0usize, &expecting),
-                                            );
                                         }
                                     };
-                                    let __field1 = match match _serde::de::SeqAccess::next_element::<
+                                    let __field1 = match _serde::de::SeqAccess::next_element_checked::<
                                         U,
-                                    >(&mut __seq) {
+                                    >(&mut __seq, 1usize, &expecting) {
                                         _serde::__private::Ok(__val) => __val,
                                         _serde::__private::Err(__err) => {
                                             return _serde::__private::Err(__err);
-                                        }
-                                    } {
-                                        _serde::__private::Some(__value) => __value,
-                                        _serde::__private::None => {
-                                            return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(1usize, &expecting),
-                                            );
                                         }
                                     };
                                     _serde::__private::Ok(GenericEnum::Map {

--- a/test_suite/tests/expand/generic_enum.expanded.rs
+++ b/test_suite/tests/expand/generic_enum.expanded.rs
@@ -309,6 +309,7 @@ const _: () = {
                                 where
                                     __A: _serde::de::SeqAccess<'de>,
                                 {
+                                    let expecting = "tuple variant GenericEnum::Seq with 2 elements";
                                     let __field0 = match match _serde::de::SeqAccess::next_element::<
                                         T,
                                     >(&mut __seq) {
@@ -320,10 +321,7 @@ const _: () = {
                                         _serde::__private::Some(__value) => __value,
                                         _serde::__private::None => {
                                             return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(
-                                                    0usize,
-                                                    &"tuple variant GenericEnum::Seq with 2 elements",
-                                                ),
+                                                _serde::de::Error::invalid_length(0usize, &expecting),
                                             );
                                         }
                                     };
@@ -338,10 +336,7 @@ const _: () = {
                                         _serde::__private::Some(__value) => __value,
                                         _serde::__private::None => {
                                             return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(
-                                                    1usize,
-                                                    &"tuple variant GenericEnum::Seq with 2 elements",
-                                                ),
+                                                _serde::de::Error::invalid_length(1usize, &expecting),
                                             );
                                         }
                                     };
@@ -462,6 +457,7 @@ const _: () = {
                                 where
                                     __A: _serde::de::SeqAccess<'de>,
                                 {
+                                    let expecting = "struct variant GenericEnum::Map with 2 elements";
                                     let __field0 = match match _serde::de::SeqAccess::next_element::<
                                         T,
                                     >(&mut __seq) {
@@ -473,10 +469,7 @@ const _: () = {
                                         _serde::__private::Some(__value) => __value,
                                         _serde::__private::None => {
                                             return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(
-                                                    0usize,
-                                                    &"struct variant GenericEnum::Map with 2 elements",
-                                                ),
+                                                _serde::de::Error::invalid_length(0usize, &expecting),
                                             );
                                         }
                                     };
@@ -491,10 +484,7 @@ const _: () = {
                                         _serde::__private::Some(__value) => __value,
                                         _serde::__private::None => {
                                             return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(
-                                                    1usize,
-                                                    &"struct variant GenericEnum::Map with 2 elements",
-                                                ),
+                                                _serde::de::Error::invalid_length(1usize, &expecting),
                                             );
                                         }
                                     };

--- a/test_suite/tests/expand/generic_struct.expanded.rs
+++ b/test_suite/tests/expand/generic_struct.expanded.rs
@@ -185,13 +185,10 @@ const _: () = {
                         } {
                         match __key {
                             __Field::__field0 => {
-                                if _serde::__private::Option::is_some(&__field0) {
-                                    return _serde::__private::Err(
-                                        <__A::Error as _serde::de::Error>::duplicate_field("x"),
-                                    );
-                                }
                                 __field0 = _serde::__private::Some(
-                                    match _serde::de::MapAccess::next_value::<T>(&mut __map) {
+                                    match _serde::de::MapAccess::next_value_checked::<
+                                        T,
+                                    >(&mut __map, &__field0, "x") {
                                         _serde::__private::Ok(__val) => __val,
                                         _serde::__private::Err(__err) => {
                                             return _serde::__private::Err(__err);

--- a/test_suite/tests/expand/generic_struct.expanded.rs
+++ b/test_suite/tests/expand/generic_struct.expanded.rs
@@ -156,6 +156,7 @@ const _: () = {
                 where
                     __A: _serde::de::SeqAccess<'de>,
                 {
+                    let expecting = "struct GenericStruct with 1 element";
                     let __field0 = match match _serde::de::SeqAccess::next_element::<
                         T,
                     >(&mut __seq) {
@@ -167,10 +168,7 @@ const _: () = {
                         _serde::__private::Some(__value) => __value,
                         _serde::__private::None => {
                             return _serde::__private::Err(
-                                _serde::de::Error::invalid_length(
-                                    0usize,
-                                    &"struct GenericStruct with 1 element",
-                                ),
+                                _serde::de::Error::invalid_length(0usize, &expecting),
                             );
                         }
                     };
@@ -350,6 +348,7 @@ const _: () = {
                 where
                     __A: _serde::de::SeqAccess<'de>,
                 {
+                    let expecting = "struct GenericStruct with 1 element";
                     if let _serde::__private::None
                         = match _serde::de::SeqAccess::next_element_seed(
                             &mut __seq,
@@ -361,10 +360,7 @@ const _: () = {
                             }
                         } {
                         return _serde::__private::Err(
-                            _serde::de::Error::invalid_length(
-                                0usize,
-                                &"struct GenericStruct with 1 element",
-                            ),
+                            _serde::de::Error::invalid_length(0usize, &expecting),
                         );
                     }
                     _serde::__private::Ok(())
@@ -530,6 +526,7 @@ const _: () = {
                 where
                     __A: _serde::de::SeqAccess<'de>,
                 {
+                    let expecting = "tuple struct GenericNewTypeStruct with 1 element";
                     let __field0 = match match _serde::de::SeqAccess::next_element::<
                         T,
                     >(&mut __seq) {
@@ -541,10 +538,7 @@ const _: () = {
                         _serde::__private::Some(__value) => __value,
                         _serde::__private::None => {
                             return _serde::__private::Err(
-                                _serde::de::Error::invalid_length(
-                                    0usize,
-                                    &"tuple struct GenericNewTypeStruct with 1 element",
-                                ),
+                                _serde::de::Error::invalid_length(0usize, &expecting),
                             );
                         }
                     };
@@ -607,6 +601,7 @@ const _: () = {
                 where
                     __A: _serde::de::SeqAccess<'de>,
                 {
+                    let expecting = "tuple struct GenericNewTypeStruct with 1 element";
                     if let _serde::__private::None
                         = match _serde::de::SeqAccess::next_element_seed(
                             &mut __seq,
@@ -618,10 +613,7 @@ const _: () = {
                             }
                         } {
                         return _serde::__private::Err(
-                            _serde::de::Error::invalid_length(
-                                0usize,
-                                &"tuple struct GenericNewTypeStruct with 1 element",
-                            ),
+                            _serde::de::Error::invalid_length(0usize, &expecting),
                         );
                     }
                     _serde::__private::Ok(())

--- a/test_suite/tests/expand/generic_struct.expanded.rs
+++ b/test_suite/tests/expand/generic_struct.expanded.rs
@@ -208,15 +208,13 @@ const _: () = {
                             }
                         }
                     }
-                    let __field0 = match __field0 {
-                        _serde::__private::Some(__field0) => __field0,
-                        _serde::__private::None => {
-                            match _serde::__private::de::missing_field("x") {
-                                _serde::__private::Ok(__val) => __val,
-                                _serde::__private::Err(__err) => {
-                                    return _serde::__private::Err(__err);
-                                }
-                            }
+                    let __field0 = match _serde::__private::de::missing_field_checked(
+                        __field0,
+                        "x",
+                    ) {
+                        _serde::__private::Ok(__val) => __val,
+                        _serde::__private::Err(__err) => {
+                            return _serde::__private::Err(__err);
                         }
                     };
                     _serde::__private::Ok(GenericStruct { x: __field0 })

--- a/test_suite/tests/expand/generic_struct.expanded.rs
+++ b/test_suite/tests/expand/generic_struct.expanded.rs
@@ -157,19 +157,12 @@ const _: () = {
                     __A: _serde::de::SeqAccess<'de>,
                 {
                     let expecting = "struct GenericStruct with 1 element";
-                    let __field0 = match match _serde::de::SeqAccess::next_element::<
+                    let __field0 = match _serde::de::SeqAccess::next_element_checked::<
                         T,
-                    >(&mut __seq) {
+                    >(&mut __seq, 0usize, &expecting) {
                         _serde::__private::Ok(__val) => __val,
                         _serde::__private::Err(__err) => {
                             return _serde::__private::Err(__err);
-                        }
-                    } {
-                        _serde::__private::Some(__value) => __value,
-                        _serde::__private::None => {
-                            return _serde::__private::Err(
-                                _serde::de::Error::invalid_length(0usize, &expecting),
-                            );
                         }
                     };
                     _serde::__private::Ok(GenericStruct { x: __field0 })
@@ -527,19 +520,12 @@ const _: () = {
                     __A: _serde::de::SeqAccess<'de>,
                 {
                     let expecting = "tuple struct GenericNewTypeStruct with 1 element";
-                    let __field0 = match match _serde::de::SeqAccess::next_element::<
+                    let __field0 = match _serde::de::SeqAccess::next_element_checked::<
                         T,
-                    >(&mut __seq) {
+                    >(&mut __seq, 0usize, &expecting) {
                         _serde::__private::Ok(__val) => __val,
                         _serde::__private::Err(__err) => {
                             return _serde::__private::Err(__err);
-                        }
-                    } {
-                        _serde::__private::Some(__value) => __value,
-                        _serde::__private::None => {
-                            return _serde::__private::Err(
-                                _serde::de::Error::invalid_length(0usize, &expecting),
-                            );
                         }
                     };
                     _serde::__private::Ok(GenericNewTypeStruct(__field0))

--- a/test_suite/tests/expand/generic_struct.expanded.rs
+++ b/test_suite/tests/expand/generic_struct.expanded.rs
@@ -22,7 +22,7 @@ const _: () = {
             let mut __serde_state = match _serde::Serializer::serialize_struct(
                 __serializer,
                 "GenericStruct",
-                false as usize + 1,
+                1usize,
             ) {
                 _serde::__private::Ok(__val) => __val,
                 _serde::__private::Err(__err) => {

--- a/test_suite/tests/expand/generic_tuple_struct.expanded.rs
+++ b/test_suite/tests/expand/generic_tuple_struct.expanded.rs
@@ -48,6 +48,7 @@ const _: () = {
                 where
                     __A: _serde::de::SeqAccess<'de>,
                 {
+                    let expecting = "tuple struct GenericTupleStruct with 2 elements";
                     let __field0 = match match _serde::de::SeqAccess::next_element::<
                         T,
                     >(&mut __seq) {
@@ -59,10 +60,7 @@ const _: () = {
                         _serde::__private::Some(__value) => __value,
                         _serde::__private::None => {
                             return _serde::__private::Err(
-                                _serde::de::Error::invalid_length(
-                                    0usize,
-                                    &"tuple struct GenericTupleStruct with 2 elements",
-                                ),
+                                _serde::de::Error::invalid_length(0usize, &expecting),
                             );
                         }
                     };
@@ -77,10 +75,7 @@ const _: () = {
                         _serde::__private::Some(__value) => __value,
                         _serde::__private::None => {
                             return _serde::__private::Err(
-                                _serde::de::Error::invalid_length(
-                                    1usize,
-                                    &"tuple struct GenericTupleStruct with 2 elements",
-                                ),
+                                _serde::de::Error::invalid_length(1usize, &expecting),
                             );
                         }
                     };
@@ -136,6 +131,7 @@ const _: () = {
                 where
                     __A: _serde::de::SeqAccess<'de>,
                 {
+                    let expecting = "tuple struct GenericTupleStruct with 2 elements";
                     if let _serde::__private::None
                         = match _serde::de::SeqAccess::next_element_seed(
                             &mut __seq,
@@ -147,10 +143,7 @@ const _: () = {
                             }
                         } {
                         return _serde::__private::Err(
-                            _serde::de::Error::invalid_length(
-                                0usize,
-                                &"tuple struct GenericTupleStruct with 2 elements",
-                            ),
+                            _serde::de::Error::invalid_length(0usize, &expecting),
                         );
                     }
                     if let _serde::__private::None
@@ -164,10 +157,7 @@ const _: () = {
                             }
                         } {
                         return _serde::__private::Err(
-                            _serde::de::Error::invalid_length(
-                                1usize,
-                                &"tuple struct GenericTupleStruct with 2 elements",
-                            ),
+                            _serde::de::Error::invalid_length(1usize, &expecting),
                         );
                     }
                     _serde::__private::Ok(())

--- a/test_suite/tests/expand/generic_tuple_struct.expanded.rs
+++ b/test_suite/tests/expand/generic_tuple_struct.expanded.rs
@@ -49,34 +49,20 @@ const _: () = {
                     __A: _serde::de::SeqAccess<'de>,
                 {
                     let expecting = "tuple struct GenericTupleStruct with 2 elements";
-                    let __field0 = match match _serde::de::SeqAccess::next_element::<
+                    let __field0 = match _serde::de::SeqAccess::next_element_checked::<
                         T,
-                    >(&mut __seq) {
+                    >(&mut __seq, 0usize, &expecting) {
                         _serde::__private::Ok(__val) => __val,
                         _serde::__private::Err(__err) => {
                             return _serde::__private::Err(__err);
-                        }
-                    } {
-                        _serde::__private::Some(__value) => __value,
-                        _serde::__private::None => {
-                            return _serde::__private::Err(
-                                _serde::de::Error::invalid_length(0usize, &expecting),
-                            );
                         }
                     };
-                    let __field1 = match match _serde::de::SeqAccess::next_element::<
+                    let __field1 = match _serde::de::SeqAccess::next_element_checked::<
                         U,
-                    >(&mut __seq) {
+                    >(&mut __seq, 1usize, &expecting) {
                         _serde::__private::Ok(__val) => __val,
                         _serde::__private::Err(__err) => {
                             return _serde::__private::Err(__err);
-                        }
-                    } {
-                        _serde::__private::Some(__value) => __value,
-                        _serde::__private::None => {
-                            return _serde::__private::Err(
-                                _serde::de::Error::invalid_length(1usize, &expecting),
-                            );
                         }
                     };
                     _serde::__private::Ok(GenericTupleStruct(__field0, __field1))

--- a/test_suite/tests/expand/lifetimes.expanded.rs
+++ b/test_suite/tests/expand/lifetimes.expanded.rs
@@ -393,15 +393,13 @@ const _: () = {
                                             }
                                         }
                                     }
-                                    let __field0 = match __field0 {
-                                        _serde::__private::Some(__field0) => __field0,
-                                        _serde::__private::None => {
-                                            match _serde::__private::de::missing_field("a") {
-                                                _serde::__private::Ok(__val) => __val,
-                                                _serde::__private::Err(__err) => {
-                                                    return _serde::__private::Err(__err);
-                                                }
-                                            }
+                                    let __field0 = match _serde::__private::de::missing_field_checked(
+                                        __field0,
+                                        "a",
+                                    ) {
+                                        _serde::__private::Ok(__val) => __val,
+                                        _serde::__private::Err(__err) => {
+                                            return _serde::__private::Err(__err);
                                         }
                                     };
                                     _serde::__private::Ok(Lifetimes::LifetimeMap {
@@ -568,15 +566,13 @@ const _: () = {
                                             }
                                         }
                                     }
-                                    let __field0 = match __field0 {
-                                        _serde::__private::Some(__field0) => __field0,
-                                        _serde::__private::None => {
-                                            match _serde::__private::de::missing_field("a") {
-                                                _serde::__private::Ok(__val) => __val,
-                                                _serde::__private::Err(__err) => {
-                                                    return _serde::__private::Err(__err);
-                                                }
-                                            }
+                                    let __field0 = match _serde::__private::de::missing_field_checked(
+                                        __field0,
+                                        "a",
+                                    ) {
+                                        _serde::__private::Ok(__val) => __val,
+                                        _serde::__private::Err(__err) => {
+                                            return _serde::__private::Err(__err);
                                         }
                                     };
                                     _serde::__private::Ok(Lifetimes::NoLifetimeMap {

--- a/test_suite/tests/expand/lifetimes.expanded.rs
+++ b/test_suite/tests/expand/lifetimes.expanded.rs
@@ -370,15 +370,10 @@ const _: () = {
                                         } {
                                         match __key {
                                             __Field::__field0 => {
-                                                if _serde::__private::Option::is_some(&__field0) {
-                                                    return _serde::__private::Err(
-                                                        <__A::Error as _serde::de::Error>::duplicate_field("a"),
-                                                    );
-                                                }
                                                 __field0 = _serde::__private::Some(
-                                                    match _serde::de::MapAccess::next_value::<
+                                                    match _serde::de::MapAccess::next_value_checked::<
                                                         &'a i32,
-                                                    >(&mut __map) {
+                                                    >(&mut __map, &__field0, "a") {
                                                         _serde::__private::Ok(__val) => __val,
                                                         _serde::__private::Err(__err) => {
                                                             return _serde::__private::Err(__err);
@@ -550,13 +545,10 @@ const _: () = {
                                         } {
                                         match __key {
                                             __Field::__field0 => {
-                                                if _serde::__private::Option::is_some(&__field0) {
-                                                    return _serde::__private::Err(
-                                                        <__A::Error as _serde::de::Error>::duplicate_field("a"),
-                                                    );
-                                                }
                                                 __field0 = _serde::__private::Some(
-                                                    match _serde::de::MapAccess::next_value::<i32>(&mut __map) {
+                                                    match _serde::de::MapAccess::next_value_checked::<
+                                                        i32,
+                                                    >(&mut __map, &__field0, "a") {
                                                         _serde::__private::Ok(__val) => __val,
                                                         _serde::__private::Err(__err) => {
                                                             return _serde::__private::Err(__err);

--- a/test_suite/tests/expand/lifetimes.expanded.rs
+++ b/test_suite/tests/expand/lifetimes.expanded.rs
@@ -337,6 +337,7 @@ const _: () = {
                                 where
                                     __A: _serde::de::SeqAccess<'de>,
                                 {
+                                    let expecting = "struct variant Lifetimes::LifetimeMap with 1 element";
                                     let __field0 = match match _serde::de::SeqAccess::next_element::<
                                         &'a i32,
                                     >(&mut __seq) {
@@ -348,10 +349,7 @@ const _: () = {
                                         _serde::__private::Some(__value) => __value,
                                         _serde::__private::None => {
                                             return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(
-                                                    0usize,
-                                                    &"struct variant Lifetimes::LifetimeMap with 1 element",
-                                                ),
+                                                _serde::de::Error::invalid_length(0usize, &expecting),
                                             );
                                         }
                                     };
@@ -526,6 +524,7 @@ const _: () = {
                                 where
                                     __A: _serde::de::SeqAccess<'de>,
                                 {
+                                    let expecting = "struct variant Lifetimes::NoLifetimeMap with 1 element";
                                     let __field0 = match match _serde::de::SeqAccess::next_element::<
                                         i32,
                                     >(&mut __seq) {
@@ -537,10 +536,7 @@ const _: () = {
                                         _serde::__private::Some(__value) => __value,
                                         _serde::__private::None => {
                                             return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(
-                                                    0usize,
-                                                    &"struct variant Lifetimes::NoLifetimeMap with 1 element",
-                                                ),
+                                                _serde::de::Error::invalid_length(0usize, &expecting),
                                             );
                                         }
                                     };

--- a/test_suite/tests/expand/lifetimes.expanded.rs
+++ b/test_suite/tests/expand/lifetimes.expanded.rs
@@ -338,19 +338,12 @@ const _: () = {
                                     __A: _serde::de::SeqAccess<'de>,
                                 {
                                     let expecting = "struct variant Lifetimes::LifetimeMap with 1 element";
-                                    let __field0 = match match _serde::de::SeqAccess::next_element::<
+                                    let __field0 = match _serde::de::SeqAccess::next_element_checked::<
                                         &'a i32,
-                                    >(&mut __seq) {
+                                    >(&mut __seq, 0usize, &expecting) {
                                         _serde::__private::Ok(__val) => __val,
                                         _serde::__private::Err(__err) => {
                                             return _serde::__private::Err(__err);
-                                        }
-                                    } {
-                                        _serde::__private::Some(__value) => __value,
-                                        _serde::__private::None => {
-                                            return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(0usize, &expecting),
-                                            );
                                         }
                                     };
                                     _serde::__private::Ok(Lifetimes::LifetimeMap {
@@ -525,19 +518,12 @@ const _: () = {
                                     __A: _serde::de::SeqAccess<'de>,
                                 {
                                     let expecting = "struct variant Lifetimes::NoLifetimeMap with 1 element";
-                                    let __field0 = match match _serde::de::SeqAccess::next_element::<
+                                    let __field0 = match _serde::de::SeqAccess::next_element_checked::<
                                         i32,
-                                    >(&mut __seq) {
+                                    >(&mut __seq, 0usize, &expecting) {
                                         _serde::__private::Ok(__val) => __val,
                                         _serde::__private::Err(__err) => {
                                             return _serde::__private::Err(__err);
-                                        }
-                                    } {
-                                        _serde::__private::Some(__value) => __value,
-                                        _serde::__private::None => {
-                                            return _serde::__private::Err(
-                                                _serde::de::Error::invalid_length(0usize, &expecting),
-                                            );
                                         }
                                     };
                                     _serde::__private::Ok(Lifetimes::NoLifetimeMap {

--- a/test_suite/tests/expand/named_map.expanded.rs
+++ b/test_suite/tests/expand/named_map.expanded.rs
@@ -297,37 +297,31 @@ const _: () = {
                             }
                         }
                     }
-                    let __field0 = match __field0 {
-                        _serde::__private::Some(__field0) => __field0,
-                        _serde::__private::None => {
-                            match _serde::__private::de::missing_field("a") {
-                                _serde::__private::Ok(__val) => __val,
-                                _serde::__private::Err(__err) => {
-                                    return _serde::__private::Err(__err);
-                                }
-                            }
+                    let __field0 = match _serde::__private::de::missing_field_checked(
+                        __field0,
+                        "a",
+                    ) {
+                        _serde::__private::Ok(__val) => __val,
+                        _serde::__private::Err(__err) => {
+                            return _serde::__private::Err(__err);
                         }
                     };
-                    let __field1 = match __field1 {
-                        _serde::__private::Some(__field1) => __field1,
-                        _serde::__private::None => {
-                            match _serde::__private::de::missing_field("b") {
-                                _serde::__private::Ok(__val) => __val,
-                                _serde::__private::Err(__err) => {
-                                    return _serde::__private::Err(__err);
-                                }
-                            }
+                    let __field1 = match _serde::__private::de::missing_field_checked(
+                        __field1,
+                        "b",
+                    ) {
+                        _serde::__private::Ok(__val) => __val,
+                        _serde::__private::Err(__err) => {
+                            return _serde::__private::Err(__err);
                         }
                     };
-                    let __field2 = match __field2 {
-                        _serde::__private::Some(__field2) => __field2,
-                        _serde::__private::None => {
-                            match _serde::__private::de::missing_field("c") {
-                                _serde::__private::Ok(__val) => __val,
-                                _serde::__private::Err(__err) => {
-                                    return _serde::__private::Err(__err);
-                                }
-                            }
+                    let __field2 = match _serde::__private::de::missing_field_checked(
+                        __field2,
+                        "c",
+                    ) {
+                        _serde::__private::Ok(__val) => __val,
+                        _serde::__private::Err(__err) => {
+                            return _serde::__private::Err(__err);
                         }
                     };
                     _serde::__private::Ok(DeNamedMap {

--- a/test_suite/tests/expand/named_map.expanded.rs
+++ b/test_suite/tests/expand/named_map.expanded.rs
@@ -26,7 +26,7 @@ const _: () = {
             let mut __serde_state = match _serde::Serializer::serialize_struct(
                 __serializer,
                 "SerNamedMap",
-                false as usize + 1 + 1 + 1,
+                3usize,
             ) {
                 _serde::__private::Ok(__val) => __val,
                 _serde::__private::Err(__err) => {

--- a/test_suite/tests/expand/named_map.expanded.rs
+++ b/test_suite/tests/expand/named_map.expanded.rs
@@ -200,49 +200,28 @@ const _: () = {
                     __A: _serde::de::SeqAccess<'de>,
                 {
                     let expecting = "struct DeNamedMap with 3 elements";
-                    let __field0 = match match _serde::de::SeqAccess::next_element::<
+                    let __field0 = match _serde::de::SeqAccess::next_element_checked::<
                         A,
-                    >(&mut __seq) {
+                    >(&mut __seq, 0usize, &expecting) {
                         _serde::__private::Ok(__val) => __val,
                         _serde::__private::Err(__err) => {
                             return _serde::__private::Err(__err);
                         }
-                    } {
-                        _serde::__private::Some(__value) => __value,
-                        _serde::__private::None => {
-                            return _serde::__private::Err(
-                                _serde::de::Error::invalid_length(0usize, &expecting),
-                            );
-                        }
                     };
-                    let __field1 = match match _serde::de::SeqAccess::next_element::<
+                    let __field1 = match _serde::de::SeqAccess::next_element_checked::<
                         B,
-                    >(&mut __seq) {
+                    >(&mut __seq, 1usize, &expecting) {
                         _serde::__private::Ok(__val) => __val,
                         _serde::__private::Err(__err) => {
                             return _serde::__private::Err(__err);
-                        }
-                    } {
-                        _serde::__private::Some(__value) => __value,
-                        _serde::__private::None => {
-                            return _serde::__private::Err(
-                                _serde::de::Error::invalid_length(1usize, &expecting),
-                            );
                         }
                     };
-                    let __field2 = match match _serde::de::SeqAccess::next_element::<
+                    let __field2 = match _serde::de::SeqAccess::next_element_checked::<
                         C,
-                    >(&mut __seq) {
+                    >(&mut __seq, 2usize, &expecting) {
                         _serde::__private::Ok(__val) => __val,
                         _serde::__private::Err(__err) => {
                             return _serde::__private::Err(__err);
-                        }
-                    } {
-                        _serde::__private::Some(__value) => __value,
-                        _serde::__private::None => {
-                            return _serde::__private::Err(
-                                _serde::de::Error::invalid_length(2usize, &expecting),
-                            );
                         }
                     };
                     _serde::__private::Ok(DeNamedMap {

--- a/test_suite/tests/expand/named_map.expanded.rs
+++ b/test_suite/tests/expand/named_map.expanded.rs
@@ -250,13 +250,10 @@ const _: () = {
                         } {
                         match __key {
                             __Field::__field0 => {
-                                if _serde::__private::Option::is_some(&__field0) {
-                                    return _serde::__private::Err(
-                                        <__A::Error as _serde::de::Error>::duplicate_field("a"),
-                                    );
-                                }
                                 __field0 = _serde::__private::Some(
-                                    match _serde::de::MapAccess::next_value::<A>(&mut __map) {
+                                    match _serde::de::MapAccess::next_value_checked::<
+                                        A,
+                                    >(&mut __map, &__field0, "a") {
                                         _serde::__private::Ok(__val) => __val,
                                         _serde::__private::Err(__err) => {
                                             return _serde::__private::Err(__err);
@@ -265,13 +262,10 @@ const _: () = {
                                 );
                             }
                             __Field::__field1 => {
-                                if _serde::__private::Option::is_some(&__field1) {
-                                    return _serde::__private::Err(
-                                        <__A::Error as _serde::de::Error>::duplicate_field("b"),
-                                    );
-                                }
                                 __field1 = _serde::__private::Some(
-                                    match _serde::de::MapAccess::next_value::<B>(&mut __map) {
+                                    match _serde::de::MapAccess::next_value_checked::<
+                                        B,
+                                    >(&mut __map, &__field1, "b") {
                                         _serde::__private::Ok(__val) => __val,
                                         _serde::__private::Err(__err) => {
                                             return _serde::__private::Err(__err);
@@ -280,13 +274,10 @@ const _: () = {
                                 );
                             }
                             __Field::__field2 => {
-                                if _serde::__private::Option::is_some(&__field2) {
-                                    return _serde::__private::Err(
-                                        <__A::Error as _serde::de::Error>::duplicate_field("c"),
-                                    );
-                                }
                                 __field2 = _serde::__private::Some(
-                                    match _serde::de::MapAccess::next_value::<C>(&mut __map) {
+                                    match _serde::de::MapAccess::next_value_checked::<
+                                        C,
+                                    >(&mut __map, &__field2, "c") {
                                         _serde::__private::Ok(__val) => __val,
                                         _serde::__private::Err(__err) => {
                                             return _serde::__private::Err(__err);

--- a/test_suite/tests/expand/named_map.expanded.rs
+++ b/test_suite/tests/expand/named_map.expanded.rs
@@ -199,6 +199,7 @@ const _: () = {
                 where
                     __A: _serde::de::SeqAccess<'de>,
                 {
+                    let expecting = "struct DeNamedMap with 3 elements";
                     let __field0 = match match _serde::de::SeqAccess::next_element::<
                         A,
                     >(&mut __seq) {
@@ -210,10 +211,7 @@ const _: () = {
                         _serde::__private::Some(__value) => __value,
                         _serde::__private::None => {
                             return _serde::__private::Err(
-                                _serde::de::Error::invalid_length(
-                                    0usize,
-                                    &"struct DeNamedMap with 3 elements",
-                                ),
+                                _serde::de::Error::invalid_length(0usize, &expecting),
                             );
                         }
                     };
@@ -228,10 +226,7 @@ const _: () = {
                         _serde::__private::Some(__value) => __value,
                         _serde::__private::None => {
                             return _serde::__private::Err(
-                                _serde::de::Error::invalid_length(
-                                    1usize,
-                                    &"struct DeNamedMap with 3 elements",
-                                ),
+                                _serde::de::Error::invalid_length(1usize, &expecting),
                             );
                         }
                     };
@@ -246,10 +241,7 @@ const _: () = {
                         _serde::__private::Some(__value) => __value,
                         _serde::__private::None => {
                             return _serde::__private::Err(
-                                _serde::de::Error::invalid_length(
-                                    2usize,
-                                    &"struct DeNamedMap with 3 elements",
-                                ),
+                                _serde::de::Error::invalid_length(2usize, &expecting),
                             );
                         }
                     };
@@ -503,6 +495,7 @@ const _: () = {
                 where
                     __A: _serde::de::SeqAccess<'de>,
                 {
+                    let expecting = "struct DeNamedMap with 3 elements";
                     if let _serde::__private::None
                         = match _serde::de::SeqAccess::next_element_seed(
                             &mut __seq,
@@ -514,10 +507,7 @@ const _: () = {
                             }
                         } {
                         return _serde::__private::Err(
-                            _serde::de::Error::invalid_length(
-                                0usize,
-                                &"struct DeNamedMap with 3 elements",
-                            ),
+                            _serde::de::Error::invalid_length(0usize, &expecting),
                         );
                     }
                     if let _serde::__private::None
@@ -531,10 +521,7 @@ const _: () = {
                             }
                         } {
                         return _serde::__private::Err(
-                            _serde::de::Error::invalid_length(
-                                1usize,
-                                &"struct DeNamedMap with 3 elements",
-                            ),
+                            _serde::de::Error::invalid_length(1usize, &expecting),
                         );
                     }
                     if let _serde::__private::None
@@ -548,10 +535,7 @@ const _: () = {
                             }
                         } {
                         return _serde::__private::Err(
-                            _serde::de::Error::invalid_length(
-                                2usize,
-                                &"struct DeNamedMap with 3 elements",
-                            ),
+                            _serde::de::Error::invalid_length(2usize, &expecting),
                         );
                     }
                     _serde::__private::Ok(())

--- a/test_suite/tests/expand/named_tuple.expanded.rs
+++ b/test_suite/tests/expand/named_tuple.expanded.rs
@@ -113,49 +113,28 @@ const _: () = {
                     __A: _serde::de::SeqAccess<'de>,
                 {
                     let expecting = "tuple struct DeNamedTuple with 3 elements";
-                    let __field0 = match match _serde::de::SeqAccess::next_element::<
+                    let __field0 = match _serde::de::SeqAccess::next_element_checked::<
                         A,
-                    >(&mut __seq) {
+                    >(&mut __seq, 0usize, &expecting) {
                         _serde::__private::Ok(__val) => __val,
                         _serde::__private::Err(__err) => {
                             return _serde::__private::Err(__err);
                         }
-                    } {
-                        _serde::__private::Some(__value) => __value,
-                        _serde::__private::None => {
-                            return _serde::__private::Err(
-                                _serde::de::Error::invalid_length(0usize, &expecting),
-                            );
-                        }
                     };
-                    let __field1 = match match _serde::de::SeqAccess::next_element::<
+                    let __field1 = match _serde::de::SeqAccess::next_element_checked::<
                         B,
-                    >(&mut __seq) {
+                    >(&mut __seq, 1usize, &expecting) {
                         _serde::__private::Ok(__val) => __val,
                         _serde::__private::Err(__err) => {
                             return _serde::__private::Err(__err);
-                        }
-                    } {
-                        _serde::__private::Some(__value) => __value,
-                        _serde::__private::None => {
-                            return _serde::__private::Err(
-                                _serde::de::Error::invalid_length(1usize, &expecting),
-                            );
                         }
                     };
-                    let __field2 = match match _serde::de::SeqAccess::next_element::<
+                    let __field2 = match _serde::de::SeqAccess::next_element_checked::<
                         C,
-                    >(&mut __seq) {
+                    >(&mut __seq, 2usize, &expecting) {
                         _serde::__private::Ok(__val) => __val,
                         _serde::__private::Err(__err) => {
                             return _serde::__private::Err(__err);
-                        }
-                    } {
-                        _serde::__private::Some(__value) => __value,
-                        _serde::__private::None => {
-                            return _serde::__private::Err(
-                                _serde::de::Error::invalid_length(2usize, &expecting),
-                            );
                         }
                     };
                     _serde::__private::Ok(DeNamedTuple(__field0, __field1, __field2))

--- a/test_suite/tests/expand/named_tuple.expanded.rs
+++ b/test_suite/tests/expand/named_tuple.expanded.rs
@@ -112,6 +112,7 @@ const _: () = {
                 where
                     __A: _serde::de::SeqAccess<'de>,
                 {
+                    let expecting = "tuple struct DeNamedTuple with 3 elements";
                     let __field0 = match match _serde::de::SeqAccess::next_element::<
                         A,
                     >(&mut __seq) {
@@ -123,10 +124,7 @@ const _: () = {
                         _serde::__private::Some(__value) => __value,
                         _serde::__private::None => {
                             return _serde::__private::Err(
-                                _serde::de::Error::invalid_length(
-                                    0usize,
-                                    &"tuple struct DeNamedTuple with 3 elements",
-                                ),
+                                _serde::de::Error::invalid_length(0usize, &expecting),
                             );
                         }
                     };
@@ -141,10 +139,7 @@ const _: () = {
                         _serde::__private::Some(__value) => __value,
                         _serde::__private::None => {
                             return _serde::__private::Err(
-                                _serde::de::Error::invalid_length(
-                                    1usize,
-                                    &"tuple struct DeNamedTuple with 3 elements",
-                                ),
+                                _serde::de::Error::invalid_length(1usize, &expecting),
                             );
                         }
                     };
@@ -159,10 +154,7 @@ const _: () = {
                         _serde::__private::Some(__value) => __value,
                         _serde::__private::None => {
                             return _serde::__private::Err(
-                                _serde::de::Error::invalid_length(
-                                    2usize,
-                                    &"tuple struct DeNamedTuple with 3 elements",
-                                ),
+                                _serde::de::Error::invalid_length(2usize, &expecting),
                             );
                         }
                     };
@@ -220,6 +212,7 @@ const _: () = {
                 where
                     __A: _serde::de::SeqAccess<'de>,
                 {
+                    let expecting = "tuple struct DeNamedTuple with 3 elements";
                     if let _serde::__private::None
                         = match _serde::de::SeqAccess::next_element_seed(
                             &mut __seq,
@@ -231,10 +224,7 @@ const _: () = {
                             }
                         } {
                         return _serde::__private::Err(
-                            _serde::de::Error::invalid_length(
-                                0usize,
-                                &"tuple struct DeNamedTuple with 3 elements",
-                            ),
+                            _serde::de::Error::invalid_length(0usize, &expecting),
                         );
                     }
                     if let _serde::__private::None
@@ -248,10 +238,7 @@ const _: () = {
                             }
                         } {
                         return _serde::__private::Err(
-                            _serde::de::Error::invalid_length(
-                                1usize,
-                                &"tuple struct DeNamedTuple with 3 elements",
-                            ),
+                            _serde::de::Error::invalid_length(1usize, &expecting),
                         );
                     }
                     if let _serde::__private::None
@@ -265,10 +252,7 @@ const _: () = {
                             }
                         } {
                         return _serde::__private::Err(
-                            _serde::de::Error::invalid_length(
-                                2usize,
-                                &"tuple struct DeNamedTuple with 3 elements",
-                            ),
+                            _serde::de::Error::invalid_length(2usize, &expecting),
                         );
                     }
                     _serde::__private::Ok(())


### PR DESCRIPTION
This PR has a series of commits that shrink the size of the code generated for `derive(Serialize, Deserialize)`, particularly for large structs.

Here are some instruction count results for some synthetic benchmarks.

Benchmark | Profile | Scenario | % Change | Significance Factor?
-- | -- | -- | -- | --
big300 | check | full | -31.80% | 159.00x
big300 | debug | full | -30.15% | 150.75x
big300 | opt | full | -29.99% | 149.96x
big200 | check | full | -29.44% | 147.19x
big200 | debug | full | -26.94% | 134.69x
big200 | opt | full | -26.83% | 134.15x
big100 | check | full | -25.50% | 127.48x
big100 | debug | full | -21.02% | 105.11x
big100 | opt | full | -20.73% | 103.64x
derive-serde | check | full | -6.50% | 32.50x
derive-serde | opt | full | -3.97% | 19.85x
derive-serde | debug | full | -3.76% | 18.82x

`big{1,2,3}00` each contain a single struct with {100,200,300} `u32` fields that is annotated with `derive(Serialize, Deserialize)`.

`derive-serde` contains a variety of structs and enums. It is identical to https://github.com/rust-lang/rust/blob/master/src/test/ui/deriving/deriving-all-codegen.rs except with the builtin trait derives replaced with `derive(Serialize, Deserialize)`.