### PR TITLE
Change used serializer methods when serialize untagged enums

### DIFF
--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -770,7 +770,7 @@ fn serialize_untagged_variant(
     match effective_style(variant) {
         Style::Unit => {
             quote_expr! {
-                _serde::Serializer::serialize_unit(__serializer)
+                _serde::Serializer::serialize_unit_struct(__serializer, #variant_name)
             }
         }
         Style::Newtype => {

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -956,7 +956,7 @@ fn serialize_struct_variant(
             quote_block! {
                 let #let_mut __serde_state = try!(_serde::Serializer::serialize_struct(
                     __serializer,
-                    #type_name,
+                    #variant_name,
                     #len,
                 ));
                 #(#serialize_fields)*

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -552,19 +552,17 @@ fn serialize_externally_tagged_variant(
             TupleVariant::ExternallyTagged {
                 type_name,
                 variant_index,
-                variant_name,
             },
             params,
             &variant.fields,
+            &variant_name,
         ),
         Style::Struct => serialize_struct_variant(
-            StructVariant::ExternallyTagged {
-                variant_index,
-                variant_name,
-            },
+            StructVariant::ExternallyTagged { variant_index },
             params,
             &variant.fields,
             &type_name,
+            &variant_name,
         ),
     }
 }
@@ -626,10 +624,11 @@ fn serialize_internally_tagged_variant(
             }
         }
         Style::Struct => serialize_struct_variant(
-            StructVariant::InternallyTagged { tag, variant_name },
+            StructVariant::InternallyTagged { tag },
             params,
             &variant.fields,
             &type_name,
+            &variant_name,
         ),
         Style::Tuple => unreachable!("checked in serde_derive_internals"),
     }
@@ -681,13 +680,17 @@ fn serialize_adjacently_tagged_variant(
                     _serde::ser::SerializeStruct::end(__struct)
                 };
             }
-            Style::Tuple => {
-                serialize_tuple_variant(TupleVariant::Untagged, params, &variant.fields)
-            }
+            Style::Tuple => serialize_tuple_variant(
+                TupleVariant::Untagged,
+                params,
+                &variant.fields,
+                &variant_name,
+            ),
             Style::Struct => serialize_struct_variant(
                 StructVariant::Untagged,
                 params,
                 &variant.fields,
+                &variant_name,
                 &variant_name,
             ),
         }
@@ -755,6 +758,8 @@ fn serialize_untagged_variant(
     variant: &Variant,
     cattrs: &attr::Container,
 ) -> Fragment {
+    let variant_name = variant.attrs.name().serialize_name();
+
     if let Some(path) = variant.attrs.serialize_with() {
         let ser = wrap_serialize_variant_with(params, path, variant);
         return quote_expr! {
@@ -781,10 +786,21 @@ fn serialize_untagged_variant(
                 #func(#field_expr, __serializer)
             }
         }
-        Style::Tuple => serialize_tuple_variant(TupleVariant::Untagged, params, &variant.fields),
+        Style::Tuple => serialize_tuple_variant(
+            TupleVariant::Untagged,
+            params,
+            &variant.fields,
+            &variant_name,
+        ),
         Style::Struct => {
             let type_name = cattrs.name().serialize_name();
-            serialize_struct_variant(StructVariant::Untagged, params, &variant.fields, &type_name)
+            serialize_struct_variant(
+                StructVariant::Untagged,
+                params,
+                &variant.fields,
+                &type_name,
+                &variant_name,
+            )
         }
     }
 }
@@ -793,7 +809,6 @@ enum TupleVariant {
     ExternallyTagged {
         type_name: String,
         variant_index: u32,
-        variant_name: String,
     },
     Untagged,
 }
@@ -802,6 +817,7 @@ fn serialize_tuple_variant(
     context: TupleVariant,
     params: &Parameters,
     fields: &[Field],
+    variant_name: &str,
 ) -> Fragment {
     let tuple_trait = match context {
         TupleVariant::ExternallyTagged { .. } => TupleTrait::SerializeTupleVariant,
@@ -832,7 +848,6 @@ fn serialize_tuple_variant(
         TupleVariant::ExternallyTagged {
             type_name,
             variant_index,
-            variant_name,
         } => {
             quote_block! {
                 let #let_mut __serde_state = try!(_serde::Serializer::serialize_tuple_variant(
@@ -858,14 +873,8 @@ fn serialize_tuple_variant(
 }
 
 enum StructVariant<'a> {
-    ExternallyTagged {
-        variant_index: u32,
-        variant_name: String,
-    },
-    InternallyTagged {
-        tag: &'a str,
-        variant_name: String,
-    },
+    ExternallyTagged { variant_index: u32 },
+    InternallyTagged { tag: &'a str },
     Untagged,
 }
 
@@ -873,10 +882,17 @@ fn serialize_struct_variant(
     context: StructVariant,
     params: &Parameters,
     fields: &[Field],
-    name: &str,
+    type_name: &str,
+    variant_name: &str,
 ) -> Fragment {
     if fields.iter().any(|field| field.attrs.flatten()) {
-        return serialize_struct_variant_with_flatten(context, params, fields, name);
+        return serialize_struct_variant_with_flatten(
+            context,
+            params,
+            fields,
+            type_name,
+            variant_name,
+        );
     }
 
     let struct_trait = match context {
@@ -907,14 +923,11 @@ fn serialize_struct_variant(
         .fold(quote!(0), |sum, expr| quote!(#sum + #expr));
 
     match context {
-        StructVariant::ExternallyTagged {
-            variant_index,
-            variant_name,
-        } => {
+        StructVariant::ExternallyTagged { variant_index } => {
             quote_block! {
                 let #let_mut __serde_state = try!(_serde::Serializer::serialize_struct_variant(
                     __serializer,
-                    #name,
+                    #type_name,
                     #variant_index,
                     #variant_name,
                     #len,
@@ -923,11 +936,11 @@ fn serialize_struct_variant(
                 _serde::ser::SerializeStructVariant::end(__serde_state)
             }
         }
-        StructVariant::InternallyTagged { tag, variant_name } => {
+        StructVariant::InternallyTagged { tag } => {
             quote_block! {
                 let mut __serde_state = try!(_serde::Serializer::serialize_struct(
                     __serializer,
-                    #name,
+                    #type_name,
                     #len + 1,
                 ));
                 try!(_serde::ser::SerializeStruct::serialize_field(
@@ -943,7 +956,7 @@ fn serialize_struct_variant(
             quote_block! {
                 let #let_mut __serde_state = try!(_serde::Serializer::serialize_struct(
                     __serializer,
-                    #name,
+                    #type_name,
                     #len,
                 ));
                 #(#serialize_fields)*
@@ -957,7 +970,8 @@ fn serialize_struct_variant_with_flatten(
     context: StructVariant,
     params: &Parameters,
     fields: &[Field],
-    name: &str,
+    type_name: &str,
+    variant_name: &str,
 ) -> Fragment {
     let struct_trait = StructTrait::SerializeMap;
     let serialize_fields = serialize_struct_visitor(fields, params, true, &struct_trait);
@@ -970,10 +984,7 @@ fn serialize_struct_variant_with_flatten(
     let let_mut = mut_if(serialized_fields.peek().is_some());
 
     match context {
-        StructVariant::ExternallyTagged {
-            variant_index,
-            variant_name,
-        } => {
+        StructVariant::ExternallyTagged { variant_index } => {
             let this_type = &params.this_type;
             let fields_ty = fields.iter().map(|f| &f.ty);
             let members = &fields.iter().map(|f| &f.member).collect::<Vec<_>>();
@@ -1005,7 +1016,7 @@ fn serialize_struct_variant_with_flatten(
 
                 _serde::Serializer::serialize_newtype_variant(
                     __serializer,
-                    #name,
+                    #type_name,
                     #variant_index,
                     #variant_name,
                     &__EnumFlatten {
@@ -1014,7 +1025,7 @@ fn serialize_struct_variant_with_flatten(
                     })
             }
         }
-        StructVariant::InternallyTagged { tag, variant_name } => {
+        StructVariant::InternallyTagged { tag } => {
             quote_block! {
                 let #let_mut __serde_state = try!(_serde::Serializer::serialize_map(
                     __serializer,

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -619,10 +619,7 @@ fn test_untagged_enum() {
     assert_tokens(
         &Untagged::A { a: 1 },
         &[
-            Token::Struct {
-                name: "Untagged",
-                len: 1,
-            },
+            Token::Struct { name: "A", len: 1 },
             Token::Str("a"),
             Token::U8(1),
             Token::StructEnd,
@@ -632,10 +629,7 @@ fn test_untagged_enum() {
     assert_tokens(
         &Untagged::B { b: 2 },
         &[
-            Token::Struct {
-                name: "Untagged",
-                len: 1,
-            },
+            Token::Struct { name: "B", len: 1 },
             Token::Str("b"),
             Token::U8(2),
             Token::StructEnd,

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -638,7 +638,8 @@ fn test_untagged_enum() {
 
     // Serializes to unit, deserializes from either depending on format's
     // preference.
-    assert_tokens(&Untagged::C, &[Token::Unit]);
+    assert_tokens(&Untagged::C, &[Token::UnitStruct { name: "C" }]);
+    assert_de_tokens(&Untagged::C, &[Token::Unit]);
     assert_de_tokens(&Untagged::C, &[Token::None]);
 
     assert_tokens(&Untagged::D(4), &[Token::U8(4)]);

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -647,11 +647,41 @@ fn test_untagged_enum() {
     assert_tokens(
         &Untagged::F(1, 2),
         &[
+            Token::TupleStruct { name: "F", len: 2 },
+            Token::U8(1),
+            Token::U8(2),
+            Token::TupleStructEnd,
+        ],
+    );
+
+    assert_de_tokens(
+        &Untagged::F(1, 2),
+        &[
             Token::Tuple { len: 2 },
             Token::U8(1),
             Token::U8(2),
             Token::TupleEnd,
         ],
+    );
+
+    assert_de_tokens_error::<Untagged>(
+        &[
+            Token::TupleStruct { name: "F", len: 1 },
+            Token::U8(1),
+            Token::TupleStructEnd,
+        ],
+        "data did not match any variant of untagged enum Untagged",
+    );
+
+    assert_de_tokens_error::<Untagged>(
+        &[
+            Token::TupleStruct { name: "F", len: 3 },
+            Token::U8(1),
+            Token::U8(2),
+            Token::U8(3),
+            Token::TupleStructEnd,
+        ],
+        "data did not match any variant of untagged enum Untagged",
     );
 
     assert_de_tokens_error::<Untagged>(
@@ -1199,6 +1229,28 @@ fn test_adjacently_tagged_enum() {
         ],
     );
 
+    // tuple struct with tag first
+    assert_de_tokens(
+        &AdjacentlyTagged::Tuple::<u8>(1, 1),
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::Str("t"),
+            Token::Str("Tuple"),
+            Token::Str("c"),
+            Token::TupleStruct {
+                name: "Tuple",
+                len: 2,
+            },
+            Token::U8(1),
+            Token::U8(1),
+            Token::TupleStructEnd,
+            Token::StructEnd,
+        ],
+    );
+
     // tuple with content first
     assert_de_tokens(
         &AdjacentlyTagged::Tuple::<u8>(1, 1),
@@ -1212,6 +1264,28 @@ fn test_adjacently_tagged_enum() {
             Token::U8(1),
             Token::U8(1),
             Token::TupleEnd,
+            Token::Str("t"),
+            Token::Str("Tuple"),
+            Token::StructEnd,
+        ],
+    );
+
+    // tuple struct with content first
+    assert_de_tokens(
+        &AdjacentlyTagged::Tuple::<u8>(1, 1),
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::Str("c"),
+            Token::TupleStruct {
+                name: "Tuple",
+                len: 2,
+            },
+            Token::U8(1),
+            Token::U8(1),
+            Token::TupleStructEnd,
             Token::Str("t"),
             Token::Str("Tuple"),
             Token::StructEnd,


### PR DESCRIPTION
Let's consider the following enum:
```rust
#[derive(serde::Serialize)]
#[serde(untagged)]
enum Untagged {
    Unit,
    Newtype(bool),
    Tuple(),
    Struct {},
}
```

Currently (1.0.145) the following functions are used to serialize enum:
|Variant|Serialized with|Suggestion
|----------------|----------|---------------
|`Enum::Unit`|`serialize_unit()`|`serialize_unit_struct("Unit")`
|`Enum::Newtype`|delegates serialization to the inner type| |
|`Enum::Tuple`|`serialize_tuple(N)`|`serialize_tuple_struct("Tuple", N)`
|`Enum::Struct`|`serialize_struct("Enum", N)`|`serialize_struct("Struct", N)`

I suggest to use methods for named variants of those methods, as shown in column **Suggestion**. That would be useful for the formats where name of type can be stored. Because in most cases name of type is not used anyway, that change shouldn't break a many.

That change seems logical in that sense, if we would consider untagged enum as an opportunity to combine various types in the Rust code that have nothing in common in the format. Instead of trying to (de)serialize a struct, a tuple or a unit struct, we (de)serialize a one enum.

One use case -- serializing enums in [quick-xml](https://github.com/tafia/quick-xml). Usually serializer don't use the type names except one case -- when we serializes top-level type. For convenience, the root element of the document can be automatically named by the type name. Because untagged enums serialized like their content, a user can expect, that serializing untagged enum would produce a name for the root element from variant name, but in reality that not the case.