### PR TITLE
Treat field-level borrow attr as duplicate of variant-level borrow attr

### DIFF
--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -1114,13 +1114,13 @@ impl Field {
             .and_then(|variant| variant.borrow.as_ref())
             .map(|borrow| Meta(borrow.clone()));
 
-        for meta_item in field
-            .attrs
-            .iter()
-            .flat_map(|attr| get_serde_meta_items(cx, attr))
-            .flatten()
-            .chain(variant_borrow)
-        {
+        for meta_item in variant_borrow.into_iter().chain(
+            field
+                .attrs
+                .iter()
+                .flat_map(|attr| get_serde_meta_items(cx, attr))
+                .flatten(),
+        ) {
             match &meta_item {
                 // Parse `#[serde(rename = "foo")]`
                 Meta(NameValue(m)) if m.path == RENAME => {

--- a/test_suite/tests/ui/borrow/duplicate_variant.stderr
+++ b/test_suite/tests/ui/borrow/duplicate_variant.stderr
@@ -1,5 +1,5 @@
 error: duplicate serde attribute `borrow`
- --> tests/ui/borrow/duplicate_variant.rs:8:13
+ --> tests/ui/borrow/duplicate_variant.rs:9:15
   |
-8 |     #[serde(borrow)]
-  |             ^^^^^^
+9 |     S(#[serde(borrow)] Str<'a>),
+  |               ^^^^^^


### PR DESCRIPTION
In the case of an enum like this:

```rust
#[derive(Deserialize)]
enum Test<'a> {
    #[serde(borrow)]
    S(#[serde(borrow)] Str<'a>),
}
```

previously serde_derive's <kbd>duplicate serde attribute 'borrow'</kbd> error message would point to the first borrow attribute, the one on the variant. This PR changes it to point to the second attribute, the one on the field. This is consistent with every other situation in which the later attribute in source order is the one that gets blamed for being a duplicate.