### PR TITLE
Add asserts for DeserializeSeed

### DIFF
--- a/serde_test/src/assert.rs
+++ b/serde_test/src/assert.rs
@@ -228,30 +228,30 @@ where
 /// ```edition2018
 /// # use serde::{de::{DeserializeSeed, Visitor}, Deserializer};
 /// # use serde_test::{assert_de_seed_tokens, Token};
-/// 
+///
 /// #[derive(Debug, PartialEq)]
 /// struct Example {
 ///     a: u8,
 ///     b: u8,
 /// }
-/// 
+///
 /// struct ExampleDeserializer(u8);
-/// 
+///
 /// impl<'de> DeserializeSeed<'de> for ExampleDeserializer {
 ///     type Value = Example;
-/// 
+///
 ///     fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
 ///         deserializer.deserialize_u8(self)
 ///     }
 /// }
-/// 
+///
 /// impl<'de> Visitor<'de> for ExampleDeserializer {
 ///     type Value = Example;
-/// 
+///
 ///     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
 ///         formatter.write_str("Example")
 ///     }
-/// 
+///
 ///     fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> {
 ///         Ok(Self::Value { a: v, b: self.0 })
 ///     }
@@ -283,30 +283,30 @@ where
 /// ```edition2018
 /// # use serde::{de::{DeserializeSeed, Visitor}, Deserializer};
 /// # use serde_test::{assert_de_seed_tokens_error, Token};
-/// 
+///
 /// #[derive(Debug, PartialEq)]
 /// struct Example {
 ///     a: u8,
 ///     b: u8,
 /// }
-/// 
+///
 /// struct ExampleDeserializer(u8);
-/// 
+///
 /// impl<'de> DeserializeSeed<'de> for ExampleDeserializer {
 ///     type Value = Example;
-/// 
+///
 ///     fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
 ///         deserializer.deserialize_u8(self)
 ///     }
 /// }
-/// 
+///
 /// impl<'de> Visitor<'de> for ExampleDeserializer {
 ///     type Value = Example;
-/// 
+///
 ///     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
 ///         formatter.write_str("Example")
 ///     }
-/// 
+///
 ///     fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> {
 ///         Ok(Self::Value { a: v, b: self.0 })
 ///     }

--- a/serde_test/src/assert.rs
+++ b/serde_test/src/assert.rs
@@ -259,10 +259,10 @@ where
 ///
 /// let example = Example { b: 0, a: 0 };
 /// let seed = ExampleDeserializer(0);
-/// assert_de_seed_tokens(&example, &[Token::U8(0)], seed);
+/// assert_de_seed_tokens(&example, seed, &[Token::U8(0)]);
 /// ```
 #[cfg_attr(not(no_track_caller), track_caller)]
-pub fn assert_de_seed_tokens<'de, T, D>(value: &T, tokens: &'de [Token], seed: D)
+pub fn assert_de_seed_tokens<'de, T, D>(value: &T, seed: D, tokens: &'de [Token])
 where
     T: PartialEq + Debug,
     D: DeserializeSeed<'de, Value = T>,
@@ -314,13 +314,13 @@ where
 ///
 /// let seed = ExampleDeserializer(0);
 /// assert_de_seed_tokens_error(
-///     &[Token::I8(0)],
 ///     seed,
+///     &[Token::I8(0)],
 ///     "invalid type: integer `0`, expected Example"
 /// );
 /// ```
 #[cfg_attr(not(no_track_caller), track_caller)]
-pub fn assert_de_seed_tokens_error<'de, T, D>(tokens: &'de [Token], seed: D, error: &str)
+pub fn assert_de_seed_tokens_error<'de, T, D>(seed: D, tokens: &'de [Token], error: &str)
 where
     T: PartialEq + Debug,
     D: DeserializeSeed<'de, Value = T>,

--- a/serde_test/src/assert.rs
+++ b/serde_test/src/assert.rs
@@ -224,6 +224,43 @@ where
 }
 
 /// Same as [`assert_de_tokens`], but for [`DeserializeSeed`].
+///
+/// ```edition2018
+/// # use serde::{de::{DeserializeSeed, Visitor}, Deserializer};
+/// # use serde_test::{assert_de_seed_tokens, Token};
+/// 
+/// #[derive(Debug, PartialEq)]
+/// struct Example {
+///     a: u8,
+///     b: u8,
+/// }
+/// 
+/// struct ExampleDeserializer(u8);
+/// 
+/// impl<'de> DeserializeSeed<'de> for ExampleDeserializer {
+///     type Value = Example;
+/// 
+///     fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
+///         deserializer.deserialize_u8(self)
+///     }
+/// }
+/// 
+/// impl<'de> Visitor<'de> for ExampleDeserializer {
+///     type Value = Example;
+/// 
+///     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+///         formatter.write_str("Example")
+///     }
+/// 
+///     fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> {
+///         Ok(Self::Value { a: v, b: self.0 })
+///     }
+/// }
+///
+/// let example = Example { b: 0, a: 0 };
+/// let seed = ExampleDeserializer(0);
+/// assert_de_seed_tokens(&example, &[Token::U8(0)], seed);
+/// ```
 #[cfg_attr(not(no_track_caller), track_caller)]
 pub fn assert_de_seed_tokens<'de, T, D>(value: &T, tokens: &'de [Token], seed: D)
 where
@@ -242,6 +279,46 @@ where
 }
 
 /// Same as [`assert_de_tokens_error`], but for [`DeserializeSeed`].
+///
+/// ```edition2018
+/// # use serde::{de::{DeserializeSeed, Visitor}, Deserializer};
+/// # use serde_test::{assert_de_seed_tokens_error, Token};
+/// 
+/// #[derive(Debug, PartialEq)]
+/// struct Example {
+///     a: u8,
+///     b: u8,
+/// }
+/// 
+/// struct ExampleDeserializer(u8);
+/// 
+/// impl<'de> DeserializeSeed<'de> for ExampleDeserializer {
+///     type Value = Example;
+/// 
+///     fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
+///         deserializer.deserialize_u8(self)
+///     }
+/// }
+/// 
+/// impl<'de> Visitor<'de> for ExampleDeserializer {
+///     type Value = Example;
+/// 
+///     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+///         formatter.write_str("Example")
+///     }
+/// 
+///     fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> {
+///         Ok(Self::Value { a: v, b: self.0 })
+///     }
+/// }
+///
+/// let seed = ExampleDeserializer(0);
+/// assert_de_seed_tokens_error(
+///     &[Token::I8(0)],
+///     seed,
+///     "invalid type: integer `0`, expected Example"
+/// );
+/// ```
 #[cfg_attr(not(no_track_caller), track_caller)]
 pub fn assert_de_seed_tokens_error<'de, T, D>(tokens: &'de [Token], seed: D, error: &str)
 where

--- a/serde_test/src/lib.rs
+++ b/serde_test/src/lib.rs
@@ -180,8 +180,8 @@ mod configure;
 mod token;
 
 pub use assert::{
-    assert_de_tokens, assert_de_tokens_error, assert_ser_tokens, assert_ser_tokens_error,
-    assert_tokens,
+    assert_de_seed_tokens, assert_de_seed_tokens_error, assert_de_tokens, assert_de_tokens_error,
+    assert_ser_tokens, assert_ser_tokens_error, assert_tokens,
 };
 pub use token::Token;
 


### PR DESCRIPTION
Equivalent asserts that accept a seed to test stateful deserialization. Was requested in #2262.