### PR TITLE
Add EnumAccessDeserializer to turn EnumAccess into a Deserializer

### DIFF
--- a/serde/src/de/value.rs
+++ b/serde/src/de/value.rs
@@ -1510,6 +1510,41 @@ where
 
 ////////////////////////////////////////////////////////////////////////////////
 
+/// A deserializer holding an `EnumAccess`.
+#[derive(Clone, Debug)]
+pub struct EnumAccessDeserializer<A> {
+    access: A,
+}
+
+impl<A> EnumAccessDeserializer<A> {
+    /// Construct a new `EnumAccessDeserializer<A>`.
+    pub fn new(access: A) -> Self {
+        EnumAccessDeserializer { access: access }
+    }
+}
+
+impl<'de, A> de::Deserializer<'de> for EnumAccessDeserializer<A>
+where
+    A: de::EnumAccess<'de>,
+{
+    type Error = A::Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_enum(self.access)
+    }
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct map struct enum identifier ignored_any
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 mod private {
     use lib::*;
 


### PR DESCRIPTION
This came up in https://github.com/dtolnay/serde-yaml/issues/338.