### PR TITLE
Remove unused after .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-test_suite/tests/expand/*.expanded.rs linguist-generated


### PR DESCRIPTION
The expand tests were removed in a649190a4d43e3ed4f5f7452ab22b7cee6ba2862, but .gitattributes still mentioned them. Because it mention only those files, I've removed it completely.

From my point of view having examples of expanded output was useful, even if they were not checked by tests, because they showed how changes in the derive macro are reflected in the generated code. But if you decide to remove them, do it completely.