### PR TITLE
Keep aliases always sorted and include aliases in expecting message for field/variant_identifier

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -2153,7 +2153,7 @@ fn deserialize_custom_identifier(
         })
         .collect();
 
-    let names = names_idents.iter().map(|(name, _, _)| name);
+    let names = names_idents.iter().flat_map(|(_, _, aliases)| aliases);
 
     let names_const = if fallthrough.is_some() {
         None

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -2281,21 +2281,6 @@ fn deserialize_identifier(
         &fallthrough_arm_tokens
     };
 
-    let u64_fallthrough_arm_tokens;
-    let u64_fallthrough_arm = if let Some(fallthrough) = &fallthrough {
-        fallthrough
-    } else {
-        let index_expecting = if is_variant { "variant" } else { "field" };
-        let fallthrough_msg = format!("{} index 0 <= i < {}", index_expecting, fields.len());
-        u64_fallthrough_arm_tokens = quote! {
-            _serde::__private::Err(_serde::de::Error::invalid_value(
-                _serde::de::Unexpected::Unsigned(__value),
-                &#fallthrough_msg,
-            ))
-        };
-        &u64_fallthrough_arm_tokens
-    };
-
     let visit_other = if collect_other_fields {
         quote! {
             fn visit_bool<__E>(self, __value: bool) -> _serde::__private::Result<Self::Value, __E>
@@ -2394,6 +2379,21 @@ fn deserialize_identifier(
             let i = i as u64;
             quote!(#i => _serde::__private::Ok(#this_value::#ident))
         });
+
+        let u64_fallthrough_arm_tokens;
+        let u64_fallthrough_arm = if let Some(fallthrough) = &fallthrough {
+            fallthrough
+        } else {
+            let index_expecting = if is_variant { "variant" } else { "field" };
+            let fallthrough_msg = format!("{} index 0 <= i < {}", index_expecting, fields.len());
+            u64_fallthrough_arm_tokens = quote! {
+                _serde::__private::Err(_serde::de::Error::invalid_value(
+                    _serde::de::Unexpected::Unsigned(__value),
+                    &#fallthrough_msg,
+                ))
+            };
+            &u64_fallthrough_arm_tokens
+        };
 
         quote! {
             fn visit_u64<__E>(self, __value: u64) -> _serde::__private::Result<Self::Value, __E>

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -643,7 +643,7 @@ fn test_unknown_field_rename_struct() {
             Token::Str("a4"),
             Token::I32(3),
         ],
-        "unknown field `a4`, expected one of `a1`, `a3`, `a2`, `a5`, `a6`",
+        "unknown field `a4`, expected one of `a1`, `a2`, `a3`, `a5`, `a6`",
     );
 }
 
@@ -837,7 +837,7 @@ fn test_unknown_field_rename_enum() {
             Token::Str("d"),
             Token::I8(2),
         ],
-        "unknown field `d`, expected one of `a`, `c`, `b`, `e`, `f`",
+        "unknown field `d`, expected one of `a`, `b`, `c`, `e`, `f`",
     );
 }
 

--- a/test_suite/tests/test_identifier.rs
+++ b/test_suite/tests/test_identifier.rs
@@ -12,6 +12,7 @@ mod variant_identifier {
     #[serde(variant_identifier)]
     enum V {
         Aaa,
+        #[serde(alias = "Ccc", alias = "Ddd")]
         Bbb,
     }
 
@@ -23,6 +24,23 @@ mod variant_identifier {
         assert_de_tokens(&V::Aaa, &[Token::U64(0)]);
         assert_de_tokens(&V::Aaa, &[Token::Str("Aaa")]);
         assert_de_tokens(&V::Aaa, &[Token::Bytes(b"Aaa")]);
+    }
+
+    #[test]
+    fn aliases() {
+        assert_de_tokens(&V::Bbb, &[Token::U8(1)]);
+        assert_de_tokens(&V::Bbb, &[Token::U16(1)]);
+        assert_de_tokens(&V::Bbb, &[Token::U32(1)]);
+        assert_de_tokens(&V::Bbb, &[Token::U64(1)]);
+
+        assert_de_tokens(&V::Bbb, &[Token::Str("Bbb")]);
+        assert_de_tokens(&V::Bbb, &[Token::Bytes(b"Bbb")]);
+
+        assert_de_tokens(&V::Bbb, &[Token::Str("Ccc")]);
+        assert_de_tokens(&V::Bbb, &[Token::Bytes(b"Ccc")]);
+
+        assert_de_tokens(&V::Bbb, &[Token::Str("Ddd")]);
+        assert_de_tokens(&V::Bbb, &[Token::Bytes(b"Ddd")]);
     }
 
     #[test]
@@ -45,11 +63,11 @@ mod variant_identifier {
         );
         assert_de_tokens_error::<V>(
             &[Token::Str("Unknown")],
-            "unknown variant `Unknown`, expected `Aaa` or `Bbb`",
+            "unknown variant `Unknown`, expected one of `Aaa`, `Bbb`, `Ccc`, `Ddd`",
         );
         assert_de_tokens_error::<V>(
             &[Token::Bytes(b"Unknown")],
-            "unknown variant `Unknown`, expected `Aaa` or `Bbb`",
+            "unknown variant `Unknown`, expected one of `Aaa`, `Bbb`, `Ccc`, `Ddd`",
         );
     }
 }
@@ -61,6 +79,7 @@ mod field_identifier {
     #[serde(field_identifier, rename_all = "snake_case")]
     enum F {
         Aaa,
+        #[serde(alias = "ccc", alias = "ddd")]
         Bbb,
     }
 
@@ -72,6 +91,23 @@ mod field_identifier {
         assert_de_tokens(&F::Aaa, &[Token::U64(0)]);
         assert_de_tokens(&F::Aaa, &[Token::Str("aaa")]);
         assert_de_tokens(&F::Aaa, &[Token::Bytes(b"aaa")]);
+    }
+
+    #[test]
+    fn aliases() {
+        assert_de_tokens(&F::Bbb, &[Token::U8(1)]);
+        assert_de_tokens(&F::Bbb, &[Token::U16(1)]);
+        assert_de_tokens(&F::Bbb, &[Token::U32(1)]);
+        assert_de_tokens(&F::Bbb, &[Token::U64(1)]);
+
+        assert_de_tokens(&F::Bbb, &[Token::Str("bbb")]);
+        assert_de_tokens(&F::Bbb, &[Token::Bytes(b"bbb")]);
+
+        assert_de_tokens(&F::Bbb, &[Token::Str("ccc")]);
+        assert_de_tokens(&F::Bbb, &[Token::Bytes(b"ccc")]);
+
+        assert_de_tokens(&F::Bbb, &[Token::Str("ddd")]);
+        assert_de_tokens(&F::Bbb, &[Token::Bytes(b"ddd")]);
     }
 
     #[test]
@@ -94,11 +130,11 @@ mod field_identifier {
         );
         assert_de_tokens_error::<F>(
             &[Token::Str("unknown")],
-            "unknown field `unknown`, expected `aaa` or `bbb`",
+            "unknown field `unknown`, expected one of `aaa`, `bbb`, `ccc`, `ddd`",
         );
         assert_de_tokens_error::<F>(
             &[Token::Bytes(b"unknown")],
-            "unknown field `unknown`, expected `aaa` or `bbb`",
+            "unknown field `unknown`, expected one of `aaa`, `bbb`, `ccc`, `ddd`",
         );
     }
 

--- a/test_suite/tests/test_identifier.rs
+++ b/test_suite/tests/test_identifier.rs
@@ -5,8 +5,9 @@
 use serde_derive::Deserialize;
 use serde_test::{assert_de_tokens, Token};
 
-#[test]
-fn test_variant_identifier() {
+mod variant_identifier {
+    use super::*;
+
     #[derive(Deserialize, Debug, PartialEq)]
     #[serde(variant_identifier)]
     enum V {
@@ -14,16 +15,20 @@ fn test_variant_identifier() {
         Bbb,
     }
 
-    assert_de_tokens(&V::Aaa, &[Token::U8(0)]);
-    assert_de_tokens(&V::Aaa, &[Token::U16(0)]);
-    assert_de_tokens(&V::Aaa, &[Token::U32(0)]);
-    assert_de_tokens(&V::Aaa, &[Token::U64(0)]);
-    assert_de_tokens(&V::Aaa, &[Token::Str("Aaa")]);
-    assert_de_tokens(&V::Aaa, &[Token::Bytes(b"Aaa")]);
+    #[test]
+    fn variant1() {
+        assert_de_tokens(&V::Aaa, &[Token::U8(0)]);
+        assert_de_tokens(&V::Aaa, &[Token::U16(0)]);
+        assert_de_tokens(&V::Aaa, &[Token::U32(0)]);
+        assert_de_tokens(&V::Aaa, &[Token::U64(0)]);
+        assert_de_tokens(&V::Aaa, &[Token::Str("Aaa")]);
+        assert_de_tokens(&V::Aaa, &[Token::Bytes(b"Aaa")]);
+    }
 }
 
-#[test]
-fn test_field_identifier() {
+mod field_identifier {
+    use super::*;
+
     #[derive(Deserialize, Debug, PartialEq)]
     #[serde(field_identifier, rename_all = "snake_case")]
     enum F {
@@ -31,58 +36,61 @@ fn test_field_identifier() {
         Bbb,
     }
 
-    assert_de_tokens(&F::Aaa, &[Token::U8(0)]);
-    assert_de_tokens(&F::Aaa, &[Token::U16(0)]);
-    assert_de_tokens(&F::Aaa, &[Token::U32(0)]);
-    assert_de_tokens(&F::Aaa, &[Token::U64(0)]);
-    assert_de_tokens(&F::Aaa, &[Token::Str("aaa")]);
-    assert_de_tokens(&F::Aaa, &[Token::Bytes(b"aaa")]);
-}
-
-#[test]
-fn test_unit_fallthrough() {
-    #[derive(Deserialize, Debug, PartialEq)]
-    #[serde(field_identifier, rename_all = "snake_case")]
-    enum F {
-        Aaa,
-        Bbb,
-        #[serde(other)]
-        Other,
+    #[test]
+    fn field1() {
+        assert_de_tokens(&F::Aaa, &[Token::U8(0)]);
+        assert_de_tokens(&F::Aaa, &[Token::U16(0)]);
+        assert_de_tokens(&F::Aaa, &[Token::U32(0)]);
+        assert_de_tokens(&F::Aaa, &[Token::U64(0)]);
+        assert_de_tokens(&F::Aaa, &[Token::Str("aaa")]);
+        assert_de_tokens(&F::Aaa, &[Token::Bytes(b"aaa")]);
     }
 
-    assert_de_tokens(&F::Other, &[Token::U8(42)]);
-    assert_de_tokens(&F::Other, &[Token::U16(42)]);
-    assert_de_tokens(&F::Other, &[Token::U32(42)]);
-    assert_de_tokens(&F::Other, &[Token::U64(42)]);
-    assert_de_tokens(&F::Other, &[Token::Str("x")]);
-}
+    #[test]
+    fn unit_fallthrough() {
+        #[derive(Deserialize, Debug, PartialEq)]
+        #[serde(field_identifier, rename_all = "snake_case")]
+        enum F {
+            Aaa,
+            Bbb,
+            #[serde(other)]
+            Other,
+        }
 
-#[test]
-fn test_newtype_fallthrough() {
-    #[derive(Deserialize, Debug, PartialEq)]
-    #[serde(field_identifier, rename_all = "snake_case")]
-    enum F {
-        Aaa,
-        Bbb,
-        Other(String),
+        assert_de_tokens(&F::Other, &[Token::U8(42)]);
+        assert_de_tokens(&F::Other, &[Token::U16(42)]);
+        assert_de_tokens(&F::Other, &[Token::U32(42)]);
+        assert_de_tokens(&F::Other, &[Token::U64(42)]);
+        assert_de_tokens(&F::Other, &[Token::Str("x")]);
     }
 
-    assert_de_tokens(&F::Other("x".to_owned()), &[Token::Str("x")]);
-}
+    #[test]
+    fn newtype_fallthrough() {
+        #[derive(Deserialize, Debug, PartialEq)]
+        #[serde(field_identifier, rename_all = "snake_case")]
+        enum F {
+            Aaa,
+            Bbb,
+            Other(String),
+        }
 
-#[test]
-fn test_newtype_fallthrough_generic() {
-    #[derive(Deserialize, Debug, PartialEq)]
-    #[serde(field_identifier, rename_all = "snake_case")]
-    enum F<T> {
-        Aaa,
-        Bbb,
-        Other(T),
+        assert_de_tokens(&F::Other("x".to_owned()), &[Token::Str("x")]);
     }
 
-    assert_de_tokens(&F::Other(42u8), &[Token::U8(42)]);
-    assert_de_tokens(&F::Other(42u16), &[Token::U16(42)]);
-    assert_de_tokens(&F::Other(42u32), &[Token::U32(42)]);
-    assert_de_tokens(&F::Other(42u64), &[Token::U64(42)]);
-    assert_de_tokens(&F::Other("x".to_owned()), &[Token::Str("x")]);
+    #[test]
+    fn newtype_fallthrough_generic() {
+        #[derive(Deserialize, Debug, PartialEq)]
+        #[serde(field_identifier, rename_all = "snake_case")]
+        enum F<T> {
+            Aaa,
+            Bbb,
+            Other(T),
+        }
+
+        assert_de_tokens(&F::Other(42u8), &[Token::U8(42)]);
+        assert_de_tokens(&F::Other(42u16), &[Token::U16(42)]);
+        assert_de_tokens(&F::Other(42u32), &[Token::U32(42)]);
+        assert_de_tokens(&F::Other(42u64), &[Token::U64(42)]);
+        assert_de_tokens(&F::Other("x".to_owned()), &[Token::Str("x")]);
+    }
 }

--- a/test_suite/tests/test_identifier.rs
+++ b/test_suite/tests/test_identifier.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::derive_partial_eq_without_eq)]
 
 use serde_derive::Deserialize;
-use serde_test::{assert_de_tokens, Token};
+use serde_test::{assert_de_tokens, assert_de_tokens_error, Token};
 
 mod variant_identifier {
     use super::*;
@@ -23,6 +23,34 @@ mod variant_identifier {
         assert_de_tokens(&V::Aaa, &[Token::U64(0)]);
         assert_de_tokens(&V::Aaa, &[Token::Str("Aaa")]);
         assert_de_tokens(&V::Aaa, &[Token::Bytes(b"Aaa")]);
+    }
+
+    #[test]
+    fn unknown() {
+        assert_de_tokens_error::<V>(
+            &[Token::U8(42)],
+            "invalid value: integer `42`, expected variant index 0 <= i < 2",
+        );
+        assert_de_tokens_error::<V>(
+            &[Token::U16(42)],
+            "invalid value: integer `42`, expected variant index 0 <= i < 2",
+        );
+        assert_de_tokens_error::<V>(
+            &[Token::U32(42)],
+            "invalid value: integer `42`, expected variant index 0 <= i < 2",
+        );
+        assert_de_tokens_error::<V>(
+            &[Token::U64(42)],
+            "invalid value: integer `42`, expected variant index 0 <= i < 2",
+        );
+        assert_de_tokens_error::<V>(
+            &[Token::Str("Unknown")],
+            "unknown variant `Unknown`, expected `Aaa` or `Bbb`",
+        );
+        assert_de_tokens_error::<V>(
+            &[Token::Bytes(b"Unknown")],
+            "unknown variant `Unknown`, expected `Aaa` or `Bbb`",
+        );
     }
 }
 
@@ -44,6 +72,34 @@ mod field_identifier {
         assert_de_tokens(&F::Aaa, &[Token::U64(0)]);
         assert_de_tokens(&F::Aaa, &[Token::Str("aaa")]);
         assert_de_tokens(&F::Aaa, &[Token::Bytes(b"aaa")]);
+    }
+
+    #[test]
+    fn unknown() {
+        assert_de_tokens_error::<F>(
+            &[Token::U8(42)],
+            "invalid value: integer `42`, expected field index 0 <= i < 2",
+        );
+        assert_de_tokens_error::<F>(
+            &[Token::U16(42)],
+            "invalid value: integer `42`, expected field index 0 <= i < 2",
+        );
+        assert_de_tokens_error::<F>(
+            &[Token::U32(42)],
+            "invalid value: integer `42`, expected field index 0 <= i < 2",
+        );
+        assert_de_tokens_error::<F>(
+            &[Token::U64(42)],
+            "invalid value: integer `42`, expected field index 0 <= i < 2",
+        );
+        assert_de_tokens_error::<F>(
+            &[Token::Str("unknown")],
+            "unknown field `unknown`, expected `aaa` or `bbb`",
+        );
+        assert_de_tokens_error::<F>(
+            &[Token::Bytes(b"unknown")],
+            "unknown field `unknown`, expected `aaa` or `bbb`",
+        );
     }
 
     #[test]


### PR DESCRIPTION
This PR fixes two problems:
- The first one is that aliases seems to be sorted in the expecting message because their are collected from `BTreeSet`, but after adding a main name to the sorted list of aliases it is not sorted anymore
- The second one is that `#[serde(field_identifier)]` and `#[serde(variant_identifier)]` does not include aliases in their default expecting message.

I've updated tests for identifiers and fix both problems. I put them into one PR because the first problem affects the newly added test for aliases for the second problem.

The last 4 commits are small refactoring that slightly reduces number of clones and optimizes generation.