### PR TITLE
Update link to `toml` crate repo

### DIFF
--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -61,7 +61,7 @@
 //! [CBOR]: https://github.com/enarx/ciborium
 //! [YAML]: https://github.com/dtolnay/serde-yaml
 //! [MessagePack]: https://github.com/3Hren/msgpack-rust
-//! [TOML]: https://github.com/alexcrichton/toml-rs
+//! [TOML]: https://github.com/toml-rs/toml
 //! [Pickle]: https://github.com/birkenfeld/serde-pickle
 //! [RON]: https://github.com/ron-rs/ron
 //! [BSON]: https://github.com/mongodb/bson-rust


### PR DESCRIPTION
https://github.com/alexcrichton/toml-rs is now archived and points towards https://github.com/toml-rs/toml