### PR TITLE
Remove unused `impl` and unnecessary struct-wrapper around tuple

### DIFF
--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -821,22 +821,6 @@ mod content {
         }
     }
 
-    impl<'de, T> DeserializeSeed<'de> for TaggedContentVisitor<'de, T>
-    where
-        T: Deserialize<'de>,
-    {
-        type Value = TaggedContent<'de, T>;
-
-        fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-        where
-            D: Deserializer<'de>,
-        {
-            // Internally tagged enums are only supported in self-describing
-            // formats.
-            deserializer.deserialize_any(self)
-        }
-    }
-
     impl<'de, T> Visitor<'de> for TaggedContentVisitor<'de, T>
     where
         T: Deserialize<'de>,

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1356,9 +1356,7 @@ fn deserialize_internally_tagged_enum(
                 params,
                 variant,
                 cattrs,
-                quote! {
-                    _serde::__private::de::ContentDeserializer::<__D::Error>::new(__tagged.content)
-                },
+                quote!(__deserializer),
             ));
 
             quote! {
@@ -1377,6 +1375,7 @@ fn deserialize_internally_tagged_enum(
         let __tagged = try!(_serde::Deserializer::deserialize_any(
             __deserializer,
             _serde::__private::de::TaggedContentVisitor::<__Field>::new(#tag, #expecting)));
+        let __deserializer = _serde::__private::de::ContentDeserializer::<__D::Error>::new(__tagged.content);
 
         match __tagged.tag {
             #(#variant_arms)*

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1372,12 +1372,12 @@ fn deserialize_internally_tagged_enum(
 
         #variants_stmt
 
-        let __tagged = try!(_serde::Deserializer::deserialize_any(
+        let (__tag, __content) = try!(_serde::Deserializer::deserialize_any(
             __deserializer,
             _serde::__private::de::TaggedContentVisitor::<__Field>::new(#tag, #expecting)));
-        let __deserializer = _serde::__private::de::ContentDeserializer::<__D::Error>::new(__tagged.content);
+        let __deserializer = _serde::__private::de::ContentDeserializer::<__D::Error>::new(__content);
 
-        match __tagged.tag {
+        match __tag {
             #(#variant_arms)*
         }
     }


### PR DESCRIPTION
This PR does some minor cleanups in the code:
- Implementation of `DeserializeSeed` for `TaggedContentVisitor` is never used, so it is removed
- struct `TaggedContent` is used only in one place in the generated code, so it will be replaced by usual tuple