### PR TITLE
Add a module with adapters for conversion Visitor to Deserializer

### DIFF
--- a/serde/src/de/adapters.rs
+++ b/serde/src/de/adapters.rs
@@ -1,0 +1,725 @@
+//! Building blocks for conversion `Visitor` into `Deserializer`.
+//!
+//! Those deserializers can be used to temporary save the argument of a `Visitor`
+//! method and pass it to the same method in which it was captured, later.
+
+use lib::*;
+
+use de::{self, Deserializer, EnumAccess, IntoDeserializer, MapAccess, SeqAccess, Visitor};
+
+primitive_deserializer!(
+    /// A deserializer holding a `bool`.
+    ///
+    /// This deserializer will call [`Visitor::visit_bool`] for all requests.
+    pub BoolDeserializer, bool, visit_bool
+);
+
+primitive_deserializer!(
+    /// A deserializer holding an `i8`.
+    ///
+    /// This deserializer will call [`Visitor::visit_i8`] for all requests.
+    pub I8Deserializer, i8, visit_i8
+);
+primitive_deserializer!(
+    /// A deserializer holding an `i16`.
+    ///
+    /// This deserializer will call [`Visitor::visit_i16`] for all requests.
+    pub I16Deserializer, i16, visit_i16
+);
+primitive_deserializer!(
+    /// A deserializer holding an `i32`.
+    ///
+    /// This deserializer will call [`Visitor::visit_i32`] for all requests.
+    pub I32Deserializer, i32, visit_i32
+);
+primitive_deserializer!(
+    /// A deserializer holding an `i64`.
+    ///
+    /// This deserializer will call [`Visitor::visit_i64`] for all requests.
+    pub I64Deserializer, i64, visit_i64
+);
+
+primitive_deserializer!(
+    /// A deserializer holding a `u8`.
+    ///
+    /// This deserializer will call [`Visitor::visit_u8`] for all requests.
+    pub U8Deserializer, u8, visit_u8
+);
+primitive_deserializer!(
+    /// A deserializer holding a `u16`.
+    ///
+    /// This deserializer will call [`Visitor::visit_u16`] for all requests.
+    pub U16Deserializer, u16, visit_u16
+);
+primitive_deserializer!(
+    /// A deserializer holding a `u32`.
+    ///
+    /// This deserializer will call [`Visitor::visit_u32`] for all requests.
+    pub U32Deserializer, u32, visit_u32
+);
+primitive_deserializer!(
+    /// A deserializer holding a `u64`.
+    ///
+    /// This deserializer will call [`Visitor::visit_u64`] for all requests.
+    pub U64Deserializer, u64, visit_u64
+);
+
+primitive_deserializer!(
+    /// A deserializer holding an `f32`.
+    ///
+    /// This deserializer will call [`Visitor::visit_f32`] for all requests.
+    pub F32Deserializer, f32, visit_f32
+);
+primitive_deserializer!(
+    /// A deserializer holding an `f64`.
+    ///
+    /// This deserializer will call [`Visitor::visit_f64`] for all requests.
+    pub F64Deserializer, f64, visit_f64
+);
+primitive_deserializer!(
+    /// A deserializer holding a `char`.
+    ///
+    /// This deserializer will call [`Visitor::visit_char`] for all requests.
+    pub CharDeserializer, char, visit_char
+);
+
+serde_if_integer128! {
+    primitive_deserializer!(
+        /// A deserializer holding an `i128`.
+        ///
+        /// This deserializer will call [`Visitor::visit_i128`] for all requests.
+        pub I128Deserializer, i128, visit_i128
+    );
+    primitive_deserializer!(
+        /// A deserializer holding a `u128`.
+        ///
+        /// This deserializer will call [`Visitor::visit_u128`] for all requests.
+        pub U128Deserializer, u128, visit_u128
+    );
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+/// A deserializer holding a `&str`.
+///
+/// This deserializer will call [`Visitor::visit_str`] for all requests.
+pub struct StrDeserializer<'a, E> {
+    value: &'a str,
+    marker: PhantomData<E>,
+}
+
+impl<'a, E> StrDeserializer<'a, E> {
+    #[allow(missing_docs)]
+    pub fn new(value: &'a str) -> Self {
+        StrDeserializer {
+            value,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<'de, 'a, E> Deserializer<'de> for StrDeserializer<'a, E>
+where
+    E: de::Error,
+{
+    type Error = E;
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str
+        string bytes byte_buf option unit unit_struct newtype_struct seq
+        tuple tuple_struct map struct enum identifier ignored_any
+    }
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_str(self.value)
+    }
+}
+
+impl_copy_clone!(StrDeserializer<'de>);
+
+impl<'a, E> Debug for StrDeserializer<'a, E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter
+            .debug_struct("StrDeserializer")
+            .field("value", &self.value)
+            .finish()
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+/// A deserializer holding a `&str` with a lifetime tied to another
+/// deserializer.
+///
+/// This deserializer will call [`Visitor::visit_borrowed_str`] for all requests.
+pub struct BorrowedStrDeserializer<'de, E> {
+    value: &'de str,
+    marker: PhantomData<E>,
+}
+
+impl<'de, E> BorrowedStrDeserializer<'de, E> {
+    #[allow(missing_docs)]
+    pub fn new(value: &'de str) -> Self {
+        BorrowedStrDeserializer {
+            value,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<'de, E> Deserializer<'de> for BorrowedStrDeserializer<'de, E>
+where
+    E: de::Error,
+{
+    type Error = E;
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str
+        string bytes byte_buf option unit unit_struct newtype_struct seq
+        tuple tuple_struct map struct enum identifier ignored_any
+    }
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_borrowed_str(self.value)
+    }
+}
+
+impl_copy_clone!(BorrowedStrDeserializer<'de>);
+
+impl<'de, E> Debug for BorrowedStrDeserializer<'de, E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter
+            .debug_struct("BorrowedStrDeserializer")
+            .field("value", &self.value)
+            .finish()
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+/// A deserializer holding a `String`.
+///
+/// This deserializer will call [`Visitor::visit_string`] for all requests.
+#[cfg(any(feature = "std", feature = "alloc"))]
+pub struct StringDeserializer<E> {
+    value: String,
+    marker: PhantomData<E>,
+}
+
+#[cfg(any(feature = "std", feature = "alloc"))]
+impl<E> StringDeserializer<E> {
+    #[allow(missing_docs)]
+    pub fn new(value: String) -> Self {
+        StringDeserializer {
+            value,
+            marker: PhantomData,
+        }
+    }
+}
+
+#[cfg(any(feature = "std", feature = "alloc"))]
+impl<'de, E> Deserializer<'de> for StringDeserializer<E>
+where
+    E: de::Error,
+{
+    type Error = E;
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str
+        string bytes byte_buf option unit unit_struct newtype_struct seq
+        tuple tuple_struct map struct enum identifier ignored_any
+    }
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_string(self.value)
+    }
+}
+
+#[cfg(any(feature = "std", feature = "alloc"))]
+impl<E> Clone for StringDeserializer<E> {
+    fn clone(&self) -> Self {
+        StringDeserializer {
+            value: self.value.clone(),
+            marker: PhantomData,
+        }
+    }
+}
+
+#[cfg(any(feature = "std", feature = "alloc"))]
+impl<E> Debug for StringDeserializer<E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter
+            .debug_struct("StringDeserializer")
+            .field("value", &self.value)
+            .finish()
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+/// A deserializer holding a `&[u8]`.
+///
+/// This deserializer will call [`Visitor::visit_bytes`] for all requests.
+pub struct BytesDeserializer<'a, E> {
+    value: &'a [u8],
+    marker: PhantomData<E>,
+}
+
+impl<'a, E> BytesDeserializer<'a, E> {
+    #[allow(missing_docs)]
+    pub fn new(value: &'a [u8]) -> Self {
+        BytesDeserializer {
+            value,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<'de, 'a, E> Deserializer<'de> for BytesDeserializer<'a, E>
+where
+    E: de::Error,
+{
+    type Error = E;
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str
+        string bytes byte_buf option unit unit_struct newtype_struct seq
+        tuple tuple_struct map struct enum identifier ignored_any
+    }
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_bytes(self.value)
+    }
+}
+
+impl_copy_clone!(BytesDeserializer<'a>);
+
+impl<'a, E> Debug for BytesDeserializer<'a, E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter
+            .debug_struct("BytesDeserializer")
+            .field("value", &self.value)
+            .finish()
+    }
+}
+
+impl<'de, 'a, E> IntoDeserializer<'de, E> for &'a [u8]
+where
+    E: de::Error,
+{
+    type Deserializer = BytesDeserializer<'a, E>;
+
+    fn into_deserializer(self) -> Self::Deserializer {
+        BytesDeserializer::new(self)
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+/// A deserializer holding a `&[u8]` with a lifetime tied to another
+/// deserializer.
+///
+/// This deserializer will call [`Visitor::visit_borrowed_bytes`] for all requests.
+pub struct BorrowedBytesDeserializer<'de, E> {
+    value: &'de [u8],
+    marker: PhantomData<E>,
+}
+
+impl<'de, E> BorrowedBytesDeserializer<'de, E> {
+    #[allow(missing_docs)]
+    pub fn new(value: &'de [u8]) -> Self {
+        BorrowedBytesDeserializer {
+            value,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<'de, E> Deserializer<'de> for BorrowedBytesDeserializer<'de, E>
+where
+    E: de::Error,
+{
+    type Error = E;
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str
+        string bytes byte_buf option unit unit_struct newtype_struct seq
+        tuple tuple_struct map struct enum identifier ignored_any
+    }
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_borrowed_bytes(self.value)
+    }
+}
+
+impl_copy_clone!(BorrowedBytesDeserializer<'de>);
+
+impl<'de, E> Debug for BorrowedBytesDeserializer<'de, E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter
+            .debug_struct("BorrowedBytesDeserializer")
+            .field("value", &self.value)
+            .finish()
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+/// A deserializer holding a `Vec<u8>`.
+///
+/// This deserializer will call [`Visitor::visit_byte_buf`] for all requests.
+#[cfg(any(feature = "std", feature = "alloc"))]
+pub struct ByteBufDeserializer<E> {
+    value: Vec<u8>,
+    marker: PhantomData<E>,
+}
+
+#[cfg(any(feature = "std", feature = "alloc"))]
+impl<E> ByteBufDeserializer<E> {
+    #[allow(missing_docs)]
+    pub fn new(value: Vec<u8>) -> Self {
+        ByteBufDeserializer {
+            value,
+            marker: PhantomData,
+        }
+    }
+}
+
+#[cfg(any(feature = "std", feature = "alloc"))]
+impl<'de, E> Deserializer<'de> for ByteBufDeserializer<E>
+where
+    E: de::Error,
+{
+    type Error = E;
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str
+        string bytes byte_buf option unit unit_struct newtype_struct seq
+        tuple tuple_struct map struct enum identifier ignored_any
+    }
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_byte_buf(self.value)
+    }
+}
+
+#[cfg(any(feature = "std", feature = "alloc"))]
+impl<E> Clone for ByteBufDeserializer<E> {
+    fn clone(&self) -> Self {
+        ByteBufDeserializer {
+            value: self.value.clone(),
+            marker: PhantomData,
+        }
+    }
+}
+
+#[cfg(any(feature = "std", feature = "alloc"))]
+impl<E> Debug for ByteBufDeserializer<E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter
+            .debug_struct("ByteBufDeserializer")
+            .field("value", &self.value)
+            .finish()
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+/// A deserializer holding a [`None`].
+///
+/// This deserializer will call [`Visitor::visit_none`] for all requests.
+pub struct NoneDeserializer<E> {
+    marker: PhantomData<E>,
+}
+
+impl<E> NoneDeserializer<E> {
+    #[allow(missing_docs)]
+    pub fn new() -> Self {
+        NoneDeserializer {
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<'de, E> Deserializer<'de> for NoneDeserializer<E>
+where
+    E: de::Error,
+{
+    type Error = E;
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str
+        string bytes byte_buf option unit unit_struct newtype_struct seq
+        tuple tuple_struct map struct enum identifier ignored_any
+    }
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_none()
+    }
+}
+
+impl_copy_clone!(NoneDeserializer);
+
+impl<E> Debug for NoneDeserializer<E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.debug_struct("NoneDeserializer").finish()
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+/// A deserializer holding a [`Some`].
+///
+/// This deserializer will call [`Visitor::visit_some`] with provided inner
+/// deserializer for all requests.
+#[derive(Clone, Copy)]
+pub struct SomeDeserializer<T> {
+    deserializer: T,
+}
+
+impl<T> SomeDeserializer<T> {
+    #[allow(missing_docs)]
+    pub fn new(deserializer: T) -> Self {
+        SomeDeserializer {
+            deserializer: deserializer,
+        }
+    }
+}
+
+impl<'de, T> Deserializer<'de> for SomeDeserializer<T>
+where
+    T: Deserializer<'de>,
+{
+    type Error = T::Error;
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str
+        string bytes byte_buf option unit unit_struct newtype_struct seq
+        tuple tuple_struct map struct enum identifier ignored_any
+    }
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_some(self.deserializer)
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+/// A deserializer holding a `()`.
+///
+/// This deserializer will call [`Visitor::visit_unit`] for all requests.
+pub struct UnitDeserializer<E> {
+    marker: PhantomData<E>,
+}
+
+impl<E> UnitDeserializer<E> {
+    #[allow(missing_docs)]
+    pub fn new() -> Self {
+        UnitDeserializer {
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<'de, E> Deserializer<'de> for UnitDeserializer<E>
+where
+    E: de::Error,
+{
+    type Error = E;
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str
+        string bytes byte_buf option unit unit_struct newtype_struct seq
+        tuple tuple_struct map struct enum identifier ignored_any
+    }
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_unit()
+    }
+}
+
+impl_copy_clone!(UnitDeserializer);
+
+impl<E> Debug for UnitDeserializer<E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.debug_struct("UnitDeserializer").finish()
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+/// A deserializer holding a newtype.
+///
+/// This deserializer will call [`Visitor::visit_newtype_struct`] with provided
+/// inner deserializer for all requests.
+#[derive(Clone, Copy)]
+pub struct NewtypeDeserializer<T> {
+    deserializer: T,
+}
+
+impl<T> NewtypeDeserializer<T> {
+    #[allow(missing_docs)]
+    pub fn new(deserializer: T) -> Self {
+        NewtypeDeserializer {
+            deserializer: deserializer,
+        }
+    }
+}
+
+impl<'de, T> Deserializer<'de> for NewtypeDeserializer<T>
+where
+    T: Deserializer<'de>,
+{
+    type Error = T::Error;
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str
+        string bytes byte_buf option unit unit_struct newtype_struct seq
+        tuple tuple_struct map struct enum identifier ignored_any
+    }
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self.deserializer)
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+/// A deserializer holding a [`SeqAccess`].
+///
+/// This deserializer will call [`Visitor::visit_seq`] for all requests.
+#[derive(Clone, Copy, Debug)]
+pub struct SeqAccessDeserializer<A> {
+    seq: A,
+}
+
+impl<A> SeqAccessDeserializer<A> {
+    #[allow(missing_docs)]
+    pub fn new(seq: A) -> Self {
+        SeqAccessDeserializer { seq }
+    }
+}
+
+impl<'de, A> Deserializer<'de> for SeqAccessDeserializer<A>
+where
+    A: SeqAccess<'de>,
+{
+    type Error = A::Error;
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str
+        string bytes byte_buf option unit unit_struct newtype_struct seq
+        tuple tuple_struct map struct enum identifier ignored_any
+    }
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_seq(self.seq)
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+/// A deserializer holding a [`MapAccess`].
+///
+/// This deserializer will call [`Visitor::visit_map`] for all requests.
+#[derive(Clone, Copy, Debug)]
+pub struct MapAccessDeserializer<A> {
+    map: A,
+}
+
+impl<A> MapAccessDeserializer<A> {
+    #[allow(missing_docs)]
+    pub fn new(map: A) -> Self {
+        MapAccessDeserializer { map }
+    }
+}
+
+impl<'de, A> Deserializer<'de> for MapAccessDeserializer<A>
+where
+    A: MapAccess<'de>,
+{
+    type Error = A::Error;
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str
+        string bytes byte_buf option unit unit_struct newtype_struct seq
+        tuple tuple_struct map struct enum identifier ignored_any
+    }
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_map(self.map)
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+/// A deserializer holding an [`EnumAccess`].
+///
+/// This deserializer will call [`Visitor::visit_enum`] for all requests.
+#[derive(Clone, Copy, Debug)]
+pub struct EnumAccessDeserializer<A> {
+    access: A,
+}
+
+impl<A> EnumAccessDeserializer<A> {
+    #[allow(missing_docs)]
+    pub fn new(access: A) -> Self {
+        EnumAccessDeserializer { access: access }
+    }
+}
+
+impl<'de, A> Deserializer<'de> for EnumAccessDeserializer<A>
+where
+    A: EnumAccess<'de>,
+{
+    type Error = A::Error;
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str
+        string bytes byte_buf option unit unit_struct newtype_struct seq
+        tuple tuple_struct map struct enum identifier ignored_any
+    }
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_enum(self.access)
+    }
+}

--- a/serde/src/de/value.rs
+++ b/serde/src/de/value.rs
@@ -148,7 +148,7 @@ impl<E> UnitDeserializer<E> {
     }
 }
 
-impl<'de, E> de::Deserializer<'de> for UnitDeserializer<E>
+impl<'de, E> Deserializer<'de> for UnitDeserializer<E>
 where
     E: de::Error,
 {
@@ -162,14 +162,14 @@ where
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: de::Visitor<'de>,
+        V: Visitor<'de>,
     {
         visitor.visit_unit()
     }
 
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: de::Visitor<'de>,
+        V: Visitor<'de>,
     {
         visitor.visit_none()
     }
@@ -203,7 +203,7 @@ where
 }
 
 #[cfg(feature = "unstable")]
-impl<'de, E> de::Deserializer<'de> for NeverDeserializer<E>
+impl<'de, E> Deserializer<'de> for NeverDeserializer<E>
 where
     E: de::Error,
 {
@@ -211,7 +211,7 @@ where
 
     fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: de::Visitor<'de>,
+        V: Visitor<'de>,
     {
         self.never
     }
@@ -257,7 +257,7 @@ macro_rules! primitive_deserializer {
             }
         }
 
-        impl<'de, E> de::Deserializer<'de> for $name<E>
+        impl<'de, E> Deserializer<'de> for $name<E>
         where
             E: de::Error,
         {
@@ -271,7 +271,7 @@ macro_rules! primitive_deserializer {
 
             fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
             where
-                V: de::Visitor<'de>,
+                V: Visitor<'de>,
             {
                 visitor.$method(self.value $($cast)*)
             }
@@ -336,7 +336,7 @@ impl<E> U32Deserializer<E> {
     }
 }
 
-impl<'de, E> de::Deserializer<'de> for U32Deserializer<E>
+impl<'de, E> Deserializer<'de> for U32Deserializer<E>
 where
     E: de::Error,
 {
@@ -350,7 +350,7 @@ where
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: de::Visitor<'de>,
+        V: Visitor<'de>,
     {
         visitor.visit_u32(self.value)
     }
@@ -362,7 +362,7 @@ where
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
-        V: de::Visitor<'de>,
+        V: Visitor<'de>,
     {
         let _ = name;
         let _ = variants;
@@ -425,7 +425,7 @@ impl<'a, E> StrDeserializer<'a, E> {
     }
 }
 
-impl<'de, 'a, E> de::Deserializer<'de> for StrDeserializer<'a, E>
+impl<'de, 'a, E> Deserializer<'de> for StrDeserializer<'a, E>
 where
     E: de::Error,
 {
@@ -433,7 +433,7 @@ where
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: de::Visitor<'de>,
+        V: Visitor<'de>,
     {
         visitor.visit_str(self.value)
     }
@@ -445,7 +445,7 @@ where
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
-        V: de::Visitor<'de>,
+        V: Visitor<'de>,
     {
         let _ = name;
         let _ = variants;
@@ -504,7 +504,7 @@ impl<'de, E> BorrowedStrDeserializer<'de, E> {
     }
 }
 
-impl<'de, E> de::Deserializer<'de> for BorrowedStrDeserializer<'de, E>
+impl<'de, E> Deserializer<'de> for BorrowedStrDeserializer<'de, E>
 where
     E: de::Error,
 {
@@ -512,7 +512,7 @@ where
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: de::Visitor<'de>,
+        V: Visitor<'de>,
     {
         visitor.visit_borrowed_str(self.value)
     }
@@ -524,7 +524,7 @@ where
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
-        V: de::Visitor<'de>,
+        V: Visitor<'de>,
     {
         let _ = name;
         let _ = variants;
@@ -605,7 +605,7 @@ impl<E> StringDeserializer<E> {
 }
 
 #[cfg(any(feature = "std", feature = "alloc"))]
-impl<'de, E> de::Deserializer<'de> for StringDeserializer<E>
+impl<'de, E> Deserializer<'de> for StringDeserializer<E>
 where
     E: de::Error,
 {
@@ -613,7 +613,7 @@ where
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: de::Visitor<'de>,
+        V: Visitor<'de>,
     {
         visitor.visit_string(self.value)
     }
@@ -625,7 +625,7 @@ where
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
-        V: de::Visitor<'de>,
+        V: Visitor<'de>,
     {
         let _ = name;
         let _ = variants;
@@ -708,7 +708,7 @@ impl<'a, E> CowStrDeserializer<'a, E> {
 }
 
 #[cfg(any(feature = "std", feature = "alloc"))]
-impl<'de, 'a, E> de::Deserializer<'de> for CowStrDeserializer<'a, E>
+impl<'de, 'a, E> Deserializer<'de> for CowStrDeserializer<'a, E>
 where
     E: de::Error,
 {
@@ -716,7 +716,7 @@ where
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: de::Visitor<'de>,
+        V: Visitor<'de>,
     {
         match self.value {
             Cow::Borrowed(string) => visitor.visit_str(string),
@@ -731,7 +731,7 @@ where
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
-        V: de::Visitor<'de>,
+        V: Visitor<'de>,
     {
         let _ = name;
         let _ = variants;
@@ -925,7 +925,7 @@ where
     }
 }
 
-impl<'de, I, T, E> de::Deserializer<'de> for SeqDeserializer<I, E>
+impl<'de, I, T, E> Deserializer<'de> for SeqDeserializer<I, E>
 where
     I: Iterator<Item = T>,
     T: IntoDeserializer<'de, E>,
@@ -935,7 +935,7 @@ where
 
     fn deserialize_any<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: de::Visitor<'de>,
+        V: Visitor<'de>,
     {
         let v = try!(visitor.visit_seq(&mut self));
         try!(self.end());
@@ -1057,7 +1057,7 @@ impl<A> SeqAccessDeserializer<A> {
     }
 }
 
-impl<'de, A> de::Deserializer<'de> for SeqAccessDeserializer<A>
+impl<'de, A> Deserializer<'de> for SeqAccessDeserializer<A>
 where
     A: de::SeqAccess<'de>,
 {
@@ -1065,7 +1065,7 @@ where
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: de::Visitor<'de>,
+        V: Visitor<'de>,
     {
         visitor.visit_seq(self.seq)
     }
@@ -1148,7 +1148,7 @@ where
     }
 }
 
-impl<'de, I, E> de::Deserializer<'de> for MapDeserializer<'de, I, E>
+impl<'de, I, E> Deserializer<'de> for MapDeserializer<'de, I, E>
 where
     I: Iterator,
     I::Item: private::Pair,
@@ -1160,7 +1160,7 @@ where
 
     fn deserialize_any<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: de::Visitor<'de>,
+        V: Visitor<'de>,
     {
         let value = try!(visitor.visit_map(&mut self));
         try!(self.end());
@@ -1169,7 +1169,7 @@ where
 
     fn deserialize_seq<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: de::Visitor<'de>,
+        V: Visitor<'de>,
     {
         let value = try!(visitor.visit_seq(&mut self));
         try!(self.end());
@@ -1178,7 +1178,7 @@ where
 
     fn deserialize_tuple<V>(self, len: usize, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: de::Visitor<'de>,
+        V: Visitor<'de>,
     {
         let _ = len;
         self.deserialize_seq(visitor)
@@ -1315,7 +1315,7 @@ where
 // sequence of pairs.
 struct PairDeserializer<A, B, E>(A, B, PhantomData<E>);
 
-impl<'de, A, B, E> de::Deserializer<'de> for PairDeserializer<A, B, E>
+impl<'de, A, B, E> Deserializer<'de> for PairDeserializer<A, B, E>
 where
     A: IntoDeserializer<'de, E>,
     B: IntoDeserializer<'de, E>,
@@ -1331,14 +1331,14 @@ where
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: de::Visitor<'de>,
+        V: Visitor<'de>,
     {
         self.deserialize_seq(visitor)
     }
 
     fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: de::Visitor<'de>,
+        V: Visitor<'de>,
     {
         let mut pair_visitor = PairVisitor(Some(self.0), Some(self.1), PhantomData);
         let pair = try!(visitor.visit_seq(&mut pair_visitor));
@@ -1354,7 +1354,7 @@ where
 
     fn deserialize_tuple<V>(self, len: usize, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: de::Visitor<'de>,
+        V: Visitor<'de>,
     {
         if len == 2 {
             self.deserialize_seq(visitor)
@@ -1458,7 +1458,7 @@ impl<A> MapAccessDeserializer<A> {
     }
 }
 
-impl<'de, A> de::Deserializer<'de> for MapAccessDeserializer<A>
+impl<'de, A> Deserializer<'de> for MapAccessDeserializer<A>
 where
     A: de::MapAccess<'de>,
 {
@@ -1466,7 +1466,7 @@ where
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: de::Visitor<'de>,
+        V: Visitor<'de>,
     {
         visitor.visit_map(self.map)
     }
@@ -1478,7 +1478,7 @@ where
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
-        V: de::Visitor<'de>,
+        V: Visitor<'de>,
     {
         visitor.visit_enum(self)
     }
@@ -1523,7 +1523,7 @@ impl<A> EnumAccessDeserializer<A> {
     }
 }
 
-impl<'de, A> de::Deserializer<'de> for EnumAccessDeserializer<A>
+impl<'de, A> Deserializer<'de> for EnumAccessDeserializer<A>
 where
     A: de::EnumAccess<'de>,
 {
@@ -1531,7 +1531,7 @@ where
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: de::Visitor<'de>,
+        V: Visitor<'de>,
     {
         visitor.visit_enum(self.access)
     }
@@ -1585,7 +1585,7 @@ mod private {
 
         fn tuple_variant<V>(self, _len: usize, _visitor: V) -> Result<V::Value, Self::Error>
         where
-            V: de::Visitor<'de>,
+            V: Visitor<'de>,
         {
             Err(de::Error::invalid_type(
                 Unexpected::UnitVariant,
@@ -1599,7 +1599,7 @@ mod private {
             _visitor: V,
         ) -> Result<V::Value, Self::Error>
         where
-            V: de::Visitor<'de>,
+            V: Visitor<'de>,
         {
             Err(de::Error::invalid_type(
                 Unexpected::UnitVariant,


### PR DESCRIPTION
Several times I have noticed that it is necessary to be able to save the value passed to `Visitor` and then send it further through `Deserializer`. In most cases, there is a suitable `Deserializer` (and even an `IntoDeserializer` implementation) for this, but not for all types, and moreover, sometimes this implementation calls another visitor method.

So here I add a dedicated module that guaranties that deserializer will pass the value only to one `Visitor` method in all cases. The `value` module re-export those deserializers that have the same behavior, as deserializers that were defined in it before. Additionally, all deserializers have been documented what they exactly does.

One example usage can be [found](https://github.com/Lucretiel/serde-bufferless/blob/a00fb677f4d01d385b3bde45c0662866cf0cc5dd/src/private/flatten.rs#L285) in POC implementation of one case for #2186, and my own implementation for #1183 also could require it (if I remember correctly).