### PR TITLE
Remove misleading `?Sized` requirement - `Deserialize` requires `Sized`

### DIFF
--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -1814,7 +1814,7 @@ where
 ///
 /// [`"rc"`]: https://serde.rs/feature-flags.html#-features-rc
 #[cfg(all(feature = "rc", any(feature = "std", feature = "alloc")))]
-impl<'de, T: ?Sized> Deserialize<'de> for RcWeak<T>
+impl<'de, T> Deserialize<'de> for RcWeak<T>
 where
     T: Deserialize<'de>,
 {
@@ -1832,7 +1832,7 @@ where
 ///
 /// [`"rc"`]: https://serde.rs/feature-flags.html#-features-rc
 #[cfg(all(feature = "rc", any(feature = "std", feature = "alloc")))]
-impl<'de, T: ?Sized> Deserialize<'de> for ArcWeak<T>
+impl<'de, T> Deserialize<'de> for ArcWeak<T>
 where
     T: Deserialize<'de>,
 {


### PR DESCRIPTION
`Deserialize` trait requires `Sized` types, so there no sense to declare `?Sized` bounds:
https://github.com/serde-rs/serde/blob/05a5b7e3c6de502d45597cbc083f28bc1d4f4626/serde/src/de/mod.rs#L537