### PR TITLE
Allow to flatten `IgnoredAny`

### DIFF
--- a/serde/src/de/ignored_any.rs
+++ b/serde/src/de/ignored_any.rs
@@ -108,7 +108,7 @@ use de::{
 /// #     Ok(())
 /// # }
 /// ```
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
 pub struct IgnoredAny;
 
 impl<'de> Visitor<'de> for IgnoredAny {

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -2811,6 +2811,13 @@ where
         visitor.visit_unit()
     }
 
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_unit()
+    }
+
     forward_to_deserialize_other! {
         deserialize_bool()
         deserialize_i8()
@@ -2833,7 +2840,6 @@ where
         deserialize_tuple(usize)
         deserialize_tuple_struct(&'static str, usize)
         deserialize_identifier()
-        deserialize_ignored_any()
     }
 }
 

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -10,7 +10,7 @@
     clippy::uninlined_format_args,
 )]
 
-use serde::de::{self, MapAccess, Unexpected, Visitor};
+use serde::de::{self, IgnoredAny, MapAccess, Unexpected, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use std::collections::{BTreeMap, HashMap};
@@ -2491,6 +2491,31 @@ fn test_flatten_option() {
             inner2: None,
         },
         &[Token::Map { len: None }, Token::MapEnd],
+    );
+}
+
+#[test]
+fn test_flatten_ignored_any() {
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct Outer {
+        #[serde(flatten)]
+        inner: IgnoredAny,
+    }
+
+    assert_de_tokens(
+        &Outer { inner: IgnoredAny },
+        &[Token::Map { len: None }, Token::MapEnd],
+    );
+
+    assert_de_tokens(
+        &Outer { inner: IgnoredAny },
+        &[
+            Token::Struct {
+                name: "DoNotMatter",
+                len: 0,
+            },
+            Token::StructEnd,
+        ],
     );
 }
 


### PR DESCRIPTION
This can be useful for use-case described in #2432 (if other problems will be solved) and if you have a generic struct with flatten field and want to pass an `IgnoredAny` for whatever reason.

I also implement `PartialEq` for `IgnoredAny` so it can be tested using `assert_de_tokens`.