### PR TITLE
Remove explicit and implied references to specific MSRVs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,8 @@ jobs:
           RUSTFLAGS: --cfg exhaustive ${{env.RUSTFLAGS}}
         if: matrix.os != 'windows'
 
-  msrv:
+  backward_compat:
+    # Note that this test does NOT imply a specific MSRV policy.
     name: Rust 1.13.0
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
-# Serde &emsp; [![Build Status]][actions] [![Latest Version]][crates.io] [![serde: rustc 1.13+]][Rust 1.13] [![serde_derive: rustc 1.31+]][Rust 1.31]
+# Serde &emsp; [![Build Status]][actions] [![Latest Version]][crates.io]
 
 [Build Status]: https://img.shields.io/github/workflow/status/serde-rs/serde/CI/master
 [actions]: https://github.com/serde-rs/serde/actions?query=branch%3Amaster
 [Latest Version]: https://img.shields.io/crates/v/serde.svg
 [crates.io]: https://crates.io/crates/serde
-[serde: rustc 1.13+]: https://img.shields.io/badge/serde-rustc_1.13+-lightgray.svg
 [serde_derive: rustc 1.31+]: https://img.shields.io/badge/serde_derive-rustc_1.31+-lightgray.svg
-[Rust 1.13]: https://blog.rust-lang.org/2016/11/10/Rust-1.13.html
-[Rust 1.31]: https://blog.rust-lang.org/2018/12/06/Rust-1.31-and-rust-2018.html
 
 **Serde is a framework for *ser*ializing and *de*serializing Rust data structures efficiently and generically.**
 

--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -12,7 +12,6 @@ keywords = ["serde", "serialization", "no_std"]
 license = "MIT OR Apache-2.0"
 readme = "crates-io.md"
 repository = "https://github.com/serde-rs/serde"
-rust-version = "1.13"
 
 [dependencies]
 serde_derive = { version = "=1.0.143", optional = true, path = "../serde_derive" }

--- a/serde_derive/Cargo.toml
+++ b/serde_derive/Cargo.toml
@@ -11,7 +11,6 @@ keywords = ["serde", "serialization", "no_std", "derive"]
 license = "MIT OR Apache-2.0"
 readme = "crates-io.md"
 repository = "https://github.com/serde-rs/serde"
-rust-version = "1.31"
 
 [features]
 default = []

--- a/serde_derive_internals/Cargo.toml
+++ b/serde_derive_internals/Cargo.toml
@@ -9,7 +9,6 @@ include = ["lib.rs", "src/**/*.rs", "LICENSE-APACHE", "LICENSE-MIT"]
 keywords = ["serde", "serialization"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/serde-rs/serde"
-rust-version = "1.31"
 
 [lib]
 path = "lib.rs"

--- a/serde_test/Cargo.toml
+++ b/serde_test/Cargo.toml
@@ -12,7 +12,6 @@ keywords = ["serde", "serialization", "testing"]
 license = "MIT OR Apache-2.0"
 readme = "crates-io.md"
 repository = "https://github.com/serde-rs/serde"
-rust-version = "1.13"
 
 [dependencies]
 serde = { version = "1.0.60", path = "../serde" }


### PR DESCRIPTION
After conversation in Twitter DM re: #2255, it became clear that
serde does not, in fact, have a specific MSRV policy, but rather
strives to be buildable with older rustc as only a practical
matter.

This led to some confusion from users, as the `rust-version`
Cargo.toml tag is often used to communicate a specific MSRV policy.

Thus, this PR simply removes references which could be confused for
a specific MSRV  policy, leaving a comment in CI that the test with
older rustc's does not imply a specific policy.