### PR TITLE
Use const generics to serialize and deserialize fixed size array of any length

### DIFF
--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -15,6 +15,7 @@ repository = "https://github.com/serde-rs/serde"
 rust-version = "1.19"
 
 [dependencies]
+rustversion = "1"
 serde_derive = { version = "=1.0.164", optional = true, path = "../serde_derive" }
 
 [dev-dependencies]

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -127,6 +127,7 @@ impl<T: ?Sized> Serialize for PhantomData<T> {
 ////////////////////////////////////////////////////////////////////////////////
 
 // Does not require T: Serialize.
+#[rustversion::before(1.51)]
 impl<T> Serialize for [T; 0] {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -137,6 +138,7 @@ impl<T> Serialize for [T; 0] {
     }
 }
 
+#[rustversion::before(1.51)]
 macro_rules! array_impls {
     ($($len:tt)+) => {
         $(
@@ -160,11 +162,30 @@ macro_rules! array_impls {
     }
 }
 
+#[rustversion::before(1.51)]
 array_impls! {
     01 02 03 04 05 06 07 08 09 10
     11 12 13 14 15 16 17 18 19 20
     21 22 23 24 25 26 27 28 29 30
     31 32
+}
+
+#[rustversion::since(1.51)]
+impl<T, const N: usize> Serialize for [T; N]
+where
+    T: Serialize,
+{
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = try!(serializer.serialize_tuple(N));
+        for e in self {
+            try!(seq.serialize_element(e));
+        }
+        seq.end()
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Since const generics (RFC-2000) were introduced since rustc version 1.51 -- this feature will be available for versions 1.51 and up.
On old versions behavior is not changed.