### PR TITLE
make the explanation show up on GitHub and crates.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ You may be looking for:
 
 ## Serde in action
 
-<details>
 <summary>
 Click to show Cargo.toml.
 <a href="https://play.rust-lang.org/?edition=2018&gist=72755f28f99afc95e01d63174b28c1f5" target="_blank">Run this code in the playground.</a>
@@ -44,7 +43,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 ```
 
-</details>
 <p></p>
 
 ```rust


### PR DESCRIPTION
For a newbie it is rather challenging to find out what needs to be added to the Cargo.toml file in order for the example to work. The information was already in the readme file, but it was hidden both in the default display of the README.md on GitHub and on [crates.io](https://crates.io/crates/serde)