### PR TITLE
test: test for empty serde args

### DIFF
--- a/test_suite/tests/ui/unexpected-literal/empty_args.rs
+++ b/test_suite/tests/ui/unexpected-literal/empty_args.rs
@@ -1,0 +1,7 @@
+use serde_derive::Serialize;
+
+#[derive(Serialize)]
+#[serde()]
+struct S;
+
+fn main() {}

--- a/test_suite/tests/ui/unexpected-literal/empty_args.stderr
+++ b/test_suite/tests/ui/unexpected-literal/empty_args.stderr
@@ -1,0 +1,5 @@
+error: unexpected end of input, unexpected token in nested attribute, expected ident
+ --> tests/ui/unexpected-literal/empty_args.rs:4:9
+  |
+4 | #[serde()]
+  |         ^


### PR DESCRIPTION
# Potential regression

Today I came acrossed with this error:
![image](https://user-images.githubusercontent.com/15936231/228110002-90a3cc11-9b85-4471-8232-5b1ef7972e72.png)

And I found [it uses `#[serde()]`][l1] all over the place, and I also found [Possible semver breaking change in serde 1.0.157][l2], , is this the expected behavier? if so, I added a test for it, if not, I will change the test and fix it



ref: oxidecomputer/progenitor/issues/394


[l1]: https://github.com/oxidecomputer/third-party-api-clients/blob/main/github/src/types.rs#L257
[l2]: https://github.com/serde-rs/serde/issues/2415