### PR TITLE
Simplify code for generation of struct deserializers

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -981,8 +981,7 @@ fn deserialize_struct(
     // structs that only have a map representation.
     let visit_seq = match *untagged {
         Untagged::No if !cattrs.has_flatten() => {
-            let all_skipped = fields.iter().all(|field| field.attrs.skip_deserializing());
-            let mut_seq = if all_skipped {
+            let mut_seq = if field_names_idents.is_empty() {
                 quote!(_)
             } else {
                 quote!(mut __seq)


### PR DESCRIPTION
The first 7 commits of this PR eliminates various duplications from the code, making it more easely to understand, as I hope.

The last 3 commits makes more obvious which code is generated for different combinations of arguments. Because not all combinations are possible, after the changes impossible variants are not representable in the code.