### PR TITLE
Fix `unstable` build

### DIFF
--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -126,10 +126,6 @@ mod utf8;
 
 pub use self::ignored_any::IgnoredAny;
 
-#[cfg(feature = "std")]
-#[doc(no_inline)]
-pub use std::error::Error as StdError;
-#[cfg(not(feature = "std"))]
 #[doc(no_inline)]
 pub use std_error::Error as StdError;
 

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -328,7 +328,6 @@ use self::__private as private;
 #[path = "de/seed.rs"]
 mod seed;
 
-#[cfg(not(any(feature = "std", feature = "unstable")))]
 mod std_error;
 
 // Re-export #[derive(Serialize, Deserialize)].

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -115,13 +115,6 @@ mod impossible;
 
 pub use self::impossible::Impossible;
 
-#[cfg(all(feature = "unstable", not(feature = "std")))]
-#[doc(inline)]
-pub use core::error::Error as StdError;
-#[cfg(feature = "std")]
-#[doc(no_inline)]
-pub use std::error::Error as StdError;
-#[cfg(not(any(feature = "std", feature = "unstable")))]
 #[doc(no_inline)]
 pub use std_error::Error as StdError;
 

--- a/serde/src/std_error.rs
+++ b/serde/src/std_error.rs
@@ -1,4 +1,13 @@
+#[cfg(not(any(feature = "std", feature = "unstable")))]
 use lib::{Debug, Display};
+
+#[cfg(all(feature = "unstable", not(feature = "std")))]
+#[doc(no_inline)]
+pub use core::error::Error;
+
+#[cfg(feature = "std")]
+#[doc(no_inline)]
+pub use std::error::Error;
 
 /// Either a re-export of std::error::Error or a new identical trait, depending
 /// on whether Serde's "std" feature is enabled.
@@ -40,6 +49,7 @@ use lib::{Debug, Display};
 /// ```edition2021
 /// impl serde::ser::StdError for MySerError {}
 /// ```
+#[cfg(not(any(feature = "std", feature = "unstable")))]
 pub trait Error: Debug + Display {
     /// The underlying cause of this error, if any.
     fn source(&self) -> Option<&(Error + 'static)> {


### PR DESCRIPTION
Before:

    $ cargo +nightly build --no-default-features --features unstable
       Compiling serde v1.0.177 (/srv/mpn/serde/serde)
    error[E0432]: unresolved import `std_error`
       --> serde/src/de/mod.rs:134:9
    134 | pub use std_error::Error as StdError;
        |         ^^^^^^^^^ maybe a missing crate `std_error`?

After:

    $ cargo +nightly build --no-default-features --features unstable
       Compiling serde v1.0.177 (/srv/mpn/serde/serde)
        Finished dev [unoptimized] target(s) in 1.28s

Note that `unstable` and non-`std` tests are still failing.

Issue: https://github.com/serde-rs/serde/issues/812