### PR TITLE
Restore bare_trait_objects lint within serde_derive code

### DIFF
--- a/precompiled/serde_derive/src/lib.rs
+++ b/precompiled/serde_derive/src/lib.rs
@@ -14,7 +14,6 @@
 //! [https://serde.rs/derive.html]: https://serde.rs/derive.html
 
 #![doc(html_root_url = "https://docs.rs/serde_derive/1.0.176")]
-#![allow(unknown_lints, bare_trait_objects)]
 
 #[cfg(not(all(target_arch = "x86_64", target_os = "linux", target_env = "gnu")))]
 include!("lib_from_source.rs");

--- a/serde_derive/src/internals/ast.rs
+++ b/serde_derive/src/internals/ast.rs
@@ -119,7 +119,7 @@ impl<'a> Container<'a> {
 }
 
 impl<'a> Data<'a> {
-    pub fn all_fields(&'a self) -> Box<Iterator<Item = &'a Field<'a>> + 'a> {
+    pub fn all_fields(&'a self) -> Box<dyn Iterator<Item = &'a Field<'a>> + 'a> {
         match self {
             Data::Enum(variants) => {
                 Box::new(variants.iter().flat_map(|variant| variant.fields.iter()))

--- a/serde_derive/src/lib.rs
+++ b/serde_derive/src/lib.rs
@@ -14,7 +14,6 @@
 //! [https://serde.rs/derive.html]: https://serde.rs/derive.html
 
 #![doc(html_root_url = "https://docs.rs/serde_derive/1.0.176")]
-#![allow(unknown_lints, bare_trait_objects)]
 // Ignored clippy lints
 #![allow(
     // clippy false positive: https://github.com/rust-lang/rust-clippy/issues/7054

--- a/serde_derive_internals/lib.rs
+++ b/serde_derive_internals/lib.rs
@@ -1,5 +1,4 @@
 #![doc(html_root_url = "https://docs.rs/serde_derive_internals/0.28.0")]
-#![allow(unknown_lints, bare_trait_objects)]
 // Ignored clippy lints
 #![allow(
     clippy::cognitive_complexity,


### PR DESCRIPTION
This `allow` is from 07266233894702cb71a9ababc001dbc60f3be8cb, when serde_derive was still compatible with Rust 1.15 which did not support `dyn Trait` syntax.