### PR TITLE
Handle remote type written without turbofish

### DIFF
--- a/serde_derive/src/lib.rs
+++ b/serde_derive/src/lib.rs
@@ -84,6 +84,7 @@ mod de;
 mod dummy;
 mod pretend;
 mod ser;
+mod this;
 mod try;
 
 #[proc_macro_derive(Serialize, attributes(serde))]

--- a/serde_derive/src/this.rs
+++ b/serde_derive/src/this.rs
@@ -1,0 +1,32 @@
+use internals::ast::Container;
+use syn::{Path, PathArguments, Token};
+
+pub fn this_type(cont: &Container) -> Path {
+    if let Some(remote) = cont.attrs.remote() {
+        let mut this = remote.clone();
+        for segment in &mut this.segments {
+            if let PathArguments::AngleBracketed(arguments) = &mut segment.arguments {
+                arguments.colon2_token = None;
+            }
+        }
+        this
+    } else {
+        Path::from(cont.ident.clone())
+    }
+}
+
+pub fn this_value(cont: &Container) -> Path {
+    if let Some(remote) = cont.attrs.remote() {
+        let mut this = remote.clone();
+        for segment in &mut this.segments {
+            if let PathArguments::AngleBracketed(arguments) = &mut segment.arguments {
+                if arguments.colon2_token.is_none() {
+                    arguments.colon2_token = Some(Token![::](arguments.lt_token.span));
+                }
+            }
+        }
+        this
+    } else {
+        Path::from(cont.ident.clone())
+    }
+}

--- a/test_suite/tests/test_remote.rs
+++ b/test_suite/tests/test_remote.rs
@@ -172,13 +172,13 @@ struct StructPubDef {
 }
 
 #[derive(Serialize, Deserialize)]
-#[serde(remote = "remote::StructGeneric::<u8>")]
+#[serde(remote = "remote::StructGeneric<u8>")]
 struct StructConcrete {
     value: u8,
 }
 
 #[derive(Serialize, Deserialize)]
-#[serde(remote = "remote::EnumGeneric::<u8>")]
+#[serde(remote = "remote::EnumGeneric<u8>")]
 enum EnumConcrete {
     Variant(u8),
 }

--- a/test_suite/tests/test_remote.rs
+++ b/test_suite/tests/test_remote.rs
@@ -74,6 +74,14 @@ mod remote {
             &self.b
         }
     }
+
+    pub struct StructGeneric<T> {
+        pub value: T,
+    }
+
+    pub enum EnumGeneric<T> {
+        Variant(T),
+    }
 }
 
 #[derive(Serialize, Deserialize)]
@@ -104,6 +112,12 @@ struct Test {
 
     #[serde(with = "StructPubDef")]
     struct_pub: remote::StructPub,
+
+    #[serde(with = "StructConcrete")]
+    struct_concrete: remote::StructGeneric<u8>,
+
+    #[serde(with = "EnumConcrete")]
+    enum_concrete: remote::EnumGeneric<u8>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -155,6 +169,18 @@ struct StructPubDef {
 
     #[serde(with = "UnitDef")]
     b: remote::Unit,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "remote::StructGeneric::<u8>")]
+struct StructConcrete {
+    value: u8,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "remote::EnumGeneric::<u8>")]
+enum EnumConcrete {
+    Variant(u8),
 }
 
 impl From<PrimitivePrivDef> for remote::PrimitivePriv {


### PR DESCRIPTION
The following already works, almost certainly by accident, but in any case we can't break it:

```rust
struct Generic<T> {
    value: T,
}

#[derive(Serialize, Deserialize)]
#[serde(remote = "Generic::<u8>")]
struct Concrete {
    value: u8,
}
```

However the turbofish in the `remote` attribute should not be necessary, since conceptually the attribute is being used to refer to a **type**, not an expression. This PR makes the attribute work as `serde(remote = "Generic<u8>")`.

Related to #2327.