### PR TITLE
derive_ser: Fix `clippy::use_self` on enum

### DIFF
--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -452,7 +452,7 @@ fn serialize_variant(
         let case = match variant.style {
             Style::Unit => {
                 quote! {
-                    #this::#variant_ident
+                    Self::#variant_ident
                 }
             }
             Style::Newtype => {


### PR DESCRIPTION
When deriving `Serialize` for an `enum` use `Self` instead of the enums name to prevent clippy from throwing
[`clippy::use-self`](https://rust-lang.github.io/rust-clippy/master/index.html#use_self).

An example which represents the issue is temporarily available here: <https://git.onders.org/finga/clippy_test>.