### PR TITLE
Allow `[derive(serde::Deserialize)]` for generic unit structs

### DIFF
--- a/test_suite/tests/test_de.rs
+++ b/test_suite/tests/test_de.rs
@@ -46,6 +46,9 @@ mod macros;
 #[derive(Copy, Clone, PartialEq, Debug, Deserialize)]
 struct UnitStruct;
 
+#[derive(Copy, Clone, PartialEq, Debug, Deserialize)]
+struct GenericUnitStruct<const N: u8>;
+
 #[derive(PartialEq, Debug, Deserialize)]
 struct NewtypeStruct(i32);
 
@@ -881,6 +884,17 @@ fn test_unit() {
 fn test_unit_struct() {
     test(UnitStruct, &[Token::Unit]);
     test(UnitStruct, &[Token::UnitStruct { name: "UnitStruct" }]);
+}
+
+#[test]
+fn test_generic_unit_struct() {
+    test(GenericUnitStruct::<8>, &[Token::Unit]);
+    test(
+        GenericUnitStruct::<8>,
+        &[Token::UnitStruct {
+            name: "GenericUnitStruct",
+        }],
+    );
 }
 
 #[test]


### PR DESCRIPTION
Allow to auto derive `Deserialize` generic unit structs such as 

```rust
#[derive(serde::Deserialize)]
struct Generic<const N: u8>;
```

see #2497