### PR TITLE
Add wasm_precomp feature

### DIFF
--- a/precompiled/.gitignore
+++ b/precompiled/.gitignore
@@ -1,1 +1,1 @@
-/serde_derive/serde_derive-x86_64-unknown-linux-gnu
+/serde_derive/serde_derive-*

--- a/precompiled/bin/main.rs
+++ b/precompiled/bin/main.rs
@@ -24,22 +24,36 @@ unsafe impl GlobalAlloc for MonotonicAllocator {
 }
 
 fn main() {
-    let mut buf = Vec::new();
-    io::stdin().read_to_end(&mut buf).unwrap();
-
-    let mut buf = InputBuffer::new(&buf);
-    let derive = match buf.read_u8() {
-        0 => serde_derive::derive_serialize,
-        1 => serde_derive::derive_deserialize,
-        2 => {
-            serde_derive::DESERIALIZE_IN_PLACE.store(true, Ordering::Relaxed);
-            serde_derive::derive_deserialize
+    let mut stdin = io::stdin();
+    let mut stdout = io::stdout();
+    loop {
+        let mut len_le32 = [0u8; 4];
+        if let Err(_) = stdin.read_exact(&mut len_le32) {
+            break;
         }
-        _ => unreachable!(),
-    };
+        let len = u32::from_le_bytes(len_le32) as usize;
+        let mut buf = Vec::with_capacity(len);
+        buf.resize(len, 0);
+        stdin.read_exact(&mut buf).unwrap();
 
-    let input = watt::load(&mut buf);
-    let output = derive(input);
-    let bytes = watt::linearize(output);
-    io::stdout().write_all(&bytes).unwrap();
+        let mut buf = InputBuffer::new(&buf);
+        let derive = match buf.read_u8() {
+            0 => serde_derive::derive_serialize,
+            1 => serde_derive::derive_deserialize,
+            2 => {
+                serde_derive::DESERIALIZE_IN_PLACE.store(true, Ordering::Relaxed);
+                serde_derive::derive_deserialize
+            }
+            _ => unreachable!(),
+        };
+
+        let input = watt::load(&mut buf);
+        let output = derive(input);
+        let bytes = watt::linearize(output);
+
+        let size = (bytes.len() as u32).to_le_bytes();
+        stdout.write_all(&size).unwrap();
+        stdout.write_all(&bytes).unwrap();
+        stdout.flush().unwrap();
+    }
 }

--- a/precompiled/build.sh
+++ b/precompiled/build.sh
@@ -5,17 +5,40 @@ set -e -x
 
 # TODO: Sanitize host filesystem paths. https://github.com/rust-lang/cargo/issues/12137
 
-cargo +nightly build \
-    --manifest-path bin/Cargo.toml \
-    --bin serde_derive \
-    --profile precompiled \
-    -Z unstable-options \
-    -Z build-std=std,panic_abort \
-    -Z build-std-features=panic_immediate_abort \
-    --target x86_64-unknown-linux-musl \
-    --out-dir serde_derive
+build () {
+    local target=$1
+    local output_target=$target
+    local -a opts=()
+    local nightly=
+    local ext=
 
-rm -f serde_derive/serde_derive-x86_64-unknown-linux-gnu
-mv serde_derive/serde_derive{,-x86_64-unknown-linux-gnu}
+    case $target in
+        x86_64-unknown-linux-musl)
+            output_target=x86_64-unknown-linux-gnu
+            nightly=+nightly
+            opts=(
+                -Z unstable-options
+                -Z build-std=std,panic_abort
+                -Z build-std-features=panic_immediate_abort
+            )
+            ;;
+        wasm32-wasi)
+            ext=.wasm
+            ;;
+    esac
+
+    cargo $nightly build \
+        --manifest-path bin/Cargo.toml \
+        --bin serde_derive \
+        --profile precompiled \
+        --target $target \
+        ${opts[@]}
+
+    rm -f serde_derive/serde_derive-$output_target$ext
+    mv target/$target/precompiled/serde_derive$ext serde_derive/serde_derive-$output_target$ext
+}
+
+build x86_64-unknown-linux-musl
+build wasm32-wasi
 
 #upx --best --lzma serde_derive/serde_derive-x86_64-unknown-linux-gnu

--- a/precompiled/serde_derive/Cargo.toml
+++ b/precompiled/serde_derive/Cargo.toml
@@ -17,6 +17,7 @@ rust-version = "1.56"
 [features]
 default = []
 deserialize_in_place = []
+wasm_precomp = []
 
 [lib]
 proc-macro = true

--- a/precompiled/serde_derive/serde_derive-wasm32-wasi
+++ b/precompiled/serde_derive/serde_derive-wasm32-wasi
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec wasmtime $0.wasm "$@"

--- a/precompiled/serde_derive/src/lib.rs
+++ b/precompiled/serde_derive/src/lib.rs
@@ -18,8 +18,8 @@
 
 extern crate proc_macro;
 
-#[cfg(not(all(target_arch = "x86_64", target_os = "linux", target_env = "gnu")))]
+#[cfg(not(any(feature = "wasm_precomp", all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"))))]
 include!("lib_from_source.rs");
 
-#[cfg(all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"))]
+#[cfg(any(feature = "wasm_precomp", all(target_arch = "x86_64", target_os = "linux", target_env = "gnu")))]
 include!("lib_precompiled.rs");

--- a/precompiled/serde_derive/src/lib_precompiled.rs
+++ b/precompiled/serde_derive/src/lib_precompiled.rs
@@ -36,10 +36,14 @@ fn derive(select: u8, input: TokenStream) -> TokenStream {
 
     let mut process = PROCESS.lock().unwrap();
     if process.is_none() {
-        let path = concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/serde_derive-x86_64-unknown-linux-gnu",
-        );
+        let path = if cfg!(feature = "wasm_precomp") {
+            concat!(env!("CARGO_MANIFEST_DIR"), "/serde_derive-wasm32-wasi",)
+        } else {
+            concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/serde_derive-x86_64-unknown-linux-gnu",
+            )
+        };
         *process = Some(
             Command::new(path)
                 .stdin(Stdio::piped())


### PR DESCRIPTION
Add wasm_precomp feature

This uses wasm32-wasi for the pre-compiled helper process, which means
- it's platform independent, and
- it's sandboxed so that there's a stronger guarantee that the process
  can't do anything other than read/write stdin/stdout.

The downsides are:
- ~~somewhat slower for proc-macro processing (2x?). This is mitigated by making the helper process persist for multiple macro invocations~~
- needs wasmtime installed in the path

There doesn't seem to be a performance impact from this. Using a persistent process, using wasm seems to
have a minimal performance difference from native code:

Native x86:
```
$ hyperfine ' cargo expand --ugly --test exhaustive >expand.rs'
Benchmark 1:  cargo expand --ugly --test exhaustive >expand.rs
  Time (mean ± σ):      1.404 s ±  0.175 s    [User: 0.543 s, System: 0.097 s]
  Range (min … max):    1.195 s …  1.820 s    10 runs
```

Wasm:
```
$ hyperfine ' cargo expand --ugly --test exhaustive >expand.rs'
Benchmark 1:  cargo expand --ugly --test exhaustive >expand.rs
  Time (mean ± σ):      1.554 s ±  0.341 s    [User: 0.547 s, System: 0.087 s]
  Range (min … max):    1.247 s …  2.429 s    10 runs
```

(This is stacked on the "persistent" branch/PR https://github.com/serde-rs/serde/pull/2523, but is logically independent from it.)