### PR TITLE
Eliminate special case on empty string passed to borrow=""

### DIFF
--- a/test_suite/tests/ui/borrow/empty_lifetimes.rs
+++ b/test_suite/tests/ui/borrow/empty_lifetimes.rs
@@ -3,6 +3,8 @@ use serde_derive::Deserialize;
 #[derive(Deserialize)]
 struct Test<'a> {
     #[serde(borrow = "")]
+    r: &'a str,
+    #[serde(borrow = "  ")]
     s: &'a str,
 }
 

--- a/test_suite/tests/ui/borrow/empty_lifetimes.stderr
+++ b/test_suite/tests/ui/borrow/empty_lifetimes.stderr
@@ -4,7 +4,7 @@ error: at least one lifetime must be borrowed
 5 |     #[serde(borrow = "")]
   |                      ^^
 
-error: failed to parse borrowed lifetimes: "  "
+error: at least one lifetime must be borrowed
  --> tests/ui/borrow/empty_lifetimes.rs:7:22
   |
 7 |     #[serde(borrow = "  ")]

--- a/test_suite/tests/ui/borrow/empty_lifetimes.stderr
+++ b/test_suite/tests/ui/borrow/empty_lifetimes.stderr
@@ -3,3 +3,9 @@ error: at least one lifetime must be borrowed
   |
 5 |     #[serde(borrow = "")]
   |                      ^^
+
+error: failed to parse borrowed lifetimes: "  "
+ --> tests/ui/borrow/empty_lifetimes.rs:7:22
+  |
+7 |     #[serde(borrow = "  ")]
+  |                      ^^^^


### PR DESCRIPTION
Previously `serde(borrow = "")` vs `serde(borrow = " ")` were treated differently, which is unexpected. These should mean the same thing.