### PR TITLE
Update the comment on simpler exhaustive matching in derive

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1256,7 +1256,7 @@ fn deserialize_externally_tagged_enum(
         // This is an empty enum like `enum Impossible {}` or an enum in which
         // all variants have `#[serde(skip_deserializing)]`.
         quote! {
-            // FIXME: Once we drop support for Rust 1.15:
+            // FIXME: Once feature(exhaustive_patterns) is stable:
             // let _serde::__private::Err(__err) = _serde::de::EnumAccess::variant::<__Field>(__data);
             // _serde::__private::Err(__err)
             _serde::__private::Result::map(
@@ -2536,7 +2536,7 @@ fn deserialize_map(
     let all_skipped = fields.iter().all(|field| field.attrs.skip_deserializing());
     let match_keys = if cattrs.deny_unknown_fields() && all_skipped {
         quote! {
-            // FIXME: Once we drop support for Rust 1.15:
+            // FIXME: Once feature(exhaustive_patterns) is stable:
             // let _serde::__private::None::<__Field> = try!(_serde::de::MapAccess::next_key(&mut __map));
             _serde::__private::Option::map(
                 try!(_serde::de::MapAccess::next_key::<__Field>(&mut __map)),
@@ -2769,7 +2769,7 @@ fn deserialize_map_in_place(
 
     let match_keys = if cattrs.deny_unknown_fields() && all_skipped {
         quote! {
-            // FIXME: Once we drop support for Rust 1.15:
+            // FIXME: Once feature(exhaustive_patterns) is stable:
             // let _serde::__private::None::<__Field> = try!(_serde::de::MapAccess::next_key(&mut __map));
             _serde::__private::Option::map(
                 try!(_serde::de::MapAccess::next_key::<__Field>(&mut __map)),


### PR DESCRIPTION
The code in these comments was supported without a feature gate in rustc 1.15.0-nightly at the time that the comments got added in #678, but was later feature gated behind `feature(never_type)` by https://github.com/rust-lang/rust/pull/39290, then by `feature(exhaustive_patterns)` in https://github.com/rust-lang/rust/pull/47630.

Closes #2379.