### PR TITLE
Switch from set-output to $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.13.0
       - name: Get timestamp for cache
         id: date
-        run: echo ::set-output name=yearmo::$(date +%Y%m)
+        run: echo yearmo=$(date +%Y%m) >> $GITHUB_OUTPUT
       - uses: actions/cache@v1
         with:
           path: ~/.cargo/registry/index


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.