### PR TITLE
Adopt tool attrs for clippy lint level attributes

### DIFF
--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -102,55 +102,51 @@
 //    https://github.com/serde-rs/serde/issues/812
 #![cfg_attr(feature = "unstable", feature(error_in_core, never_type))]
 #![allow(unknown_lints, bare_trait_objects, deprecated)]
-#![cfg_attr(feature = "cargo-clippy", allow(renamed_and_removed_lints))]
 // Ignored clippy and clippy_pedantic lints
-#![cfg_attr(
-    feature = "cargo-clippy",
-    allow(
-        // clippy bug: https://github.com/rust-lang/rust-clippy/issues/5704
-        unnested_or_patterns,
-        // clippy bug: https://github.com/rust-lang/rust-clippy/issues/7768
-        semicolon_if_nothing_returned,
-        // not available in our oldest supported compiler
-        empty_enum,
-        type_repetition_in_bounds, // https://github.com/rust-lang/rust-clippy/issues/8772
-        // integer and float ser/de requires these sorts of casts
-        cast_possible_truncation,
-        cast_possible_wrap,
-        cast_sign_loss,
-        // things are often more readable this way
-        cast_lossless,
-        module_name_repetitions,
-        option_if_let_else,
-        single_match_else,
-        type_complexity,
-        use_self,
-        zero_prefixed_literal,
-        // correctly used
-        derive_partial_eq_without_eq,
-        enum_glob_use,
-        explicit_auto_deref,
-        let_underscore_untyped,
-        map_err_ignore,
-        new_without_default,
-        result_unit_err,
-        wildcard_imports,
-        // not practical
-        needless_pass_by_value,
-        similar_names,
-        too_many_lines,
-        // preference
-        doc_markdown,
-        unseparated_literal_suffix,
-        // false positive
-        needless_doctest_main,
-        // noisy
-        missing_errors_doc,
-        must_use_candidate,
-    )
+#![allow(
+    // clippy bug: https://github.com/rust-lang/rust-clippy/issues/5704
+    clippy::unnested_or_patterns,
+    // clippy bug: https://github.com/rust-lang/rust-clippy/issues/7768
+    clippy::semicolon_if_nothing_returned,
+    // not available in our oldest supported compiler
+    clippy::empty_enum,
+    clippy::type_repetition_in_bounds, // https://github.com/rust-lang/rust-clippy/issues/8772
+    // integer and float ser/de requires these sorts of casts
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss,
+    // things are often more readable this way
+    clippy::cast_lossless,
+    clippy::module_name_repetitions,
+    clippy::option_if_let_else,
+    clippy::single_match_else,
+    clippy::type_complexity,
+    clippy::use_self,
+    clippy::zero_prefixed_literal,
+    // correctly used
+    clippy::derive_partial_eq_without_eq,
+    clippy::enum_glob_use,
+    clippy::explicit_auto_deref,
+    clippy::let_underscore_untyped,
+    clippy::map_err_ignore,
+    clippy::new_without_default,
+    clippy::result_unit_err,
+    clippy::wildcard_imports,
+    // not practical
+    clippy::needless_pass_by_value,
+    clippy::similar_names,
+    clippy::too_many_lines,
+    // preference
+    clippy::doc_markdown,
+    clippy::unseparated_literal_suffix,
+    // false positive
+    clippy::needless_doctest_main,
+    // noisy
+    clippy::missing_errors_doc,
+    clippy::must_use_candidate,
 )]
 // Restrictions
-#![cfg_attr(feature = "cargo-clippy", deny(question_mark_used))]
+#![deny(clippy::question_mark_used)]
 // Rustc lints.
 #![deny(missing_docs, unused_imports)]
 


### PR DESCRIPTION
Requires Rust 1.31+.