### PR TITLE
Serialize and deserialize a tagged newtype variant over unit () as if it was a unit variant

### DIFF
--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -1272,7 +1272,6 @@ mod content {
                 //
                 // We want {"result": "Success"} to deserialize into `Response<T>`.
                 Content::Map(ref v) if v.is_empty() => visitor.visit_unit(),
-                Content::Seq(ref v) if v.is_empty() => visitor.visit_unit(),
                 _ => Err(self.invalid_type(&visitor)),
             }
         }

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -1262,6 +1262,17 @@ mod content {
         {
             match self.content {
                 Content::Unit => visitor.visit_unit(),
+
+                // As a special case, allow deserializing newtype variant containing unit. E.G:
+                // #[derive(Deserialize)]
+                // #[serde(tag = "result")]
+                // enum Response<T> {
+                //     Success(T),
+                // }
+                //
+                // We want {"result": "Success"} to deserialize into `Response<T>`.
+                Content::Map(ref v) if v.is_empty() => visitor.visit_unit(),
+                Content::Seq(ref v) if v.is_empty() => visitor.visit_unit(),
                 _ => Err(self.invalid_type(&visitor)),
             }
         }

--- a/serde/src/private/ser.rs
+++ b/serde/src/private/ser.rs
@@ -51,7 +51,6 @@ enum Unsupported {
     String,
     ByteArray,
     Optional,
-    Unit,
     #[cfg(any(feature = "std", feature = "alloc"))]
     UnitStruct,
     Sequence,
@@ -70,7 +69,6 @@ impl Display for Unsupported {
             Unsupported::String => formatter.write_str("a string"),
             Unsupported::ByteArray => formatter.write_str("a byte array"),
             Unsupported::Optional => formatter.write_str("an optional"),
-            Unsupported::Unit => formatter.write_str("unit"),
             #[cfg(any(feature = "std", feature = "alloc"))]
             Unsupported::UnitStruct => formatter.write_str("unit struct"),
             Unsupported::Sequence => formatter.write_str("a sequence"),
@@ -184,7 +182,9 @@ where
     }
 
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-        Err(self.bad_type(Unsupported::Unit))
+        let mut map = try!(self.delegate.serialize_map(Some(1)));
+        try!(map.serialize_entry(self.tag, self.variant_name));
+        map.end()
     }
 
     fn serialize_unit_struct(self, _: &'static str) -> Result<Self::Ok, Self::Error> {

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -2319,15 +2319,6 @@ fn test_internally_tagged_enum_new_type_with_unit() {
             Token::MapEnd,
         ],
     );
-    assert_ser_tokens(
-        &Data::A(()),
-        &[
-            Token::Map { len: Some(1) },
-            Token::Str("t"),
-            Token::Str("A"),
-            Token::MapEnd,
-        ],
-    );
 }
 
 #[test]

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -2303,6 +2303,34 @@ fn test_internally_tagged_enum_containing_flatten() {
 }
 
 #[test]
+fn test_internally_tagged_enum_new_type_with_unit() {
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    #[serde(tag = "t")]
+    enum Data {
+        A(()),
+    }
+
+    assert_tokens(
+        &Data::A(()),
+        &[
+            Token::Map { len: Some(1) },
+            Token::Str("t"),
+            Token::Str("A"),
+            Token::MapEnd,
+        ],
+    );
+    assert_ser_tokens(
+        &Data::A(()),
+        &[
+            Token::Map { len: Some(1) },
+            Token::Str("t"),
+            Token::Str("A"),
+            Token::MapEnd,
+        ],
+    );
+}
+
+#[test]
 fn test_adjacently_tagged_enum_containing_flatten() {
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
     #[serde(tag = "t", content = "c")]


### PR DESCRIPTION
Let's say we have the following enum:
```rust
#[derive(Serialize, Deserialize, Debug)]
#[serde(tag = "result", rename_all = "snake_case")]
enum Response<T> {
    Success(T),
    Error {
        ...
    },
}
```
This PR makes it possible to serialize and deserialize `Response::Success(())` into and from `{"result": "success"}`. Previously, this was not possible when the type parameter `T` was `()`.

Note that this is the same behaviour as if `Response::Success` would be a unit variant, but now it can be used in a more general context.

See [This part of the docs](https://serde.rs/enum-representations.html) for a background to internally tagged enums.

It's my first time contributing to Serde, so please appologise any mistakes regarding the contribution process.

References #2302 