### PR TITLE
Eliminate 'de lifetime from visitors of const generic unit struct

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -410,28 +410,17 @@ fn deserialize_unit_struct(params: &Parameters, cattrs: &attr::Container) -> Fra
     let this_type = &params.this_type;
     let this_value = &params.this_value;
     let type_name = cattrs.name().deserialize_name();
-    let (de_impl_generics, de_ty_generics, ty_generics, where_clause) =
-        split_with_de_lifetime(params);
-    let delife = params.borrowed.de_lifetime();
+    let (impl_generics, ty_generics, where_clause) = params.generics.split_for_impl();
+    let de_impl_generics = DeImplGenerics(params);
 
     let expecting = format!("unit struct {}", params.type_name());
     let expecting = cattrs.expecting().unwrap_or(&expecting);
 
-    let visitor_expr = quote! {
-        __Visitor {
-            marker: _serde::__private::PhantomData::<#this_type #ty_generics>,
-            lifetime: _serde::__private::PhantomData,
-        }
-    };
-
     quote_block! {
         #[doc(hidden)]
-        struct __Visitor #de_impl_generics #where_clause {
-            marker: _serde::__private::PhantomData<#this_type #ty_generics>,
-            lifetime: _serde::__private::PhantomData<&#delife ()>,
-        }
+        struct __Visitor #impl_generics #where_clause;
 
-        impl #de_impl_generics _serde::de::Visitor<#delife> for __Visitor #de_ty_generics #where_clause {
+        impl #de_impl_generics _serde::de::Visitor<'de> for __Visitor #ty_generics #where_clause {
             type Value = #this_type #ty_generics;
 
             fn expecting(&self, __formatter: &mut _serde::__private::Formatter) -> _serde::__private::fmt::Result {
@@ -447,7 +436,7 @@ fn deserialize_unit_struct(params: &Parameters, cattrs: &attr::Container) -> Fra
             }
         }
 
-        _serde::Deserializer::deserialize_unit_struct(__deserializer, #type_name, #visitor_expr)
+        _serde::Deserializer::deserialize_unit_struct(__deserializer, #type_name, __Visitor)
     }
 }
 


### PR DESCRIPTION
In #2500 I was trying to figure out whether the two PhantomData in `__Visitor` are necessary i.e. if there is any case that compiles with them and breaks without them. I came up with this one:

```rust
#[derive(Deserialize)]
#[serde(bound(deserialize = "[&'de str; N]: Copy"))]
struct GenericUnitStruct<const N: usize>;
```

```console
error[E0401]: can't use generic parameters from outer item
 --> src/main.rs:4:29
  |
3 | #[derive(Deserialize)]
  |          ----------- lifetime parameter from outer item
4 | #[serde(bound(deserialize = "[&'de str; N]: Copy"))]
  |                             ^^^^^^^^^^^^^^^^^^^^^ use of generic parameter from outer item
  |
  = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
help: consider making the bound lifetime-generic with a new `'de` lifetime
  |
4 | #[serde(bound(deserialize = for<'de> "[&'de str; N]: Copy"))]
  |                             ++++++++
help: consider introducing lifetime `'de` here
  |
5 | struct GenericUnitStruct<'de, const N: usize>;
  |                          ++++

error: impl method assumes more implied bounds than the corresponding trait method
 --> src/main.rs:3:10
  |
3 | #[derive(Deserialize)]
  |          ^^^^^^^^^^^
  |
  = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
  = note: for more information, see issue #105572 <https://github.com/rust-lang/rust/issues/105572>
  = note: `#[deny(implied_bounds_entailment)]` on by default
  = note: this error originates in the derive macro `Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)
```