### PR TITLE
Add ui test of malformed attribute containing expression

### DIFF
--- a/test_suite/tests/ui/malformed/trailing_expr.rs
+++ b/test_suite/tests/ui/malformed/trailing_expr.rs
@@ -1,0 +1,9 @@
+use serde_derive::Serialize;
+
+#[derive(Serialize)]
+struct S {
+    #[serde(skip_serializing_if, x.is_empty())]
+    x: Vec<()>,
+}
+
+fn main() {}

--- a/test_suite/tests/ui/malformed/trailing_expr.stderr
+++ b/test_suite/tests/ui/malformed/trailing_expr.stderr
@@ -1,0 +1,5 @@
+error: expected `,`
+ --> tests/ui/malformed/trailing_expr.rs:5:35
+  |
+5 |     #[serde(skip_serializing_if, x.is_empty())]
+  |                                   ^


### PR DESCRIPTION
I'm hoping to improve this error in an upcoming PR.