### PR TITLE
Delete tombstones of the `__private` module

### DIFF
--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -1231,9 +1231,9 @@ pub trait Deserializer<'de>: Sized {
         self,
         _: crate::actually_private::T,
         visitor: V,
-    ) -> Result<crate::private::de::Content<'de>, Self::Error>
+    ) -> Result<crate::__private::de::Content<'de>, Self::Error>
     where
-        V: Visitor<'de, Value = crate::private::de::Content<'de>>,
+        V: Visitor<'de, Value = crate::__private::de::Content<'de>>,
     {
         self.deserialize_any(visitor)
     }

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -307,11 +307,6 @@ pub use crate::ser::{Serialize, Serializer};
 #[path = "private/mod.rs"]
 pub mod __private;
 
-#[allow(unused_imports)]
-use self::__private as export;
-#[allow(unused_imports)]
-use self::__private as private;
-
 #[path = "de/seed.rs"]
 mod seed;
 


### PR DESCRIPTION
These are previous names of the `__private` module &mdash; first `serde::export` then `serde::private` then `serde::__private` &mdash; in all cases marked `doc(hidden)` and documented as not public API. Leaving a tombstone made rustc give a better diagnostic _"module is private"_ rather than _"unresolved import"_. But the rename to `__private` was 2.5 years ago in dd1f4b483ee204d58465064f6e5bf5a457543b54 so it's unlikely anyone is still benefiting from the tombstone at this point.