### PR TITLE
When a serde(untagged) enum can't deser, show all the reasons why

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1693,9 +1693,9 @@ fn deserialize_untagged_enum(
         num_variants += 1;
      }
 
-     // We need two copies of this iterator, and it's not cloneable
+     // We need two copies of this iterator
      let err_identifiers1 = (0..num_variants).map(|idx| format_ident!("_err{}", idx));
-     let err_identifiers2 = (0..num_variants).map(|idx| format_ident!("_err{}", idx));
+     let err_identifiers2 = err_identifiers1.clone();
 
      quote_block! {
         let __content = try!(<_serde::__private::de::Content as _serde::Deserialize>::deserialize(__deserializer));

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -2776,7 +2776,8 @@ fn test_expecting_message_untagged_tagged_enum() {
         Untagged,
     }
 
-    assert_de_tokens_error::<Enum>(&[Token::Str("Untagged")], r#"something strange..."#);
+    assert_de_tokens_error::<Enum>(&[Token::Str("Untagged")], r#"something strange...
+Untagged: invalid type: string "Untagged", expected unit variant Enum::Untagged"#);
 }
 
 #[test]


### PR DESCRIPTION
I was writing some code recently that uses `serde(untagged)` for an enum when deserializing certain JSON schema, but I was unhappy with the quality of the error messages I was getting, because it doesn't really tell you why each possibility doesn't work.

I noticed that there is a TODO item in the `serde_derive` proc macro code that generates this deserialization.

I decided that trying to improve the error messages upstream in serde-derive is easier than trying to change how I'm using serde, so I took a stab at implementing this TODO, and updating the tests that test error messages, and writing some more tests.

I have tried to follow the patterns and conventions that I have seen elsewhere in the serde-derive source code, and I think that the code gen is good in that it uses `format_args!` like other parts of serde error handling and avoids making a new dynamic memory allocation. When untagged deserialization fails, the errors are collected on the stack rather than in a new dynamically-sized container.

Let me know if you think this is a good direction, I'm happy to iterate if this patch is interesting to you. Thanks for building serde, it's great.