### PR TITLE
Remove some Serialize trait bounds

### DIFF
--- a/serde/build.rs
+++ b/serde/build.rs
@@ -89,6 +89,7 @@ fn main() {
         println!("cargo:rustc-cfg=no_core_try_from");
         println!("cargo:rustc-cfg=no_num_nonzero_signed");
         println!("cargo:rustc-cfg=no_systemtime_checked_add");
+        println!("cargo:rustc-cfg=no_relaxed_trait_bounds");
     }
 
     // Whitelist of archs that support std::sync::atomic module. Ideally we

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -182,7 +182,25 @@ where
     }
 }
 
-#[cfg(any(feature = "std", feature = "alloc"))]
+#[cfg(all(any(feature = "std", feature = "alloc"), not(no_relaxed_trait_bounds)))]
+macro_rules! seq_impl {
+    ($ty:ident < T $(: $tbound1:ident $(+ $tbound2:ident)*)* $(, $typaram:ident : $bound:ident)* >) => {
+        impl<T $(, $typaram)*> Serialize for $ty<T $(, $typaram)*>
+        where
+            T: Serialize,
+        {
+            #[inline]
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                serializer.collect_seq(self)
+            }
+        }
+    }
+}
+
+#[cfg(all(any(feature = "std", feature = "alloc"), no_relaxed_trait_bounds))]
 macro_rules! seq_impl {
     ($ty:ident < T $(: $tbound1:ident $(+ $tbound2:ident)*)* $(, $typaram:ident : $bound:ident)* >) => {
         impl<T $(, $typaram)*> Serialize for $ty<T $(, $typaram)*>


### PR DESCRIPTION
Containers for the most part do not have any trait requirements for
iterating over them. So these bounds are unnecessary when Serializing
only.