### PR TITLE
Make the serde helper process persistent.

### DIFF
--- a/precompiled/bin/main.rs
+++ b/precompiled/bin/main.rs
@@ -24,22 +24,36 @@ unsafe impl GlobalAlloc for MonotonicAllocator {
 }
 
 fn main() {
-    let mut buf = Vec::new();
-    io::stdin().read_to_end(&mut buf).unwrap();
-
-    let mut buf = InputBuffer::new(&buf);
-    let derive = match buf.read_u8() {
-        0 => serde_derive::derive_serialize,
-        1 => serde_derive::derive_deserialize,
-        2 => {
-            serde_derive::DESERIALIZE_IN_PLACE.store(true, Ordering::Relaxed);
-            serde_derive::derive_deserialize
+    let mut stdin = io::stdin();
+    let mut stdout = io::stdout();
+    loop {
+        let mut len_le32 = [0u8; 4];
+        if let Err(_) = stdin.read_exact(&mut len_le32) {
+            break;
         }
-        _ => unreachable!(),
-    };
+        let len = u32::from_le_bytes(len_le32) as usize;
+        let mut buf = Vec::with_capacity(len);
+        buf.resize(len, 0);
+        stdin.read_exact(&mut buf).unwrap();
 
-    let input = watt::load(&mut buf);
-    let output = derive(input);
-    let bytes = watt::linearize(output);
-    io::stdout().write_all(&bytes).unwrap();
+        let mut buf = InputBuffer::new(&buf);
+        let derive = match buf.read_u8() {
+            0 => serde_derive::derive_serialize,
+            1 => serde_derive::derive_deserialize,
+            2 => {
+                serde_derive::DESERIALIZE_IN_PLACE.store(true, Ordering::Relaxed);
+                serde_derive::derive_deserialize
+            }
+            _ => unreachable!(),
+        };
+
+        let input = watt::load(&mut buf);
+        let output = derive(input);
+        let bytes = watt::linearize(output);
+
+        let size = (bytes.len() as u32).to_le_bytes();
+        stdout.write_all(&size).unwrap();
+        stdout.write_all(&bytes).unwrap();
+        stdout.flush().unwrap();
+    }
 }


### PR DESCRIPTION
Rather than starting the helper process for every proc-macro invocation, start it on the first macro invocation and keep it around. The goal is to amortize the process startup cost across multiple macro invocations.

The process loops waiting for multiple requests, until it gets an EOF on its stdin, whereupon it exits. This will happen when the rustc process exits and closes its end of the stdin pipe.

To do this, this change extends the protocol to prefix each chunk of data with a 32-bit little-endian length, so that each side knows how much to read, rather than relying on reading to EOF.

This in combination with #2522 has some additional risk of memory overflow, but it would require an *enormous*
amount of serde invocations in one crate.

Using the same clang-ast benchmark in the original PR, there's a noticable improvement:

Process-per-macro:
```
$ hyperfine ' cargo expand --ugly --test exhaustive >expand.rs'
Benchmark 1:  cargo expand --ugly --test exhaustive >expand.rs
  Time (mean ± σ):      1.891 s ±  0.192 s    [User: 1.010 s, System: 0.460 s]
  Range (min … max):    1.666 s …  2.173 s    10 runs
 ```
Persistent process:
```
$ hyperfine ' cargo expand --ugly --test exhaustive >expand.rs'
Benchmark 1:  cargo expand --ugly --test exhaustive >expand.rs
  Time (mean ± σ):      1.524 s ±  0.233 s    [User: 0.561 s, System: 0.102 s]
  Range (min … max):    1.297 s …  2.074 s    10 runs
```