### PR TITLE
Accept empty #[serde()] attribute

### DIFF
--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -307,6 +307,12 @@ impl Container {
                 continue;
             }
 
+            if let syn::Meta::List(meta) = &attr.meta {
+                if meta.tokens.is_empty() {
+                    continue;
+                }
+            }
+
             if let Err(err) = attr.parse_nested_meta(|meta| {
                 if meta.path == RENAME {
                     // #[serde(rename = "foo")]
@@ -762,6 +768,12 @@ impl Variant {
                 continue;
             }
 
+            if let syn::Meta::List(meta) = &attr.meta {
+                if meta.tokens.is_empty() {
+                    continue;
+                }
+            }
+
             if let Err(err) = attr.parse_nested_meta(|meta| {
                 if meta.path == RENAME {
                     // #[serde(rename = "foo")]
@@ -1031,6 +1043,12 @@ impl Field {
         for attr in &field.attrs {
             if attr.path() != SERDE {
                 continue;
+            }
+
+            if let syn::Meta::List(meta) = &attr.meta {
+                if meta.tokens.is_empty() {
+                    continue;
+                }
             }
 
             if let Err(err) = attr.parse_nested_meta(|meta| {

--- a/test_suite/tests/regression/issue2415.rs
+++ b/test_suite/tests/regression/issue2415.rs
@@ -1,0 +1,5 @@
+use serde_derive::Serialize;
+
+#[derive(Serialize)]
+#[serde()]
+pub struct S;


### PR DESCRIPTION
Fixes #2415. Closes #2421.