### PR TITLE
Add `Deserializer::deserialize_identifier` support for adjacently tagged enums

### DIFF
--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -3022,7 +3022,7 @@ fn test_expecting_message_adjacently_tagged_enum() {
 
     assert_de_tokens_error::<Enum>(
         &[Token::Map { len: None }, Token::Unit],
-        r#"invalid type: unit value, expected "tag", "content", or other ignored fields"#,
+        r#"invalid type: unit value, expected "tag", "content", b"tag", b"content", 0, 1, or other ignored field identifiers"#,
     );
 
     // Check that #[serde(expecting = "...")] doesn't affect variant identifier error message

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -1086,6 +1086,34 @@ fn test_adjacently_tagged_enum() {
         ],
     );
 
+    // unit with no content (integer tag)
+    assert_de_tokens(
+        &AdjacentlyTagged::Unit::<u8>,
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::U64(0),
+            Token::Str("Unit"),
+            Token::StructEnd,
+        ],
+    );
+
+    // unit with no content (bytes tag)
+    assert_de_tokens(
+        &AdjacentlyTagged::Unit::<u8>,
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::Bytes(b"t"),
+            Token::Str("Unit"),
+            Token::StructEnd,
+        ],
+    );
+
     // unit with tag first
     assert_de_tokens(
         &AdjacentlyTagged::Unit::<u8>,
@@ -1102,6 +1130,38 @@ fn test_adjacently_tagged_enum() {
         ],
     );
 
+    // unit with tag first (integer tag)
+    assert_de_tokens(
+        &AdjacentlyTagged::Unit::<u8>,
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::U64(0),
+            Token::Str("Unit"),
+            Token::U64(1),
+            Token::Unit,
+            Token::StructEnd,
+        ],
+    );
+
+    // unit with tag first (bytes tag)
+    assert_de_tokens(
+        &AdjacentlyTagged::Unit::<u8>,
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::Bytes(b"t"),
+            Token::Str("Unit"),
+            Token::Bytes(b"c"),
+            Token::Unit,
+            Token::StructEnd,
+        ],
+    );
+
     // unit with content first
     assert_de_tokens(
         &AdjacentlyTagged::Unit::<u8>,
@@ -1113,6 +1173,38 @@ fn test_adjacently_tagged_enum() {
             Token::Str("c"),
             Token::Unit,
             Token::Str("t"),
+            Token::Str("Unit"),
+            Token::StructEnd,
+        ],
+    );
+
+    // unit with content first (integer tag)
+    assert_de_tokens(
+        &AdjacentlyTagged::Unit::<u8>,
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::U64(1),
+            Token::Unit,
+            Token::U64(0),
+            Token::Str("Unit"),
+            Token::StructEnd,
+        ],
+    );
+
+    // unit with content first (bytes tag)
+    assert_de_tokens(
+        &AdjacentlyTagged::Unit::<u8>,
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::Bytes(b"c"),
+            Token::Unit,
+            Token::Bytes(b"t"),
             Token::Str("Unit"),
             Token::StructEnd,
         ],
@@ -1140,6 +1232,50 @@ fn test_adjacently_tagged_enum() {
         ],
     );
 
+    // unit with excess content (f, g, 3) (integer tag)
+    assert_de_tokens(
+        &AdjacentlyTagged::Unit::<u8>,
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::Str("f"),
+            Token::Unit,
+            Token::U64(0),
+            Token::Str("Unit"),
+            Token::Str("g"),
+            Token::Unit,
+            Token::U64(1),
+            Token::Unit,
+            Token::U64(3),
+            Token::Unit,
+            Token::StructEnd,
+        ],
+    );
+
+    // unit with excess content (f, b"g", 3) (bytes tag)
+    assert_de_tokens(
+        &AdjacentlyTagged::Unit::<u8>,
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::Str("f"),
+            Token::Unit,
+            Token::Bytes(b"t"),
+            Token::Str("Unit"),
+            Token::Bytes(b"g"),
+            Token::Unit,
+            Token::Str("c"),
+            Token::Unit,
+            Token::U64(3),
+            Token::Unit,
+            Token::StructEnd,
+        ],
+    );
+
     // newtype with tag first
     assert_tokens(
         &AdjacentlyTagged::Newtype::<u8>(1),
@@ -1151,6 +1287,38 @@ fn test_adjacently_tagged_enum() {
             Token::Str("t"),
             Token::Str("Newtype"),
             Token::Str("c"),
+            Token::U8(1),
+            Token::StructEnd,
+        ],
+    );
+
+    // newtype with tag first (integer tag)
+    assert_de_tokens(
+        &AdjacentlyTagged::Newtype::<u8>(1),
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::U64(0),
+            Token::Str("Newtype"),
+            Token::U64(1),
+            Token::U8(1),
+            Token::StructEnd,
+        ],
+    );
+
+    // newtype with tag first (bytes tag)
+    assert_de_tokens(
+        &AdjacentlyTagged::Newtype::<u8>(1),
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::Bytes(b"t"),
+            Token::Str("Newtype"),
+            Token::Bytes(b"c"),
             Token::U8(1),
             Token::StructEnd,
         ],
@@ -1172,6 +1340,38 @@ fn test_adjacently_tagged_enum() {
         ],
     );
 
+    // newtype with content first (integer tag)
+    assert_de_tokens(
+        &AdjacentlyTagged::Newtype::<u8>(1),
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::U64(1),
+            Token::U8(1),
+            Token::U64(0),
+            Token::Str("Newtype"),
+            Token::StructEnd,
+        ],
+    );
+
+    // newtype with content first (bytes tag)
+    assert_de_tokens(
+        &AdjacentlyTagged::Newtype::<u8>(1),
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::Bytes(b"c"),
+            Token::U8(1),
+            Token::Bytes(b"t"),
+            Token::Str("Newtype"),
+            Token::StructEnd,
+        ],
+    );
+
     // optional newtype with no content field
     assert_de_tokens(
         &AdjacentlyTagged::Newtype::<Option<u8>>(None),
@@ -1181,6 +1381,34 @@ fn test_adjacently_tagged_enum() {
                 len: 1,
             },
             Token::Str("t"),
+            Token::Str("Newtype"),
+            Token::StructEnd,
+        ],
+    );
+
+    // optional newtype with no content field (integer tag)
+    assert_de_tokens(
+        &AdjacentlyTagged::Newtype::<Option<u8>>(None),
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 1,
+            },
+            Token::U64(0),
+            Token::Str("Newtype"),
+            Token::StructEnd,
+        ],
+    );
+
+    // optional newtype with no content field (bytes tag)
+    assert_de_tokens(
+        &AdjacentlyTagged::Newtype::<Option<u8>>(None),
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 1,
+            },
+            Token::Bytes(b"t"),
             Token::Str("Newtype"),
             Token::StructEnd,
         ],
@@ -1197,6 +1425,44 @@ fn test_adjacently_tagged_enum() {
             Token::Str("t"),
             Token::Str("Tuple"),
             Token::Str("c"),
+            Token::Tuple { len: 2 },
+            Token::U8(1),
+            Token::U8(1),
+            Token::TupleEnd,
+            Token::StructEnd,
+        ],
+    );
+
+    // tuple with tag first (integer tag)
+    assert_de_tokens(
+        &AdjacentlyTagged::Tuple::<u8>(1, 1),
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::U64(0),
+            Token::Str("Tuple"),
+            Token::U64(1),
+            Token::Tuple { len: 2 },
+            Token::U8(1),
+            Token::U8(1),
+            Token::TupleEnd,
+            Token::StructEnd,
+        ],
+    );
+
+    // tuple with tag first (bytes tag)
+    assert_de_tokens(
+        &AdjacentlyTagged::Tuple::<u8>(1, 1),
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::Bytes(b"t"),
+            Token::Str("Tuple"),
+            Token::Bytes(b"c"),
             Token::Tuple { len: 2 },
             Token::U8(1),
             Token::U8(1),
@@ -1224,6 +1490,44 @@ fn test_adjacently_tagged_enum() {
         ],
     );
 
+    // tuple with content first (integer tag)
+    assert_de_tokens(
+        &AdjacentlyTagged::Tuple::<u8>(1, 1),
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::U64(1),
+            Token::Tuple { len: 2 },
+            Token::U8(1),
+            Token::U8(1),
+            Token::TupleEnd,
+            Token::U64(0),
+            Token::Str("Tuple"),
+            Token::StructEnd,
+        ],
+    );
+
+    // tuple with content first (bytes tag)
+    assert_de_tokens(
+        &AdjacentlyTagged::Tuple::<u8>(1, 1),
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::Bytes(b"c"),
+            Token::Tuple { len: 2 },
+            Token::U8(1),
+            Token::U8(1),
+            Token::TupleEnd,
+            Token::Bytes(b"t"),
+            Token::Str("Tuple"),
+            Token::StructEnd,
+        ],
+    );
+
     // struct with tag first
     assert_tokens(
         &AdjacentlyTagged::Struct::<u8> { f: 1 },
@@ -1235,6 +1539,50 @@ fn test_adjacently_tagged_enum() {
             Token::Str("t"),
             Token::Str("Struct"),
             Token::Str("c"),
+            Token::Struct {
+                name: "Struct",
+                len: 1,
+            },
+            Token::Str("f"),
+            Token::U8(1),
+            Token::StructEnd,
+            Token::StructEnd,
+        ],
+    );
+
+    // struct with tag first (integer tag)
+    assert_de_tokens(
+        &AdjacentlyTagged::Struct::<u8> { f: 1 },
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::U64(0),
+            Token::Str("Struct"),
+            Token::U64(1),
+            Token::Struct {
+                name: "Struct",
+                len: 1,
+            },
+            Token::Str("f"),
+            Token::U8(1),
+            Token::StructEnd,
+            Token::StructEnd,
+        ],
+    );
+
+    // struct with tag first (bytes tag)
+    assert_de_tokens(
+        &AdjacentlyTagged::Struct::<u8> { f: 1 },
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::Bytes(b"t"),
+            Token::Str("Struct"),
+            Token::Bytes(b"c"),
             Token::Struct {
                 name: "Struct",
                 len: 1,
@@ -1267,6 +1615,50 @@ fn test_adjacently_tagged_enum() {
             Token::StructEnd,
         ],
     );
+
+    // struct with content first (integer tag)
+    assert_de_tokens(
+        &AdjacentlyTagged::Struct::<u8> { f: 1 },
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::U64(1),
+            Token::Struct {
+                name: "Struct",
+                len: 1,
+            },
+            Token::Str("f"),
+            Token::U8(1),
+            Token::StructEnd,
+            Token::U64(0),
+            Token::Str("Struct"),
+            Token::StructEnd,
+        ],
+    );
+
+    // struct with content first (bytes tag)
+    assert_de_tokens(
+        &AdjacentlyTagged::Struct::<u8> { f: 1 },
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::Bytes(b"c"),
+            Token::Struct {
+                name: "Struct",
+                len: 1,
+            },
+            Token::Str("f"),
+            Token::U8(1),
+            Token::StructEnd,
+            Token::Bytes(b"t"),
+            Token::Str("Struct"),
+            Token::StructEnd,
+        ],
+    );
 }
 
 #[test]
@@ -1292,6 +1684,126 @@ fn test_adjacently_tagged_enum_deny_unknown_fields() {
         ],
     );
 
+    assert_de_tokens(
+        &AdjacentlyTagged::Unit,
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::U64(0),
+            Token::Str("Unit"),
+            Token::U64(1),
+            Token::Unit,
+            Token::StructEnd,
+        ],
+    );
+
+    assert_de_tokens(
+        &AdjacentlyTagged::Unit,
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::Bytes(b"t"),
+            Token::Str("Unit"),
+            Token::Bytes(b"c"),
+            Token::Unit,
+            Token::StructEnd,
+        ],
+    );
+
+    assert_de_tokens(
+        &AdjacentlyTagged::Unit,
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::Str("t"),
+            Token::Str("Unit"),
+            Token::U64(1),
+            Token::Unit,
+            Token::StructEnd,
+        ],
+    );
+
+    assert_de_tokens(
+        &AdjacentlyTagged::Unit,
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::U64(0),
+            Token::Str("Unit"),
+            Token::Str("c"),
+            Token::Unit,
+            Token::StructEnd,
+        ],
+    );
+
+    assert_de_tokens(
+        &AdjacentlyTagged::Unit,
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::Bytes(b"t"),
+            Token::Str("Unit"),
+            Token::U64(1),
+            Token::Unit,
+            Token::StructEnd,
+        ],
+    );
+
+    assert_de_tokens(
+        &AdjacentlyTagged::Unit,
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::Bytes(b"t"),
+            Token::Str("Unit"),
+            Token::Str("c"),
+            Token::Unit,
+            Token::StructEnd,
+        ],
+    );
+
+    assert_de_tokens(
+        &AdjacentlyTagged::Unit,
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::Str("c"),
+            Token::Unit,
+            Token::Bytes(b"t"),
+            Token::Str("Unit"),
+            Token::StructEnd,
+        ],
+    );
+
+    assert_de_tokens(
+        &AdjacentlyTagged::Unit,
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::Str("c"),
+            Token::Unit,
+            Token::Bytes(b"t"),
+            Token::Str("Unit"),
+            Token::StructEnd,
+        ],
+    );
+
     assert_de_tokens_error::<AdjacentlyTagged>(
         &[
             Token::Struct {
@@ -1304,7 +1816,7 @@ fn test_adjacently_tagged_enum_deny_unknown_fields() {
             Token::Unit,
             Token::Str("h"),
         ],
-        r#"invalid value: string "h", expected "t" or "c""#,
+        r#"invalid value: string "h", expected "t", "c", b"t", b"c", 0 or 1"#,
     );
 
     assert_de_tokens_error::<AdjacentlyTagged>(
@@ -1315,7 +1827,7 @@ fn test_adjacently_tagged_enum_deny_unknown_fields() {
             },
             Token::Str("h"),
         ],
-        r#"invalid value: string "h", expected "t" or "c""#,
+        r#"invalid value: string "h", expected "t", "c", b"t", b"c", 0 or 1"#,
     );
 
     assert_de_tokens_error::<AdjacentlyTagged>(
@@ -1328,7 +1840,55 @@ fn test_adjacently_tagged_enum_deny_unknown_fields() {
             Token::Unit,
             Token::Str("h"),
         ],
-        r#"invalid value: string "h", expected "t" or "c""#,
+        r#"invalid value: string "h", expected "t", "c", b"t", b"c", 0 or 1"#,
+    );
+
+    assert_de_tokens_error::<AdjacentlyTagged>(
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::U64(2),
+        ],
+        r#"invalid value: integer `2`, expected "t", "c", b"t", b"c", 0 or 1"#,
+    );
+
+    assert_de_tokens_error::<AdjacentlyTagged>(
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::U64(0),
+            Token::Str("Unit"),
+            Token::U64(3),
+        ],
+        r#"invalid value: integer `3`, expected "t", "c", b"t", b"c", 0 or 1"#,
+    );
+
+    assert_de_tokens_error::<AdjacentlyTagged>(
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::Bytes(b"h"),
+        ],
+        r#"invalid value: byte array, expected "t", "c", b"t", b"c", 0 or 1"#,
+    );
+
+    assert_de_tokens_error::<AdjacentlyTagged>(
+        &[
+            Token::Struct {
+                name: "AdjacentlyTagged",
+                len: 2,
+            },
+            Token::Bytes(b"c"),
+            Token::Unit,
+            Token::Bytes(b"h"),
+        ],
+        r#"invalid value: byte array, expected "t", "c", b"t", b"c", 0 or 1"#,
     );
 }
 

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -1094,7 +1094,7 @@ fn test_adjacently_tagged_enum() {
                 name: "AdjacentlyTagged",
                 len: 2,
             },
-            Token::U64(0),
+            Token::U64(0), // tag field
             Token::Str("Unit"),
             Token::StructEnd,
         ],
@@ -1138,9 +1138,9 @@ fn test_adjacently_tagged_enum() {
                 name: "AdjacentlyTagged",
                 len: 2,
             },
-            Token::U64(0),
+            Token::U64(0), // tag field
             Token::Str("Unit"),
-            Token::U64(1),
+            Token::U64(1), // content field
             Token::Unit,
             Token::StructEnd,
         ],
@@ -1186,9 +1186,9 @@ fn test_adjacently_tagged_enum() {
                 name: "AdjacentlyTagged",
                 len: 2,
             },
-            Token::U64(1),
+            Token::U64(1), // content field
             Token::Unit,
-            Token::U64(0),
+            Token::U64(0), // tag field
             Token::Str("Unit"),
             Token::StructEnd,
         ],
@@ -1242,13 +1242,13 @@ fn test_adjacently_tagged_enum() {
             },
             Token::Str("f"),
             Token::Unit,
-            Token::U64(0),
+            Token::U64(0), // tag field
             Token::Str("Unit"),
             Token::Str("g"),
             Token::Unit,
-            Token::U64(1),
+            Token::U64(1), // content field
             Token::Unit,
-            Token::U64(3),
+            Token::U64(3), // unknown field
             Token::Unit,
             Token::StructEnd,
         ],
@@ -1300,9 +1300,9 @@ fn test_adjacently_tagged_enum() {
                 name: "AdjacentlyTagged",
                 len: 2,
             },
-            Token::U64(0),
+            Token::U64(0), // tag field
             Token::Str("Newtype"),
-            Token::U64(1),
+            Token::U64(1), // content field
             Token::U8(1),
             Token::StructEnd,
         ],
@@ -1348,9 +1348,9 @@ fn test_adjacently_tagged_enum() {
                 name: "AdjacentlyTagged",
                 len: 2,
             },
-            Token::U64(1),
+            Token::U64(1), // content field
             Token::U8(1),
-            Token::U64(0),
+            Token::U64(0), // tag field
             Token::Str("Newtype"),
             Token::StructEnd,
         ],
@@ -1394,7 +1394,7 @@ fn test_adjacently_tagged_enum() {
                 name: "AdjacentlyTagged",
                 len: 1,
             },
-            Token::U64(0),
+            Token::U64(0), // tag field
             Token::Str("Newtype"),
             Token::StructEnd,
         ],
@@ -1441,9 +1441,9 @@ fn test_adjacently_tagged_enum() {
                 name: "AdjacentlyTagged",
                 len: 2,
             },
-            Token::U64(0),
+            Token::U64(0), // tag field
             Token::Str("Tuple"),
-            Token::U64(1),
+            Token::U64(1), // content field
             Token::Tuple { len: 2 },
             Token::U8(1),
             Token::U8(1),
@@ -1498,12 +1498,12 @@ fn test_adjacently_tagged_enum() {
                 name: "AdjacentlyTagged",
                 len: 2,
             },
-            Token::U64(1),
+            Token::U64(1), // content field
             Token::Tuple { len: 2 },
             Token::U8(1),
             Token::U8(1),
             Token::TupleEnd,
-            Token::U64(0),
+            Token::U64(0), // tag field
             Token::Str("Tuple"),
             Token::StructEnd,
         ],
@@ -1558,9 +1558,9 @@ fn test_adjacently_tagged_enum() {
                 name: "AdjacentlyTagged",
                 len: 2,
             },
-            Token::U64(0),
+            Token::U64(0), // tag field
             Token::Str("Struct"),
-            Token::U64(1),
+            Token::U64(1), // content field
             Token::Struct {
                 name: "Struct",
                 len: 1,
@@ -1624,7 +1624,7 @@ fn test_adjacently_tagged_enum() {
                 name: "AdjacentlyTagged",
                 len: 2,
             },
-            Token::U64(1),
+            Token::U64(1), // content field
             Token::Struct {
                 name: "Struct",
                 len: 1,
@@ -1632,7 +1632,7 @@ fn test_adjacently_tagged_enum() {
             Token::Str("f"),
             Token::U8(1),
             Token::StructEnd,
-            Token::U64(0),
+            Token::U64(0), // tag field
             Token::Str("Struct"),
             Token::StructEnd,
         ],
@@ -1691,9 +1691,9 @@ fn test_adjacently_tagged_enum_deny_unknown_fields() {
                 name: "AdjacentlyTagged",
                 len: 2,
             },
-            Token::U64(0),
+            Token::U64(0), // tag field
             Token::Str("Unit"),
-            Token::U64(1),
+            Token::U64(1), // content field
             Token::Unit,
             Token::StructEnd,
         ],
@@ -1723,7 +1723,7 @@ fn test_adjacently_tagged_enum_deny_unknown_fields() {
             },
             Token::Str("t"),
             Token::Str("Unit"),
-            Token::U64(1),
+            Token::U64(1), // content field
             Token::Unit,
             Token::StructEnd,
         ],
@@ -1736,7 +1736,7 @@ fn test_adjacently_tagged_enum_deny_unknown_fields() {
                 name: "AdjacentlyTagged",
                 len: 2,
             },
-            Token::U64(0),
+            Token::U64(0), // tag field
             Token::Str("Unit"),
             Token::Str("c"),
             Token::Unit,
@@ -1753,7 +1753,7 @@ fn test_adjacently_tagged_enum_deny_unknown_fields() {
             },
             Token::Bytes(b"t"),
             Token::Str("Unit"),
-            Token::U64(1),
+            Token::U64(1), // content field
             Token::Unit,
             Token::StructEnd,
         ],
@@ -1860,7 +1860,7 @@ fn test_adjacently_tagged_enum_deny_unknown_fields() {
                 name: "AdjacentlyTagged",
                 len: 2,
             },
-            Token::U64(0),
+            Token::U64(0), // tag field
             Token::Str("Unit"),
             Token::U64(3),
         ],


### PR DESCRIPTION
Adjancently tagged enum should behave like a struct with 2 elements, the tag and the content such as

```rust 
struct Foo<'a, T> {
  tag: &'a str,
  content: T
}
```

This is the case for most format until you come across a format that serialize structs with fields identifier other than `&str`. for exemple auto derived struct handle the case where the field identifier is an unsigned number, or a `&[u8]`, not just `&str`. 

This is due to the fact that  `TagOrContentFieldVisitor` and `TagContentOtherFieldVisitor` directly calls `Deserializer::deserialize_str` and only handle cases for `&str`, any other format are rejected.

This PR enable `TagOrContentFieldVisitor` and `TagContentOtherFieldVisitor` to call `Deserializer::visit_identifier` and handle the case for `&str`, `&[u8]` and unsigned numbers.

This modifications should only allow more flexibility and should'nt conflict with flattened adjacently tagged enums, as those serialize as a map and not a struct.