### PR TITLE
Simplify parsing of where-predicates in bound attribute

### DIFF
--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -1627,11 +1627,9 @@ fn parse_lit_into_where(
 ) -> Result<Vec<syn::WherePredicate>, ()> {
     let string = get_lit_str2(cx, attr_name, meta_item_name, lit)?;
 
-    let where_string = syn::LitStr::new(&format!("where {}", string.value()), string.span());
-
-    where_string
-        .parse::<syn::WhereClause>()
-        .map(|wh| wh.predicates.into_iter().collect())
+    string
+        .parse_with(Punctuated::<syn::WherePredicate, Token![,]>::parse_terminated)
+        .map(|predicates| predicates.into_iter().collect())
         .map_err(|err| cx.error_spanned_by(lit, err))
 }
 


### PR DESCRIPTION
This code to do `format!("where {}", string)` is from https://github.com/serde-rs/serde/commit/660ea7bd7bd0525ae07b49ff67bdeb4238c7e741 using syntex, before syn, where there was no `Parse` trait to allow parsing arbitrary data structures. Only a predetermined small set of syntax tree nodes supported being parsed.

Doing the attribute parsing with syn we no longer need to synthesize and parse a whole WhereClause, but instead just the intended syntax of the attribute.