### PR TITLE
Implement serialization of tuple variants of flatten enums

### DIFF
--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -3015,7 +3015,7 @@ mod flatten {
 
             #[test]
             fn structs() {
-                #[derive(Serialize, Deserialize, PartialEq, Debug)]
+                #[derive(Debug, PartialEq, Serialize, Deserialize)]
                 struct Flatten {
                     #[serde(flatten)]
                     x: X,
@@ -3023,27 +3023,25 @@ mod flatten {
                     y: Y,
                 }
 
-                #[derive(Serialize, Deserialize, PartialEq, Debug)]
+                #[derive(Debug, PartialEq, Serialize, Deserialize)]
                 #[serde(tag = "typeX")]
                 enum X {
                     A { a: i32 },
                     B { b: i32 },
                 }
 
-                #[derive(Serialize, Deserialize, PartialEq, Debug)]
+                #[derive(Debug, PartialEq, Serialize, Deserialize)]
                 #[serde(tag = "typeY")]
                 enum Y {
                     C { c: i32 },
                     D { d: i32 },
                 }
 
-                let s = Flatten {
-                    x: X::B { b: 1 },
-                    y: Y::D { d: 2 },
-                };
-
                 assert_tokens(
-                    &s,
+                    &Flatten {
+                        x: X::B { b: 1 },
+                        y: Y::D { d: 2 },
+                    },
                     &[
                         Token::Map { len: None },
                         Token::Str("typeX"),
@@ -3061,7 +3059,7 @@ mod flatten {
 
             #[test]
             fn unit_enum_with_unknown_fields() {
-                #[derive(Deserialize, PartialEq, Debug)]
+                #[derive(Debug, PartialEq, Deserialize)]
                 struct Flatten {
                     #[serde(flatten)]
                     x: X,
@@ -3069,25 +3067,23 @@ mod flatten {
                     y: Y,
                 }
 
-                #[derive(Deserialize, PartialEq, Debug)]
+                #[derive(Debug, PartialEq, Deserialize)]
                 #[serde(tag = "typeX")]
                 enum X {
                     A,
                 }
 
-                #[derive(Deserialize, PartialEq, Debug)]
+                #[derive(Debug, PartialEq, Deserialize)]
                 #[serde(tag = "typeY")]
                 enum Y {
                     B { c: u32 },
                 }
 
-                let s = Flatten {
-                    x: X::A,
-                    y: Y::B { c: 0 },
-                };
-
                 assert_de_tokens(
-                    &s,
+                    &Flatten {
+                        x: X::A,
+                        y: Y::B { c: 0 },
+                    },
                     &[
                         Token::Map { len: None },
                         Token::Str("typeX"),
@@ -3105,26 +3101,24 @@ mod flatten {
         mod untagged {
             use super::*;
 
+            #[derive(Debug, PartialEq, Serialize, Deserialize)]
+            struct Flatten {
+                #[serde(flatten)]
+                data: Enum,
+            }
+
+            #[derive(Debug, PartialEq, Serialize, Deserialize)]
+            #[serde(untagged)]
+            enum Enum {
+                Struct { a: i32 },
+            }
+
             #[test]
             fn struct_() {
-                #[derive(Serialize, Deserialize, PartialEq, Debug)]
-                struct Flatten {
-                    #[serde(flatten)]
-                    data: Enum,
-                }
-
-                #[derive(Serialize, Deserialize, PartialEq, Debug)]
-                #[serde(untagged)]
-                enum Enum {
-                    Struct { a: i32 },
-                }
-
-                let data = Flatten {
-                    data: Enum::Struct { a: 0 },
-                };
-
                 assert_tokens(
-                    &data,
+                    &Flatten {
+                        data: Enum::Struct { a: 0 },
+                    },
                     &[
                         Token::Map { len: None },
                         Token::Str("a"),

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -2856,7 +2856,7 @@ mod flatten {
                     },
                     &[
                         Token::Map { len: None },
-                        Token::Str("Struct"),
+                        Token::Str("Struct"), // variant
                         Token::Struct {
                             len: 2,
                             name: "Struct",
@@ -2889,10 +2889,10 @@ mod flatten {
             struct NewtypeWrapper(pub Enum);
 
             #[derive(Debug, PartialEq, Serialize, Deserialize)]
-            #[serde(tag = "type", content = "value")]
+            #[serde(tag = "tag", content = "content")]
             enum Enum {
-                Struct { index: u32, value: u32 },
                 Newtype(NewtypeVariant),
+                Struct { index: u32, value: u32 },
             }
 
             #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -2914,9 +2914,9 @@ mod flatten {
                         Token::Map { len: None },
                         Token::Str("outer"),
                         Token::U32(42),
-                        Token::Str("type"),
+                        Token::Str("tag"),
                         Token::Str("Struct"),
-                        Token::Str("value"),
+                        Token::Str("content"),
                         Token::Struct {
                             len: 2,
                             name: "Struct",
@@ -2942,9 +2942,9 @@ mod flatten {
                         Token::Map { len: None },
                         Token::Str("outer"),
                         Token::U32(42),
-                        Token::Str("type"),
+                        Token::Str("tag"),
                         Token::Str("Newtype"),
-                        Token::Str("value"),
+                        Token::Str("content"),
                         Token::Struct {
                             len: 1,
                             name: "NewtypeVariant",

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -2830,25 +2830,24 @@ mod flatten {
             use super::*;
 
             #[derive(Debug, PartialEq, Serialize, Deserialize)]
-            struct FlattenStructEnumWrapper {
+            struct Flatten {
                 #[serde(flatten)]
-                data: FlattenStructEnum,
+                data: Enum,
                 #[serde(flatten)]
                 extra: HashMap<String, String>,
             }
 
             #[derive(Debug, PartialEq, Serialize, Deserialize)]
-            #[serde(rename_all = "snake_case")]
-            enum FlattenStructEnum {
-                InsertInteger { index: u32, value: u32 },
+            enum Enum {
+                Struct { index: u32, value: u32 },
             }
 
             #[test]
-            fn test_flatten_struct_enum() {
+            fn struct_() {
                 let mut extra = HashMap::new();
                 extra.insert("extra_key".into(), "extra value".into());
-                let change_request = FlattenStructEnumWrapper {
-                    data: FlattenStructEnum::InsertInteger {
+                let change_request = Flatten {
+                    data: Enum::Struct {
                         index: 0,
                         value: 42,
                     },
@@ -2858,7 +2857,7 @@ mod flatten {
                     &change_request,
                     &[
                         Token::Map { len: None },
-                        Token::Str("insert_integer"),
+                        Token::Str("Struct"),
                         Token::Map { len: None },
                         Token::Str("index"),
                         Token::U32(0),
@@ -2874,10 +2873,10 @@ mod flatten {
                     &change_request,
                     &[
                         Token::Map { len: None },
-                        Token::Str("insert_integer"),
+                        Token::Str("Struct"),
                         Token::Struct {
                             len: 2,
-                            name: "insert_integer",
+                            name: "Struct",
                         },
                         Token::Str("index"),
                         Token::U32(0),
@@ -2896,32 +2895,32 @@ mod flatten {
             use super::*;
 
             #[derive(Debug, PartialEq, Serialize, Deserialize)]
-            struct FlattenStructTagContentEnumWrapper {
+            struct Flatten {
                 outer: u32,
                 #[serde(flatten)]
-                data: FlattenStructTagContentEnumNewtype,
+                data: NewtypeWrapper,
             }
 
             #[derive(Debug, PartialEq, Serialize, Deserialize)]
-            struct FlattenStructTagContentEnumNewtype(pub FlattenStructTagContentEnum);
+            struct NewtypeWrapper(pub Enum);
 
             #[derive(Debug, PartialEq, Serialize, Deserialize)]
-            #[serde(rename_all = "snake_case", tag = "type", content = "value")]
-            enum FlattenStructTagContentEnum {
-                InsertInteger { index: u32, value: u32 },
-                NewtypeVariant(FlattenStructTagContentEnumNewtypeVariant),
+            #[serde(tag = "type", content = "value")]
+            enum Enum {
+                Struct { index: u32, value: u32 },
+                Newtype(NewtypeVariant),
             }
 
             #[derive(Debug, PartialEq, Serialize, Deserialize)]
-            struct FlattenStructTagContentEnumNewtypeVariant {
+            struct NewtypeVariant {
                 value: u32,
             }
 
             #[test]
-            fn test_flatten_struct_tag_content_enum() {
-                let change_request = FlattenStructTagContentEnumWrapper {
+            fn struct_() {
+                let change_request = Flatten {
                     outer: 42,
-                    data: FlattenStructTagContentEnumNewtype(FlattenStructTagContentEnum::InsertInteger {
+                    data: NewtypeWrapper(Enum::Struct {
                         index: 0,
                         value: 42,
                     }),
@@ -2933,7 +2932,7 @@ mod flatten {
                         Token::Str("outer"),
                         Token::U32(42),
                         Token::Str("type"),
-                        Token::Str("insert_integer"),
+                        Token::Str("Struct"),
                         Token::Str("value"),
                         Token::Map { len: None },
                         Token::Str("index"),
@@ -2951,11 +2950,11 @@ mod flatten {
                         Token::Str("outer"),
                         Token::U32(42),
                         Token::Str("type"),
-                        Token::Str("insert_integer"),
+                        Token::Str("Struct"),
                         Token::Str("value"),
                         Token::Struct {
                             len: 2,
-                            name: "insert_integer",
+                            name: "Struct",
                         },
                         Token::Str("index"),
                         Token::U32(0),
@@ -2968,12 +2967,10 @@ mod flatten {
             }
 
             #[test]
-            fn test_flatten_struct_tag_content_enum_newtype() {
-                let change_request = FlattenStructTagContentEnumWrapper {
+            fn newtype() {
+                let change_request = Flatten {
                     outer: 42,
-                    data: FlattenStructTagContentEnumNewtype(FlattenStructTagContentEnum::NewtypeVariant(
-                        FlattenStructTagContentEnumNewtypeVariant { value: 23 },
-                    )),
+                    data: NewtypeWrapper(Enum::Newtype(NewtypeVariant { value: 23 })),
                 };
                 assert_de_tokens(
                     &change_request,
@@ -2982,7 +2979,7 @@ mod flatten {
                         Token::Str("outer"),
                         Token::U32(42),
                         Token::Str("type"),
-                        Token::Str("newtype_variant"),
+                        Token::Str("Newtype"),
                         Token::Str("value"),
                         Token::Map { len: None },
                         Token::Str("value"),
@@ -2998,11 +2995,11 @@ mod flatten {
                         Token::Str("outer"),
                         Token::U32(42),
                         Token::Str("type"),
-                        Token::Str("newtype_variant"),
+                        Token::Str("Newtype"),
                         Token::Str("value"),
                         Token::Struct {
                             len: 1,
-                            name: "FlattenStructTagContentEnumNewtypeVariant",
+                            name: "NewtypeVariant",
                         },
                         Token::Str("value"),
                         Token::U32(23),
@@ -3017,9 +3014,9 @@ mod flatten {
             use super::*;
 
             #[test]
-            fn test_flatten_internally_tagged() {
+            fn structs() {
                 #[derive(Serialize, Deserialize, PartialEq, Debug)]
-                struct S {
+                struct Flatten {
                     #[serde(flatten)]
                     x: X,
                     #[serde(flatten)]
@@ -3040,7 +3037,7 @@ mod flatten {
                     D { d: i32 },
                 }
 
-                let s = S {
+                let s = Flatten {
                     x: X::B { b: 1 },
                     y: Y::D { d: 2 },
                 };
@@ -3063,9 +3060,9 @@ mod flatten {
             }
 
             #[test]
-            fn test_flattened_internally_tagged_unit_enum_with_unknown_fields() {
+            fn unit_enum_with_unknown_fields() {
                 #[derive(Deserialize, PartialEq, Debug)]
-                struct S {
+                struct Flatten {
                     #[serde(flatten)]
                     x: X,
                     #[serde(flatten)]
@@ -3084,7 +3081,7 @@ mod flatten {
                     B { c: u32 },
                 }
 
-                let s = S {
+                let s = Flatten {
                     x: X::A,
                     y: Y::B { c: 0 },
                 };
@@ -3109,21 +3106,21 @@ mod flatten {
             use super::*;
 
             #[test]
-            fn test_flatten_untagged_enum() {
+            fn struct_() {
                 #[derive(Serialize, Deserialize, PartialEq, Debug)]
-                struct Outer {
+                struct Flatten {
                     #[serde(flatten)]
-                    inner: Inner,
+                    data: Enum,
                 }
 
                 #[derive(Serialize, Deserialize, PartialEq, Debug)]
                 #[serde(untagged)]
-                enum Inner {
-                    Variant { a: i32 },
+                enum Enum {
+                    Struct { a: i32 },
                 }
 
-                let data = Outer {
-                    inner: Inner::Variant { a: 0 },
+                let data = Flatten {
+                    data: Enum::Struct { a: 0 },
                 };
 
                 assert_tokens(

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -2841,11 +2841,66 @@ mod flatten {
 
             #[derive(Debug, PartialEq, Serialize, Deserialize)]
             enum Enum {
+                Tuple(u32, u32),
                 Struct { index: u32, value: u32 },
             }
 
+            /// Reaches crate::private::de::content::VariantDeserializer::tuple_variant
+            /// Content::Seq case
+            /// via FlatMapDeserializer::deserialize_enum
             #[test]
-            fn struct_() {
+            fn tuple() {
+                assert_tokens(
+                    &Flatten {
+                        data: Enum::Tuple(0, 42),
+                        extra: HashMap::from_iter([("extra_key".into(), "extra value".into())]),
+                    },
+                    &[
+                        Token::Map { len: None },
+                        Token::Str("Tuple"), // variant
+                        Token::Seq { len: Some(2) },
+                        Token::U32(0),
+                        Token::U32(42),
+                        Token::SeqEnd,
+                        Token::Str("extra_key"),
+                        Token::Str("extra value"),
+                        Token::MapEnd,
+                    ],
+                );
+            }
+
+            /// Reaches crate::private::de::content::VariantDeserializer::struct_variant
+            /// Content::Seq case
+            /// via FlatMapDeserializer::deserialize_enum
+            #[test]
+            fn struct_from_seq() {
+                assert_de_tokens(
+                    &Flatten {
+                        data: Enum::Struct {
+                            index: 0,
+                            value: 42,
+                        },
+                        extra: HashMap::from_iter([("extra_key".into(), "extra value".into())]),
+                    },
+                    &[
+                        Token::Map { len: None },
+                        Token::Str("Struct"), // variant
+                        Token::Seq { len: Some(2) },
+                        Token::U32(0),  // index
+                        Token::U32(42), // value
+                        Token::SeqEnd,
+                        Token::Str("extra_key"),
+                        Token::Str("extra value"),
+                        Token::MapEnd,
+                    ],
+                );
+            }
+
+            /// Reaches crate::private::de::content::VariantDeserializer::struct_variant
+            /// Content::Map case
+            /// via FlatMapDeserializer::deserialize_enum
+            #[test]
+            fn struct_from_map() {
                 assert_tokens(
                     &Flatten {
                         data: Enum::Struct {

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -2828,6 +2828,7 @@ mod flatten {
 
         mod externally_tagged {
             use super::*;
+            use std::iter::FromIterator;
 
             #[derive(Debug, PartialEq, Serialize, Deserialize)]
             struct Flatten {
@@ -2845,15 +2846,13 @@ mod flatten {
 
             #[test]
             fn struct_() {
-                let mut extra = HashMap::new();
-                extra.insert("extra_key".into(), "extra value".into());
                 assert_tokens(
                     &Flatten {
                         data: Enum::Struct {
                             index: 0,
                             value: 42,
                         },
-                        extra,
+                        extra: HashMap::from_iter([("extra_key".into(), "extra value".into())]),
                     },
                     &[
                         Token::Map { len: None },

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -2833,6 +2833,7 @@ mod flatten {
             struct Flatten {
                 #[serde(flatten)]
                 data: Enum,
+
                 #[serde(flatten)]
                 extra: HashMap<String, String>,
             }
@@ -2846,31 +2847,14 @@ mod flatten {
             fn struct_() {
                 let mut extra = HashMap::new();
                 extra.insert("extra_key".into(), "extra value".into());
-                let change_request = Flatten {
-                    data: Enum::Struct {
-                        index: 0,
-                        value: 42,
+                assert_tokens(
+                    &Flatten {
+                        data: Enum::Struct {
+                            index: 0,
+                            value: 42,
+                        },
+                        extra,
                     },
-                    extra,
-                };
-                assert_de_tokens(
-                    &change_request,
-                    &[
-                        Token::Map { len: None },
-                        Token::Str("Struct"),
-                        Token::Map { len: None },
-                        Token::Str("index"),
-                        Token::U32(0),
-                        Token::Str("value"),
-                        Token::U32(42),
-                        Token::MapEnd,
-                        Token::Str("extra_key"),
-                        Token::Str("extra value"),
-                        Token::MapEnd,
-                    ],
-                );
-                assert_ser_tokens(
-                    &change_request,
                     &[
                         Token::Map { len: None },
                         Token::Str("Struct"),
@@ -2897,6 +2881,7 @@ mod flatten {
             #[derive(Debug, PartialEq, Serialize, Deserialize)]
             struct Flatten {
                 outer: u32,
+
                 #[serde(flatten)]
                 data: NewtypeWrapper,
             }
@@ -2918,33 +2903,14 @@ mod flatten {
 
             #[test]
             fn struct_() {
-                let change_request = Flatten {
-                    outer: 42,
-                    data: NewtypeWrapper(Enum::Struct {
-                        index: 0,
-                        value: 42,
-                    }),
-                };
-                assert_de_tokens(
-                    &change_request,
-                    &[
-                        Token::Map { len: None },
-                        Token::Str("outer"),
-                        Token::U32(42),
-                        Token::Str("type"),
-                        Token::Str("Struct"),
-                        Token::Str("value"),
-                        Token::Map { len: None },
-                        Token::Str("index"),
-                        Token::U32(0),
-                        Token::Str("value"),
-                        Token::U32(42),
-                        Token::MapEnd,
-                        Token::MapEnd,
-                    ],
-                );
-                assert_ser_tokens(
-                    &change_request,
+                assert_tokens(
+                    &Flatten {
+                        outer: 42,
+                        data: NewtypeWrapper(Enum::Struct {
+                            index: 0,
+                            value: 42,
+                        }),
+                    },
                     &[
                         Token::Map { len: None },
                         Token::Str("outer"),
@@ -2968,28 +2934,11 @@ mod flatten {
 
             #[test]
             fn newtype() {
-                let change_request = Flatten {
-                    outer: 42,
-                    data: NewtypeWrapper(Enum::Newtype(NewtypeVariant { value: 23 })),
-                };
-                assert_de_tokens(
-                    &change_request,
-                    &[
-                        Token::Map { len: None },
-                        Token::Str("outer"),
-                        Token::U32(42),
-                        Token::Str("type"),
-                        Token::Str("Newtype"),
-                        Token::Str("value"),
-                        Token::Map { len: None },
-                        Token::Str("value"),
-                        Token::U32(23),
-                        Token::MapEnd,
-                        Token::MapEnd,
-                    ],
-                );
-                assert_ser_tokens(
-                    &change_request,
+                assert_tokens(
+                    &Flatten {
+                        outer: 42,
+                        data: NewtypeWrapper(Enum::Newtype(NewtypeVariant { value: 23 })),
+                    },
                     &[
                         Token::Map { len: None },
                         Token::Str("outer"),

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -1430,6 +1430,9 @@ fn test_enum_in_internally_tagged_enum() {
         ],
     );
 
+    // Reaches crate::private::de::content::VariantDeserializer::tuple_variant
+    // Content::Seq case
+    // via ContentDeserializer::deserialize_enum
     assert_tokens(
         &Outer::Inner(Inner::Tuple(1, 1)),
         &[
@@ -1448,6 +1451,9 @@ fn test_enum_in_internally_tagged_enum() {
         ],
     );
 
+    // Reaches crate::private::de::content::VariantDeserializer::struct_variant
+    // Content::Map case
+    // via ContentDeserializer::deserialize_enum
     assert_tokens(
         &Outer::Inner(Inner::Struct { f: 1 }),
         &[
@@ -1462,6 +1468,23 @@ fn test_enum_in_internally_tagged_enum() {
             Token::Str("f"),
             Token::U8(1),
             Token::StructEnd,
+            Token::MapEnd,
+        ],
+    );
+
+    // Reaches crate::private::de::content::VariantDeserializer::struct_variant
+    // Content::Seq case
+    // via ContentDeserializer::deserialize_enum
+    assert_de_tokens(
+        &Outer::Inner(Inner::Struct { f: 1 }),
+        &[
+            Token::Map { len: Some(2) },
+            Token::Str("type"),
+            Token::Str("Inner"),
+            Token::Str("Struct"),
+            Token::Seq { len: Some(1) },
+            Token::U8(1), // f
+            Token::SeqEnd,
             Token::MapEnd,
         ],
     );


### PR DESCRIPTION
Actually, I investigating a way of possible fixes of #1183, during which I try to narrow frontier of work as much as possible. I investigating an idea of using configurable buffer instead of generic `Content`. During that I found that generalizing of this type requires some knowledge of the `Content` internals -- `VariantDeserializer::tuple_variant` and `VariantDeserializer::struct_variant` does the matching over `Content`s content:
https://github.com/serde-rs/serde/blob/25381be0c93f32aa43ce0e399c45442965e81ecc/serde/src/private/de.rs#L1553-L1557
https://github.com/serde-rs/serde/blob/25381be0c93f32aa43ce0e399c45442965e81ecc/serde/src/private/de.rs#L1576-L1583

Here I noticed, that `MapDeserializer` and `SeqDeserializer` are different structs from the common [`de::value`](https://docs.rs/serde/latest/serde/de/value/index.html) module. At first glance the difference is cosmetic, so I tried to remove custom implementations and use counterparts from `de::value`. The last commit of this PR does that and actually that was the commit that I want to PR.

Because this change could have non-obvious consequences, I tried to find tests that reaches changed code paths. During that I found that for some of them there are no tests, so I write them.

However, in the process of writing tests, it turned out that deserialization of the enum tuple variant from sequence is supported, but such an enumeration cannot be serialized. So in the end I implemented that and close the gap.

When writing tests, I tried to organize them hierarchically, because in the current approach it is completely incomprehensible which parts are tested and which are not. Tests piled into a heap without any system. I found, that organizing tests using built-in capabilities of Rust -- modules -- greatly improves readability of tests and understanding of what is tested. Because tests in this PR not the main thing on which I focus, you can find that organizing of them are slightly incomplete. That is true. I plan to clean them up in the following PRs.