### PR TITLE
Revert Buf::as_str safety change from PR 2319

### DIFF
--- a/serde/src/de/format.rs
+++ b/serde/src/de/format.rs
@@ -7,13 +7,13 @@ pub(super) struct Buf<'a> {
 }
 
 impl<'a> Buf<'a> {
-    pub(super) fn new(bytes: &'a mut [u8]) -> Self {
+    pub fn new(bytes: &'a mut [u8]) -> Self {
         Buf { bytes, offset: 0 }
     }
 
-    pub(super) unsafe fn as_str(&self) -> &str {
+    pub fn as_str(&self) -> &str {
         let slice = &self.bytes[..self.offset];
-        str::from_utf8_unchecked(slice)
+        unsafe { str::from_utf8_unchecked(slice) }
     }
 }
 

--- a/serde/src/de/format.rs
+++ b/serde/src/de/format.rs
@@ -1,19 +1,19 @@
 use lib::fmt::{self, Write};
 use lib::str;
 
-pub struct Buf<'a> {
+pub(super) struct Buf<'a> {
     bytes: &'a mut [u8],
     offset: usize,
 }
 
 impl<'a> Buf<'a> {
-    pub fn new(bytes: &'a mut [u8]) -> Self {
+    pub(super) fn new(bytes: &'a mut [u8]) -> Self {
         Buf { bytes, offset: 0 }
     }
 
-    pub fn as_str(&self) -> &str {
+    pub(super) unsafe fn as_str(&self) -> &str {
         let slice = &self.bytes[..self.offset];
-        unsafe { str::from_utf8_unchecked(slice) }
+        str::from_utf8_unchecked(slice)
     }
 }
 

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -1376,11 +1376,7 @@ pub trait Visitor<'de>: Sized {
             let mut buf = [0u8; 58];
             let mut writer = format::Buf::new(&mut buf);
             fmt::Write::write_fmt(&mut writer, format_args!("integer `{}` as i128", v)).unwrap();
-
-            // Safety: This is safe because we only wrote UTF-8 into the buffer.
-            let s = unsafe { writer.as_str() };
-
-            Err(Error::invalid_type(Unexpected::Other(s), &self))
+            Err(Error::invalid_type(Unexpected::Other(writer.as_str()), &self))
         }
     }
 
@@ -1442,11 +1438,7 @@ pub trait Visitor<'de>: Sized {
             let mut buf = [0u8; 57];
             let mut writer = format::Buf::new(&mut buf);
             fmt::Write::write_fmt(&mut writer, format_args!("integer `{}` as u128", v)).unwrap();
-
-            // Safety: This is safe because we only wrote UTF-8 into the buffer.
-            let s = unsafe { writer.as_str() };
-
-            Err(Error::invalid_type(Unexpected::Other(s), &self))
+            Err(Error::invalid_type(Unexpected::Other(writer.as_str()), &self))
         }
     }
 

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -1376,7 +1376,11 @@ pub trait Visitor<'de>: Sized {
             let mut buf = [0u8; 58];
             let mut writer = format::Buf::new(&mut buf);
             fmt::Write::write_fmt(&mut writer, format_args!("integer `{}` as i128", v)).unwrap();
-            Err(Error::invalid_type(Unexpected::Other(writer.as_str()), &self))
+
+            // Safety: This is safe because we only wrote UTF-8 into the buffer.
+            let s = unsafe { writer.as_str() };
+
+            Err(Error::invalid_type(Unexpected::Other(s), &self))
         }
     }
 
@@ -1438,7 +1442,11 @@ pub trait Visitor<'de>: Sized {
             let mut buf = [0u8; 57];
             let mut writer = format::Buf::new(&mut buf);
             fmt::Write::write_fmt(&mut writer, format_args!("integer `{}` as u128", v)).unwrap();
-            Err(Error::invalid_type(Unexpected::Other(writer.as_str()), &self))
+
+            // Safety: This is safe because we only wrote UTF-8 into the buffer.
+            let s = unsafe { writer.as_str() };
+
+            Err(Error::invalid_type(Unexpected::Other(s), &self))
         }
     }
 

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -736,8 +736,9 @@ impl Serialize for net::Ipv4Addr {
                 // Skip over delimiters that we initialized buf with
                 written += format_u8(*oct, &mut buf[written + 1..]) + 1;
             }
-            // We've only written ASCII bytes to the buffer, so it is valid UTF-8
-            serializer.serialize_str(unsafe { str::from_utf8_unchecked(&buf[..written]) })
+            // Safety: We've only written ASCII bytes to the buffer, so it is valid UTF-8
+            let buf = unsafe { str::from_utf8_unchecked(&buf[..written]) };
+            serializer.serialize_str(buf)
         } else {
             self.octets().serialize(serializer)
         }


### PR DESCRIPTION
Per https://github.com/serde-rs/serde/pull/2319#pullrequestreview-1176747235, the API enforces that the caller only wrote UTF-8 into the buffer.

This PR includes the 2 commits from #2319.