### PR TITLE
Show deserialized value in the `assert_de_tokens_error` message

### DIFF
--- a/serde_test/src/assert.rs
+++ b/serde_test/src/assert.rs
@@ -206,11 +206,15 @@ where
 #[cfg_attr(not(no_track_caller), track_caller)]
 pub fn assert_de_tokens_error<'de, T>(tokens: &'de [Token], error: &str)
 where
-    T: Deserialize<'de>,
+    T: Deserialize<'de> + Debug,
 {
     let mut de = Deserializer::new(tokens);
     match T::deserialize(&mut de) {
-        Ok(_) => panic!("tokens deserialized successfully"),
+        Ok(x) => assert_eq!(
+            error,
+            format!("{:?}", x),
+            "expected error (left) but tokens deserialized successfully (right)"
+        ),
         Err(e) => assert_eq!(e, *error),
     }
 

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -2769,19 +2769,19 @@ fn test_alias_in_flatten_context() {
 
 #[test]
 fn test_expecting_message() {
-    #[derive(Deserialize, PartialEq, Debug)]
+    #[derive(Deserialize, Debug)]
     #[serde(expecting = "something strange...")]
     struct Unit;
 
-    #[derive(Deserialize)]
+    #[derive(Deserialize, Debug)]
     #[serde(expecting = "something strange...")]
     struct Newtype(bool);
 
-    #[derive(Deserialize)]
+    #[derive(Deserialize, Debug)]
     #[serde(expecting = "something strange...")]
     struct Tuple(u32, bool);
 
-    #[derive(Deserialize)]
+    #[derive(Deserialize, Debug)]
     #[serde(expecting = "something strange...")]
     struct Struct {
         question: String,
@@ -2811,7 +2811,7 @@ fn test_expecting_message() {
 
 #[test]
 fn test_expecting_message_externally_tagged_enum() {
-    #[derive(Deserialize)]
+    #[derive(Deserialize, Debug)]
     #[serde(expecting = "something strange...")]
     enum Enum {
         ExternallyTagged,
@@ -2831,7 +2831,7 @@ fn test_expecting_message_externally_tagged_enum() {
 
 #[test]
 fn test_expecting_message_internally_tagged_enum() {
-    #[derive(Deserialize)]
+    #[derive(Deserialize, Debug)]
     #[serde(tag = "tag")]
     #[serde(expecting = "something strange...")]
     enum Enum {
@@ -2852,7 +2852,7 @@ fn test_expecting_message_internally_tagged_enum() {
 
 #[test]
 fn test_expecting_message_adjacently_tagged_enum() {
-    #[derive(Deserialize)]
+    #[derive(Deserialize, Debug)]
     #[serde(tag = "tag", content = "content")]
     #[serde(expecting = "something strange...")]
     enum Enum {
@@ -2878,7 +2878,7 @@ fn test_expecting_message_adjacently_tagged_enum() {
 
 #[test]
 fn test_expecting_message_untagged_tagged_enum() {
-    #[derive(Deserialize)]
+    #[derive(Deserialize, Debug)]
     #[serde(untagged)]
     #[serde(expecting = "something strange...")]
     enum Enum {
@@ -2890,14 +2890,14 @@ fn test_expecting_message_untagged_tagged_enum() {
 
 #[test]
 fn test_expecting_message_identifier_enum() {
-    #[derive(Deserialize)]
+    #[derive(Deserialize, Debug)]
     #[serde(field_identifier)]
     #[serde(expecting = "something strange...")]
     enum FieldEnum {
         Field,
     }
 
-    #[derive(Deserialize)]
+    #[derive(Deserialize, Debug)]
     #[serde(variant_identifier)]
     #[serde(expecting = "something strange...")]
     enum VariantEnum {


### PR DESCRIPTION
This PR improves error message when the type in `assert_de_tokens_error` deserialized successful when it shouldn't.

For example, the call
```rust
assert_de_tokens_error::<Enum>(
    &[
        Token::Map { len: Some(2) },
        Token::Str("a"),
        Token::I32(1),
        Token::Str("a"),
        Token::I32(42),
        Token::MapEnd,
    ],
    "duplicate field `a`",
);
```
could return the following result:
```
---- untagged::duplicate_field_in_struct stdout ----
thread 'untagged::duplicate_field_in_struct' panicked at 'assertion failed: `(left == right)`
  left: `"duplicate field `a`"`,
 right: `"StructWithSkipped { a: NotDeserializable }"`: expected error (left) but tokens deserialized successfully (right)', test_suite\tests\test_de_enum.rs:506:9
```
compared to this (current):
```
---- untagged::duplicate_field_in_struct stdout ----
thread 'untagged::duplicate_field_in_struct' panicked at 'tokens deserialized successfully', test_suite\tests\test_de_enum.rs:506:9
```

Unfortunately, this is breaking change, but:
- usually the types that you test also tested with `assert_de_tokens` which requires `Debug`. So there are high probability that `Debug` already implemented for your types
- this is testing code which should not be many. [According to lib.rs](https://lib.rs/crates/serde_test/rev) there are few dependers, so it can be acceptable to make a small breaking change to improve usability