### PR TITLE
Allowed Enum variants to be individually marked as untagged

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1184,7 +1184,7 @@ fn deserialize_enum(
     }
 }
 
-fn deserialize_homogenious_enum(
+fn deserialize_homogeneous_enum(
     params: &Parameters,
     variants: &[Variant],
     cattrs: &attr::Container,

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1173,14 +1173,14 @@ fn deserialize_enum(
     {
         Some((variant_idx, _)) => {
             let (tagged, untagged) = variants.split_at(variant_idx);
-            let tagged_frag = Expr(deserialize_homogenious_enum(params, tagged, cattrs));
+            let tagged_frag = Expr(deserialize_homogeneous_enum(params, tagged, cattrs));
             let tagged_frag = |deserializer| Expr(quote_block! {
                 let __deserializer = #deserializer;
                 #tagged_frag
             });
             deserialize_untagged_enum_after(params, untagged, cattrs, Some(tagged_frag))
         }
-        None => deserialize_homogenious_enum(params, variants, cattrs),
+        None => deserialize_homogeneous_enum(params, variants, cattrs),
     }
 }
 

--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -798,6 +798,7 @@ pub struct Variant {
     serialize_with: Option<syn::ExprPath>,
     deserialize_with: Option<syn::ExprPath>,
     borrow: Option<BorrowAttribute>,
+    untagged: bool,
 }
 
 struct BorrowAttribute {
@@ -820,6 +821,7 @@ impl Variant {
         let mut serialize_with = Attr::none(cx, SERIALIZE_WITH);
         let mut deserialize_with = Attr::none(cx, DESERIALIZE_WITH);
         let mut borrow = Attr::none(cx, BORROW);
+        let mut untagged = BoolAttr::none(cx, UNTAGGED);
 
         for meta_item in variant
             .attrs
@@ -991,6 +993,11 @@ impl Variant {
                     }
                 },
 
+                // Parse `#[serde(untagged)]`
+                Meta(Path(word)) if word == UNTAGGED => {
+                    untagged.set_true(word);
+                }
+
                 Meta(meta_item) => {
                     let path = meta_item
                         .path()
@@ -1022,6 +1029,7 @@ impl Variant {
             serialize_with: serialize_with.get(),
             deserialize_with: deserialize_with.get(),
             borrow: borrow.get(),
+            untagged: untagged.get(),
         }
     }
 
@@ -1072,6 +1080,10 @@ impl Variant {
 
     pub fn deserialize_with(&self) -> Option<&syn::ExprPath> {
         self.deserialize_with.as_ref()
+    }
+
+    pub fn untagged(&self) -> bool {
+        self.untagged
     }
 }
 

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -477,17 +477,17 @@ fn serialize_variant(
             }
         };
 
-        let body = Match(match cattrs.tag() {
-            attr::TagType::External => {
+        let body = Match(match (cattrs.tag(), variant.attrs.untagged()) {
+            (attr::TagType::External, false) => {
                 serialize_externally_tagged_variant(params, variant, variant_index, cattrs)
             }
-            attr::TagType::Internal { tag } => {
+            (attr::TagType::Internal { tag }, false) => {
                 serialize_internally_tagged_variant(params, variant, cattrs, tag)
             }
-            attr::TagType::Adjacent { tag, content } => {
+            (attr::TagType::Adjacent { tag, content }, false) => {
                 serialize_adjacently_tagged_variant(params, variant, cattrs, tag, content)
             }
-            attr::TagType::None => serialize_untagged_variant(params, variant, cattrs),
+            (attr::TagType::None, _) | (_, true) => serialize_untagged_variant(params, variant, cattrs),
         });
 
         quote! {

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -2411,13 +2411,143 @@ fn test_partially_untagged_enum() {
     assert_tokens(
         &data,
         &[
-            Token::TupleVariant {name: "Exp", variant: "Lambda", len: 2},
+            Token::TupleVariant {
+                name: "Exp",
+                variant: "Lambda",
+                len: 2,
+            },
             Token::U32(0),
-            Token::Tuple{len: 2},
+            Token::Tuple { len: 2 },
             Token::U32(0),
             Token::U32(0),
             Token::TupleEnd,
             Token::TupleVariantEnd,
+        ],
+    );
+}
+
+#[test]
+fn test_partially_untagged_enum_generic() {
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    enum Either<L, R> {
+        Left(L),
+        #[serde(untagged)]
+        Right(R),
+    }
+    type MyEither = Either<Either<u32, String>, bool>;
+    use Either::*;
+
+    assert_tokens::<MyEither>(&Right(true), &[Token::Bool(true)]);
+
+    assert_tokens::<MyEither>(
+        &Left(Right("Hello".into())),
+        &[
+            Token::NewtypeVariant {
+                name: "Either",
+                variant: "Left",
+            },
+            Token::String("Hello"),
+        ],
+    );
+
+    assert_tokens::<MyEither>(
+        &Left(Left(5)),
+        &[
+            Token::NewtypeVariant {
+                name: "Either",
+                variant: "Left",
+            },
+            Token::NewtypeVariant {
+                name: "Either",
+                variant: "Left",
+            },
+            Token::U32(5),
+        ],
+    );
+}
+
+#[test]
+fn test_partially_untagged_enum_desugared() {
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    enum Test {
+        A(u32, u32),
+        B(u32),
+        #[serde(untagged)]
+        C(u32),
+        #[serde(untagged)]
+        D(u32, u32),
+    }
+    use Test::*;
+
+    mod desugared {
+        use super::*;
+        #[derive(Serialize, Deserialize, PartialEq, Debug)]
+        pub(super) enum Test {
+            A(u32, u32),
+            B(u32),
+        }
+    }
+    use desugared::Test as TestTagged;
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    #[serde(untagged)]
+    enum TestUntagged {
+        Tagged(TestTagged),
+        C(u32),
+        D(u32, u32),
+    }
+
+    impl From<Test> for TestUntagged {
+        fn from(test: Test) -> Self {
+            match test {
+                A(x, y) => TestUntagged::Tagged(TestTagged::A(x, y)),
+                B(x) => TestUntagged::Tagged(TestTagged::B(x)),
+                C(x) => TestUntagged::C(x),
+                D(x, y) => TestUntagged::D(x, y),
+            }
+        }
+    }
+
+    fn assert_tokens_desugared(value: Test, tokens: &[Token]) {
+        assert_tokens(&value, tokens);
+        let desugared: TestUntagged = value.into();
+        assert_tokens(&desugared, tokens);
+    }
+
+    assert_tokens_desugared(
+        A(0, 1),
+        &[
+            Token::TupleVariant {
+                name: "Test",
+                variant: "A",
+                len: 2,
+            },
+            Token::U32(0),
+            Token::U32(1),
+            Token::TupleVariantEnd,
+        ],
+    );
+
+    assert_tokens_desugared(
+        B(1),
+        &[
+            Token::NewtypeVariant {
+                name: "Test",
+                variant: "B",
+            },
+            Token::U32(1),
+        ],
+    );
+
+    assert_tokens_desugared(C(2), &[Token::U32(2)]);
+
+    assert_tokens_desugared(
+        D(3, 5),
+        &[
+            Token::Tuple { len: 2 },
+            Token::U32(3),
+            Token::U32(5),
+            Token::TupleEnd,
         ],
     );
 }

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -2396,6 +2396,33 @@ fn test_untagged_enum_containing_flatten() {
 }
 
 #[test]
+fn test_partially_untagged_enum() {
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    enum Exp {
+        Lambda(u32, Box<Exp>),
+        #[serde(untagged)]
+        App(Box<Exp>, Box<Exp>),
+        #[serde(untagged)]
+        Var(u32),
+    }
+    use Exp::*;
+
+    let data = Lambda(0, Box::new(App(Box::new(Var(0)), Box::new(Var(0)))));
+    assert_tokens(
+        &data,
+        &[
+            Token::TupleVariant {name: "Exp", variant: "Lambda", len: 2},
+            Token::U32(0),
+            Token::Tuple{len: 2},
+            Token::U32(0),
+            Token::U32(0),
+            Token::TupleEnd,
+            Token::TupleVariantEnd,
+        ],
+    );
+}
+
+#[test]
 fn test_flatten_untagged_enum() {
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
     struct Outer {

--- a/test_suite/tests/ui/enum-representation/partially_tagged_wrong_order.rs
+++ b/test_suite/tests/ui/enum-representation/partially_tagged_wrong_order.rs
@@ -1,0 +1,10 @@
+use serde_derive::Serialize;
+
+#[derive(Serialize)]
+enum E {
+    #[serde(untagged)]
+    A(u8),
+    B(String),
+}
+
+fn main() {}

--- a/test_suite/tests/ui/enum-representation/partially_tagged_wrong_order.stderr
+++ b/test_suite/tests/ui/enum-representation/partially_tagged_wrong_order.stderr
@@ -1,0 +1,5 @@
+error: all variants with the #[serde(untagged)] attribute must be placed at the end of the enum
+ --> tests/ui/enum-representation/partially_tagged_wrong_order.rs:7:5
+  |
+7 |     B(String),
+  |     ^


### PR DESCRIPTION
This should hopefully resolve #1402.

This can be thought of as applying the following transformation
```rust
#[derive(Serialize, Deserialize)
enum Test {
  A(u32, u32),
  B(u32),
  #[serde(untagged)]
  C(u32),
  #[serde(untagged)]
  D(u32, u32),
}
```
to
```rust
#[derive(Serialize, Deserialize)
enum TestTagged {
  A(u32, u32),
  B(u32),
}

#[derive(Serialize, Deserialize)
#[serde(untagged)]
enum TestUntagged {
  Tagged(TestTagged),
  C(u32),
  D(u32, u32)
}

#[derive(Serialize, Deserialize)
#[serde(from = "TestUntagged")]
#[serde(into = "TestUntagged")]
enum Test {
  ...
}
```
The actual implementation generates the implementation directly allowing it to also work efficiently for recursive enums.

The current version includes a restriction that all variants marked as `untagged` appear at the end of the enum (after the tagged variants) in order to keep the implementation strategy consistent with an alternate strategy of attempting to deserialize each variant in order.

Deserialize could also be implemented to accept all of the variants with tags, only falling back to untagged if none of them match, I'm not sure if this would be preferred.