### PR TITLE
Add support of `dot.case` and `SCREAMING.DOT.CASE` rename on variant and field

### DIFF
--- a/serde_derive/src/internals/case.rs
+++ b/serde_derive/src/internals/case.rs
@@ -33,6 +33,10 @@ pub enum RenameRule {
     KebabCase,
     /// Rename direct children to "SCREAMING-KEBAB-CASE" style.
     ScreamingKebabCase,
+    /// Rename direct children to "dot.case" style.
+    DotCase,
+    /// Rename direct children to "SCREAMING.DOT.CASE" style.
+    ScreamingDotCase,
 }
 
 static RENAME_RULES: &[(&str, RenameRule)] = &[
@@ -44,6 +48,8 @@ static RENAME_RULES: &[(&str, RenameRule)] = &[
     ("SCREAMING_SNAKE_CASE", ScreamingSnakeCase),
     ("kebab-case", KebabCase),
     ("SCREAMING-KEBAB-CASE", ScreamingKebabCase),
+    ("dot.case", DotCase),
+    ("SCREAMING.DOT.CASE", ScreamingDotCase),
 ];
 
 impl RenameRule {
@@ -80,6 +86,10 @@ impl RenameRule {
             ScreamingKebabCase => ScreamingSnakeCase
                 .apply_to_variant(variant)
                 .replace('_', "-"),
+            DotCase => SnakeCase.apply_to_variant(variant).replace('_', "."),
+            ScreamingDotCase => ScreamingSnakeCase
+                .apply_to_variant(variant)
+                .replace('_', "."),
         }
     }
 
@@ -110,6 +120,8 @@ impl RenameRule {
             ScreamingSnakeCase => field.to_ascii_uppercase(),
             KebabCase => field.replace('_', "-"),
             ScreamingKebabCase => ScreamingSnakeCase.apply_to_field(field).replace('_', "-"),
+            DotCase => field.replace('_', "."),
+            ScreamingDotCase => ScreamingSnakeCase.apply_to_field(field).replace('_', "."),
         }
     }
 }
@@ -135,9 +147,9 @@ impl<'a> Display for ParseError<'a> {
 
 #[test]
 fn rename_variants() {
-    for &(original, lower, upper, camel, snake, screaming, kebab, screaming_kebab) in &[
+    for &(original, lower, upper, camel, snake, screaming, kebab, screaming_kebab, dot, screaming_dot) in &[
         (
-            "Outcome", "outcome", "OUTCOME", "outcome", "outcome", "OUTCOME", "outcome", "OUTCOME",
+            "Outcome", "outcome", "OUTCOME", "outcome", "outcome", "OUTCOME", "outcome", "OUTCOME", "outcome", "OUTCOME",
         ),
         (
             "VeryTasty",
@@ -148,9 +160,11 @@ fn rename_variants() {
             "VERY_TASTY",
             "very-tasty",
             "VERY-TASTY",
+            "very.tasty",
+            "VERY.TASTY",
         ),
-        ("A", "a", "A", "a", "a", "A", "a", "A"),
-        ("Z42", "z42", "Z42", "z42", "z42", "Z42", "z42", "Z42"),
+        ("A", "a", "A", "a", "a", "A", "a", "A", "a", "A"),
+        ("Z42", "z42", "Z42", "z42", "z42", "Z42", "z42", "Z42", "z42", "Z42"),
     ] {
         assert_eq!(None.apply_to_variant(original), original);
         assert_eq!(LowerCase.apply_to_variant(original), lower);
@@ -164,14 +178,19 @@ fn rename_variants() {
             ScreamingKebabCase.apply_to_variant(original),
             screaming_kebab
         );
+        assert_eq!(DotCase.apply_to_variant(original), dot);
+        assert_eq!(
+            ScreamingDotCase.apply_to_variant(original),
+            screaming_dot
+        );
     }
 }
 
 #[test]
 fn rename_fields() {
-    for &(original, upper, pascal, camel, screaming, kebab, screaming_kebab) in &[
+    for &(original, upper, pascal, camel, screaming, kebab, screaming_kebab, dot, screaming_dot) in &[
         (
-            "outcome", "OUTCOME", "Outcome", "outcome", "OUTCOME", "outcome", "OUTCOME",
+            "outcome", "OUTCOME", "Outcome", "outcome", "OUTCOME", "outcome", "OUTCOME", "outcome", "OUTCOME",
         ),
         (
             "very_tasty",
@@ -181,9 +200,11 @@ fn rename_fields() {
             "VERY_TASTY",
             "very-tasty",
             "VERY-TASTY",
+            "very.tasty",
+            "VERY.TASTY",
         ),
-        ("a", "A", "A", "a", "A", "a", "A"),
-        ("z42", "Z42", "Z42", "z42", "Z42", "z42", "Z42"),
+        ("a", "A", "A", "a", "A", "a", "A", "a", "A"),
+        ("z42", "Z42", "Z42", "z42", "Z42", "z42", "Z42", "z42", "Z42"),
     ] {
         assert_eq!(None.apply_to_field(original), original);
         assert_eq!(UpperCase.apply_to_field(original), upper);
@@ -193,5 +214,7 @@ fn rename_fields() {
         assert_eq!(ScreamingSnakeCase.apply_to_field(original), screaming);
         assert_eq!(KebabCase.apply_to_field(original), kebab);
         assert_eq!(ScreamingKebabCase.apply_to_field(original), screaming_kebab);
+        assert_eq!(DotCase.apply_to_field(original), dot);
+        assert_eq!(ScreamingDotCase.apply_to_field(original), screaming_dot);
     }
 }

--- a/serde_derive/src/internals/case.rs
+++ b/serde_derive/src/internals/case.rs
@@ -147,9 +147,21 @@ impl<'a> Display for ParseError<'a> {
 
 #[test]
 fn rename_variants() {
-    for &(original, lower, upper, camel, snake, screaming, kebab, screaming_kebab, dot, screaming_dot) in &[
+    for &(
+        original,
+        lower,
+        upper,
+        camel,
+        snake,
+        screaming,
+        kebab,
+        screaming_kebab,
+        dot,
+        screaming_dot,
+    ) in &[
         (
-            "Outcome", "outcome", "OUTCOME", "outcome", "outcome", "OUTCOME", "outcome", "OUTCOME", "outcome", "OUTCOME",
+            "Outcome", "outcome", "OUTCOME", "outcome", "outcome", "OUTCOME", "outcome", "OUTCOME",
+            "outcome", "OUTCOME",
         ),
         (
             "VeryTasty",
@@ -164,7 +176,9 @@ fn rename_variants() {
             "VERY.TASTY",
         ),
         ("A", "a", "A", "a", "a", "A", "a", "A", "a", "A"),
-        ("Z42", "z42", "Z42", "z42", "z42", "Z42", "z42", "Z42", "z42", "Z42"),
+        (
+            "Z42", "z42", "Z42", "z42", "z42", "Z42", "z42", "Z42", "z42", "Z42",
+        ),
     ] {
         assert_eq!(None.apply_to_variant(original), original);
         assert_eq!(LowerCase.apply_to_variant(original), lower);
@@ -179,33 +193,35 @@ fn rename_variants() {
             screaming_kebab
         );
         assert_eq!(DotCase.apply_to_variant(original), dot);
-        assert_eq!(
-            ScreamingDotCase.apply_to_variant(original),
-            screaming_dot
-        );
+        assert_eq!(ScreamingDotCase.apply_to_variant(original), screaming_dot);
     }
 }
 
 #[test]
 fn rename_fields() {
-    for &(original, upper, pascal, camel, screaming, kebab, screaming_kebab, dot, screaming_dot) in &[
-        (
-            "outcome", "OUTCOME", "Outcome", "outcome", "OUTCOME", "outcome", "OUTCOME", "outcome", "OUTCOME",
-        ),
-        (
-            "very_tasty",
-            "VERY_TASTY",
-            "VeryTasty",
-            "veryTasty",
-            "VERY_TASTY",
-            "very-tasty",
-            "VERY-TASTY",
-            "very.tasty",
-            "VERY.TASTY",
-        ),
-        ("a", "A", "A", "a", "A", "a", "A", "a", "A"),
-        ("z42", "Z42", "Z42", "z42", "Z42", "z42", "Z42", "z42", "Z42"),
-    ] {
+    for &(original, upper, pascal, camel, screaming, kebab, screaming_kebab, dot, screaming_dot) in
+        &[
+            (
+                "outcome", "OUTCOME", "Outcome", "outcome", "OUTCOME", "outcome", "OUTCOME",
+                "outcome", "OUTCOME",
+            ),
+            (
+                "very_tasty",
+                "VERY_TASTY",
+                "VeryTasty",
+                "veryTasty",
+                "VERY_TASTY",
+                "very-tasty",
+                "VERY-TASTY",
+                "very.tasty",
+                "VERY.TASTY",
+            ),
+            ("a", "A", "A", "a", "A", "a", "A", "a", "A"),
+            (
+                "z42", "Z42", "Z42", "z42", "Z42", "z42", "Z42", "z42", "Z42",
+            ),
+        ]
+    {
         assert_eq!(None.apply_to_field(original), original);
         assert_eq!(UpperCase.apply_to_field(original), upper);
         assert_eq!(PascalCase.apply_to_field(original), pascal);

--- a/test_suite/tests/ui/rename/container_unknown_rename_rule.stderr
+++ b/test_suite/tests/ui/rename/container_unknown_rename_rule.stderr
@@ -1,4 +1,4 @@
-error: unknown rename rule `rename_all = "abc"`, expected one of "lowercase", "UPPERCASE", "PascalCase", "camelCase", "snake_case", "SCREAMING_SNAKE_CASE", "kebab-case", "SCREAMING-KEBAB-CASE"
+error: unknown rename rule `rename_all = "abc"`, expected one of "lowercase", "UPPERCASE", "PascalCase", "camelCase", "snake_case", "SCREAMING_SNAKE_CASE", "kebab-case", "SCREAMING-KEBAB-CASE", "dot.case", "SCREAMING.DOT.CASE"
  --> tests/ui/rename/container_unknown_rename_rule.rs:4:22
   |
 4 | #[serde(rename_all = "abc")]

--- a/test_suite/tests/ui/rename/variant_unknown_rename_rule.stderr
+++ b/test_suite/tests/ui/rename/variant_unknown_rename_rule.stderr
@@ -1,4 +1,4 @@
-error: unknown rename rule `rename_all = "abc"`, expected one of "lowercase", "UPPERCASE", "PascalCase", "camelCase", "snake_case", "SCREAMING_SNAKE_CASE", "kebab-case", "SCREAMING-KEBAB-CASE"
+error: unknown rename rule `rename_all = "abc"`, expected one of "lowercase", "UPPERCASE", "PascalCase", "camelCase", "snake_case", "SCREAMING_SNAKE_CASE", "kebab-case", "SCREAMING-KEBAB-CASE", "dot.case", "SCREAMING.DOT.CASE"
  --> tests/ui/rename/variant_unknown_rename_rule.rs:5:26
   |
 5 |     #[serde(rename_all = "abc")]


### PR DESCRIPTION
Add support of `Dotcase` and `CapitalDotcase`  for compatibility with scala libs [`enumeratum`](https://github.com/lloydmeta/enumeratum#mixins-to-override-the-name) serialization (using [`circe`](https://circe.github.io/circe/) for example).

Idea is to add `dot.case` and `SCREAMING.DOT.CASE` to rename_all `RenameRule` for Serialize and Deserialize fields and variants.
```rust 
use serde::Serialize;

#[derive(Serialize)]
#[serde(rename_all = "dot.case")]
struct Person {
    first_name: String,
    last_name: String,
}

fn main() {
    let person = Person {
        first_name: "Graydon".to_string(),
        last_name: "Hoare".to_string(),
    };

    let json = serde_json::to_string_pretty(&person).unwrap();

    // Prints:
    //    {
    //      "first.name": "Graydon",
    //      "last.name": "Hoare"
    //    }
    println!("{}", json);
}
```
I'm not sure if that's all that is need to do or if it's missing additional changes. 