### PR TITLE
Fix incorrect representation of tuples with skipped fields

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -448,6 +448,10 @@ enum TupleForm<'a> {
     Untagged(&'a syn::Ident),
 }
 
+/// Generates code that will read specified `fields` in order, one-by-one,
+/// and then construct a final value from them. All skipped fields will receive
+/// their default values, all other will be read using the code, returned by
+/// the `read_field` function.
 fn read_fields_in_order(
     type_path: &TokenStream,
     params: &Parameters,
@@ -455,6 +459,7 @@ fn read_fields_in_order(
     is_struct: bool,
     cattrs: &attr::Container,
     expecting: &str,
+    read_field: impl Fn(&Parameters, usize, &Field, &attr::Container, &str) -> TokenStream,
 ) -> Fragment {
     let vars = (0..fields.len()).map(field_i as fn(_) -> _);
 
@@ -477,7 +482,7 @@ fn read_fields_in_order(
                 let #var = #default;
             }
         } else {
-            let read = read_from_seq_access(params, index_in_seq, field, cattrs, expecting);
+            let read = read_field(params, index_in_seq, field, cattrs, expecting);
             index_in_seq += 1;
             quote! {
                 let #var = #read;
@@ -564,6 +569,9 @@ fn read_from_seq_access(
     }
 }
 
+/// Generates code that will read specified `fields` in order, one-by-one,
+/// and then construct a final value from them. All skipped fields will receive
+/// their default values, all other will be read from a `SeqAccess`.
 #[cfg(feature = "deserialize_in_place")]
 fn read_fields_in_order_in_place(
     params: &Parameters,

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -448,7 +448,7 @@ enum TupleForm<'a> {
     Untagged(&'a syn::Ident),
 }
 
-fn deserialize_seq(
+fn read_fields_in_order(
     type_path: &TokenStream,
     params: &Parameters,
     fields: &[Field],
@@ -565,7 +565,7 @@ fn read_from_seq_access(
 }
 
 #[cfg(feature = "deserialize_in_place")]
-fn deserialize_seq_in_place(
+fn read_fields_in_order_in_place(
     params: &Parameters,
     fields: &[Field],
     cattrs: &attr::Container,

--- a/serde_derive/src/de/struct_.rs
+++ b/serde_derive/src/de/struct_.rs
@@ -1,10 +1,10 @@
 use crate::de::identifier;
 use crate::de::{
-    deserialize_seq, expr_is_missing, field_i, has_flatten, wrap_deserialize_field_with,
+    expr_is_missing, field_i, has_flatten, read_fields_in_order, wrap_deserialize_field_with,
     FieldWithAliases, Parameters, StructForm,
 };
 #[cfg(feature = "deserialize_in_place")]
-use crate::de::{deserialize_seq_in_place, place_lifetime};
+use crate::de::{place_lifetime, read_fields_in_order_in_place};
 use crate::fragment::{Expr, Fragment, Match, Stmts};
 use crate::internals::ast::Field;
 use crate::internals::attr;
@@ -79,7 +79,7 @@ pub(super) fn deserialize(
                 quote!(mut __seq)
             };
 
-            let visit_seq = Stmts(deserialize_seq(
+            let visit_seq = Stmts(read_fields_in_order(
                 &type_path, params, fields, true, cattrs, expecting,
             ));
 
@@ -456,7 +456,9 @@ pub(super) fn deserialize_in_place(
     } else {
         quote!(mut __seq)
     };
-    let visit_seq = Stmts(deserialize_seq_in_place(params, fields, cattrs, expecting));
+    let visit_seq = Stmts(read_fields_in_order_in_place(
+        params, fields, cattrs, expecting,
+    ));
     let visit_map = Stmts(deserialize_map_in_place(params, fields, cattrs));
     let field_names = deserialized_fields.iter().flat_map(|field| field.aliases);
     let type_name = cattrs.name().deserialize_name();

--- a/serde_derive/src/de/struct_.rs
+++ b/serde_derive/src/de/struct_.rs
@@ -1,7 +1,7 @@
 use crate::de::identifier;
 use crate::de::{
-    expr_is_missing, field_i, has_flatten, read_fields_in_order, wrap_deserialize_field_with,
-    FieldWithAliases, Parameters, StructForm,
+    expr_is_missing, field_i, has_flatten, read_fields_in_order, read_from_seq_access,
+    wrap_deserialize_field_with, FieldWithAliases, Parameters, StructForm,
 };
 #[cfg(feature = "deserialize_in_place")]
 use crate::de::{place_lifetime, read_fields_in_order_in_place};
@@ -80,7 +80,13 @@ pub(super) fn deserialize(
             };
 
             let visit_seq = Stmts(read_fields_in_order(
-                &type_path, params, fields, true, cattrs, expecting,
+                &type_path,
+                params,
+                fields,
+                true,
+                cattrs,
+                expecting,
+                read_from_seq_access,
             ));
 
             Some(quote! {

--- a/serde_derive/src/de/tuple.rs
+++ b/serde_derive/src/de/tuple.rs
@@ -1,4 +1,4 @@
-use crate::de::{has_flatten, read_fields_in_order, Parameters, TupleForm};
+use crate::de::{has_flatten, read_fields_in_order, read_from_seq_access, Parameters, TupleForm};
 #[cfg(feature = "deserialize_in_place")]
 use crate::de::{place_lifetime, read_fields_in_order_in_place};
 use crate::fragment::{Fragment, Stmts};
@@ -66,7 +66,13 @@ pub(super) fn deserialize(
     };
 
     let visit_seq = Stmts(read_fields_in_order(
-        &type_path, params, fields, false, cattrs, expecting,
+        &type_path,
+        params,
+        fields,
+        false,
+        cattrs,
+        expecting,
+        read_from_seq_access,
     ));
 
     let visitor_expr = quote! {

--- a/serde_derive/src/de/tuple.rs
+++ b/serde_derive/src/de/tuple.rs
@@ -1,6 +1,6 @@
-use crate::de::{deserialize_seq, has_flatten, Parameters, TupleForm};
+use crate::de::{has_flatten, read_fields_in_order, Parameters, TupleForm};
 #[cfg(feature = "deserialize_in_place")]
-use crate::de::{deserialize_seq_in_place, place_lifetime};
+use crate::de::{place_lifetime, read_fields_in_order_in_place};
 use crate::fragment::{Fragment, Stmts};
 use crate::internals::ast::Field;
 use crate::internals::attr;
@@ -65,7 +65,7 @@ pub(super) fn deserialize(
         _ => None,
     };
 
-    let visit_seq = Stmts(deserialize_seq(
+    let visit_seq = Stmts(read_fields_in_order(
         &type_path, params, fields, false, cattrs, expecting,
     ));
 
@@ -226,7 +226,9 @@ pub(super) fn deserialize_in_place(
         None
     };
 
-    let visit_seq = Stmts(deserialize_seq_in_place(params, fields, cattrs, expecting));
+    let visit_seq = Stmts(read_fields_in_order_in_place(
+        params, fields, cattrs, expecting,
+    ));
 
     let visitor_expr = quote! {
         __Visitor {

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -233,6 +233,11 @@ fn serialize_newtype_struct(
     field: &Field,
     cattrs: &attr::Container,
 ) -> Fragment {
+    // For `struct Tuple1as0(#[serde(skip)] u8);` cases
+    if field.attrs.skip_serializing() {
+        return serialize_tuple_struct(params, &[], cattrs);
+    }
+
     let type_name = cattrs.name().serialize_name();
 
     let mut field_expr = get_member(

--- a/test_suite/tests/test_skip.rs
+++ b/test_suite/tests/test_skip.rs
@@ -87,7 +87,6 @@ mod tuple_struct {
         );
     }
 
-    /* FIXME: compilation error: https://github.com/serde-rs/serde/issues/2105
     #[test]
     fn tuple1as0() {
         /// This newtype struct in the serialized form the same as `struct Tuple0();`
@@ -107,7 +106,7 @@ mod tuple_struct {
                 Token::TupleStructEnd,
             ],
         );
-    }*/
+    }
 
     #[test]
     fn tuple2as0() {

--- a/test_suite/tests/test_skip.rs
+++ b/test_suite/tests/test_skip.rs
@@ -1,0 +1,322 @@
+//! Tests for `#[serde(skip)]` behavior
+
+use serde_derive::{Deserialize, Serialize};
+use serde_test::{assert_de_tokens, assert_tokens, Token};
+
+/// This helper struct does not implement neither `Deserialize` or `Serialize`.
+/// This should not prevent to use it in the skipped fields.
+#[derive(Debug, PartialEq, Default)]
+struct NotSerializableOrDeserializable;
+
+#[test]
+fn unit() {
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct Unit;
+
+    let value = Unit;
+
+    // Uses visit_unit
+    assert_tokens(&value, &[Token::UnitStruct { name: "Unit" }]);
+
+    // Uses visit_unit
+    assert_de_tokens(&value, &[Token::Unit]);
+}
+
+mod tuple_struct {
+    use super::*;
+
+    #[test]
+    fn tuple0() {
+        #[derive(Debug, PartialEq, Deserialize, Serialize)]
+        struct Tuple0();
+
+        let value = Tuple0();
+
+        // Uses visit_seq
+        assert_tokens(
+            &value,
+            &[
+                Token::TupleStruct {
+                    name: "Tuple0",
+                    len: 0,
+                },
+                Token::TupleStructEnd,
+            ],
+        );
+    }
+
+    #[test]
+    fn tuple1() {
+        #[derive(Debug, PartialEq, Deserialize, Serialize)]
+        struct Tuple1(u32);
+
+        let value = Tuple1(42);
+
+        // Uses visit_newtype_struct
+        assert_tokens(
+            &value,
+            &[Token::NewtypeStruct { name: "Tuple1" }, Token::U32(42)],
+        );
+
+        // Uses visit_seq
+        assert_de_tokens(
+            &value,
+            &[Token::Seq { len: None }, Token::U32(42), Token::SeqEnd],
+        );
+    }
+
+    #[test]
+    fn tuple2() {
+        #[derive(Debug, PartialEq, Deserialize, Serialize)]
+        struct Tuple2(u32, u32);
+
+        let value = Tuple2(4, 2);
+
+        // Uses visit_seq
+        assert_tokens(
+            &value,
+            &[
+                Token::TupleStruct {
+                    name: "Tuple2",
+                    len: 2,
+                },
+                Token::U32(4),
+                Token::U32(2),
+                Token::TupleStructEnd,
+            ],
+        );
+    }
+
+    /* FIXME: compilation error: https://github.com/serde-rs/serde/issues/2105
+    #[test]
+    fn tuple1as0() {
+        /// This newtype struct in the serialized form the same as `struct Tuple0();`
+        #[derive(Debug, PartialEq, Deserialize, Serialize)]
+        struct Tuple1as0(#[serde(skip)] NotSerializableOrDeserializable);
+
+        let value = Tuple1as0(NotSerializableOrDeserializable);
+
+        // Uses visit_seq
+        assert_tokens(
+            &value,
+            &[
+                Token::TupleStruct {
+                    name: "Tuple1as0",
+                    len: 0,
+                },
+                Token::TupleStructEnd,
+            ],
+        );
+    }*/
+
+    #[test]
+    fn tuple2as0() {
+        /// This tuple struct in the serialized form the same as `struct Tuple0();`
+        #[derive(Debug, PartialEq, Deserialize, Serialize)]
+        struct Tuple2as0(
+            #[serde(skip)] NotSerializableOrDeserializable,
+            #[serde(skip)] NotSerializableOrDeserializable,
+        );
+
+        let value = Tuple2as0(
+            NotSerializableOrDeserializable,
+            NotSerializableOrDeserializable,
+        );
+
+        // Uses visit_seq
+        assert_tokens(
+            &value,
+            &[
+                Token::TupleStruct {
+                    name: "Tuple2as0",
+                    len: 0,
+                },
+                Token::TupleStructEnd,
+            ],
+        );
+    }
+
+    #[test]
+    fn tuple2as1() {
+        /// This tuple struct in the serialized form the same as `struct Tuple1(u32);`
+        #[derive(Debug, PartialEq, Deserialize, Serialize)]
+        struct Tuple2as1(#[serde(skip)] NotSerializableOrDeserializable, u32);
+
+        let value = Tuple2as1(NotSerializableOrDeserializable, 20);
+
+        // Uses visit_seq
+        assert_tokens(
+            &value,
+            &[
+                Token::TupleStruct {
+                    name: "Tuple2as1",
+                    len: 1,
+                },
+                Token::U32(20),
+                Token::TupleStructEnd,
+            ],
+        );
+
+        // Uses visit_newtype_struct
+        assert_de_tokens(
+            &value,
+            &[Token::NewtypeStruct { name: "Tuple2as1" }, Token::U32(20)],
+        );
+    }
+
+    #[test]
+    fn tuple3as2() {
+        /// This tuple struct in the serialized form the same as `struct Tuple2(u32, u32);`
+        #[derive(Debug, PartialEq, Deserialize, Serialize)]
+        struct Tuple3as2(#[serde(skip)] NotSerializableOrDeserializable, u32, u32);
+
+        let value = Tuple3as2(NotSerializableOrDeserializable, 20, 30);
+
+        // Uses visit_seq
+        assert_tokens(
+            &value,
+            &[
+                Token::TupleStruct {
+                    name: "Tuple3as2",
+                    len: 2,
+                },
+                Token::U32(20),
+                Token::U32(30),
+                Token::TupleStructEnd,
+            ],
+        );
+    }
+}
+
+mod struct_ {
+    use super::*;
+
+    #[test]
+    fn struct0() {
+        #[derive(Debug, PartialEq, Deserialize, Serialize)]
+        struct Struct0 {}
+
+        let value = Struct0 {};
+
+        // Uses visit_map
+        assert_tokens(
+            &value,
+            &[
+                Token::Struct {
+                    name: "Struct0",
+                    len: 0,
+                },
+                Token::StructEnd,
+            ],
+        );
+
+        // Uses visit_seq
+        assert_de_tokens(&value, &[Token::Seq { len: None }, Token::SeqEnd]);
+    }
+
+    #[test]
+    fn struct1() {
+        #[derive(Debug, PartialEq, Deserialize, Serialize)]
+        struct Struct1 {
+            a: u32,
+        }
+
+        let value = Struct1 { a: 42 };
+
+        // Uses visit_map
+        assert_tokens(
+            &value,
+            &[
+                Token::Struct {
+                    name: "Struct1",
+                    len: 1,
+                },
+                Token::Str("a"),
+                Token::U32(42),
+                Token::StructEnd,
+            ],
+        );
+
+        // Uses visit_seq
+        assert_de_tokens(
+            &value,
+            &[
+                Token::Seq { len: None },
+                Token::U32(42), // a
+                Token::SeqEnd,
+            ],
+        );
+    }
+
+    #[test]
+    fn struct2as0() {
+        /// This struct in the serialized form the same as `struct Struct0 {}`
+        #[derive(Debug, PartialEq, Deserialize, Serialize)]
+        struct Struct2as0 {
+            #[serde(skip)]
+            a: NotSerializableOrDeserializable,
+            #[serde(skip)]
+            b: NotSerializableOrDeserializable,
+        }
+
+        let value = Struct2as0 {
+            a: NotSerializableOrDeserializable,
+            b: NotSerializableOrDeserializable,
+        };
+
+        // Uses visit_map
+        assert_tokens(
+            &value,
+            &[
+                Token::Struct {
+                    name: "Struct2as0",
+                    len: 0,
+                },
+                Token::StructEnd,
+            ],
+        );
+
+        // Uses visit_seq
+        assert_de_tokens(&value, &[Token::Seq { len: None }, Token::SeqEnd]);
+    }
+
+    #[test]
+    fn struct2as1() {
+        /// This struct in the serialized form the same as `struct Struct1 { b: u32 }`
+        #[derive(Debug, PartialEq, Deserialize, Serialize)]
+        struct Struct2as1 {
+            #[serde(skip)]
+            a: NotSerializableOrDeserializable,
+            b: u32,
+        }
+
+        let value = Struct2as1 {
+            a: NotSerializableOrDeserializable,
+            b: 20,
+        };
+
+        // Uses visit_map
+        assert_tokens(
+            &value,
+            &[
+                Token::Struct {
+                    name: "Struct2as1",
+                    len: 1,
+                },
+                Token::Str("b"),
+                Token::U32(20),
+                Token::StructEnd,
+            ],
+        );
+
+        // Uses visit_seq
+        assert_de_tokens(
+            &value,
+            &[
+                Token::Seq { len: None },
+                Token::U32(20), // b
+                Token::SeqEnd,
+            ],
+        );
+    }
+}


### PR DESCRIPTION
This PR fixes #2105 and give some insights about the current situation with skipped fields.

You can see what changed in the generated code by running the following commands:
- place [skip.txt](https://github.com/serde-rs/serde/files/12131031/skip.txt) into `test_suite/tests` folder and change it extension to `.rs`
- run the following command:
   ```console
   ...\serde\test_suite> cargo expand --all-features --test skip > skip-N.rs
   ```
   where `N` is some number.

When commit message contains words "Changes in generated code" that means that output of the command above was changed. I recommend to diff it against the previous result and explore the difference. There will be 4 files -- baseline and three changed.

Overall changes over all commits:
- `Tuple1as0`, `Tuple1as0Default`, `Tuple1as0With`:
  - removed `visit_newtype_struct`
  - changed `*_newtype_struct` -> `*_tuple_struct(0)`
- `Tuple2as1`, `Tuple2as1Default`, `Tuple2as1With`:
  - added `visit_newtype_struct`

The table below summarizes the current behavior and the new behavior, introduced in this PR. Empty cells in the last column means that the behavior wasn't changed.

The *behavior* columns shows which methods are used to serialize or deserialize a type. The number in parenthesis is a count of fields which passed to the corresponding method.

<table>
<tr><th>Code</th><th>Current behavior</th><th>Fixed behavior</th></tr>

<tr><th colspan="3">Unit representations</th></tr>
<tr><td>

```rust
struct Unit;
```
</td><td>

`serialize_unit_struct`  
`deserialize_unit_struct`  
`visit_unit`  
</td><td></td></tr>

<tr><th colspan="3">Tuple representations</th></tr>
<tr><td>

```rust
struct Tuple0();
```
</td><td>

`serialize_tuple_struct(0)`  
`deserialize_tuple_struct(0)`  
`visit_seq`  
</td>
<td>

:information_source: It would be better to use Unit representation [(see below)](#list-of-inconsistencies)</td></tr>

<tr><td>

```rust
// Can be named
// Newtype(u8)
struct Tuple1(u8);
```
</td><td>

`serialize_newtype_struct`  
`deserialize_newtype_struct`  
`visit_newtype_struct`  
`visit_seq`  
</td><td></td></tr>

<tr><td>

```rust
struct Tuple2(u8, u8);
```
</td><td>

`serialize_tuple_struct(2)`  
`deserialize_tuple_struct(2)`  
`visit_seq`  
</td><td></td></tr>

<tr><td>

```rust
// The same as Tuple0
struct Tuple1as0(
    #[serde(skip)] u8,
);
```
#2105
</td><td>

`serialize_newtype_struct`  
`deserialize_newtype_struct`  
`visit_newtype_struct`  
`visit_seq`  
</td><td>

`serialize_tuple_struct(0)`  
`deserialize_tuple_struct(0)`  
`visit_seq`  
:information_source: It would be better to use Unit representation [(see below)](#list-of-inconsistencies)
</td></tr>

<tr><td>

```rust
// The same as Tuple0
struct Tuple2as0(
    #[serde(skip)] u8,
    #[serde(skip)] u8,
);
```
</td><td>

`serialize_tuple_struct(0)`  
`deserialize_tuple_struct(0)`  
`visit_seq`  
</td><td>

:information_source: It would be better to use Unit representation [(see below)](#list-of-inconsistencies)</td></tr>

<tr><td>

```rust
// The same as Tuple1
struct Tuple2as1(
    #[serde(skip)] u8,
    u8,
);
```
</td><td>

`serialize_tuple_struct(1)`  
`deserialize_tuple_struct(1)`  
`visit_seq`  
</td><td>

`serialize_tuple_struct(1)`  
`deserialize_tuple_struct(1)`  
`visit_newtype_struct`  
`visit_seq`  
:information_source: It would be better to use Newtype representation [(see below)](#list-of-inconsistencies)</td></tr>
</td></tr>

<tr><th colspan="3">Struct representations</th></tr>

<tr><td>

```rust
struct Struct0 {}
```
</td><td>

`serialize_struct`  
`deserialize_struct`  
`visit_seq`  
`visit_map`  
</td><td></td></tr>

<tr><td>

```rust
struct Struct1 {
    a: u8,
}
```
</td><td>

`serialize_struct`  
`deserialize_struct`  
`visit_seq`  
`visit_map`  
</td><td></td></tr>

<tr><td>

```rust
struct Struct2as0 {
    #[serde(skip)]
    a: u8,
    #[serde(skip)]
    b: u8,
}

```
</td><td>

`serialize_struct`  
`deserialize_struct`  
`visit_seq`  
`visit_map`  
</td><td></td></tr>

<tr><td>

```rust
struct Struct2as1 {
    #[serde(skip)]
    a: u8,
    b: u8,
}

```
</td><td>

`serialize_struct`  
`deserialize_struct`  
`visit_seq`  
`visit_map`  
</td><td></td></tr>
</table>


Enum variant representations
============================
The following changes also was implemented by I plan to ship them in separate PR due to some debating changes. I left my finding here to have the overall picture about skipped fields in one place.

The first debating change is to how to represent `tuple(0)` tuples? Should we represent them as a sequences with zero fields, or as a unit structs? Motivation for the unit structs is that that is the only way to skip all fields in a tuple and still represent it as a unit. This is currently done for `Enum::Tuple1as0`, but only for it. `Enum::Tuple2as0` no longer follows this agreement as well as all tuple structs, which introduces more confusion. I am inclined to this option, since to have an always empty sequence is somewhat strange.

The second debating change, maybe we should make the behavior configurable? Introduce a new attribute like `#[serde(tuple)]` to produce `tuple(0)` and `tuple(1)` forms from `TupleXas0` and `TupleXas1` tuples?

<table>
<tr><th>Code</th><th>Current behavior</th><th>Suggested behavior</th></tr>
<tr><th colspan="3">Enum::Unit representations</th></tr>
<tr><td>

```rust
enum Enum {
  Unit,
}
```
</td><td>

`serialize_unit_variant`  
`unit_variant`  
</td><td></td></tr>

<tr><th colspan="3">Enum::Tuple representations</th></tr>
<tr><td>

```rust
enum Enum {
  Tuple0(),
}
```
</td><td>

`serialize_tuple_variant(0)`  
`tuple_variant(0)`  
`visit_seq`  
</td>
<td>

`serialize_unit_variant`  
`unit_variant`  
</td></tr>

<tr><td>

```rust
// Can be called
// Enum::Newtype(u8)
enum Enum {
  Tuple1(u8),
}
```
</td><td>

`serialize_newtype_variant`  
`newtype_variant`  
</td><td></td></tr>

<tr><td>

```rust
enum Enum {
  Tuple2(u8, u8),
}
```
</td><td>

`serialize_tuple_variant(2)`  
`tuple_variant(2)`  
`visit_seq`  
</td><td></td></tr>

<tr><td>

```rust
// The same as
// Enum::Tuple0
enum Enum {
  Tuple1as0(
    #[serde(skip)] u8,
  ),
}
```
</td><td>

`serialize_unit_variant`  
`unit_variant`  
</td><td></td></tr>

<tr><td>

```rust
// The same as
// Enum::Tuple0
enum Enum {
  Tuple2as0(
    #[serde(skip)] u8,
    #[serde(skip)] u8,
  ),
}
```
</td><td>

`serialize_tuple_variant(0)`  
`tuple_variant(0)`  
`visit_seq`  
</td><td>

`serialize_unit_variant`  
`unit_variant`  
</td></tr>

<tr><td>

```rust
// The same as
// Enum::Tuple1
enum Enum {
  Tuple2as1(
    #[serde(skip)] u8,
    u8,
  ),
}
```
#2224
</td><td>

`serialize_tuple_variant(1)`  
`tuple_variant(1)`  
`visit_seq`  
</td><td>

`serialize_newtype_variant`  
`newtype_variant`  
</td></tr>

<tr><th colspan="3">Enum::Struct representations</th></tr>

<tr><td>

```rust
enum Enum {
  Struct0 {},
}
```
</td><td>

`serialize_struct_variant(0)`  
`struct_variant`  
`visit_seq`  
`visit_map`  
</td><td></td></tr>

<tr><td>

```rust
enum Enum {
  Struct1 {
    a: u8,
  },
}
```
</td><td>

`serialize_struct_variant(1)`  
`struct_variant`  
`visit_seq`  
`visit_map`  
</td><td></td></tr>

<tr><td>

```rust
enum Enum {
  // The same as
  // Enum::Struct0
  Struct2as0 {
    #[serde(skip)]
    a: u8,
    #[serde(skip)]
    b: u8,
  },
}

```
</td><td>

`serialize_struct_variant(0)`  
`struct_variant`  
`visit_seq`  
`visit_map`  
</td><td></td></tr>

<tr><td>

```rust
enum Enum {
  // The same as
  // Enum::Struct1
  Struct2as1 {
    #[serde(skip)]
    a: u8,
    b: u8,
  },
}

```
</td><td>

`serialize_struct_variant(1)`  
`struct_variant`  
`visit_seq`  
`visit_map`  
</td><td></td></tr>
</table>

<a name="list-of-inconsistencies">List of inconsistencies</a>
======================
As I said before, the current behavior contains a bunch of inconsistencies.

For example, an enum tuple variant with zero fields represented as a tuple with zero fields, but tuple variant with one skipped field represented as a unit. At the same time, tuple variant with 2 or more fields, all skipped, again represented as a tuple with zero fields. The same is applied to tuples with one effective field -- sometimes it is represented as a newtype, sometimes as a tuple with one field. I suggest to unify behavior across all cases that I summarized in the following table:

<table>
<tr><th>Value</th><th>Serialized form</th><th>Suggested form</th></tr>
<tr><th colspan="3">Types with zero fields in serialized form</th></tr>
<tr><td>

`Tuple0()`</td><td>Represented as a tuple with zero fields</td><td>unit</td></tr>
<tr><td>

`Tuple1as0(Skipped)`</td><td>:warning: Incorrectly represented as a newtype struct (bug #2105)</td><td>unit</td></tr>
<tr><td>

`Tuple2as0(Skipped, Skipped)`</td><td>Represented as a tuple with zero fields</td><td>unit</td></tr>

<tr><th colspan="3">Types with 1 field in serialized form</th></tr>
<tr><td>

`Tuple1(x)`</td><td>Represented as a newtype `x`</td><td></td></tr>
<tr><td>

`Tuple2as1(Skipped, x)`</td><td>:exclamation: Represented as a tuple with 1 field</td><td>newtype</td></tr>


<tr><th colspan="3">Enum variants with zero fields in serialized form</th></tr>
<tr><td>

`Enum::Tuple0()`</td><td>Represented as a tuple with zero fields</td><td>unit</td></tr>
<tr><td>

`Enum::Tuple1as0(Skipped)`</td><td>:exclamation: Represented as a unit struct</td><td></td></tr>
<tr><td>

`Enum::Tuple2as0(Skipped, Skipped)`</td><td>Represented as a tuple with zero fields</td><td>unit</td></tr>

<tr><th colspan="3">Enum variants with 1 field in serialized form</th></tr>
<tr><td>

`Enum::Tuple1(x)`</td><td>Represented as a newtype `x`</td><td></td></tr>
<tr><td>

`Enum::Tuple2as1(Skipped, x)`</td><td>:exclamation: Represented as a tuple with 1 field (#2224)</td><td>newtype</td></tr>
</table>

Legend:
- :warning: Bugs that leads to compilation errors
- :exclamation: Inconsistency in a block of similar table rows
