### PR TITLE
Relax orderings of Serialize impl for atomic types to match the latest stable

### DIFF
--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -916,7 +916,7 @@ macro_rules! atomic_impl {
                     S: Serializer,
                 {
                     // Matches the atomic ordering used in libcore for the Debug impl
-                    self.load(Ordering::SeqCst).serialize(serializer)
+                    self.load(Ordering::Relaxed).serialize(serializer)
                 }
             }
         )*


### PR DESCRIPTION
The standard library changed orderings of `Debug` impl for atomic types from `SeqCst` to `Relaxed` in Rust 1.63 (latest stable): https://github.com/rust-lang/rust/pull/97026

This PR relaxes the orderings of `Serialize` impl for atomic types to match the latest stable.

https://github.com/serde-rs/serde/blob/ebd06eebdbbacf0c2d5beeb6ebddc77bb2e37bd4/serde/src/ser/impls.rs#L918-L919