### PR TITLE
Add `std::any::Provider` support to `Serializer`

### DIFF
--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -100,7 +100,7 @@
 // discussion of these features please refer to this issue:
 //
 //    https://github.com/serde-rs/serde/issues/812
-#![cfg_attr(feature = "unstable", feature(error_in_core, never_type))]
+#![cfg_attr(feature = "unstable", feature(error_in_core, never_type, provide_any))]
 #![allow(unknown_lints, bare_trait_objects, deprecated)]
 #![cfg_attr(feature = "cargo-clippy", allow(renamed_and_removed_lints))]
 // Ignored clippy and clippy_pedantic lints

--- a/serde/src/private/doc.rs
+++ b/serde/src/private/doc.rs
@@ -2,6 +2,7 @@
 
 use lib::*;
 
+use de;
 use ser;
 
 #[doc(hidden)]
@@ -9,6 +10,15 @@ use ser;
 pub struct Error;
 
 impl ser::Error for Error {
+    fn custom<T>(_: T) -> Self
+    where
+        T: Display,
+    {
+        unimplemented!()
+    }
+}
+
+impl de::Error for Error {
     fn custom<T>(_: T) -> Self
     where
         T: Display,


### PR DESCRIPTION
Turn a `Serializer` into a [`std::any::Provider`] in a backward compatible way.

This allows specialization between a `Serializer` and a `Serialize` in a generic way.

The one particular use case I have in mind is for [`serde_dynamo`]. DynamoDB supports lists of generic items – which is what `serde_dynamo` currently uses to serialize e.g. a `Vec<String>`. However, DynamoDB also supports specialized types like [String Set] that it would be nice to be able to opt in to.

Using [`std::any::Provider`], this could look something like this:

```rust
/// A specialized serializer
///
/// This would most likely be used with `#[serde(with = "string_set")]`
struct StringSet<T>(T);

impl<T> Serialize for StringSet<T> where T: Serialize {
    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
    where
        S: serde::Serializer,
    {
        if let Some(string_set_serializer) = std::any::request_value::<serde_dynamo::StringSetSerializer>(&serializer.provider()) {
            self.0.serialize(string_set_serializer)
        } else {
            self.0.serialize(serializer)
        }
    }
}

/// In user code, a struct that wants `strings` to be serialized
/// using a DynamoDb string set *if* the serializer is
/// `serde_dynamo`
#[derive(Debug, Serialize, Deserialize)]
struct Subject {
    strings: StringSet<Vec<String>>,
}
```

With this set up, `Subject.strings` would be serialized as normal using `serde_json`

```json
{
    "strings": ["one", "two"]
}
```

but when using `serde_dynamo`, `Subject.strings` would use the specific `StringSetSerializer` to get custom behavior.

This is a very specific example where `serde_dynamo` would likely provide both the `StringSet` wrapper and the `StringSetSerializer`.

There *may* also be situations where the ecosystem would develop common practices. One example is the `Serializer::is_human_readable` function. If this existed before that was introduced, it's *possible* the serializers could have provided `struct IsHumanReadable(bool)` and serializers could have used that to determine how to display timestamps. It's possible that this alleviates some of the need for https://github.com/serde-rs/serde/pull/455, but I haven't looked at every use case there.

Links regarding [`std::any::Provider`]:

* `std::any::Provider` RFC: https://rust-lang.github.io/rfcs/3192-dyno.html
* `std::any::Provider` tracking issue: https://github.com/rust-lang/rust/issues/96024

Implementation notes:

* ~I opted for getting this out for discussion and review quickly, which means I didn't spend too much time on documentation and zero time on tests. If this is an approach the team is interested in, I'll be happy to revisit those.~ I've added doc tests to `provide` and `provider`.
* ~There doesn't necessarily need to be a `Serializer::provider` convenience method. We could use documentation to push implementors to use `SerializerProvider::wrap(&serializer)` when they need a provider.~ Based on doc tests and some experimenting, I think having the default `provider` method is valuable.
* ~This is most useful to my use case on `Serializer`, but I wonder if it also would be useful on the `Serialize*` sub-traits of `Serializer`, and/or on `Deserialize` traits.~ I've added this to `Deserialize` as well.

[`std::any::Provider`]: https://doc.rust-lang.org/nightly/core/any/trait.Provider.html
[`serde_dynamo`]: https://docs.rs/serde_dynamo
[String Set]: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html