### PR TITLE
Explicitly use `edition = "2015"`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,11 +69,11 @@ jobs:
         if: matrix.os != 'windows'
 
   msrv:
-    name: Rust 1.13.0
+    name: Rust 1.31.0
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.13.0
+      - uses: dtolnay/rust-toolchain@1.31.0
       - name: Get timestamp for cache
         id: date
         run: echo ::set-output name=yearmo::$(date +%Y%m)
@@ -91,29 +91,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [1.19.0, 1.20.0, 1.21.0, 1.25.0, 1.26.0, 1.34.0]
+        rust: [1.34.0]
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{matrix.rust}}
-      - run: cd serde && cargo build --no-default-features
-      - run: cd serde && cargo build
-
-  more:
-    name: Rust ${{matrix.rust}}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        rust: [1.27.0, 1.28.0]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{matrix.rust}}
-        # Work around failing to parse manifest because editions are unstable.
-      - run: sed -i /test_suite/d Cargo.toml
       - run: cd serde && cargo build --no-default-features
       - run: cd serde && cargo build
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
-# Serde &emsp; [![Build Status]][actions] [![Latest Version]][crates.io] [![serde: rustc 1.13+]][Rust 1.13] [![serde_derive: rustc 1.31+]][Rust 1.31]
+# Serde &emsp; [![Build Status]][actions] [![Latest Version]][crates.io] [![serde: rustc 1.31+]][Rust 1.31] [![serde_derive: rustc 1.31+]][Rust 1.31]
 
 [Build Status]: https://img.shields.io/github/workflow/status/serde-rs/serde/CI/master
 [actions]: https://github.com/serde-rs/serde/actions?query=branch%3Amaster
 [Latest Version]: https://img.shields.io/crates/v/serde.svg
 [crates.io]: https://crates.io/crates/serde
-[serde: rustc 1.13+]: https://img.shields.io/badge/serde-rustc_1.13+-lightgray.svg
+[serde: rustc 1.31+]: https://img.shields.io/badge/serde-rustc_1.31+-lightgray.svg
 [serde_derive: rustc 1.31+]: https://img.shields.io/badge/serde_derive-rustc_1.31+-lightgray.svg
-[Rust 1.13]: https://blog.rust-lang.org/2016/11/10/Rust-1.13.html
 [Rust 1.31]: https://blog.rust-lang.org/2018/12/06/Rust-1.31-and-rust-2018.html
 
 **Serde is a framework for *ser*ializing and *de*serializing Rust data structures efficiently and generically.**

--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -13,6 +13,7 @@ license = "MIT OR Apache-2.0"
 readme = "crates-io.md"
 repository = "https://github.com/serde-rs/serde"
 rust-version = "1.13"
+edition = "2015"
 
 [dependencies]
 serde_derive = { version = "=1.0.143", optional = true, path = "../serde_derive" }

--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["serde", "serialization", "no_std"]
 license = "MIT OR Apache-2.0"
 readme = "crates-io.md"
 repository = "https://github.com/serde-rs/serde"
-rust-version = "1.13"
+rust-version = "1.31"
 edition = "2015"
 
 [dependencies]

--- a/serde_derive/Cargo.toml
+++ b/serde_derive/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT OR Apache-2.0"
 readme = "crates-io.md"
 repository = "https://github.com/serde-rs/serde"
 rust-version = "1.31"
+edition = "2015"
 
 [features]
 default = []

--- a/serde_derive_internals/Cargo.toml
+++ b/serde_derive_internals/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["serde", "serialization"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/serde-rs/serde"
 rust-version = "1.31"
+edition = "2015"
 
 [lib]
 path = "lib.rs"

--- a/serde_test/Cargo.toml
+++ b/serde_test/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["serde", "serialization", "testing"]
 license = "MIT OR Apache-2.0"
 readme = "crates-io.md"
 repository = "https://github.com/serde-rs/serde"
-rust-version = "1.13"
+rust-version = "1.31"
 edition = "2015"
 
 [dependencies]

--- a/serde_test/Cargo.toml
+++ b/serde_test/Cargo.toml
@@ -13,6 +13,7 @@ license = "MIT OR Apache-2.0"
 readme = "crates-io.md"
 repository = "https://github.com/serde-rs/serde"
 rust-version = "1.13"
+edition = "2015"
 
 [dependencies]
 serde = { version = "1.0.60", path = "../serde" }


### PR DESCRIPTION
This way `cargo package` won't implictily insert a `resolver = "1"` configuration. This fixes the inadversial MSRV bump mentioned in issue [#2255].

[#2255]: https://github.com/serde-rs/serde/issues/2255