### PR TITLE
Fix roundtrip of enum with skipped variant

### DIFF
--- a/test_suite/tests/test_de.rs
+++ b/test_suite/tests/test_de.rs
@@ -1637,7 +1637,7 @@ fn test_enum_map() {
 fn test_enum_unit_usize() {
     test(
         Enum::Unit,
-        &[Token::Enum { name: "Enum" }, Token::U32(0), Token::Unit],
+        &[Token::Enum { name: "Enum" }, Token::U32(1), Token::Unit],
     );
 }
 

--- a/test_suite/tests/test_de_error.rs
+++ b/test_suite/tests/test_de_error.rs
@@ -1243,8 +1243,8 @@ fn test_duplicate_field_enum() {
 #[test]
 fn test_enum_out_of_range() {
     assert_de_tokens_error::<Enum>(
-        &[Token::Enum { name: "Enum" }, Token::U32(5), Token::Unit],
-        "invalid value: integer `5`, expected variant index 0 <= i < 5",
+        &[Token::Enum { name: "Enum" }, Token::U32(6), Token::Unit],
+        "invalid value: integer `6`, expected variant index 1 <= i < 6",
     );
 }
 


### PR DESCRIPTION
On enums with a skipped variant that is not the last one, the generated serialization and deserialization code map the variants of the enum to different variant indices. In `deserialize_identifier`, the variant index starts at 0 and counts up once per non-skipped variant. However, for serialization the index is always the index of the variant within the enum.

This PR corrects the deserialization code to always use the index of the variant within the enum.

This was surfaced in https://github.com/jamesmunns/postcard/issues/79.