### PR TITLE
Show derive macros in serde's rustdoc

### DIFF
--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -27,6 +27,7 @@ doc-scrape-examples = false
 features = ["derive", "rc"]
 
 [package.metadata.docs.rs]
+features = ["derive"]
 targets = ["x86_64-unknown-linux-gnu"]
 
 

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -338,8 +338,9 @@ mod std_error;
 #[allow(unused_imports)]
 #[macro_use]
 extern crate serde_derive;
+
+/// Derive macro available if serde is built with `features = ["derive"]`.
 #[cfg(feature = "serde_derive")]
-#[doc(hidden)]
 pub use serde_derive::{Deserialize, Serialize};
 
 #[cfg(all(not(no_serde_derive), any(feature = "std", feature = "alloc")))]


### PR DESCRIPTION
I don't recall why these were hidden originally, other than this code is from the earliest days of proc macro support in rustc so probably rustdoc rendered it in an incorrect or confusing way at the time.

---

![Screenshot from 2023-03-14 00-30-25](https://user-images.githubusercontent.com/1940490/224927088-a51178f6-9e09-448b-b18b-a7e223515b5b.png)
