### PR TITLE
Allow bytes for adjacently tagged enums

### DIFF
--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -990,6 +990,19 @@ mod content {
                 Ok(TagContentOtherField::Other)
             }
         }
+
+        fn visit_bytes<E>(self, field: &[u8]) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            if field == self.tag.as_bytes() {
+                Ok(TagContentOtherField::Tag)
+            } else if field == self.content.as_bytes() {
+                Ok(TagContentOtherField::Content)
+            } else {
+                Ok(TagContentOtherField::Other)
+            }
+        }
     }
 
     /// Not public API

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -2318,6 +2318,59 @@ fn test_internally_tagged_enum_new_type_with_unit() {
 }
 
 #[test]
+fn test_adjacently_tagged_enum_bytes() {
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    #[serde(tag = "t", content = "c")]
+    enum Data {
+        A { a: i32 },
+    }
+
+    let data = Data::A { a: 0 };
+
+    assert_tokens(
+        &data,
+        &[
+            Token::Struct {
+                name: "Data",
+                len: 2,
+            },
+            Token::Str("t"),
+            Token::Str("A"),
+            Token::Str("c"),
+            Token::Struct {
+                name: "A",
+                len: 1,
+            },
+            Token::Str("a"),
+            Token::I32(0),
+            Token::StructEnd,
+            Token::StructEnd,
+        ],
+    );
+
+    assert_de_tokens(
+        &data,
+        &[
+            Token::Struct {
+                name: "Data",
+                len: 2,
+            },
+            Token::Bytes(b"t"),
+            Token::Str("A"),
+            Token::Bytes(b"c"),
+            Token::Struct {
+                name: "A",
+                len: 1,
+            },
+            Token::Str("a"),
+            Token::I32(0),
+            Token::StructEnd,
+            Token::StructEnd,
+        ],
+    );
+}
+
+#[test]
 fn test_adjacently_tagged_enum_containing_flatten() {
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
     #[serde(tag = "t", content = "c")]


### PR DESCRIPTION
This pull request will add support for `Bytes` as the tag and content field name in adjacently tagged enums. This addresses the issue raised here: https://github.com/BurntSushi/rust-csv/issues/278

Code changes are in `TagContentOtherFieldVisitor` as suggested by the investigation in the above issue, and a unit test is added to cover this case. The unit test currently fails on serde/master.