### PR TITLE
Refactor code that generates `__Field` enums

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1247,13 +1247,10 @@ fn prepare_enum_variant_enum(
         }
     };
 
-    let fallthrough = if let Some(other_idx) = other_idx {
+    let fallthrough = other_idx.map(|other_idx| {
         let ignore_variant = variant_names_idents[other_idx].1.clone();
-        let fallthrough = quote!(_serde::__private::Ok(__Field::#ignore_variant));
-        Some(fallthrough)
-    } else {
-        None
-    };
+        quote!(_serde::__private::Ok(__Field::#ignore_variant))
+    });
 
     let variant_visitor = Stmts(deserialize_generated_identifier(
         &variant_names_idents,

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1247,19 +1247,19 @@ fn prepare_enum_variant_enum(
         }
     };
 
-    let (ignore_variant, fallthrough) = if let Some(other_idx) = other_idx {
+    let fallthrough = if let Some(other_idx) = other_idx {
         let ignore_variant = variant_names_idents[other_idx].1.clone();
         let fallthrough = quote!(_serde::__private::Ok(__Field::#ignore_variant));
-        (None, Some(fallthrough))
+        Some(fallthrough)
     } else {
-        (None, None)
+        None
     };
 
     let variant_visitor = Stmts(deserialize_generated_identifier(
         &variant_names_idents,
         cattrs,
         true,
-        ignore_variant,
+        None,
         fallthrough,
     ));
 

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -965,12 +965,7 @@ fn deserialize_struct(
             )
         })
         .collect();
-    let field_visitor = Stmts(deserialize_generated_identifier(
-        &field_names_idents,
-        cattrs,
-        false,
-        None,
-    ));
+    let field_visitor = deserialize_field_identifier(&field_names_idents, cattrs);
 
     // untagged struct variants do not get a visit_seq method. The same applies to
     // structs that only have a map representation.
@@ -1128,12 +1123,7 @@ fn deserialize_struct_in_place(
         })
         .collect();
 
-    let field_visitor = Stmts(deserialize_generated_identifier(
-        &field_names_idents,
-        cattrs,
-        false,
-        None,
-    ));
+    let field_visitor = deserialize_field_identifier(&field_names_idents, cattrs);
 
     let mut_seq = if field_names_idents.is_empty() {
         quote!(_)
@@ -2050,6 +2040,20 @@ fn deserialize_generated_identifier(
             }
         }
     }
+}
+
+/// Generates enum and its `Deserialize` implementation that represents each
+/// non-skipped field of the struct
+fn deserialize_field_identifier(
+    fields: &[(&str, Ident, &BTreeSet<String>)],
+    cattrs: &attr::Container,
+) -> Stmts {
+    Stmts(deserialize_generated_identifier(
+        fields,
+        cattrs,
+        false,
+        None,
+    ))
 }
 
 // Generates `Deserialize::deserialize` body for an enum with


### PR DESCRIPTION
This PR makes a small refactoring in order to remove complexity in `deserialize_generated_identifier` about determining `ignore_variant` and `fallthrough` values. Because both values depends only on input parameters, I moved they determination from `deserialize_generated_identifier` to the calling functions. Thus, it is easier to understand which pairs of parameters are possible