### PR TITLE
Delete unused serde_derive #[macro_use]

### DIFF
--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -335,8 +335,6 @@ mod std_error;
 // be annoying for crates that provide handwritten impls or data formats. They
 // would need to disable default features and then explicitly re-enable std.
 #[cfg(feature = "serde_derive")]
-#[allow(unused_imports)]
-#[macro_use]
 extern crate serde_derive;
 
 /// Derive macro available if serde is built with `features = ["derive"]`.


### PR DESCRIPTION
In old versions of rustc (1.15 through 1.29) it would cause a warning if this #\[macro_use\] was not present.

```console
warning: proc macro crates and `#[no_link]` crates have no effect without `#[macro_use]`
   --> serde/src/lib.rs:340:1
    |
340 | extern crate serde_derive;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
```

These days serde_derive requires a newer compiler than that, so the bogus warning would never occur.