### PR TITLE
Eliminate some duplicated code

### DIFF
--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -2775,7 +2775,11 @@ where
     where
         V: Visitor<'de>,
     {
-        visitor.visit_map(FlatMapAccess::new(self.0.iter()))
+        visitor.visit_map(FlatMapAccess {
+            iter: self.0.iter(),
+            pending_content: None,
+            _marker: PhantomData,
+        })
     }
 
     fn deserialize_struct<V>(
@@ -2787,7 +2791,12 @@ where
     where
         V: Visitor<'de>,
     {
-        visitor.visit_map(FlatStructAccess::new(self.0.iter_mut(), fields))
+        visitor.visit_map(FlatStructAccess {
+            iter: self.0.iter_mut(),
+            pending_content: None,
+            fields: fields,
+            _marker: PhantomData,
+        })
     }
 
     fn deserialize_newtype_struct<V>(self, _name: &str, visitor: V) -> Result<V::Value, Self::Error>
@@ -2848,19 +2857,6 @@ struct FlatMapAccess<'a, 'de: 'a, E> {
 }
 
 #[cfg(any(feature = "std", feature = "alloc"))]
-impl<'a, 'de, E> FlatMapAccess<'a, 'de, E> {
-    fn new(
-        iter: slice::Iter<'a, Option<(Content<'de>, Content<'de>)>>,
-    ) -> FlatMapAccess<'a, 'de, E> {
-        FlatMapAccess {
-            iter: iter,
-            pending_content: None,
-            _marker: PhantomData,
-        }
-    }
-}
-
-#[cfg(any(feature = "std", feature = "alloc"))]
 impl<'a, 'de, E> MapAccess<'de> for FlatMapAccess<'a, 'de, E>
 where
     E: Error,
@@ -2902,21 +2898,6 @@ struct FlatStructAccess<'a, 'de: 'a, E> {
     pending_content: Option<Content<'de>>,
     fields: &'static [&'static str],
     _marker: PhantomData<E>,
-}
-
-#[cfg(any(feature = "std", feature = "alloc"))]
-impl<'a, 'de, E> FlatStructAccess<'a, 'de, E> {
-    fn new(
-        iter: slice::IterMut<'a, Option<(Content<'de>, Content<'de>)>>,
-        fields: &'static [&'static str],
-    ) -> FlatStructAccess<'a, 'de, E> {
-        FlatStructAccess {
-            iter: iter,
-            pending_content: None,
-            fields: fields,
-            _marker: PhantomData,
-        }
-    }
 }
 
 #[cfg(any(feature = "std", feature = "alloc"))]

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -2841,7 +2841,7 @@ where
 }
 
 #[cfg(any(feature = "std", feature = "alloc"))]
-pub struct FlatMapAccess<'a, 'de: 'a, E> {
+struct FlatMapAccess<'a, 'de: 'a, E> {
     iter: slice::Iter<'a, Option<(Content<'de>, Content<'de>)>>,
     pending_content: Option<&'a Content<'de>>,
     _marker: PhantomData<E>,
@@ -2897,7 +2897,7 @@ where
 }
 
 #[cfg(any(feature = "std", feature = "alloc"))]
-pub struct FlatStructAccess<'a, 'de: 'a, E> {
+struct FlatStructAccess<'a, 'de: 'a, E> {
     iter: slice::IterMut<'a, Option<(Content<'de>, Content<'de>)>>,
     pending_content: Option<Content<'de>>,
     fields: &'static [&'static str],

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -3084,23 +3084,29 @@ struct DeTypeGenerics<'a>(&'a Parameters);
 #[cfg(feature = "deserialize_in_place")]
 struct InPlaceTypeGenerics<'a>(&'a Parameters);
 
+/// If `'de` lifetime is defined, prepends it to list of generics
+/// and then produces tokens for declaration generics on type
+fn to_tokens(mut generics: syn::Generics, borrowed: &BorrowedLifetimes, tokens: &mut TokenStream) {
+    if borrowed.de_lifetime_param().is_some() {
+        let def = syn::LifetimeParam {
+            attrs: Vec::new(),
+            lifetime: syn::Lifetime::new("'de", Span::call_site()),
+            colon_token: None,
+            bounds: Punctuated::new(),
+        };
+        // Prepend 'de lifetime to list of generics
+        generics.params = Some(syn::GenericParam::Lifetime(def))
+            .into_iter()
+            .chain(generics.params)
+            .collect();
+    }
+    let (_, ty_generics, _) = generics.split_for_impl();
+    ty_generics.to_tokens(tokens);
+}
+
 impl<'a> ToTokens for DeTypeGenerics<'a> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let mut generics = self.0.generics.clone();
-        if self.0.borrowed.de_lifetime_param().is_some() {
-            let def = syn::LifetimeParam {
-                attrs: Vec::new(),
-                lifetime: syn::Lifetime::new("'de", Span::call_site()),
-                colon_token: None,
-                bounds: Punctuated::new(),
-            };
-            generics.params = Some(syn::GenericParam::Lifetime(def))
-                .into_iter()
-                .chain(generics.params)
-                .collect();
-        }
-        let (_, ty_generics, _) = generics.split_for_impl();
-        ty_generics.to_tokens(tokens);
+        to_tokens(self.0.generics.clone(), &self.0.borrowed, tokens);
     }
 }
 
@@ -3113,20 +3119,7 @@ impl<'a> ToTokens for InPlaceTypeGenerics<'a> {
             .chain(generics.params)
             .collect();
 
-        if self.0.borrowed.de_lifetime_param().is_some() {
-            let def = syn::LifetimeParam {
-                attrs: Vec::new(),
-                lifetime: syn::Lifetime::new("'de", Span::call_site()),
-                colon_token: None,
-                bounds: Punctuated::new(),
-            };
-            generics.params = Some(syn::GenericParam::Lifetime(def))
-                .into_iter()
-                .chain(generics.params)
-                .collect();
-        }
-        let (_, ty_generics, _) = generics.split_for_impl();
-        ty_generics.to_tokens(tokens);
+        to_tokens(generics, &self.0.borrowed, tokens);
     }
 }
 


### PR DESCRIPTION
The first commit removes the one copy of the `FlatMapAccess` struct.

The third commit removes superfluous constructors of `FlatMapAccess` and `FlatStructAccess`. Since `FlatInternallyTaggedAccess` did without it, it seems to me that this is acceptable. Besides, I found that without constructors that used only in one place to construct a struct is is a little easier to understand the code.

The last two commits extracts repeated code into functions.