### PR TITLE
Fix generation of non-existent lifetime `'de` when enum contains a #[serde(flatten)] field and a `'static` reference

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -954,6 +954,7 @@ fn deserialize_struct(
             lifetime: _serde::__private::PhantomData,
         }
     };
+    let need_seed = deserializer.is_none();
     let dispatch = if let Some(deserializer) = deserializer {
         quote! {
             _serde::Deserializer::deserialize_any(#deserializer, #visitor_expr)
@@ -999,7 +1000,7 @@ fn deserialize_struct(
         _ => None,
     };
 
-    let visitor_seed = if is_enum && cattrs.has_flatten() {
+    let visitor_seed = if need_seed && is_enum && cattrs.has_flatten() {
         Some(quote! {
             impl #de_impl_generics _serde::de::DeserializeSeed<#delife> for __Visitor #de_ty_generics #where_clause {
                 type Value = #this_type #ty_generics;

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1006,7 +1006,7 @@ fn deserialize_struct(
 
                 fn deserialize<__D>(self, __deserializer: __D) -> _serde::__private::Result<Self::Value, __D::Error>
                 where
-                    __D: _serde::Deserializer<'de>,
+                    __D: _serde::Deserializer<#delife>,
                 {
                     _serde::Deserializer::deserialize_map(__deserializer, self)
                 }

--- a/test_suite/tests/test_gen.rs
+++ b/test_suite/tests/test_gen.rs
@@ -892,3 +892,53 @@ pub struct RemotePackedNonCopyDef {
 impl Drop for RemotePackedNonCopyDef {
     fn drop(&mut self) {}
 }
+
+//////////////////////////////////////////////////////////////////////////
+
+/// Regression tests for <https://github.com/serde-rs/serde/issues/2371>
+#[allow(dead_code)]
+mod static_and_flatten {
+    use super::*;
+
+    #[derive(Deserialize)]
+    struct Nested;
+
+    #[derive(Deserialize)]
+    enum ExternallyTagged {
+        Flatten {
+            #[serde(flatten)]
+            nested: Nested,
+            string: &'static str,
+        },
+    }
+
+    #[derive(Deserialize)]
+    #[serde(tag = "tag")]
+    enum InternallyTagged {
+        Flatten {
+            #[serde(flatten)]
+            nested: Nested,
+            string: &'static str,
+        },
+    }
+
+    #[derive(Deserialize)]
+    #[serde(tag = "tag", content = "content")]
+    enum AdjacentlyTagged {
+        Flatten {
+            #[serde(flatten)]
+            nested: Nested,
+            string: &'static str,
+        },
+    }
+
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum UntaggedWorkaround {
+        Flatten {
+            #[serde(flatten)]
+            nested: Nested,
+            string: &'static str,
+        },
+    }
+}


### PR DESCRIPTION
New `test_gen` tests prevents future regressions.

Fixes #2371.