### PR TITLE
add `serialize_map_struct` and `deserialize_map_struct`

### DIFF
--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -1113,6 +1113,22 @@ pub trait Deserializer<'de>: Sized {
     where
         V: Visitor<'de>;
 
+    /// Hint that the `Deserialize` type is expecting a map of key-value pairs.
+    /// Additional name and fields information is provided
+    fn deserialize_map_struct<V>(
+        self,
+        name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let _ = name;
+        let _ = fields;
+        self.deserialize_map(visitor)
+    }
+
     /// Hint that the `Deserialize` type is expecting a struct with a particular
     /// name and fields.
     fn deserialize_struct<V>(

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -367,6 +367,8 @@ fn serialize_struct_as_map(
     let serialize_fields =
         serialize_struct_visitor(fields, params, false, &StructTrait::SerializeMap);
 
+    let type_name = cattrs.name().serialize_name();
+
     let tag_field = serialize_struct_tag_field(cattrs, &StructTrait::SerializeMap);
     let tag_field_exists = !tag_field.is_empty();
 
@@ -396,7 +398,7 @@ fn serialize_struct_as_map(
     };
 
     quote_block! {
-        let #let_mut __serde_state = try!(_serde::Serializer::serialize_map(__serializer, #len));
+        let #let_mut __serde_state = try!(_serde::Serializer::serialize_map_struct(__serializer, #type_name, #len));
         #tag_field
         #(#serialize_fields)*
         _serde::ser::SerializeMap::end(__serde_state)
@@ -1296,7 +1298,7 @@ impl StructTrait {
     fn serialize_field(&self, span: Span) -> TokenStream {
         match *self {
             StructTrait::SerializeMap => {
-                quote_spanned!(span=> _serde::ser::SerializeMap::serialize_entry)
+                quote_spanned!(span=> _serde::ser::SerializeMap::serialize_field)
             }
             StructTrait::SerializeStruct => {
                 quote_spanned!(span=> _serde::ser::SerializeStruct::serialize_field)

--- a/serde_test/src/de.rs
+++ b/serde_test/src/de.rs
@@ -159,7 +159,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
                 self.visit_seq(Some(len), Token::TupleStructEnd, visitor)
             }
             Token::Map { len } => self.visit_map(len, Token::MapEnd, visitor),
-            Token::MapStruct { len, .. } => self.visit_map(len, Token::MapEnd, visitor),
+            Token::MapStruct { len, .. } => self.visit_map(len, Token::MapStructEnd, visitor),
             Token::Struct { len, .. } => self.visit_map(Some(len), Token::StructEnd, visitor),
             Token::Enum { .. } => {
                 let variant = self.next_token();
@@ -231,6 +231,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             | Token::TupleEnd
             | Token::TupleStructEnd
             | Token::MapEnd
+            | Token::MapStructEnd
             | Token::StructEnd
             | Token::TupleVariantEnd
             | Token::StructVariantEnd => {

--- a/serde_test/src/de.rs
+++ b/serde_test/src/de.rs
@@ -159,6 +159,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
                 self.visit_seq(Some(len), Token::TupleStructEnd, visitor)
             }
             Token::Map { len } => self.visit_map(len, Token::MapEnd, visitor),
+            Token::MapStruct { len, .. } => self.visit_map(len, Token::MapEnd, visitor),
             Token::Struct { len, .. } => self.visit_map(Some(len), Token::StructEnd, visitor),
             Token::Enum { .. } => {
                 let variant = self.next_token();

--- a/serde_test/src/ser.rs
+++ b/serde_test/src/ser.rs
@@ -277,12 +277,18 @@ impl<'s, 'a> ser::Serializer for &'s mut Serializer<'a> {
         len: Option<usize>,
     ) -> Result<Self::SerializeMap, Self::Error> {
         assert_next_token!(self, MapStruct { name, len });
-        Ok(Variant { ser: self, end: Token::MapStructEnd })
+        Ok(Variant {
+            ser: self,
+            end: Token::MapStructEnd,
+        })
     }
 
     fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Error> {
         assert_next_token!(self, Map { len });
-        Ok(Variant { ser: self, end: Token::MapEnd })
+        Ok(Variant {
+            ser: self,
+            end: Token::MapEnd,
+        })
     }
 
     fn serialize_struct(self, name: &'static str, len: usize) -> Result<Self, Error> {

--- a/serde_test/src/ser.rs
+++ b/serde_test/src/ser.rs
@@ -271,6 +271,15 @@ impl<'s, 'a> ser::Serializer for &'s mut Serializer<'a> {
         }
     }
 
+    fn serialize_map_struct(
+        self,
+        name: &'static str,
+        len: Option<usize>,
+    ) -> Result<Self::SerializeMap, Self::Error> {
+        assert_next_token!(self, MapStruct { name, len });
+        Ok(self)
+    }
+
     fn serialize_map(self, len: Option<usize>) -> Result<Self, Error> {
         assert_next_token!(self, Map { len });
         Ok(self)

--- a/serde_test/src/token.rs
+++ b/serde_test/src/token.rs
@@ -395,6 +395,42 @@ pub enum Token {
     /// An indicator of the end of a map.
     MapEnd,
 
+    /// The header to a map.
+    ///
+    /// After this header are the entries of the map, followed by `MapEnd`.
+    ///
+    /// ```edition2018
+    /// # use serde::{Serialize, Deserialize};
+    /// # use serde_test::{assert_tokens, Token};
+    /// #
+    /// use std::collections::BTreeMap;
+    /// #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    /// struct S {
+    ///     a: u8,
+    ///     #[serde(flatten)]
+    ///     other: BTreeMap<char, i32>,
+    /// }
+    /// let mut map = BTreeMap::new();
+    /// map.insert('A', 65);
+    /// map.insert('Z', 90);
+    /// let s = S { a: 0, other: map };
+    ///
+    /// assert_tokens(&s, &[
+    ///     Token::MapStruct { name: "S", len: None },
+    ///     Token::Str("a"),
+    ///     Token::U8(0),
+    ///     Token::Char('A'),
+    ///     Token::I32(65),
+    ///     Token::Char('Z'),
+    ///     Token::I32(90),
+    ///     Token::MapEnd,
+    /// ]);
+    /// ```
+    MapStruct {
+        name: &'static str,
+        len: Option<usize>,
+    },
+
     /// The header of a struct.
     ///
     /// After this header are the fields of the struct, followed by `StructEnd`.

--- a/serde_test/src/token.rs
+++ b/serde_test/src/token.rs
@@ -423,13 +423,16 @@ pub enum Token {
     ///     Token::I32(65),
     ///     Token::Char('Z'),
     ///     Token::I32(90),
-    ///     Token::MapEnd,
+    ///     Token::MapStructEnd,
     /// ]);
     /// ```
     MapStruct {
         name: &'static str,
         len: Option<usize>,
     },
+
+    /// An indicator of the end of a map.
+    MapStructEnd,
 
     /// The header of a struct.
     ///

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -1642,7 +1642,7 @@ fn test_collect_other() {
             Token::U32(2),
             Token::Str("c"),
             Token::U32(3),
-            Token::MapEnd,
+            Token::MapStructEnd,
         ],
     );
 }
@@ -1674,7 +1674,7 @@ fn test_flatten_struct_enum() {
             Token::MapEnd,
             Token::Str("extra_key"),
             Token::Str("extra value"),
-            Token::MapEnd,
+            Token::MapStructEnd,
         ],
     );
     assert_ser_tokens(
@@ -1696,7 +1696,7 @@ fn test_flatten_struct_enum() {
             Token::StructEnd,
             Token::Str("extra_key"),
             Token::Str("extra value"),
-            Token::MapEnd,
+            Token::MapStructEnd,
         ],
     );
 }
@@ -1728,7 +1728,7 @@ fn test_flatten_struct_tag_content_enum() {
             Token::Str("value"),
             Token::U32(42),
             Token::MapEnd,
-            Token::MapEnd,
+            Token::MapStructEnd,
         ],
     );
     assert_ser_tokens(
@@ -1752,7 +1752,7 @@ fn test_flatten_struct_tag_content_enum() {
             Token::Str("value"),
             Token::U32(42),
             Token::StructEnd,
-            Token::MapEnd,
+            Token::MapStructEnd,
         ],
     );
 }
@@ -1781,7 +1781,7 @@ fn test_flatten_struct_tag_content_enum_newtype() {
             Token::Str("value"),
             Token::U32(23),
             Token::MapEnd,
-            Token::MapEnd,
+            Token::MapStructEnd,
         ],
     );
     assert_ser_tokens(
@@ -1803,7 +1803,7 @@ fn test_flatten_struct_tag_content_enum_newtype() {
             Token::Str("value"),
             Token::U32(23),
             Token::StructEnd,
-            Token::MapEnd,
+            Token::MapStructEnd,
         ],
     );
 }
@@ -1909,7 +1909,7 @@ fn test_complex_flatten() {
             Token::U32(3),
             Token::Str("z"),
             Token::U32(4),
-            Token::MapEnd,
+            Token::MapStructEnd,
         ],
     );
 
@@ -1951,7 +1951,7 @@ fn test_complex_flatten() {
             Token::U32(3),
             Token::Str("z"),
             Token::U32(4),
-            Token::MapEnd,
+            Token::MapStructEnd,
         ],
     );
 }
@@ -2020,7 +2020,7 @@ fn test_flatten_unit() {
             },
             Token::Str("status"),
             Token::U64(0),
-            Token::MapEnd,
+            Token::MapStructEnd,
         ],
     );
 }
@@ -2059,7 +2059,7 @@ fn test_flatten_unsupported_type() {
             Token::Str("foo"),
             Token::Str("a"),
             Token::Str("b"),
-            Token::MapEnd,
+            Token::MapStructEnd,
         ],
         "can only flatten structs and maps",
     );
@@ -2094,7 +2094,7 @@ fn test_non_string_keys() {
             Token::U32(3),
             Token::U32(0),
             Token::U32(42),
-            Token::MapEnd,
+            Token::MapStructEnd,
         ],
     );
 }
@@ -2130,7 +2130,7 @@ fn test_lifetime_propagation_for_flatten() {
             },
             Token::Str("x"),
             Token::U32(42),
-            Token::MapEnd,
+            Token::MapStructEnd,
         ],
     );
 
@@ -2147,7 +2147,7 @@ fn test_lifetime_propagation_for_flatten() {
             },
             Token::BorrowedStr("x"),
             Token::U32(42),
-            Token::MapEnd,
+            Token::MapStructEnd,
         ],
     );
 
@@ -2160,7 +2160,7 @@ fn test_lifetime_propagation_for_flatten() {
             },
             Token::BorrowedStr("x"),
             Token::U32(42),
-            Token::MapEnd,
+            Token::MapStructEnd,
         ],
     );
 
@@ -2179,7 +2179,7 @@ fn test_lifetime_propagation_for_flatten() {
             Token::U8(120),
             Token::SeqEnd,
             Token::U32(42),
-            Token::MapEnd,
+            Token::MapStructEnd,
         ],
     );
 
@@ -2192,7 +2192,7 @@ fn test_lifetime_propagation_for_flatten() {
             },
             Token::BorrowedBytes(b"x"),
             Token::U32(42),
-            Token::MapEnd,
+            Token::MapStructEnd,
         ],
     );
 }
@@ -2229,7 +2229,7 @@ fn test_flatten_enum_newtype() {
             Token::Str("k"),
             Token::Str("v"),
             Token::MapEnd,
-            Token::MapEnd,
+            Token::MapStructEnd,
         ],
     );
 }
@@ -2278,7 +2278,7 @@ fn test_flatten_internally_tagged() {
             Token::Str("D"),
             Token::Str("d"),
             Token::I32(2),
-            Token::MapEnd,
+            Token::MapStructEnd,
         ],
     );
 }
@@ -2482,7 +2482,7 @@ fn test_flatten_untagged_enum() {
             },
             Token::Str("a"),
             Token::I32(0),
-            Token::MapEnd,
+            Token::MapStructEnd,
         ],
     );
 }
@@ -2521,7 +2521,7 @@ fn test_flatten_option() {
             Token::I32(1),
             Token::Str("inner2"),
             Token::I32(2),
-            Token::MapEnd,
+            Token::MapStructEnd,
         ],
     );
 
@@ -2537,7 +2537,7 @@ fn test_flatten_option() {
             },
             Token::Str("inner1"),
             Token::I32(1),
-            Token::MapEnd,
+            Token::MapStructEnd,
         ],
     );
 
@@ -2553,7 +2553,7 @@ fn test_flatten_option() {
             },
             Token::Str("inner2"),
             Token::I32(2),
-            Token::MapEnd,
+            Token::MapStructEnd,
         ],
     );
 
@@ -2567,7 +2567,7 @@ fn test_flatten_option() {
                 name: "Outer",
                 len: None,
             },
-            Token::MapEnd,
+            Token::MapStructEnd,
         ],
     );
 }

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -1632,7 +1632,10 @@ fn test_collect_other() {
     assert_tokens(
         &CollectOther { a: 1, b: 2, extra },
         &[
-            Token::Map { len: None },
+            Token::MapStruct {
+                name: "CollectOther",
+                len: None,
+            },
             Token::Str("a"),
             Token::U32(1),
             Token::Str("b"),
@@ -1658,7 +1661,10 @@ fn test_flatten_struct_enum() {
     assert_de_tokens(
         &change_request,
         &[
-            Token::Map { len: None },
+            Token::MapStruct {
+                name: "FlattenStructEnumWrapper",
+                len: None,
+            },
             Token::Str("insert_integer"),
             Token::Map { len: None },
             Token::Str("index"),
@@ -1674,7 +1680,10 @@ fn test_flatten_struct_enum() {
     assert_ser_tokens(
         &change_request,
         &[
-            Token::Map { len: None },
+            Token::MapStruct {
+                name: "FlattenStructEnumWrapper",
+                len: None,
+            },
             Token::Str("insert_integer"),
             Token::Struct {
                 len: 2,
@@ -1704,7 +1713,10 @@ fn test_flatten_struct_tag_content_enum() {
     assert_de_tokens(
         &change_request,
         &[
-            Token::Map { len: None },
+            Token::MapStruct {
+                name: "FlattenStructTagContentEnumWrapper",
+                len: None,
+            },
             Token::Str("outer"),
             Token::U32(42),
             Token::Str("type"),
@@ -1722,7 +1734,10 @@ fn test_flatten_struct_tag_content_enum() {
     assert_ser_tokens(
         &change_request,
         &[
-            Token::Map { len: None },
+            Token::MapStruct {
+                name: "FlattenStructTagContentEnumWrapper",
+                len: None,
+            },
             Token::Str("outer"),
             Token::U32(42),
             Token::Str("type"),
@@ -1753,7 +1768,10 @@ fn test_flatten_struct_tag_content_enum_newtype() {
     assert_de_tokens(
         &change_request,
         &[
-            Token::Map { len: None },
+            Token::MapStruct {
+                name: "FlattenStructTagContentEnumWrapper",
+                len: None,
+            },
             Token::Str("outer"),
             Token::U32(42),
             Token::Str("type"),
@@ -1769,7 +1787,10 @@ fn test_flatten_struct_tag_content_enum_newtype() {
     assert_ser_tokens(
         &change_request,
         &[
-            Token::Map { len: None },
+            Token::MapStruct {
+                name: "FlattenStructTagContentEnumWrapper",
+                len: None,
+            },
             Token::Str("outer"),
             Token::U32(42),
             Token::Str("type"),
@@ -1865,7 +1886,10 @@ fn test_complex_flatten() {
             z: 4,
         },
         &[
-            Token::Map { len: None },
+            Token::MapStruct {
+                name: "Outer",
+                len: None,
+            },
             Token::Str("y"),
             Token::U32(0),
             Token::Str("a"),
@@ -1903,7 +1927,10 @@ fn test_complex_flatten() {
             z: 4,
         },
         &[
-            Token::Map { len: None },
+            Token::MapStruct {
+                name: "Outer",
+                len: None,
+            },
             Token::Str("y"),
             Token::U32(0),
             Token::Str("a"),
@@ -1987,7 +2014,10 @@ fn test_flatten_unit() {
             status: 0,
         },
         &[
-            Token::Map { len: None },
+            Token::MapStruct {
+                name: "Response",
+                len: None,
+            },
             Token::Str("status"),
             Token::U64(0),
             Token::MapEnd,
@@ -2010,7 +2040,10 @@ fn test_flatten_unsupported_type() {
             inner: "bar".into(),
         },
         &[
-            Token::Map { len: None },
+            Token::MapStruct {
+                name: "Outer",
+                len: None,
+            },
             Token::Str("outer"),
             Token::Str("foo"),
         ],
@@ -2018,7 +2051,10 @@ fn test_flatten_unsupported_type() {
     );
     assert_de_tokens_error::<Outer>(
         &[
-            Token::Map { len: None },
+            Token::MapStruct {
+                name: "Outer",
+                len: None,
+            },
             Token::Str("outer"),
             Token::Str("foo"),
             Token::Str("a"),
@@ -2048,7 +2084,10 @@ fn test_non_string_keys() {
             mapping,
         },
         &[
-            Token::Map { len: None },
+            Token::MapStruct {
+                name: "TestStruct",
+                len: None,
+            },
             Token::Str("name"),
             Token::Str("peter"),
             Token::Str("age"),
@@ -2085,7 +2124,10 @@ fn test_lifetime_propagation_for_flatten() {
     assert_tokens(
         &A { t: owned_map },
         &[
-            Token::Map { len: None },
+            Token::MapStruct {
+                name: "A",
+                len: None,
+            },
             Token::Str("x"),
             Token::U32(42),
             Token::MapEnd,
@@ -2099,7 +2141,10 @@ fn test_lifetime_propagation_for_flatten() {
             t: borrowed_map.clone(),
         },
         &[
-            Token::Map { len: None },
+            Token::MapStruct {
+                name: "B",
+                len: None,
+            },
             Token::BorrowedStr("x"),
             Token::U32(42),
             Token::MapEnd,
@@ -2109,7 +2154,10 @@ fn test_lifetime_propagation_for_flatten() {
     assert_de_tokens(
         &B { t: borrowed_map },
         &[
-            Token::Map { len: None },
+            Token::MapStruct {
+                name: "B",
+                len: None,
+            },
             Token::BorrowedStr("x"),
             Token::U32(42),
             Token::MapEnd,
@@ -2123,7 +2171,10 @@ fn test_lifetime_propagation_for_flatten() {
             t: borrowed_map.clone(),
         },
         &[
-            Token::Map { len: None },
+            Token::MapStruct {
+                name: "C",
+                len: None,
+            },
             Token::Seq { len: Some(1) },
             Token::U8(120),
             Token::SeqEnd,
@@ -2135,7 +2186,10 @@ fn test_lifetime_propagation_for_flatten() {
     assert_de_tokens(
         &C { t: borrowed_map },
         &[
-            Token::Map { len: None },
+            Token::MapStruct {
+                name: "C",
+                len: None,
+            },
             Token::BorrowedBytes(b"x"),
             Token::U32(42),
             Token::MapEnd,
@@ -2166,7 +2220,10 @@ fn test_flatten_enum_newtype() {
     assert_tokens(
         &s,
         &[
-            Token::Map { len: None },
+            Token::MapStruct {
+                name: "S",
+                len: None,
+            },
             Token::Str("Q"),
             Token::Map { len: Some(1) },
             Token::Str("k"),
@@ -2209,7 +2266,10 @@ fn test_flatten_internally_tagged() {
     assert_tokens(
         &s,
         &[
-            Token::Map { len: None },
+            Token::MapStruct {
+                name: "S",
+                len: None,
+            },
             Token::Str("typeX"),
             Token::Str("B"),
             Token::Str("b"),
@@ -2416,7 +2476,10 @@ fn test_flatten_untagged_enum() {
     assert_tokens(
         &data,
         &[
-            Token::Map { len: None },
+            Token::MapStruct {
+                name: "Outer",
+                len: None,
+            },
             Token::Str("a"),
             Token::I32(0),
             Token::MapEnd,
@@ -2450,7 +2513,10 @@ fn test_flatten_option() {
             inner2: Some(Inner2 { inner2: 2 }),
         },
         &[
-            Token::Map { len: None },
+            Token::MapStruct {
+                name: "Outer",
+                len: None,
+            },
             Token::Str("inner1"),
             Token::I32(1),
             Token::Str("inner2"),
@@ -2465,7 +2531,10 @@ fn test_flatten_option() {
             inner2: None,
         },
         &[
-            Token::Map { len: None },
+            Token::MapStruct {
+                name: "Outer",
+                len: None,
+            },
             Token::Str("inner1"),
             Token::I32(1),
             Token::MapEnd,
@@ -2478,7 +2547,10 @@ fn test_flatten_option() {
             inner2: Some(Inner2 { inner2: 2 }),
         },
         &[
-            Token::Map { len: None },
+            Token::MapStruct {
+                name: "Outer",
+                len: None,
+            },
             Token::Str("inner2"),
             Token::I32(2),
             Token::MapEnd,
@@ -2490,7 +2562,13 @@ fn test_flatten_option() {
             inner1: None,
             inner2: None,
         },
-        &[Token::Map { len: None }, Token::MapEnd],
+        &[
+            Token::MapStruct {
+                name: "Outer",
+                len: None,
+            },
+            Token::MapEnd,
+        ],
     );
 }
 

--- a/test_suite/tests/test_de.rs
+++ b/test_suite/tests/test_de.rs
@@ -60,6 +60,15 @@ struct Struct {
 }
 
 #[derive(PartialEq, Debug, Deserialize)]
+struct MapStruct {
+    a: i32,
+    b: i32,
+    c: i32,
+    #[serde(flatten)]
+    others: BTreeMap<String, i32>,
+}
+
+#[derive(PartialEq, Debug, Deserialize)]
 #[serde(default)]
 struct StructDefault<T> {
     a: i32,

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -1481,7 +1481,10 @@ fn test_internally_tagged_struct_with_flattened_field() {
     assert_tokens(
         &Struct { flat: Enum::A(0) },
         &[
-            Token::Map { len: None },
+            Token::MapStruct {
+                name: "Struct",
+                len: None,
+            },
             Token::Str("tag_struct"),
             Token::Str("Struct"),
             Token::Str("tag_enum"),

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -1491,7 +1491,7 @@ fn test_internally_tagged_struct_with_flattened_field() {
             Token::Str("A"),
             Token::Str("content"),
             Token::U64(0),
-            Token::MapEnd,
+            Token::MapStructEnd,
         ],
     );
 


### PR DESCRIPTION
This might fixes #2350, #1346 and #1584.

**This PR should not break any exist crates/code.**

## Problem
When a struct `S` has a field with attr `flatten`, the struct would be treated as map
```rust
struct S {
  name: String,
  #[serde(flatten)]
  others: HashMap<String, i32>,
}

```
This approach works well widely in format that doesn't care with type name (like `serde_json`), while sometimes it's annoying that we would like to treat map and struct differently (like [ron](https://github.com/ron-rs/ron/issues/115), [envy](https://github.com/softprops/envy/issues/26)).

## This PR
add `serialize_map_struct` and `deserialize_map_struct`
```rust
    fn deserialize_map_struct<V>(
        self,
        name: &'static str,
        fields: &'static [&'static str],
        visitor: V,
    ) -> Result<V::Value, Self::Error>
    where
        V: Visitor<'de>,
    {
        let _ = name;
        let _ = fields;
        self.deserialize_map(visitor)
    }

    fn serialize_map_struct(
        self,
        name: &'static str,
        len: Option<usize>,
    ) -> Result<Self::SerializeMap, Self::Error> {
        let _ = name;
        let _ = len;
        self.serialize_map(len)
    }
```
1. which simply delegates to `serialize_map` and `deserialize_map`, so nothing would be broken
2. pass `name` (as well as `fields` in deserialize), so your serializer could tell it is a struct other than map
3. add `serialize_field` to `SerializeMap` in order to get field names if you interest.
4. consist with other interface
   * we have `serialize_tuple`, `serialize_tuple_struct` and `serialize_tuple_variant` all handle with tuple, but with different parameters to indicate different semantics,
   * the same story goes with `serialize_unit`, `serialize_newtype_struct`, `serialize_struct`,
   * now it went to `serialize_map`. `serialize_map_struct` is also a map, just come with additional information for struct.

## Alternatives
https://github.com/ron-rs/ron/issues/115#issuecomment-1519121167 shows a workaround that used in [serde-starlark](https://github.com/dtolnay/serde-starlark)
```rust
#[derive(Serialize)]
pub struct RustLibrary {
    // ...
    #[serde(flatten)]
    pub common: CommonAttrs,
}

#[derive(Serialize)]
#[serde(untagged)]
pub enum Starlark {
    // ...
    #[serde(serialize_with = "serialize::rust_library")]
    RustLibrary(RustLibrary),
}

// serialize::rust_library
pub fn rust_library<S>(rule: &RustLibrary, serializer: S) -> Result<S::Ok, S::Error>
where
    S: Serializer,
{
    FunctionCall::new("rust_library", rule).serialize(serializer)
}
```
It wrapped with [`FunctionCall`](https://docs.rs/serde_starlark/latest/serde_starlark/struct.FunctionCall.html) which gives `RustLibrary` struct name, as well as force child struct to be parsed as struct,
```rust
impl<'a, S> Serializer for FunctionCallSerializer<'a, S>
where
    S: Serializer,
{
    // ...
    fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
        let len = len.unwrap_or(2);
        let mut delegate = self.delegate.serialize_struct("(", len)?;
        delegate.serialize_field("", self.function)?;
        Ok(FunctionCallArgs { delegate })
    }
}
```
This approach could handle things well for custom struct, but it is common that the `flatten` structs are import from some crates (and maybe deeply nested), so users had no control on this.