### PR TITLE
Eliminate special case on empty string passed to bound=""

### DIFF
--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -1626,9 +1626,6 @@ fn parse_lit_into_where(
     lit: &syn::Lit,
 ) -> Result<Vec<syn::WherePredicate>, ()> {
     let string = get_lit_str2(cx, attr_name, meta_item_name, lit)?;
-    if string.value().is_empty() {
-        return Ok(Vec::new());
-    }
 
     let where_string = syn::LitStr::new(&format!("where {}", string.value()), string.span());
 


### PR DESCRIPTION
Similar to #2392.

This works just fine if we make syn parse `"where "` as a syn::WhereClause.

The `serde(bound = "")` attribute is definitely not common enough that it would warrant a micro-optimization.