### PR TITLE
Ignore deprecation warnings for derived `Serialize`/`Deserialize` impls

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -54,6 +54,7 @@ pub fn expand_derive_deserialize(
 
         quote! {
             #[automatically_derived]
+            #[allow(deprecated)]
             impl #de_impl_generics #serde::Deserialize<#delife> for #ident #ty_generics #where_clause {
                 fn deserialize<__D>(__deserializer: __D) -> #serde::__private::Result<Self, __D::Error>
                 where

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -46,6 +46,7 @@ pub fn expand_derive_serialize(
     } else {
         quote! {
             #[automatically_derived]
+            #[allow(deprecated)]
             impl #impl_generics #serde::Serialize for #ident #ty_generics #where_clause {
                 fn serialize<__S>(&self, __serializer: __S) -> #serde::__private::Result<__S::Ok, __S::Error>
                 where

--- a/test_suite/tests/test_deprecated.rs
+++ b/test_suite/tests/test_deprecated.rs
@@ -1,0 +1,11 @@
+// Asset that derived `Serialize` and `Deserialize` impls don't emit
+// deprecation warnings when the type itself is deprecated.
+// This test will fail to compile if a deprecation warning is emitted.
+
+#![deny(deprecated)]
+
+use serde::{Deserialize, Serialize};
+
+#[deprecated]
+#[derive(Serialize, Deserialize)]
+pub struct DeprecatedItem {}


### PR DESCRIPTION
Fixes the depreciation warnings when deriving `Serialize` or `Deserialize` on a depreciated item.

For example the following code currently emits a bunch of warnings, which come from the derived `Serialize`/`Deserialize` impls:
```rust
#[derive(Debug, Serialize, Deserialize)]
#[deprecated]
struct UserId(u64);
```

Note that the `Debug` does not emit any warning.