### PR TITLE
Take into account `deny_unknown_fields` attribute when deserialzie struct from sequence

### DIFF
--- a/test_suite/tests/regression/issue2432.rs
+++ b/test_suite/tests/regression/issue2432.rs
@@ -1,0 +1,392 @@
+//! This tests tries to deserialize `Struct` from the following JSON representations:
+//!
+//! - From mapping
+//!   ```json
+//!   {
+//!       "number": 1234,
+//!       "text": "hello",
+//!       "dont": 345.234,
+//!       "really": [],
+//!       "care": true
+//!   }
+//!   ```
+//! - From sequence:
+//!   ```json
+//!   [
+//!       1234,
+//!       "hello",
+//!       345.234,
+//!       [],
+//!       true
+//!   ]
+//!   ```
+use serde::Deserialize;
+use serde_test::{Token, assert_de_tokens, assert_de_tokens_error};
+
+mod no_deny_unknown_fields {
+    use super::*;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Struct {
+        number: i32,
+        text: String,
+    }
+
+    #[test]
+    fn struct_() {
+        let value = Struct {
+            number: 1234,
+            text: "hello".to_string(),
+        };
+
+        assert_de_tokens(
+            &value,
+            &[
+                Token::Struct { name: "Struct", len: 5 },
+                Token::Str("number"),
+                Token::I32(1234),
+                Token::Str("text"),
+                Token::Str("hello"),
+                Token::StructEnd,
+            ],
+        );
+
+        assert_de_tokens(
+            &value,
+            &[
+                Token::Struct { name: "Struct", len: 5 },
+                Token::Str("number"),
+                Token::I32(1234),
+                Token::Str("text"),
+                Token::Str("hello"),
+                Token::Str("dont"),
+                Token::F32(345.234),
+                Token::Str("really"),
+                Token::Seq { len: None },
+                Token::SeqEnd,
+                Token::Str("care"),
+                Token::Bool(true),
+                Token::StructEnd,
+            ],
+        );
+    }
+
+    #[test]
+    fn map() {
+        let value = Struct {
+            number: 1234,
+            text: "hello".to_string(),
+        };
+
+        assert_de_tokens(
+            &value,
+            &[
+                Token::Map { len: None },
+                Token::Str("number"),
+                Token::I32(1234),
+                Token::Str("text"),
+                Token::Str("hello"),
+                Token::MapEnd,
+            ],
+        );
+
+        assert_de_tokens(
+            &value,
+            &[
+                Token::Map { len: None },
+                Token::Str("number"),
+                Token::I32(1234),
+                Token::Str("text"),
+                Token::Str("hello"),
+                Token::Str("dont"),
+                Token::F32(345.234),
+                Token::Str("really"),
+                Token::Seq { len: None },
+                Token::SeqEnd,
+                Token::Str("care"),
+                Token::Bool(true),
+                Token::MapEnd,
+            ],
+        );
+    }
+
+//------------------------------------------------------------------------------
+
+    #[test]
+    fn seq() {
+        let value = Struct {
+            number: 1234,
+            text: "hello".to_string(),
+        };
+
+        assert_de_tokens(
+            &value,
+            &[
+                Token::Seq { len: None },
+                Token::I32(1234),           // number
+                Token::Str("hello"),        // text
+                Token::SeqEnd,
+            ],
+        );
+
+        assert_de_tokens(
+            &value,
+            &[
+                Token::Seq { len: None },
+                Token::I32(1234),           // number
+                Token::Str("hello"),        // text
+                Token::F32(345.234),        // dont
+                Token::Seq { len: None },   // really
+                Token::SeqEnd,
+                Token::Bool(true),          // care
+                Token::SeqEnd,
+            ],
+        );
+    }
+
+    #[test]
+    fn tuple() {
+        let value = Struct {
+            number: 1234,
+            text: "hello".to_string(),
+        };
+
+        assert_de_tokens(
+            &value,
+            &[
+                Token::Tuple { len: 2 },
+                Token::I32(1234),           // number
+                Token::Str("hello"),        // text
+                Token::TupleEnd,
+            ],
+        );
+
+        assert_de_tokens(
+            &value,
+            &[
+                Token::Tuple { len: 5 },
+                Token::I32(1234),           // number
+                Token::Str("hello"),        // text
+                Token::F32(345.234),        // dont
+                Token::Seq { len: None },   // really
+                Token::SeqEnd,
+                Token::Bool(true),          // care
+                Token::TupleEnd,
+            ],
+        );
+    }
+
+    #[test]
+    fn tuple_struct() {
+        let value = Struct {
+            number: 1234,
+            text: "hello".to_string(),
+        };
+
+        assert_de_tokens(
+            &value,
+            &[
+                Token::TupleStruct { name: "DoNotMatter", len: 2 },
+                Token::I32(1234),           // number
+                Token::Str("hello"),        // text
+                Token::TupleStructEnd,
+            ],
+        );
+
+        assert_de_tokens(
+            &value,
+            &[
+                Token::TupleStruct { name: "DoNotMatter", len: 5 },
+                Token::I32(1234),           // number
+                Token::Str("hello"),        // text
+                Token::F32(345.234),        // dont
+                Token::Seq { len: None },   // really
+                Token::SeqEnd,
+                Token::Bool(true),          // care
+                Token::TupleStructEnd,
+            ],
+        );
+    }
+}
+
+mod deny_unknown_fields {
+    use super::*;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    #[serde(deny_unknown_fields)]
+    struct Struct {
+        number: i32,
+        text: String,
+    }
+
+    #[test]
+    fn struct_() {
+        assert_de_tokens(
+            &Struct {
+                number: 1234,
+                text: "hello".to_string(),
+            },
+            &[
+                Token::Struct { name: "Struct", len: 2 },
+                Token::Str("number"),
+                Token::I32(1234),
+                Token::Str("text"),
+                Token::Str("hello"),
+                Token::StructEnd,
+            ],
+        );
+
+        assert_de_tokens_error::<Struct>(
+            &[
+                Token::Struct { name: "Struct", len: 5 },
+                Token::Str("number"),
+                Token::I32(1234),
+                Token::Str("text"),
+                Token::Str("hello"),
+                Token::Str("dont"),
+                Token::F32(345.234),
+                // Tokens that could follow, but assert_de_tokens_error do not want them
+                // Token::Str("really"),
+                // Token::Seq { len: None },
+                // Token::SeqEnd,
+                // Token::Str("care"),
+                // Token::Bool(true),
+                // Token::StructEnd,
+            ],
+            "unknown field `dont`, expected `number` or `text`",
+        );
+    }
+
+    #[test]
+    fn map() {
+        assert_de_tokens(
+            &Struct {
+                number: 1234,
+                text: "hello".to_string(),
+            },
+            &[
+                Token::Map { len: None },
+                Token::Str("number"),
+                Token::I32(1234),
+                Token::Str("text"),
+                Token::Str("hello"),
+                Token::MapEnd,
+            ],
+        );
+
+        assert_de_tokens_error::<Struct>(
+            &[
+                Token::Map { len: None },
+                Token::Str("number"),
+                Token::I32(1234),
+                Token::Str("text"),
+                Token::Str("hello"),
+                Token::Str("dont"),
+                Token::F32(345.234),
+                // Tokens that could follow, but assert_de_tokens_error do not want them
+                // Token::Str("really"),
+                // Token::Seq { len: None },
+                // Token::SeqEnd,
+                // Token::Str("care"),
+                // Token::Bool(true),
+                // Token::MapEnd,
+            ],
+            "unknown field `dont`, expected `number` or `text`",
+        );
+    }
+
+//------------------------------------------------------------------------------
+
+    #[test]
+    fn seq() {
+        assert_de_tokens(
+            &Struct {
+                number: 1234,
+                text: "hello".to_string(),
+            },
+            &[
+                Token::Seq { len: None },
+                Token::I32(1234),           // number
+                Token::Str("hello"),        // text
+                Token::SeqEnd,
+            ],
+        );
+
+        assert_de_tokens_error::<Struct>(
+            &[
+                Token::Seq { len: None },
+                Token::I32(1234),           // number
+                Token::Str("hello"),        // text
+                Token::F32(345.234),        // dont
+                // Tokens that could follow, but assert_de_tokens_error do not want them
+                // Token::Seq { len: None },   // really
+                // Token::SeqEnd,
+                // Token::Bool(true),          // care
+                // Token::SeqEnd,
+            ],
+            "invalid length 2, expected struct Struct with 2 elements",
+        );
+    }
+
+    #[test]
+    fn tuple() {
+        assert_de_tokens(
+            &Struct {
+                number: 1234,
+                text: "hello".to_string(),
+            },
+            &[
+                Token::Tuple { len: 2 },
+                Token::I32(1234),           // number
+                Token::Str("hello"),        // text
+                Token::TupleEnd,
+            ],
+        );
+
+        assert_de_tokens_error::<Struct>(
+            &[
+                Token::Tuple { len: 5 },
+                Token::I32(1234),           // number
+                Token::Str("hello"),        // text
+                Token::F32(345.234),        // dont
+                // Tokens that could follow, but assert_de_tokens_error do not want them
+                // Token::Seq { len: None },   // really
+                // Token::SeqEnd,
+                // Token::Bool(true),          // care
+                // Token::TupleEnd,
+            ],
+            "invalid length 2, expected struct Struct with 2 elements",
+        );
+    }
+
+    #[test]
+    fn tuple_struct() {
+        assert_de_tokens(
+            &Struct {
+                number: 1234,
+                text: "hello".to_string(),
+            },
+            &[
+                Token::TupleStruct { name: "DoNotMatter", len: 2 },
+                Token::I32(1234),           // number
+                Token::Str("hello"),        // text
+                Token::TupleStructEnd,
+            ],
+        );
+
+        assert_de_tokens_error::<Struct>(
+            &[
+                Token::TupleStruct { name: "DoNotMatter", len: 5 },
+                Token::I32(1234),           // number
+                Token::Str("hello"),        // text
+                Token::F32(345.234),        // dont
+                // Tokens that could follow, but assert_de_tokens_error do not want them
+                // Token::Seq { len: None },   // really
+                // Token::SeqEnd,
+                // Token::Bool(true),          // care
+                // Token::TupleStructEnd,
+            ],
+            "invalid length 2, expected struct Struct with 2 elements",
+        );
+    }
+}

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -606,7 +606,7 @@ fn test_enum_state_field() {
 #[test]
 fn test_untagged_enum() {
     #[derive(Debug, PartialEq, Serialize, Deserialize)]
-    #[serde(untagged)]
+    #[serde(untagged, deny_unknown_fields)]
     enum Untagged {
         A { a: u8 },
         B { b: u8 },


### PR DESCRIPTION
This PR expands scope of `deny_unknown_fields` container attribute to sequences, making behaviour consistent when struct deserialized from a map or from a sequence:

```rust
#[derive(Deserialize)]
struct A {
    number: i32,
    text: String,
}
```
could be deserialized from
```json
{
    "number": 1234,
    "text": "hello",
    "dont": 345.234,
    "really": [],
    "care": true
}
```
and from
```json
[
    1234,
    "hello",
    345.234,
    [],
    true
]
```

The
```rust
#[derive(Deserialize)]
#[serde(deny_unknown_fields)]
struct A {
    number: i32,
    text: String,
}
```
could be deserialized only from
```json
{
    "number": 1234,
    "text": "hello"
}
```
and from
```json
[
    1234,
    "hello"
]
```

Closes #2432