### PR TITLE
add syn_full feature to serde_derive

### DIFF
--- a/serde_derive/Cargo.toml
+++ b/serde_derive/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = "1.56"
 [features]
 default = []
 deserialize_in_place = []
+syn_full = ["syn/full"]
 
 [lib]
 name = "serde_derive"


### PR DESCRIPTION
This allows users of `serde_derive` to transitively enable the "syn/full" feature.
While this fixes a problem I'm having I haven't put much thought into its general desirability.


### Background

I'd like code like this to compile:

```rust
#[derive(serde::Deserialize)]
struct Foo<T: strum::EnumCount> {
    foo: heapless::Vec<u8, T::COUNT>,
}
```

However Rust currently requires us to write it like so ([link](https://github.com/rust-lang/rust/issues/43408#issuecomment-917600907))

```rust
#![feature(generic_const_exprs)]

#[derive(serde::Deserialize)]
struct Foo<T: strum::EnumCount>
where
    [(); { T::COUNT }]:,
{
    foo: heapless::Vec<u8, { T::COUNT }>,
}
```

The weird where clause requires the "syn/full" feature