### PR TITLE
Make StdError identical to core::error::Error on feature="unstable"

### DIFF
--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -88,7 +88,7 @@
 // discussion of these features please refer to this issue:
 //
 //    https://github.com/serde-rs/serde/issues/812
-#![cfg_attr(feature = "unstable", feature(never_type))]
+#![cfg_attr(feature = "unstable", feature(error_in_core, never_type))]
 #![allow(unknown_lints, bare_trait_objects, deprecated)]
 #![cfg_attr(feature = "cargo-clippy", allow(renamed_and_removed_lints))]
 // Ignored clippy and clippy_pedantic lints
@@ -303,7 +303,7 @@ use self::__private as private;
 #[path = "de/seed.rs"]
 mod seed;
 
-#[cfg(not(feature = "std"))]
+#[cfg(not(any(feature = "std", feature = "unstable")))]
 mod std_error;
 
 // Re-export #[derive(Serialize, Deserialize)].

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -115,10 +115,13 @@ mod impossible;
 
 pub use self::impossible::Impossible;
 
+#[cfg(all(feature = "unstable", not(feature = "std")))]
+#[doc(inline)]
+pub use core::error::Error as StdError;
 #[cfg(feature = "std")]
 #[doc(no_inline)]
 pub use std::error::Error as StdError;
-#[cfg(not(feature = "std"))]
+#[cfg(not(any(feature = "std", feature = "unstable")))]
 #[doc(no_inline)]
 pub use std_error::Error as StdError;
 


### PR DESCRIPTION
Without this, a user might be forced to implement 2 different duplicate traits when using serde in no-std mode.

```rust
impl serde::ser::StdError for MySerError {...}

impl core::error::Error for MySerError {...}

impl serde::Serializer for MySerializer {
    type Error = MySerError;
    ...
}
```