### PR TITLE
Allow `#[serde(default)]` on tuple structs

### DIFF
--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -405,20 +405,20 @@ impl Container {
                         if let Some(path) = parse_lit_into_expr_path(cx, DEFAULT, &meta)? {
                             match &item.data {
                                 syn::Data::Struct(syn::DataStruct { fields, .. }) => match fields {
-                                    syn::Fields::Named(_) => {
+                                    syn::Fields::Named(_) | syn::Fields::Unnamed(_) => {
                                         default.set(&meta.path, Default::Path(path));
                                     }
-                                    syn::Fields::Unnamed(_) | syn::Fields::Unit => {
-                                        let msg = "#[serde(default = \"...\")] can only be used on structs with named fields";
+                                    syn::Fields::Unit => {
+                                        let msg = "#[serde(default = \"...\")] can only be used on structs with fields";
                                         cx.syn_error(meta.error(msg));
                                     }
                                 },
                                 syn::Data::Enum(_) => {
-                                    let msg = "#[serde(default = \"...\")] can only be used on structs with named fields";
+                                    let msg = "#[serde(default = \"...\")] can only be used on structs with fields";
                                     cx.syn_error(meta.error(msg));
                                 }
                                 syn::Data::Union(_) => {
-                                    let msg = "#[serde(default = \"...\")] can only be used on structs with named fields";
+                                    let msg = "#[serde(default = \"...\")] can only be used on structs with fields";
                                     cx.syn_error(meta.error(msg));
                                 }
                             }
@@ -427,20 +427,20 @@ impl Container {
                         // #[serde(default)]
                         match &item.data {
                             syn::Data::Struct(syn::DataStruct { fields, .. }) => match fields {
-                                syn::Fields::Named(_) => {
+                                syn::Fields::Named(_) | syn::Fields::Unnamed(_) => {
                                     default.set(meta.path, Default::Default);
                                 }
-                                syn::Fields::Unnamed(_) | syn::Fields::Unit => {
-                                    let msg = "#[serde(default)] can only be used on structs with named fields";
+                                syn::Fields::Unit => {
+                                    let msg = "#[serde(default)] can only be used on structs with fields";
                                     cx.error_spanned_by(fields, msg);
                                 }
                             },
                             syn::Data::Enum(_) => {
-                                let msg = "#[serde(default)] can only be used on structs with named fields";
+                                let msg = "#[serde(default)] can only be used on structs with fields";
                                 cx.syn_error(meta.error(msg));
                             }
                             syn::Data::Union(_) => {
-                                let msg = "#[serde(default)] can only be used on structs with named fields";
+                                let msg = "#[serde(default)] can only be used on structs with fields";
                                 cx.syn_error(meta.error(msg));
                             }
                         }

--- a/test_suite/tests/ui/default-attribute/enum.stderr
+++ b/test_suite/tests/ui/default-attribute/enum.stderr
@@ -1,4 +1,4 @@
-error: #[serde(default)] can only be used on structs with named fields
+error: #[serde(default)] can only be used on structs with fields
  --> tests/ui/default-attribute/enum.rs:4:9
   |
 4 | #[serde(default)]

--- a/test_suite/tests/ui/default-attribute/enum_path.stderr
+++ b/test_suite/tests/ui/default-attribute/enum_path.stderr
@@ -1,4 +1,4 @@
-error: #[serde(default = "...")] can only be used on structs with named fields
+error: #[serde(default = "...")] can only be used on structs with fields
  --> tests/ui/default-attribute/enum_path.rs:4:9
   |
 4 | #[serde(default = "default_e")]

--- a/test_suite/tests/ui/default-attribute/nameless_struct_fields.rs
+++ b/test_suite/tests/ui/default-attribute/nameless_struct_fields.rs
@@ -1,7 +1,0 @@
-use serde_derive::Deserialize;
-
-#[derive(Deserialize)]
-#[serde(default)]
-struct T(u8, u8);
-
-fn main() {}

--- a/test_suite/tests/ui/default-attribute/nameless_struct_fields.stderr
+++ b/test_suite/tests/ui/default-attribute/nameless_struct_fields.stderr
@@ -1,5 +1,0 @@
-error: #[serde(default)] can only be used on structs with named fields
- --> tests/ui/default-attribute/nameless_struct_fields.rs:5:9
-  |
-5 | struct T(u8, u8);
-  |         ^^^^^^^^

--- a/test_suite/tests/ui/default-attribute/nameless_struct_fields_path.rs
+++ b/test_suite/tests/ui/default-attribute/nameless_struct_fields_path.rs
@@ -1,7 +1,0 @@
-use serde_derive::Deserialize;
-
-#[derive(Deserialize)]
-#[serde(default = "default_t")]
-struct T(u8, u8);
-
-fn main() {}

--- a/test_suite/tests/ui/default-attribute/nameless_struct_fields_path.stderr
+++ b/test_suite/tests/ui/default-attribute/nameless_struct_fields_path.stderr
@@ -1,5 +1,0 @@
-error: #[serde(default = "...")] can only be used on structs with named fields
- --> tests/ui/default-attribute/nameless_struct_fields_path.rs:4:9
-  |
-4 | #[serde(default = "default_t")]
-  |         ^^^^^^^^^^^^^^^^^^^^^

--- a/test_suite/tests/ui/default-attribute/tuple_struct.rs
+++ b/test_suite/tests/ui/default-attribute/tuple_struct.rs
@@ -1,0 +1,48 @@
+use serde_derive::Deserialize;
+
+/// No errors expected
+#[derive(Deserialize)]
+struct T0(u8, u8);
+
+/// No errors expected:
+/// - if both fields are provided, both gets value from data
+/// - if only one field is provided, the second gets default value
+#[derive(Deserialize)]
+struct T1(u8, #[serde(default)] u8);
+
+/// Errors expected -- the first field can get default value only if sequence is
+/// empty, but that mean that all other fields cannot be deserialized without
+/// errors, so the `#[serde(default)]` attribute is superfluous
+#[derive(Deserialize)]
+struct T2(#[serde(default)] u8, u8, u8);
+
+/// No errors expected:
+/// - if both fields are provided, both gets value from data
+/// - if only one field is provided, the second gets default value
+/// - if none fields are provided, both gets default value
+#[derive(Deserialize)]
+struct T3(#[serde(default)] u8, #[serde(default)] u8);
+
+////////////////////////////////////////////////////////////////////////////////
+
+/// No errors expected -- missing fields gets default values
+#[derive(Deserialize, Default)]
+#[serde(default)]
+struct T4(u8, u8);
+
+/// No errors expected -- missing fields gets default values
+#[derive(Deserialize, Default)]
+#[serde(default)]
+struct T5(#[serde(default)] u8, u8);
+
+/// No errors expected -- missing fields gets default values
+#[derive(Deserialize, Default)]
+#[serde(default)]
+struct T6(u8, #[serde(default)] u8);
+
+/// No errors expected -- missing fields gets default values
+#[derive(Deserialize, Default)]
+#[serde(default)]
+struct T7(#[serde(default)] u8, #[serde(default)] u8);
+
+fn main() {}

--- a/test_suite/tests/ui/default-attribute/tuple_struct.stderr
+++ b/test_suite/tests/ui/default-attribute/tuple_struct.stderr
@@ -1,0 +1,11 @@
+error: struct or field must have #[serde(default)] because previous field 0 have #[serde(default)]
+  --> tests/ui/default-attribute/tuple_struct.rs:17:33
+   |
+17 | struct T2(#[serde(default)] u8, u8, u8);
+   |                                 ^^
+
+error: struct or field must have #[serde(default)] because previous field 0 have #[serde(default)]
+  --> tests/ui/default-attribute/tuple_struct.rs:17:37
+   |
+17 | struct T2(#[serde(default)] u8, u8, u8);
+   |                                     ^^

--- a/test_suite/tests/ui/default-attribute/tuple_struct_path.rs
+++ b/test_suite/tests/ui/default-attribute/tuple_struct_path.rs
@@ -1,0 +1,77 @@
+use serde_derive::Deserialize;
+
+fn d<T>() -> T {
+    unimplemented!()
+}
+
+/// No errors expected:
+/// - if both fields are provided, both gets value from data
+/// - if only one field is provided, the second gets default value
+#[derive(Deserialize)]
+struct T1(u8, #[serde(default = "d")] u8);
+
+/// Errors expected -- the first field can get default value only if sequence is
+/// empty, but that mean that all other fields cannot be deserialized without
+/// errors, so the `#[serde(default)]` attribute is superfluous
+#[derive(Deserialize)]
+struct T2(#[serde(default = "d")] u8, u8, u8);
+
+/// No errors expected:
+/// - if both fields are provided, both gets value from data
+/// - if only one field is provided, the second gets default value
+/// - if none fields are provided, both gets default value
+#[derive(Deserialize)]
+struct T3(#[serde(default = "d")] u8, #[serde(default = "d")] u8);
+
+////////////////////////////////////////////////////////////////////////////////
+
+/// No errors expected -- missing fields gets default values
+#[derive(Deserialize, Default)]
+#[serde(default)]
+struct T1D(#[serde(default = "d")] u8, u8);
+
+/// No errors expected -- missing fields gets default values
+#[derive(Deserialize, Default)]
+#[serde(default)]
+struct T2D(u8, #[serde(default = "d")] u8);
+
+/// No errors expected -- missing fields gets default values
+#[derive(Deserialize, Default)]
+#[serde(default)]
+struct T3D(#[serde(default = "d")] u8, #[serde(default = "d")] u8);
+
+////////////////////////////////////////////////////////////////////////////////
+
+/// No errors expected -- missing fields gets default values
+#[derive(Deserialize)]
+#[serde(default = "d")]
+struct T1Path(#[serde(default)] u8, u8);
+
+/// No errors expected -- missing fields gets default values
+#[derive(Deserialize)]
+#[serde(default = "d")]
+struct T2Path(u8, #[serde(default)] u8);
+
+/// No errors expected -- missing fields gets default values
+#[derive(Deserialize)]
+#[serde(default = "d")]
+struct T3Path(#[serde(default)] u8, #[serde(default)] u8);
+
+////////////////////////////////////////////////////////////////////////////////
+
+/// No errors expected -- missing fields gets default values
+#[derive(Deserialize)]
+#[serde(default = "d")]
+struct T1PathD(#[serde(default = "d")] u8, u8);
+
+/// No errors expected -- missing fields gets default values
+#[derive(Deserialize)]
+#[serde(default = "d")]
+struct T2PathD(u8, #[serde(default = "d")] u8);
+
+/// No errors expected -- missing fields gets default values
+#[derive(Deserialize)]
+#[serde(default = "d")]
+struct T3PathD(#[serde(default = "d")] u8, #[serde(default = "d")] u8);
+
+fn main() {}

--- a/test_suite/tests/ui/default-attribute/tuple_struct_path.stderr
+++ b/test_suite/tests/ui/default-attribute/tuple_struct_path.stderr
@@ -1,0 +1,11 @@
+error: struct or field must have #[serde(default)] because previous field 0 have #[serde(default)]
+  --> tests/ui/default-attribute/tuple_struct_path.rs:17:39
+   |
+17 | struct T2(#[serde(default = "d")] u8, u8, u8);
+   |                                       ^^
+
+error: struct or field must have #[serde(default)] because previous field 0 have #[serde(default)]
+  --> tests/ui/default-attribute/tuple_struct_path.rs:17:43
+   |
+17 | struct T2(#[serde(default = "d")] u8, u8, u8);
+   |                                           ^^


### PR DESCRIPTION
Right now you cannot place `#[serde(default)]` at tuple struct, although it is possible to mark individual fields as `#[serde(default)]`:

```rust
#[derive(Deserialize)]
struct Tuple(
  // possible, but make no sense in that case, because if
  // field will be set to default value that means that sequence
  // is exhausted and the next field will fail to deserialize
  #[serde(default)] u8,
  u8,
);
#[derive(Deserialize)]
#[serde(default)] // impossible, but make sense
struct Tuple(
  #[serde(default)] u8,
  u8,
);
```
This PR fixes that and also guaranties that tuple structs will always have a trail of defaulted non-skipped fields as soon as first defaulted field is appear.