### PR TITLE
Use explicit re-export of `serde_derive` to give rustc more info

### DIFF
--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -340,7 +340,7 @@ mod std_error;
 extern crate serde_derive;
 #[cfg(feature = "serde_derive")]
 #[doc(hidden)]
-pub use serde_derive::*;
+pub use serde_derive::{Deserialize, Serialize};
 
 #[cfg(all(not(no_serde_derive), any(feature = "std", feature = "alloc")))]
 mod actually_private {


### PR DESCRIPTION
rustc will start looking behind `#[cfg(FALSE)]` items to start giving better diagnostics. By using an explicit re-export instead of a glob export, we tell rustc that `Deserialize` and `Serialize` exist here.

I'm not sure whether it's worth it to open this PR before upstream has been merged, but since this adds minimal maintenance effort and may even make the code nicer I opened it already, feel free to wait if you prefer.

Upstream PR: rust-lang/rust#109005