### PR TITLE
Improve error reporting about mismatched signature in `with` and `default` attributes

### DIFF
--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -8,6 +8,7 @@ use std::iter::FromIterator;
 use syn::meta::ParseNestedMeta;
 use syn::parse::ParseStream;
 use syn::punctuated::Punctuated;
+use syn::spanned::Spanned;
 use syn::{parse_quote, token, Ident, Lifetime, Token};
 
 // This module handles parsing of `#[serde(...)]` attributes. The entrypoints
@@ -898,13 +899,13 @@ impl Variant {
                         ser_path
                             .path
                             .segments
-                            .push(Ident::new("serialize", Span::call_site()).into());
+                            .push(Ident::new("serialize", ser_path.span()).into());
                         serialize_with.set(&meta.path, ser_path);
                         let mut de_path = path;
                         de_path
                             .path
                             .segments
-                            .push(Ident::new("deserialize", Span::call_site()).into());
+                            .push(Ident::new("deserialize", de_path.span()).into());
                         deserialize_with.set(&meta.path, de_path);
                     }
                 } else if meta.path == SERIALIZE_WITH {
@@ -1180,13 +1181,13 @@ impl Field {
                         ser_path
                             .path
                             .segments
-                            .push(Ident::new("serialize", Span::call_site()).into());
+                            .push(Ident::new("serialize", ser_path.span()).into());
                         serialize_with.set(&meta.path, ser_path);
                         let mut de_path = path;
                         de_path
                             .path
                             .segments
-                            .push(Ident::new("deserialize", Span::call_site()).into());
+                            .push(Ident::new("deserialize", de_path.span()).into());
                         deserialize_with.set(&meta.path, de_path);
                     }
                 } else if meta.path == BOUND {

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -1229,9 +1229,15 @@ fn wrap_serialize_with(
         })
     });
 
-    quote!({
+    // If #serialize_with returns wrong type, error will be reported on here.
+    // We attach span of the path to this piece so error will be reported
+    // on the #[serde(with = "...")]
+    //                       ^^^^^
+    quote_spanned!(serialize_with.span()=> {
         #[doc(hidden)]
         struct __SerializeWith #wrapper_impl_generics #where_clause {
+            // If #field_tys is empty, `values` does not used
+            #[allow(dead_code)]
             values: (#(&'__a #field_tys, )*),
             phantom: _serde::__private::PhantomData<#this_type #ty_generics>,
         }

--- a/test_suite/tests/ui/default-attribute/incorrect_type_enum_adjacently_tagged.rs
+++ b/test_suite/tests/ui/default-attribute/incorrect_type_enum_adjacently_tagged.rs
@@ -1,0 +1,22 @@
+//! Ensures that error message points to the path in attribute
+use serde_derive::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(tag = "tag", content = "content")]
+enum Enum {
+    // Newtype variants does not use the provided path, so it is forbidden here
+    // Newtype(#[serde(default = "main")] u8),
+    Tuple(
+        u8,
+        #[serde(default = "main")] i8,
+    ),
+    Struct {
+        #[serde(default = "main")]
+        f1: u8,
+        f2: u8,
+        #[serde(default = "main")]
+        f3: i8,
+    },
+}
+
+fn main() {}

--- a/test_suite/tests/ui/default-attribute/incorrect_type_enum_adjacently_tagged.stderr
+++ b/test_suite/tests/ui/default-attribute/incorrect_type_enum_adjacently_tagged.stderr
@@ -1,0 +1,35 @@
+error[E0308]: `match` arms have incompatible types
+  --> tests/ui/default-attribute/incorrect_type_enum_adjacently_tagged.rs:11:27
+   |
+4  | #[derive(Deserialize)]
+   |          -----------
+   |          |
+   |          this is found to be of type `i8`
+   |          `match` arms have incompatible types
+...
+11 |         #[serde(default = "main")] i8,
+   |                           ^^^^^^ expected `i8`, found `()`
+
+error[E0308]: `match` arms have incompatible types
+  --> tests/ui/default-attribute/incorrect_type_enum_adjacently_tagged.rs:14:27
+   |
+4  | #[derive(Deserialize)]
+   |          -----------
+   |          |
+   |          this is found to be of type `u8`
+   |          `match` arms have incompatible types
+...
+14 |         #[serde(default = "main")]
+   |                           ^^^^^^ expected `u8`, found `()`
+
+error[E0308]: `match` arms have incompatible types
+  --> tests/ui/default-attribute/incorrect_type_enum_adjacently_tagged.rs:17:27
+   |
+4  | #[derive(Deserialize)]
+   |          -----------
+   |          |
+   |          this is found to be of type `i8`
+   |          `match` arms have incompatible types
+...
+17 |         #[serde(default = "main")]
+   |                           ^^^^^^ expected `i8`, found `()`

--- a/test_suite/tests/ui/default-attribute/incorrect_type_enum_externally_tagged.rs
+++ b/test_suite/tests/ui/default-attribute/incorrect_type_enum_externally_tagged.rs
@@ -1,0 +1,21 @@
+//! Ensures that error message points to the path in attribute
+use serde_derive::Deserialize;
+
+#[derive(Deserialize)]
+enum Enum {
+    // Newtype variants does not use the provided path, so it is forbidden here
+    // Newtype(#[serde(default = "main")] u8),
+    Tuple(
+        u8,
+        #[serde(default = "main")] i8,
+    ),
+    Struct {
+        #[serde(default = "main")]
+        f1: u8,
+        f2: u8,
+        #[serde(default = "main")]
+        f3: i8,
+    },
+}
+
+fn main() {}

--- a/test_suite/tests/ui/default-attribute/incorrect_type_enum_externally_tagged.stderr
+++ b/test_suite/tests/ui/default-attribute/incorrect_type_enum_externally_tagged.stderr
@@ -1,0 +1,35 @@
+error[E0308]: `match` arms have incompatible types
+  --> tests/ui/default-attribute/incorrect_type_enum_externally_tagged.rs:10:27
+   |
+4  | #[derive(Deserialize)]
+   |          -----------
+   |          |
+   |          this is found to be of type `i8`
+   |          `match` arms have incompatible types
+...
+10 |         #[serde(default = "main")] i8,
+   |                           ^^^^^^ expected `i8`, found `()`
+
+error[E0308]: `match` arms have incompatible types
+  --> tests/ui/default-attribute/incorrect_type_enum_externally_tagged.rs:13:27
+   |
+4  | #[derive(Deserialize)]
+   |          -----------
+   |          |
+   |          this is found to be of type `u8`
+   |          `match` arms have incompatible types
+...
+13 |         #[serde(default = "main")]
+   |                           ^^^^^^ expected `u8`, found `()`
+
+error[E0308]: `match` arms have incompatible types
+  --> tests/ui/default-attribute/incorrect_type_enum_externally_tagged.rs:16:27
+   |
+4  | #[derive(Deserialize)]
+   |          -----------
+   |          |
+   |          this is found to be of type `i8`
+   |          `match` arms have incompatible types
+...
+16 |         #[serde(default = "main")]
+   |                           ^^^^^^ expected `i8`, found `()`

--- a/test_suite/tests/ui/default-attribute/incorrect_type_enum_internally_tagged.rs
+++ b/test_suite/tests/ui/default-attribute/incorrect_type_enum_internally_tagged.rs
@@ -1,0 +1,19 @@
+//! Ensures that error message points to the path in attribute
+use serde_derive::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(tag = "tag")]
+enum Enum {
+    // Newtype variants does not use the provided path, so it is forbidden here
+    // Newtype(#[serde(default = "main")] u8),
+    // Tuple variants does not supported in internally tagged enums
+    Struct {
+        #[serde(default = "main")]
+        f1: u8,
+        f2: u8,
+        #[serde(default = "main")]
+        f3: i8,
+    },
+}
+
+fn main() {}

--- a/test_suite/tests/ui/default-attribute/incorrect_type_enum_internally_tagged.stderr
+++ b/test_suite/tests/ui/default-attribute/incorrect_type_enum_internally_tagged.stderr
@@ -1,0 +1,23 @@
+error[E0308]: `match` arms have incompatible types
+  --> tests/ui/default-attribute/incorrect_type_enum_internally_tagged.rs:11:27
+   |
+4  | #[derive(Deserialize)]
+   |          -----------
+   |          |
+   |          this is found to be of type `u8`
+   |          `match` arms have incompatible types
+...
+11 |         #[serde(default = "main")]
+   |                           ^^^^^^ expected `u8`, found `()`
+
+error[E0308]: `match` arms have incompatible types
+  --> tests/ui/default-attribute/incorrect_type_enum_internally_tagged.rs:14:27
+   |
+4  | #[derive(Deserialize)]
+   |          -----------
+   |          |
+   |          this is found to be of type `i8`
+   |          `match` arms have incompatible types
+...
+14 |         #[serde(default = "main")]
+   |                           ^^^^^^ expected `i8`, found `()`

--- a/test_suite/tests/ui/default-attribute/incorrect_type_enum_untagged.rs
+++ b/test_suite/tests/ui/default-attribute/incorrect_type_enum_untagged.rs
@@ -1,0 +1,22 @@
+//! Ensures that error message points to the path in attribute
+use serde_derive::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum Enum {
+    // Newtype variants does not use the provided path, so it is forbidden here
+    // Newtype(#[serde(default = "main")] u8),
+    Tuple(
+        u8,
+        #[serde(default = "main")] i8,
+    ),
+    Struct {
+        #[serde(default = "main")]
+        f1: u8,
+        f2: u8,
+        #[serde(default = "main")]
+        f3: i8,
+    },
+}
+
+fn main() {}

--- a/test_suite/tests/ui/default-attribute/incorrect_type_enum_untagged.stderr
+++ b/test_suite/tests/ui/default-attribute/incorrect_type_enum_untagged.stderr
@@ -1,0 +1,35 @@
+error[E0308]: `match` arms have incompatible types
+  --> tests/ui/default-attribute/incorrect_type_enum_untagged.rs:11:27
+   |
+4  | #[derive(Deserialize)]
+   |          -----------
+   |          |
+   |          this is found to be of type `i8`
+   |          `match` arms have incompatible types
+...
+11 |         #[serde(default = "main")] i8,
+   |                           ^^^^^^ expected `i8`, found `()`
+
+error[E0308]: `match` arms have incompatible types
+  --> tests/ui/default-attribute/incorrect_type_enum_untagged.rs:14:27
+   |
+4  | #[derive(Deserialize)]
+   |          -----------
+   |          |
+   |          this is found to be of type `u8`
+   |          `match` arms have incompatible types
+...
+14 |         #[serde(default = "main")]
+   |                           ^^^^^^ expected `u8`, found `()`
+
+error[E0308]: `match` arms have incompatible types
+  --> tests/ui/default-attribute/incorrect_type_enum_untagged.rs:17:27
+   |
+4  | #[derive(Deserialize)]
+   |          -----------
+   |          |
+   |          this is found to be of type `i8`
+   |          `match` arms have incompatible types
+...
+17 |         #[serde(default = "main")]
+   |                           ^^^^^^ expected `i8`, found `()`

--- a/test_suite/tests/ui/default-attribute/incorrect_type_newtype.rs
+++ b/test_suite/tests/ui/default-attribute/incorrect_type_newtype.rs
@@ -1,0 +1,8 @@
+//! Ensures that error message points to the path in attribute
+use serde_derive::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(default = "main")]
+struct Newtype(#[serde(default = "main")] u8);
+
+fn main() {}

--- a/test_suite/tests/ui/default-attribute/incorrect_type_newtype.stderr
+++ b/test_suite/tests/ui/default-attribute/incorrect_type_newtype.stderr
@@ -1,0 +1,37 @@
+error[E0308]: mismatched types
+ --> tests/ui/default-attribute/incorrect_type_newtype.rs:5:19
+  |
+5 | #[serde(default = "main")]
+  |                   ^^^^^^
+  |                   |
+  |                   expected `Newtype`, found `()`
+  |                   expected due to this
+
+error[E0308]: `match` arms have incompatible types
+ --> tests/ui/default-attribute/incorrect_type_newtype.rs:6:34
+  |
+4 | #[derive(Deserialize)]
+  |          -----------
+  |          |
+  |          this is found to be of type `u8`
+  |          `match` arms have incompatible types
+5 | #[serde(default = "main")]
+6 | struct Newtype(#[serde(default = "main")] u8);
+  |                                  ^^^^^^ expected `u8`, found `()`
+
+error[E0308]: mismatched types
+ --> tests/ui/default-attribute/incorrect_type_newtype.rs:5:19
+  |
+5 | #[serde(default = "main")]
+  |                   ^^^^^^ expected `Newtype`, found `()`
+6 | struct Newtype(#[serde(default = "main")] u8);
+  |        ------- expected due to this
+
+error[E0308]: mismatched types
+ --> tests/ui/default-attribute/incorrect_type_newtype.rs:6:34
+  |
+4 | #[derive(Deserialize)]
+  |          ----------- expected due to the type of this binding
+5 | #[serde(default = "main")]
+6 | struct Newtype(#[serde(default = "main")] u8);
+  |                                  ^^^^^^ expected `u8`, found `()`

--- a/test_suite/tests/ui/default-attribute/incorrect_type_struct.rs
+++ b/test_suite/tests/ui/default-attribute/incorrect_type_struct.rs
@@ -1,0 +1,14 @@
+//! Ensures that error message points to the path in attribute
+use serde_derive::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(default = "main")]
+struct Struct {
+    #[serde(default = "main")]
+    f1: u8,
+    f2: u8,
+    #[serde(default = "main")]
+    f3: i8,
+}
+
+fn main() {}

--- a/test_suite/tests/ui/default-attribute/incorrect_type_struct.stderr
+++ b/test_suite/tests/ui/default-attribute/incorrect_type_struct.stderr
@@ -1,0 +1,58 @@
+error[E0308]: mismatched types
+ --> tests/ui/default-attribute/incorrect_type_struct.rs:5:19
+  |
+5 | #[serde(default = "main")]
+  |                   ^^^^^^
+  |                   |
+  |                   expected `Struct`, found `()`
+  |                   expected due to this
+
+error[E0308]: `match` arms have incompatible types
+ --> tests/ui/default-attribute/incorrect_type_struct.rs:7:23
+  |
+4 | #[derive(Deserialize)]
+  |          -----------
+  |          |
+  |          this is found to be of type `u8`
+  |          `match` arms have incompatible types
+...
+7 |     #[serde(default = "main")]
+  |                       ^^^^^^ expected `u8`, found `()`
+
+error[E0308]: `match` arms have incompatible types
+  --> tests/ui/default-attribute/incorrect_type_struct.rs:10:23
+   |
+4  | #[derive(Deserialize)]
+   |          -----------
+   |          |
+   |          this is found to be of type `i8`
+   |          `match` arms have incompatible types
+...
+10 |     #[serde(default = "main")]
+   |                       ^^^^^^ expected `i8`, found `()`
+
+error[E0308]: mismatched types
+ --> tests/ui/default-attribute/incorrect_type_struct.rs:5:19
+  |
+5 | #[serde(default = "main")]
+  |                   ^^^^^^ expected `Struct`, found `()`
+6 | struct Struct {
+  |        ------ expected due to this
+
+error[E0308]: mismatched types
+ --> tests/ui/default-attribute/incorrect_type_struct.rs:7:23
+  |
+4 | #[derive(Deserialize)]
+  |          ----------- expected due to the type of this binding
+...
+7 |     #[serde(default = "main")]
+  |                       ^^^^^^ expected `u8`, found `()`
+
+error[E0308]: mismatched types
+  --> tests/ui/default-attribute/incorrect_type_struct.rs:10:23
+   |
+4  | #[derive(Deserialize)]
+   |          ----------- expected due to the type of this binding
+...
+10 |     #[serde(default = "main")]
+   |                       ^^^^^^ expected `i8`, found `()`

--- a/test_suite/tests/ui/default-attribute/incorrect_type_tuple.rs
+++ b/test_suite/tests/ui/default-attribute/incorrect_type_tuple.rs
@@ -1,0 +1,11 @@
+//! Ensures that error message points to the path in attribute
+use serde_derive::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(default = "main")]
+struct Tuple(
+    u8,
+    #[serde(default = "main")] i8,
+);
+
+fn main() {}

--- a/test_suite/tests/ui/default-attribute/incorrect_type_tuple.stderr
+++ b/test_suite/tests/ui/default-attribute/incorrect_type_tuple.stderr
@@ -1,0 +1,37 @@
+error[E0308]: mismatched types
+ --> tests/ui/default-attribute/incorrect_type_tuple.rs:5:19
+  |
+5 | #[serde(default = "main")]
+  |                   ^^^^^^
+  |                   |
+  |                   expected `Tuple`, found `()`
+  |                   expected due to this
+
+error[E0308]: `match` arms have incompatible types
+ --> tests/ui/default-attribute/incorrect_type_tuple.rs:8:23
+  |
+4 | #[derive(Deserialize)]
+  |          -----------
+  |          |
+  |          this is found to be of type `i8`
+  |          `match` arms have incompatible types
+...
+8 |     #[serde(default = "main")] i8,
+  |                       ^^^^^^ expected `i8`, found `()`
+
+error[E0308]: mismatched types
+ --> tests/ui/default-attribute/incorrect_type_tuple.rs:5:19
+  |
+5 | #[serde(default = "main")]
+  |                   ^^^^^^ expected `Tuple`, found `()`
+6 | struct Tuple(
+  |        ----- expected due to this
+
+error[E0308]: mismatched types
+ --> tests/ui/default-attribute/incorrect_type_tuple.rs:8:23
+  |
+4 | #[derive(Deserialize)]
+  |          ----------- expected due to the type of this binding
+...
+8 |     #[serde(default = "main")] i8,
+  |                       ^^^^^^ expected `i8`, found `()`

--- a/test_suite/tests/ui/default-attribute/union.rs
+++ b/test_suite/tests/ui/default-attribute/union.rs
@@ -1,0 +1,9 @@
+use serde_derive::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(default)]
+union Union {
+    f: u8,
+}
+
+fn main() {}

--- a/test_suite/tests/ui/default-attribute/union.stderr
+++ b/test_suite/tests/ui/default-attribute/union.stderr
@@ -1,0 +1,14 @@
+error: #[serde(default)] can only be used on structs
+ --> tests/ui/default-attribute/union.rs:4:9
+  |
+4 | #[serde(default)]
+  |         ^^^^^^^
+
+error: Serde does not support derive for unions
+ --> tests/ui/default-attribute/union.rs:4:1
+  |
+4 | / #[serde(default)]
+5 | | union Union {
+6 | |     f: u8,
+7 | | }
+  | |_^

--- a/test_suite/tests/ui/default-attribute/union_path.rs
+++ b/test_suite/tests/ui/default-attribute/union_path.rs
@@ -1,0 +1,9 @@
+use serde_derive::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(default = "default_u")]
+union Union {
+    f: u8,
+}
+
+fn main() {}

--- a/test_suite/tests/ui/default-attribute/union_path.stderr
+++ b/test_suite/tests/ui/default-attribute/union_path.stderr
@@ -1,0 +1,14 @@
+error: #[serde(default = "...")] can only be used on structs
+ --> tests/ui/default-attribute/union_path.rs:4:9
+  |
+4 | #[serde(default = "default_u")]
+  |         ^^^^^^^^^^^^^^^^^^^^^
+
+error: Serde does not support derive for unions
+ --> tests/ui/default-attribute/union_path.rs:4:1
+  |
+4 | / #[serde(default = "default_u")]
+5 | | union Union {
+6 | |     f: u8,
+7 | | }
+  | |_^

--- a/test_suite/tests/ui/default-attribute/unit.rs
+++ b/test_suite/tests/ui/default-attribute/unit.rs
@@ -1,0 +1,7 @@
+use serde_derive::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(default)]
+struct Unit;
+
+fn main() {}

--- a/test_suite/tests/ui/default-attribute/unit.stderr
+++ b/test_suite/tests/ui/default-attribute/unit.stderr
@@ -1,0 +1,7 @@
+error: #[serde(default)] can only be used on structs that have fields
+ --> tests/ui/default-attribute/unit.rs:3:10
+  |
+3 | #[derive(Deserialize)]
+  |          ^^^^^^^^^^^
+  |
+  = note: this error originates in the derive macro `Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/test_suite/tests/ui/default-attribute/unit_path.rs
+++ b/test_suite/tests/ui/default-attribute/unit_path.rs
@@ -1,0 +1,7 @@
+use serde_derive::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(default = "default_u")]
+struct Unit;
+
+fn main() {}

--- a/test_suite/tests/ui/default-attribute/unit_path.stderr
+++ b/test_suite/tests/ui/default-attribute/unit_path.stderr
@@ -1,0 +1,5 @@
+error: #[serde(default = "...")] can only be used on structs that have fields
+ --> tests/ui/default-attribute/unit_path.rs:4:9
+  |
+4 | #[serde(default = "default_u")]
+  |         ^^^^^^^^^^^^^^^^^^^^^

--- a/test_suite/tests/ui/with/incorrect_type.rs
+++ b/test_suite/tests/ui/with/incorrect_type.rs
@@ -1,0 +1,23 @@
+use serde_derive::{Deserialize, Serialize};
+
+mod w {
+    use serde::{Deserializer, Serializer};
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(_: D) -> Result<(), D::Error> {
+        unimplemented!()
+    }
+    pub fn serialize<T, S: Serializer>(_: S) -> Result<S::Ok, S::Error> {
+        unimplemented!()
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct W(#[serde(with = "w")] u8, u8);
+
+#[derive(Serialize, Deserialize)]
+struct S(#[serde(serialize_with = "w::serialize")] u8, u8);
+
+#[derive(Serialize, Deserialize)]
+struct D(#[serde(deserialize_with = "w::deserialize")] u8, u8);
+
+fn main() {}

--- a/test_suite/tests/ui/with/incorrect_type.stderr
+++ b/test_suite/tests/ui/with/incorrect_type.stderr
@@ -1,0 +1,97 @@
+error[E0277]: the trait bound `&u8: Serializer` is not satisfied
+  --> tests/ui/with/incorrect_type.rs:14:10
+   |
+14 | #[derive(Serialize, Deserialize)]
+   |          ^^^^^^^^^ the trait `Serializer` is not implemented for `&u8`
+15 | struct W(#[serde(with = "w")] u8, u8);
+   |                         --- required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `Serializer`:
+             &'a mut Formatter<'b>
+             FlatMapSerializer<'a, M>
+             _::_serde::__private::ser::content::ContentSerializer<E>
+note: required by a bound in `w::serialize`
+  --> tests/ui/with/incorrect_type.rs:9:28
+   |
+9  |     pub fn serialize<T, S: Serializer>(_: S) -> Result<S::Ok, S::Error> {
+   |                            ^^^^^^^^^^ required by this bound in `serialize`
+
+error[E0061]: this function takes 1 argument but 2 arguments were supplied
+  --> tests/ui/with/incorrect_type.rs:15:25
+   |
+15 | struct W(#[serde(with = "w")] u8, u8);
+   |                         ^^^ unexpected argument #2 of type `__S`
+   |
+note: function defined here
+  --> tests/ui/with/incorrect_type.rs:9:12
+   |
+9  |     pub fn serialize<T, S: Serializer>(_: S) -> Result<S::Ok, S::Error> {
+   |            ^^^^^^^^^                   ----
+
+error[E0277]: the trait bound `&u8: Serializer` is not satisfied
+  --> tests/ui/with/incorrect_type.rs:15:25
+   |
+15 | struct W(#[serde(with = "w")] u8, u8);
+   |                         ^^^ the trait `Serializer` is not implemented for `&u8`
+   |
+   = help: the following other types implement trait `Serializer`:
+             &'a mut Formatter<'b>
+             FlatMapSerializer<'a, M>
+             _::_serde::__private::ser::content::ContentSerializer<E>
+
+error[E0308]: `?` operator has incompatible types
+  --> tests/ui/with/incorrect_type.rs:15:25
+   |
+15 | struct W(#[serde(with = "w")] u8, u8);
+   |                         ^^^ expected `u8`, found `()`
+   |
+   = note: `?` operator cannot convert from `()` to `u8`
+
+error[E0277]: the trait bound `&u8: Serializer` is not satisfied
+  --> tests/ui/with/incorrect_type.rs:17:10
+   |
+17 | #[derive(Serialize, Deserialize)]
+   |          ^^^^^^^^^ the trait `Serializer` is not implemented for `&u8`
+18 | struct S(#[serde(serialize_with = "w::serialize")] u8, u8);
+   |                                   -------------- required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `Serializer`:
+             &'a mut Formatter<'b>
+             FlatMapSerializer<'a, M>
+             _::_serde::__private::ser::content::ContentSerializer<E>
+note: required by a bound in `w::serialize`
+  --> tests/ui/with/incorrect_type.rs:9:28
+   |
+9  |     pub fn serialize<T, S: Serializer>(_: S) -> Result<S::Ok, S::Error> {
+   |                            ^^^^^^^^^^ required by this bound in `serialize`
+
+error[E0061]: this function takes 1 argument but 2 arguments were supplied
+  --> tests/ui/with/incorrect_type.rs:18:35
+   |
+18 | struct S(#[serde(serialize_with = "w::serialize")] u8, u8);
+   |                                   ^^^^^^^^^^^^^^ unexpected argument #2 of type `__S`
+   |
+note: function defined here
+  --> tests/ui/with/incorrect_type.rs:9:12
+   |
+9  |     pub fn serialize<T, S: Serializer>(_: S) -> Result<S::Ok, S::Error> {
+   |            ^^^^^^^^^                   ----
+
+error[E0277]: the trait bound `&u8: Serializer` is not satisfied
+  --> tests/ui/with/incorrect_type.rs:18:35
+   |
+18 | struct S(#[serde(serialize_with = "w::serialize")] u8, u8);
+   |                                   ^^^^^^^^^^^^^^ the trait `Serializer` is not implemented for `&u8`
+   |
+   = help: the following other types implement trait `Serializer`:
+             &'a mut Formatter<'b>
+             FlatMapSerializer<'a, M>
+             _::_serde::__private::ser::content::ContentSerializer<E>
+
+error[E0308]: `?` operator has incompatible types
+  --> tests/ui/with/incorrect_type.rs:21:37
+   |
+21 | struct D(#[serde(deserialize_with = "w::deserialize")] u8, u8);
+   |                                     ^^^^^^^^^^^^^^^^ expected `u8`, found `()`
+   |
+   = note: `?` operator cannot convert from `()` to `u8`


### PR DESCRIPTION
This PR changes the errors reported by `rustc` when signature of function specified in
- `#[serde(with = "...")]` 
- `#[serde(deserialize_with = "...")]`
- `#[serde(serialize_with = "...")]`
- `#[serde(default = "...")]`

is wrong. With this PR error will point to the `"..."`.