### PR TITLE
Use syn::Error's combine() API instead of Vec<syn::Error>

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -15,9 +15,7 @@ use this;
 use std::collections::BTreeSet;
 use std::ptr;
 
-pub fn expand_derive_deserialize(
-    input: &mut syn::DeriveInput,
-) -> Result<TokenStream, Vec<syn::Error>> {
+pub fn expand_derive_deserialize(input: &mut syn::DeriveInput) -> syn::Result<TokenStream> {
     replace_receiver(input);
 
     let ctxt = Ctxt::new();

--- a/serde_derive/src/internals/ctxt.rs
+++ b/serde_derive/src/internals/ctxt.rs
@@ -44,12 +44,19 @@ impl Ctxt {
     }
 
     /// Consume this object, producing a formatted error string if there are errors.
-    pub fn check(self) -> Result<(), Vec<syn::Error>> {
-        let errors = self.errors.borrow_mut().take().unwrap();
-        match errors.len() {
-            0 => Ok(()),
-            _ => Err(errors),
+    pub fn check(self) -> syn::Result<()> {
+        let mut errors = self.errors.borrow_mut().take().unwrap().into_iter();
+
+        let mut combined = match errors.next() {
+            Some(first) => first,
+            None => return Ok(()),
+        };
+
+        for rest in errors {
+            combined.combine(rest);
         }
+
+        Err(combined)
     }
 }
 

--- a/serde_derive/src/lib.rs
+++ b/serde_derive/src/lib.rs
@@ -92,7 +92,7 @@ mod try;
 pub fn derive_serialize(input: TokenStream) -> TokenStream {
     let mut input = parse_macro_input!(input as DeriveInput);
     ser::expand_derive_serialize(&mut input)
-        .unwrap_or_else(to_compile_errors)
+        .unwrap_or_else(syn::Error::into_compile_error)
         .into()
 }
 
@@ -100,11 +100,6 @@ pub fn derive_serialize(input: TokenStream) -> TokenStream {
 pub fn derive_deserialize(input: TokenStream) -> TokenStream {
     let mut input = parse_macro_input!(input as DeriveInput);
     de::expand_derive_deserialize(&mut input)
-        .unwrap_or_else(to_compile_errors)
+        .unwrap_or_else(syn::Error::into_compile_error)
         .into()
-}
-
-fn to_compile_errors(errors: Vec<syn::Error>) -> proc_macro2::TokenStream {
-    let compile_errors = errors.iter().map(syn::Error::to_compile_error);
-    quote!(#(#compile_errors)*)
 }

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -10,9 +10,7 @@ use internals::{attr, replace_receiver, Ctxt, Derive};
 use pretend;
 use this;
 
-pub fn expand_derive_serialize(
-    input: &mut syn::DeriveInput,
-) -> Result<TokenStream, Vec<syn::Error>> {
+pub fn expand_derive_serialize(input: &mut syn::DeriveInput) -> syn::Result<TokenStream> {
     replace_receiver(input);
 
     let ctxt = Ctxt::new();


### PR DESCRIPTION
This code is from before syn::Error supported `combine`.