### PR TITLE
Add a test of serde(bound = "") attribute

### DIFF
--- a/test_suite/tests/test_gen.rs
+++ b/test_suite/tests/test_gen.rs
@@ -257,6 +257,16 @@ fn test_gen() {
     }
     assert::<VariantWithTraits2<X, X>>();
 
+    type PhantomDataAlias<T> = PhantomData<T>;
+
+    #[derive(Serialize, Deserialize)]
+    #[serde(bound = "")]
+    struct PhantomDataWrapper<T> {
+        #[serde(default)]
+        field: PhantomDataAlias<T>,
+    }
+    assert::<PhantomDataWrapper<X>>();
+
     #[derive(Serialize, Deserialize)]
     struct CowStr<'a>(Cow<'a, str>);
     assert::<CowStr>();


### PR DESCRIPTION
Without `serde(bound = "")`, serde_derive infers a bound of `T: Serialize` for the generated Serialize impl and `T: Deserialize<'de> + Default` for the Deserialize impl. `X` implements none of these so the generated code would fail to compile.

```console
error[E0277]: the trait bound `X: Serialize` is not satisfied
   --> test_suite/tests/test_gen.rs:268:14
    |
268 |     assert::<PhantomDataWrapper<X>>();
    |              ^^^^^^^^^^^^^^^^^^^^^ the trait `Serialize` is not implemented for `X`
    |
    = help: the following other types implement trait `Serialize`:
              &'a T
              &'a mut T
              ()
              (T0, T1)
              (T0, T1, T2)
              (T0, T1, T2, T3)
              (T0, T1, T2, T3, T4)
              (T0, T1, T2, T3, T4, T5)
            and 248 others
note: required for `PhantomDataWrapper<X>` to implement `Serialize`
   --> test_suite/tests/test_gen.rs:262:14
    |
262 |     #[derive(Serialize, Deserialize)]
    |              ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
263 |     //#[serde(bound = "")]
264 |     struct PhantomDataWrapper<T> {
    |            ^^^^^^^^^^^^^^^^^^^^^
note: required by a bound in `assert`
   --> test_suite/tests/test_gen.rs:767:14
    |
767 | fn assert<T: Serialize + DeserializeOwned>() {}
    |              ^^^^^^^^^ required by this bound in `assert`
    = note: this error originates in the derive macro `Serialize` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the trait bound `X: Deserialize<'_>` is not satisfied
   --> test_suite/tests/test_gen.rs:268:14
    |
268 |     assert::<PhantomDataWrapper<X>>();
    |              ^^^^^^^^^^^^^^^^^^^^^ the trait `Deserialize<'_>` is not implemented for `X`
    |
    = help: the following other types implement trait `Deserialize<'de>`:
              <&'a Path as Deserialize<'de>>
              <&'a [u8] as Deserialize<'de>>
              <&'a str as Deserialize<'de>>
              <() as Deserialize<'de>>
              <(T0, T1) as Deserialize<'de>>
              <(T0, T1, T2) as Deserialize<'de>>
              <(T0, T1, T2, T3) as Deserialize<'de>>
              <(T0, T1, T2, T3, T4) as Deserialize<'de>>
            and 331 others
note: required for `PhantomDataWrapper<X>` to implement `for<'de> Deserialize<'de>`
   --> test_suite/tests/test_gen.rs:262:25
    |
262 |     #[derive(Serialize, Deserialize)]
    |                         ^^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
263 |     //#[serde(bound = "")]
264 |     struct PhantomDataWrapper<T> {
    |            ^^^^^^^^^^^^^^^^^^^^^
    = note: required for `PhantomDataWrapper<X>` to implement `DeserializeOwned`
note: required by a bound in `assert`
   --> test_suite/tests/test_gen.rs:767:26
    |
767 | fn assert<T: Serialize + DeserializeOwned>() {}
    |                          ^^^^^^^^^^^^^^^^ required by this bound in `assert`
    = note: this error originates in the derive macro `Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the trait bound `X: Default` is not satisfied
   --> test_suite/tests/test_gen.rs:268:14
    |
268 |     assert::<PhantomDataWrapper<X>>();
    |              ^^^^^^^^^^^^^^^^^^^^^ the trait `Default` is not implemented for `X`
    |
note: required for `PhantomDataWrapper<X>` to implement `for<'de> Deserialize<'de>`
   --> test_suite/tests/test_gen.rs:262:25
    |
262 |     #[derive(Serialize, Deserialize)]
    |                         ^^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
263 |     //#[serde(bound = "")]
264 |     struct PhantomDataWrapper<T> {
    |            ^^^^^^^^^^^^^^^^^^^^^
    = note: required for `PhantomDataWrapper<X>` to implement `DeserializeOwned`
note: required by a bound in `assert`
   --> test_suite/tests/test_gen.rs:767:26
    |
767 | fn assert<T: Serialize + DeserializeOwned>() {}
    |                          ^^^^^^^^^^^^^^^^ required by this bound in `assert`
    = note: this error originates in the derive macro `Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider annotating `X` with `#[derive(Default)]`
    |
779 | #[derive(Default)]
    |
```