### PR TITLE
Allow to deserialize struct variants of untagged and adjacently tagged enums from seq

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1008,29 +1008,28 @@ fn deserialize_struct(
 
     // untagged struct variants do not get a visit_seq method. The same applies to
     // structs that only have a map representation.
-    let visit_seq = match form {
-        _ if cattrs.has_flatten() => None,
-        _ => {
-            let mut_seq = if field_names_idents.is_empty() {
-                quote!(_)
-            } else {
-                quote!(mut __seq)
-            };
+    let visit_seq = if cattrs.has_flatten() {
+        None
+    } else {
+        let mut_seq = if field_names_idents.is_empty() {
+            quote!(_)
+        } else {
+            quote!(mut __seq)
+        };
 
-            let visit_seq = Stmts(deserialize_seq(
-                &type_path, params, fields, true, cattrs, expecting,
-            ));
+        let visit_seq = Stmts(deserialize_seq(
+            &type_path, params, fields, true, cattrs, expecting,
+        ));
 
-            Some(quote! {
-                #[inline]
-                fn visit_seq<__A>(self, #mut_seq: __A) -> _serde::__private::Result<Self::Value, __A::Error>
-                where
-                    __A: _serde::de::SeqAccess<#delife>,
-                {
-                    #visit_seq
-                }
-            })
-        }
+        Some(quote! {
+            #[inline]
+            fn visit_seq<__A>(self, #mut_seq: __A) -> _serde::__private::Result<Self::Value, __A::Error>
+            where
+                __A: _serde::de::SeqAccess<#delife>,
+            {
+                #visit_seq
+            }
+        })
     };
     let visit_map = Stmts(deserialize_map(&type_path, params, fields, cattrs));
 

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1009,7 +1009,6 @@ fn deserialize_struct(
     // untagged struct variants do not get a visit_seq method. The same applies to
     // structs that only have a map representation.
     let visit_seq = match form {
-        StructForm::Untagged(..) => None,
         _ if cattrs.has_flatten() => None,
         _ => {
             let mut_seq = if field_names_idents.is_empty() {

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -628,6 +628,10 @@ fn test_untagged_enum() {
             Token::StructEnd,
         ],
     );
+    assert_de_tokens(
+        &Untagged::A { a: 1 },
+        &[Token::Tuple { len: 1 }, Token::U8(1), Token::TupleEnd],
+    );
 
     assert_tokens(
         &Untagged::B { b: 2 },
@@ -658,11 +662,6 @@ fn test_untagged_enum() {
             Token::U8(2),
             Token::TupleEnd,
         ],
-    );
-
-    assert_de_tokens_error::<Untagged>(
-        &[Token::Tuple { len: 1 }, Token::U8(1), Token::TupleEnd],
-        "data did not match any variant of untagged enum Untagged",
     );
 
     assert_de_tokens_error::<Untagged>(


### PR DESCRIPTION
The artificial limitation on use of `visit_seq` method was introduced in serde-rs/serde#1058 without any rationale. I suggest to remove it. The consequences are:

- Struct variants of adjacently tagged enums now can be deserialized using `visit_seq` method
- Struct variants of untagged enums now can be deserialized using `visit_seq` method
  - Because each variant in untagged enum are tried in the declaration order that means that tuple variants always should be defined before struct variants in enum declaration. We can check that during compilation time and issue a warning about that (we can also issue some other warnings in that stage (#1740 related), for example, structs with similar fields that cannot be distinguished or can be incorrectly distinguished, that is why I didn't include that code in that PR).

This change has a sense, because you already can do the same by wrapping an ordinary struct into a Newtype variant, but I think, that change from
```rust
enum Enum {
  Struct {
    // fields
  },
}
```
to
```rust
struct Struct {
  // fields
}
enum Enum {
  Struct(Struct),
}
```
should not change the behavior because this situation can arise during refactoring and changing behavior can be surprising.

I didn't include tests in that PR, because correct test suite should cover all possible situations, and many of them have certain problems. I plan to include a full testsuite in my upcoming PR for fixing serde-rs/serde#2105.

Right now you can see what changed in the generated code by running the following commands:
- place [skip.txt](https://github.com/serde-rs/serde/files/11585014/skip.txt) into `test_suite/tests` folder and change its extension to `.rs`
- run the following command in master and this PR and compare the generated output:
   ```console
   ...\serde\test_suite> cargo expand --all-features --test skip
   ```

Closes serde-rs/serde#2473, closes serde-rs/json#1049