### PR TITLE
Implement serialization and deserialization of 'core::convert::Infallible'

### DIFF
--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -428,6 +428,17 @@ serde_if_integer128! {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+impl<'de> Deserialize<'de> for core::convert::Infallible {
+    fn deserialize<D>(_: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Err(D::Error::custom("cannot deserialize `Infallible`"))
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 struct CharVisitor;
 
 impl<'de> Visitor<'de> for CharVisitor {

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -40,6 +40,17 @@ serde_if_integer128! {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+impl Serialize for core::convert::Infallible {
+    fn serialize<S>(&self, _: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match *self {}
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 impl Serialize for str {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -86,6 +86,7 @@
 //!    - RangeInclusive\<T\>
 //!    - Bound\<T\>
 //!    - num::NonZero*
+//!    - core::convert::Infallible
 //!    - `!` *(unstable)*
 //!  - **Net types**:
 //!    - IpAddr


### PR DESCRIPTION
As the usage of analogous implementations for `!` (`never` type) is currently unstable, I suppose, it would be good to have these implementations for the `Infallible` type, as it could be pretty helpful sometimes, but own `Infallible` struct is boilerplate.

For example, consider the app, written using the Tauri framework. It needs to have a command, that returns a plain value, but for a reason, it is not possible to create such a command if it is async and has references as arguments. The only way currently is to return a `Result` type, but if the action is infallible, it may be redundant. Currently, the only way to make this happen is to put as an error type `()` or own implementation if `Infallible`

```rust
#[tauri::command]
pub async fn is_logged_in(login_info: State<'_, Mutex<Option<LoginInfo>>>) -> Result<bool, ()> {
    Ok(login_info.lock().await.is_some())
}
```

I think there may be more examples like this. Storing Results in logs or something.