### PR TITLE
Redefine `try` macro to omit From::from error conversion

### DIFF
--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -249,6 +249,19 @@ mod lib {
     pub use self::core::time::Duration;
 }
 
+// None of this crate's error handling needs the `From::from` error conversion
+// performed implicitly by the `?` operator or the standard library's `try!`
+// macro. This simplified macro gives a 5.5% improvement in compile time
+// compared to standard `try!`, and 9% improvement compared to `?`.
+macro_rules! try {
+    ($expr:expr) => {
+        match $expr {
+            Ok(val) => val,
+            Err(err) => return Err(err),
+        }
+    };
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 #[macro_use]


### PR DESCRIPTION
None of the error handling in serde needs the `From::from` error conversion performed implicitly by the `?` operator or the standard library's `try!` macro. This PR adds a simplified macro that gives a 5.5% improvement in compile time compared to standard `try!`, and 9% improvement compared to `?`. The same trick has already been in use by serde_derive since #1226.

| | `check` time | rmeta size | `build` time | rlib size |
|---|---|---|---|---|
| standard library `try!` | 2.15 sec | 3,568 K | 2.53 sec | 6,943 K |
| `?` operator | 2.23 sec | 3,568 K | 2.62 sec | 7,137 K |
| this PR | 2.03 sec | 3,569 K | 2.39 sec | 6,829 K |

`build` time is measured by `time rustc --cfg 'feature="std"' serde/src/lib.rs --crate-type=lib`, and `check` time is the same but with `--emit=metadata`.
