### PR TITLE
Use `const` generics for fixed-size arrays

### DIFF
--- a/serde/build.rs
+++ b/serde/build.rs
@@ -94,6 +94,12 @@ fn main() {
         println!("cargo:rustc-cfg=no_relaxed_trait_bounds");
     }
 
+    // Constant generics stabilized in Rust 1.59:
+    // https://blog.rust-lang.org/2022/02/24/Rust-1.59.0.html#const-generics-defaults-and-interleaving
+    if minor < 59 {
+        println!("cargo:rustc-cfg=no_const_generics_defaults");
+    }
+
     // Support for #[cfg(target_has_atomic = "...")] stabilized in Rust 1.60.
     if minor < 60 {
         println!("cargo:rustc-cfg=no_target_has_atomic");

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -126,7 +126,33 @@ impl<T: ?Sized> Serialize for PhantomData<T> {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+#[cfg(not(no_const_generics_defaults))]
+macro_rules! impl_serialize_array_with_const_generics {
+    () => {
+        impl<T, const N: usize> Serialize for [T; N]
+        where
+            T: Serialize,
+        {
+            #[inline]
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                let mut seq = try!(serializer.serialize_tuple(N));
+                for e in self {
+                    try!(seq.serialize_element(e));
+                }
+                seq.end()
+            }
+        }
+    };
+}
+
+#[cfg(not(no_const_generics_defaults))]
+impl_serialize_array_with_const_generics!();
+
 // Does not require T: Serialize.
+#[cfg(no_const_generics_defaults)]
 impl<T> Serialize for [T; 0] {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -137,6 +163,7 @@ impl<T> Serialize for [T; 0] {
     }
 }
 
+#[cfg(no_const_generics_defaults)]
 macro_rules! array_impls {
     ($($len:tt)+) => {
         $(
@@ -160,6 +187,7 @@ macro_rules! array_impls {
     }
 }
 
+#[cfg(no_const_generics_defaults)]
 array_impls! {
     01 02 03 04 05 06 07 08 09 10
     11 12 13 14 15 16 17 18 19 20

--- a/test_suite/tests/test_gen.rs
+++ b/test_suite/tests/test_gen.rs
@@ -355,6 +355,13 @@ fn test_gen() {
     #[serde(deny_unknown_fields)]
     struct UnitDenyUnknown;
 
+    #[cfg(not(no_const_generics_defaults))]
+    #[derive(Serialize, Deserialize)]
+    struct EmptyArray {
+        empty: [u16; 0],
+    }
+
+    #[cfg(no_const_generics_defaults)]
     #[derive(Serialize, Deserialize)]
     struct EmptyArray {
         empty: [X; 0],


### PR DESCRIPTION
This PR implements `const` generics for fixed-size arrays.

- For deserializing, some manual memory management is used. However, in theory, the compiler should optimize the code back to the original code due to loop unrolling and memory optimizations.
- Because the size parameter is now generic, `T` must always be serializable, even for empty tuple types.