### PR TITLE
Fix `Deserializer` of `serde_test` to correctly deserialize unit variants from integers/strings/bytes

### DIFF
--- a/serde_test/src/de.rs
+++ b/serde_test/src/de.rs
@@ -256,7 +256,10 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             Token::Enum { name: n } if name == n => {
                 self.next_token()?;
 
-                visitor.visit_enum(DeserializerEnumVisitor { de: self })
+                visitor.visit_enum(DeserializerEnumVisitor {
+                    de: self,
+                    optional_token: false,
+                })
             }
             Token::UnitVariant { name: n, .. }
             | Token::NewtypeVariant { name: n, .. }
@@ -264,8 +267,24 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             | Token::StructVariant { name: n, .. }
                 if name == n =>
             {
-                visitor.visit_enum(DeserializerEnumVisitor { de: self })
+                visitor.visit_enum(DeserializerEnumVisitor {
+                    de: self,
+                    optional_token: false,
+                })
             }
+            Token::Str(_)
+            | Token::BorrowedStr(_)
+            | Token::String(_)
+            | Token::Bytes(_)
+            | Token::BorrowedBytes(_)
+            | Token::ByteBuf(_)
+            | Token::U8(_)
+            | Token::U16(_)
+            | Token::U32(_)
+            | Token::U64(_) => visitor.visit_enum(DeserializerEnumVisitor {
+                de: self,
+                optional_token: true,
+            }),
             _ => self.deserialize_any(visitor),
         }
     }
@@ -454,6 +473,7 @@ impl<'de, 'a> MapAccess<'de> for DeserializerMapVisitor<'a, 'de> {
 
 struct DeserializerEnumVisitor<'a, 'de: 'a> {
     de: &'a mut Deserializer<'de>,
+    optional_token: bool,
 }
 
 impl<'de, 'a> EnumAccess<'de> for DeserializerEnumVisitor<'a, 'de> {
@@ -485,12 +505,19 @@ impl<'de, 'a> VariantAccess<'de> for DeserializerEnumVisitor<'a, 'de> {
     type Error = Error;
 
     fn unit_variant(self) -> Result<(), Error> {
-        match self.de.peek_token()? {
-            Token::UnitVariant { .. } => {
+        // Sometimes unit variant doesn't require tokens in stream
+        let token = if self.optional_token {
+            self.de.peek_token_opt()
+        } else {
+            Some(self.de.peek_token()?)
+        };
+        match token {
+            Some(Token::UnitVariant { .. }) => {
                 self.de.next_token()?;
                 Ok(())
             }
-            _ => Deserialize::deserialize(self.de),
+            Some(_) => Deserialize::deserialize(self.de),
+            None => Ok(()),
         }
     }
 

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -2818,8 +2818,8 @@ fn test_expecting_message_externally_tagged_enum() {
     }
 
     assert_de_tokens_error::<Enum>(
-        &[Token::Str("ExternallyTagged")],
-        r#"invalid type: string "ExternallyTagged", expected something strange..."#,
+        &[Token::Bool(true)],
+        r#"invalid type: boolean `true`, expected something strange..."#,
     );
 
     // Check that #[serde(expecting = "...")] doesn't affect variant identifier error message

--- a/test_suite/tests/test_de.rs
+++ b/test_suite/tests/test_de.rs
@@ -1567,6 +1567,19 @@ fn test_enum_unit() {
             variant: "Unit",
         }],
     );
+
+    test(Enum::Unit, &[Token::Str("Unit")]);
+    test(Enum::Unit, &[Token::BorrowedStr("Unit")]);
+    test(Enum::Unit, &[Token::String("Unit")]);
+
+    test(Enum::Unit, &[Token::Bytes(b"Unit")]);
+    test(Enum::Unit, &[Token::BorrowedBytes(b"Unit")]);
+    test(Enum::Unit, &[Token::ByteBuf(b"Unit")]);
+
+    test(Enum::Unit, &[Token::U8(0)]);
+    test(Enum::Unit, &[Token::U16(0)]);
+    test(Enum::Unit, &[Token::U32(0)]);
+    test(Enum::Unit, &[Token::U64(0)]);
 }
 
 #[test]

--- a/test_suite/tests/test_value.rs
+++ b/test_suite/tests/test_value.rs
@@ -6,15 +6,22 @@ use serde::{Deserialize, Deserializer};
 use serde_test::{assert_de_tokens, Token};
 use std::fmt;
 
+#[derive(Deserialize, Debug, PartialEq)]
+enum E {
+    A,
+    B,
+}
+
 #[test]
 fn test_u32_to_enum() {
-    #[derive(Deserialize, Debug, PartialEq)]
-    enum E {
-        A,
-        B,
-    }
-
     let deserializer = IntoDeserializer::<value::Error>::into_deserializer(1u32);
+    let e: E = E::deserialize(deserializer).unwrap();
+    assert_eq!(E::B, e);
+}
+
+#[test]
+fn test_str_to_enum() {
+    let deserializer = IntoDeserializer::<value::Error>::into_deserializer("B");
     let e: E = E::deserialize(deserializer).unwrap();
     assert_eq!(E::B, e);
 }


### PR DESCRIPTION
This is actually possible, but `Deserializer` of `serde_test` returns an error instead of deserialization