### PR TITLE
Add `#[serde(with)]` for containers

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -283,6 +283,8 @@ fn deserialize_body(cont: &Container, params: &Parameters) -> Fragment {
         deserialize_from(type_from)
     } else if let Some(type_try_from) = cont.attrs.type_try_from() {
         deserialize_try_from(type_try_from)
+    } else if let Some(with) = cont.attrs.deserialize_with() {
+        deserialize_with(with)
     } else if let attr::Identifier::No = cont.attrs.identifier() {
         match &cont.data {
             Data::Enum(variants) => deserialize_enum(params, variants, &cont.attrs),
@@ -311,6 +313,7 @@ fn deserialize_in_place_body(cont: &Container, params: &Parameters) -> Option<St
     if cont.attrs.transparent()
         || cont.attrs.type_from().is_some()
         || cont.attrs.type_try_from().is_some()
+        || cont.attrs.deserialize_with().is_some()
         || cont.attrs.identifier().is_some()
         || cont
             .data
@@ -403,6 +406,12 @@ fn deserialize_try_from(type_try_from: &syn::Type) -> Fragment {
         _serde::__private::Result::and_then(
             <#type_try_from as _serde::Deserialize>::deserialize(__deserializer),
             |v| _serde::__private::TryFrom::try_from(v).map_err(_serde::de::Error::custom))
+    }
+}
+
+fn deserialize_with(with: &syn::ExprPath) -> Fragment {
+    quote_block! {
+        #with(__deserializer)
     }
 }
 

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -171,6 +171,8 @@ fn serialize_body(cont: &Container, params: &Parameters) -> Fragment {
         serialize_transparent(cont, params)
     } else if let Some(type_into) = cont.attrs.type_into() {
         serialize_into(params, type_into)
+    } else if let Some(with) = cont.attrs.serialize_with() {
+        serialize_with(params, with)
     } else {
         match &cont.data {
             Data::Enum(variants) => serialize_enum(params, variants, &cont.attrs),
@@ -215,6 +217,13 @@ fn serialize_into(params: &Parameters, type_into: &syn::Type) -> Fragment {
         _serde::Serialize::serialize(
             &_serde::__private::Into::<#type_into>::into(_serde::__private::Clone::clone(#self_var)),
             __serializer)
+    }
+}
+
+fn serialize_with(params: &Parameters, with: &syn::ExprPath) -> Fragment {
+    let self_var = &params.self_var;
+    quote_block! {
+        #with(#self_var, __serializer)
     }
 }
 


### PR DESCRIPTION
Why this is useful:

* It will enable `#[serde_with::serde_as(as = "SomeSerdeWithUtil")]` to be applied on a container.

* It can be easily used with code-generators such as [prost-build](https://docs.rs/prost-build). For example:

```rust
    prost_build::Config::new()
        .type_attribute(
            "my_messages.MyMessageType",
            "#[derive(Serialize, Deserialize)] #[serde(with = \"my_message_type\")]",
        )
        .complie_protos(&["my_messages.proto"])
        .unwrap();
```