### PR TITLE
Simplify code in deserialize_in_place_struct and implement #2387 for in-place case

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1185,7 +1185,9 @@ fn deserialize_struct_in_place(
     };
     let visit_seq = Stmts(deserialize_seq_in_place(params, fields, cattrs, expecting));
     let visit_map = Stmts(deserialize_map_in_place(params, fields, cattrs));
-    let field_names = field_names_idents.iter().map(|(name, _, _)| name);
+    let field_names = field_names_idents
+        .iter()
+        .flat_map(|(_, _, aliases)| aliases);
 
     let visitor_expr = quote! {
         __Visitor {

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1178,8 +1178,7 @@ fn deserialize_struct_in_place(
         None,
     ));
 
-    let all_skipped = fields.iter().all(|field| field.attrs.skip_deserializing());
-    let visitor_var = if all_skipped {
+    let mut_seq = if field_names_idents.is_empty() {
         quote!(_)
     } else {
         quote!(mut __seq)
@@ -1230,7 +1229,7 @@ fn deserialize_struct_in_place(
             }
 
             #[inline]
-            fn visit_seq<__A>(self, #visitor_var: __A) -> _serde::__private::Result<Self::Value, __A::Error>
+            fn visit_seq<__A>(self, #mut_seq: __A) -> _serde::__private::Result<Self::Value, __A::Error>
             where
                 __A: _serde::de::SeqAccess<#delife>,
             {


### PR DESCRIPTION
This PR makes a small refactoring which, I think, improves undertanding of the code that will be generated. During this work I found, that #2387 did not change code generation for in-place case, so the last commit fixes that. The strange thing, that tests does not catch this. I tried to see the generated code using
```console
serde\test_suite> cargo expand --test test_annotations --all-features
```
and it shows that `deserialize_in_place` method doesn't generated. I tried
- add explicit dependency to the `serde_derive` here:
  https://github.com/serde-rs/serde/blob/25381be0c93f32aa43ce0e399c45442965e81ecc/test_suite/Cargo.toml#L11-L13
- add explicit requirement for the test:
  ```toml
  [[test]]
  name = "test_annotations"
  required-features = ["serde_derive/deserialize_in_place"]
  ```
- add a new feature `deserialize_in_place = ["serde_derive/deserialize_in_place"]` here:
  https://github.com/serde-rs/serde/blob/25381be0c93f32aa43ce0e399c45442965e81ecc/test_suite/Cargo.toml#L8-L10
- combine the previous two attempts

Nothing of this is work. So I do not know how to test those changes. I would be appreciate if someone point me out how to correctly test this. 