### PR TITLE
Remove `#[doc(hidden)]` from `deserialize_in_place`.

### DIFF
--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -554,17 +554,14 @@ pub trait Deserialize<'de>: Sized {
     /// If you manually implement this, your recursive deserializations should
     /// use `deserialize_in_place`.
     ///
-    /// This method is stable and an official public API, but hidden from the
-    /// documentation because it is almost never what newbies are looking for.
-    /// Showing it in rustdoc would cause it to be featured more prominently
-    /// than it deserves.
-    #[doc(hidden)]
+    /// It is almost always preferable to use [`deserialize`] instead of
+    /// [`deserialize_in_place`]. Make sure to benchmark before using it.
     fn deserialize_in_place<D>(deserializer: D, place: &mut Self) -> Result<(), D::Error>
     where
         D: Deserializer<'de>,
     {
         // Default implementation just delegates to `deserialize` impl.
-        *place = try!(Deserialize::deserialize(deserializer));
+        *place = Deserialize::deserialize(deserializer)?;
         Ok(())
     }
 }


### PR DESCRIPTION
As proposed in #2204, this PR removes `#[doc(hidden)]` from `deserialize_in_place`, replacing it with a notice that `deserialize` is usually preferred. That issue contains the full justification for this change.

Fixes #2204