### PR TITLE
Add `try_into`, `borrowed_into`, and `borrowed_try_into` attributes

### DIFF
--- a/serde/src/private/mod.rs
+++ b/serde/src/private/mod.rs
@@ -23,7 +23,7 @@ pub use self::string::from_utf8_lossy;
 pub use lib::{ToString, Vec};
 
 #[cfg(not(no_core_try_from))]
-pub use lib::convert::TryFrom;
+pub use lib::convert::{TryFrom, TryInto};
 
 mod string {
     use lib::*;

--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -212,6 +212,8 @@ pub struct Container {
     type_try_from: Option<syn::Type>,
     type_into: Option<syn::Type>,
     type_try_into: Option<syn::Type>,
+    type_borrowed_into: Option<syn::Type>,
+    type_borrowed_try_into: Option<syn::Type>,
     remote: Option<syn::Path>,
     identifier: Identifier,
     has_flatten: bool,
@@ -298,6 +300,8 @@ impl Container {
         let mut type_try_from = Attr::none(cx, TRY_FROM);
         let mut type_into = Attr::none(cx, INTO);
         let mut type_try_into = Attr::none(cx, TRY_INTO);
+        let mut type_borrowed_into = Attr::none(cx, BORROWED_INTO);
+        let mut type_borrowed_try_into = Attr::none(cx, BORROWED_TRY_INTO);
         let mut remote = Attr::none(cx, REMOTE);
         let mut field_identifier = BoolAttr::none(cx, FIELD_IDENTIFIER);
         let mut variant_identifier = BoolAttr::none(cx, VARIANT_IDENTIFIER);
@@ -475,6 +479,16 @@ impl Container {
                     if let Some(try_into_ty) = parse_lit_into_ty(cx, TRY_INTO, &meta)? {
                         type_try_into.set_opt(&meta.path, Some(try_into_ty));
                     }
+                } else if meta.path == BORROWED_INTO {
+                    // #[serde(borrowed_into = "Type")]
+                    if let Some(borrowed_into_ty) = parse_lit_into_ty(cx, TRY_INTO, &meta)? {
+                        type_borrowed_into.set_opt(&meta.path, Some(borrowed_into_ty));
+                    }
+                } else if meta.path == BORROWED_TRY_INTO {
+                    // #[serde(borrowed_try_into = "Type")]
+                    if let Some(borrowed_try_into_ty) = parse_lit_into_ty(cx, TRY_INTO, &meta)? {
+                        type_borrowed_try_into.set_opt(&meta.path, Some(borrowed_try_into_ty));
+                    }
                 } else if meta.path == REMOTE {
                     // #[serde(remote = "...")]
                     if let Some(path) = parse_lit_into_path(cx, REMOTE, &meta)? {
@@ -542,6 +556,8 @@ impl Container {
             type_try_from: type_try_from.get(),
             type_into: type_into.get(),
             type_try_into: type_try_into.get(),
+            type_borrowed_into: type_borrowed_into.get(),
+            type_borrowed_try_into: type_borrowed_try_into.get(),
             remote: remote.get(),
             identifier: decide_identifier(cx, item, field_identifier, variant_identifier),
             has_flatten: false,
@@ -597,6 +613,14 @@ impl Container {
 
     pub fn type_try_into(&self) -> Option<&syn::Type> {
         self.type_try_into.as_ref()
+    }
+
+    pub fn type_borrowed_into(&self) -> Option<&syn::Type> {
+        self.type_borrowed_into.as_ref()
+    }
+
+    pub fn type_borrowed_try_into(&self) -> Option<&syn::Type> {
+        self.type_borrowed_try_into.as_ref()
     }
 
     pub fn remote(&self) -> Option<&syn::Path> {

--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -211,6 +211,7 @@ pub struct Container {
     type_from: Option<syn::Type>,
     type_try_from: Option<syn::Type>,
     type_into: Option<syn::Type>,
+    type_try_into: Option<syn::Type>,
     remote: Option<syn::Path>,
     identifier: Identifier,
     has_flatten: bool,
@@ -296,6 +297,7 @@ impl Container {
         let mut type_from = Attr::none(cx, FROM);
         let mut type_try_from = Attr::none(cx, TRY_FROM);
         let mut type_into = Attr::none(cx, INTO);
+        let mut type_try_into = Attr::none(cx, TRY_INTO);
         let mut remote = Attr::none(cx, REMOTE);
         let mut field_identifier = BoolAttr::none(cx, FIELD_IDENTIFIER);
         let mut variant_identifier = BoolAttr::none(cx, VARIANT_IDENTIFIER);
@@ -468,6 +470,11 @@ impl Container {
                     if let Some(into_ty) = parse_lit_into_ty(cx, INTO, &meta)? {
                         type_into.set_opt(&meta.path, Some(into_ty));
                     }
+                } else if meta.path == TRY_INTO {
+                    // #[serde(try_into = "Type")]
+                    if let Some(try_into_ty) = parse_lit_into_ty(cx, TRY_INTO, &meta)? {
+                        type_try_into.set_opt(&meta.path, Some(try_into_ty));
+                    }
                 } else if meta.path == REMOTE {
                     // #[serde(remote = "...")]
                     if let Some(path) = parse_lit_into_path(cx, REMOTE, &meta)? {
@@ -534,6 +541,7 @@ impl Container {
             type_from: type_from.get(),
             type_try_from: type_try_from.get(),
             type_into: type_into.get(),
+            type_try_into: type_try_into.get(),
             remote: remote.get(),
             identifier: decide_identifier(cx, item, field_identifier, variant_identifier),
             has_flatten: false,
@@ -585,6 +593,10 @@ impl Container {
 
     pub fn type_into(&self) -> Option<&syn::Type> {
         self.type_into.as_ref()
+    }
+
+    pub fn type_try_into(&self) -> Option<&syn::Type> {
+        self.type_try_into.as_ref()
     }
 
     pub fn remote(&self) -> Option<&syn::Path> {

--- a/serde_derive/src/internals/check.rs
+++ b/serde_derive/src/internals/check.rs
@@ -362,6 +362,20 @@ fn check_transparent(cx: &Ctxt, cont: &mut Container, derive: Derive) {
         );
     }
 
+    if cont.attrs.type_borrowed_into().is_some() {
+        cx.error_spanned_by(
+            cont.original,
+            "#[serde(transparent)] is not allowed with #[serde(borrowed_into = \"...\")]",
+        );
+    }
+
+    if cont.attrs.type_borrowed_try_into().is_some() {
+        cx.error_spanned_by(
+            cont.original,
+            "#[serde(transparent)] is not allowed with #[serde(borrowed_try_into = \"...\")]",
+        );
+    }
+
     let fields = match &mut cont.data {
         Data::Enum(_) => {
             cx.error_spanned_by(
@@ -446,10 +460,20 @@ fn check_from_and_try_from(cx: &Ctxt, cont: &mut Container) {
 }
 
 fn check_into_variants(cx: &Ctxt, cont: &mut Container) {
-    if cont.attrs.type_into().is_some() && cont.attrs.type_try_into().is_some() {
+    let count = [
+        cont.attrs.type_into().is_some(),
+        cont.attrs.type_try_into().is_some(),
+        cont.attrs.type_borrowed_into().is_some(),
+        cont.attrs.type_borrowed_try_into().is_some(),
+    ]
+    .iter()
+    .filter(|&&b| b)
+    .count();
+
+    if count > 1 {
         cx.error_spanned_by(
             cont.original,
-            "#[serde(into = \"...\")] and #[serde(try_into = \"...\")] conflict with each other",
+            "#[serde(into = \"...\")], #[serde(try_into = \"...\")], #[serde(borrowed_into = \"...\")], and #[serde(borrowed_try_into = \"...\")] conflict with each other",
         );
     }
 }

--- a/serde_derive/src/internals/check.rs
+++ b/serde_derive/src/internals/check.rs
@@ -15,6 +15,7 @@ pub fn check(cx: &Ctxt, cont: &mut Container, derive: Derive) {
     check_adjacent_tag_conflict(cx, cont);
     check_transparent(cx, cont, derive);
     check_from_and_try_from(cx, cont);
+    check_into_variants(cx, cont);
 }
 
 // Remote derive definition type must have either all of the generics of the
@@ -354,6 +355,13 @@ fn check_transparent(cx: &Ctxt, cont: &mut Container, derive: Derive) {
         );
     }
 
+    if cont.attrs.type_try_into().is_some() {
+        cx.error_spanned_by(
+            cont.original,
+            "#[serde(transparent)] is not allowed with #[serde(try_into = \"...\")]",
+        );
+    }
+
     let fields = match &mut cont.data {
         Data::Enum(_) => {
             cx.error_spanned_by(
@@ -433,6 +441,15 @@ fn check_from_and_try_from(cx: &Ctxt, cont: &mut Container) {
         cx.error_spanned_by(
             cont.original,
             "#[serde(from = \"...\")] and #[serde(try_from = \"...\")] conflict with each other",
+        );
+    }
+}
+
+fn check_into_variants(cx: &Ctxt, cont: &mut Container) {
+    if cont.attrs.type_into().is_some() && cont.attrs.type_try_into().is_some() {
+        cx.error_spanned_by(
+            cont.original,
+            "#[serde(into = \"...\")] and #[serde(try_into = \"...\")] conflict with each other",
         );
     }
 }

--- a/serde_derive/src/internals/symbol.rs
+++ b/serde_derive/src/internals/symbol.rs
@@ -6,6 +6,8 @@ pub struct Symbol(&'static str);
 
 pub const ALIAS: Symbol = Symbol("alias");
 pub const BORROW: Symbol = Symbol("borrow");
+pub const BORROWED_INTO: Symbol = Symbol("borrowed_into");
+pub const BORROWED_TRY_INTO: Symbol = Symbol("borrowed_try_into");
 pub const BOUND: Symbol = Symbol("bound");
 pub const CONTENT: Symbol = Symbol("content");
 pub const CRATE: Symbol = Symbol("crate");

--- a/serde_derive/src/internals/symbol.rs
+++ b/serde_derive/src/internals/symbol.rs
@@ -34,6 +34,7 @@ pub const SKIP_SERIALIZING_IF: Symbol = Symbol("skip_serializing_if");
 pub const TAG: Symbol = Symbol("tag");
 pub const TRANSPARENT: Symbol = Symbol("transparent");
 pub const TRY_FROM: Symbol = Symbol("try_from");
+pub const TRY_INTO: Symbol = Symbol("try_into");
 pub const UNTAGGED: Symbol = Symbol("untagged");
 pub const VARIANT_IDENTIFIER: Symbol = Symbol("variant_identifier");
 pub const WITH: Symbol = Symbol("with");

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -171,6 +171,8 @@ fn serialize_body(cont: &Container, params: &Parameters) -> Fragment {
         serialize_transparent(cont, params)
     } else if let Some(type_into) = cont.attrs.type_into() {
         serialize_into(params, type_into)
+    } else if let Some(type_try_into) = cont.attrs.type_try_into() {
+        serialize_try_into(params, type_try_into)
     } else {
         match &cont.data {
             Data::Enum(variants) => serialize_enum(params, variants, &cont.attrs),
@@ -215,6 +217,20 @@ fn serialize_into(params: &Parameters, type_into: &syn::Type) -> Fragment {
         _serde::Serialize::serialize(
             &_serde::__private::Into::<#type_into>::into(_serde::__private::Clone::clone(#self_var)),
             __serializer)
+    }
+}
+
+fn serialize_try_into(params: &Parameters, type_into: &syn::Type) -> Fragment {
+    let self_var = &params.self_var;
+    quote_block! {
+        _serde::__private::Result::and_then(
+            _serde::__private::Result::map_err(
+                _serde::__private::TryInto::<#type_into>::try_into(
+                    _serde::__private::Clone::clone(#self_var)
+                ),
+                _serde::ser::Error::custom
+            ),
+            |v| _serde::Serialize::serialize(&v, __serializer))
     }
 }
 

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -173,6 +173,10 @@ fn serialize_body(cont: &Container, params: &Parameters) -> Fragment {
         serialize_into(params, type_into)
     } else if let Some(type_try_into) = cont.attrs.type_try_into() {
         serialize_try_into(params, type_try_into)
+    } else if let Some(type_borrowed_into) = cont.attrs.type_borrowed_into() {
+        serialize_borrowed_into(params, type_borrowed_into)
+    } else if let Some(type_borrowed_try_into) = cont.attrs.type_borrowed_try_into() {
+        serialize_borrowed_try_into(params, type_borrowed_try_into)
     } else {
         match &cont.data {
             Data::Enum(variants) => serialize_enum(params, variants, &cont.attrs),
@@ -228,6 +232,27 @@ fn serialize_try_into(params: &Parameters, type_into: &syn::Type) -> Fragment {
                 _serde::__private::TryInto::<#type_into>::try_into(
                     _serde::__private::Clone::clone(#self_var)
                 ),
+                _serde::ser::Error::custom
+            ),
+            |v| _serde::Serialize::serialize(&v, __serializer))
+    }
+}
+
+fn serialize_borrowed_into(params: &Parameters, type_into: &syn::Type) -> Fragment {
+    let self_var = &params.self_var;
+    quote_block! {
+        _serde::Serialize::serialize(
+            &_serde::__private::Into::<#type_into>::into(#self_var),
+            __serializer)
+    }
+}
+
+fn serialize_borrowed_try_into(params: &Parameters, type_into: &syn::Type) -> Fragment {
+    let self_var = &params.self_var;
+    quote_block! {
+        _serde::__private::Result::and_then(
+            _serde::__private::Result::map_err(
+                _serde::__private::TryInto::<#type_into>::try_into(#self_var),
                 _serde::ser::Error::custom
             ),
             |v| _serde::Serialize::serialize(&v, __serializer))


### PR DESCRIPTION
For the `borrowed_*` the user needs to implement `impl<'a> Into<IntoType> for &'a Type`. With this the cloing of the value will not happen.