### PR TITLE
Use correct tokens in test to represent an enum variant

### DIFF
--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -313,6 +313,8 @@ mod content {
         }
     }
 
+    /// Used to capture data in [`Content`] from other deserializers.
+    /// Cannot capture externally tagged enums, `i128` and `u128`.
     struct ContentVisitor<'de> {
         value: PhantomData<Content<'de>>,
     }
@@ -528,6 +530,8 @@ mod content {
         Content(Content<'de>),
     }
 
+    /// Serves as a seed for deserializing a key of internally tagged enum.
+    /// Cannot capture externally tagged enums, `i128` and `u128`.
     struct TagOrContentVisitor<'de> {
         name: &'static str,
         value: PhantomData<TagOrContent<'de>>,
@@ -813,6 +817,9 @@ mod content {
     }
 
     /// Used by generated code to deserialize an internally tagged enum.
+    ///
+    /// Captures map or sequence from the original deserializer and searches
+    /// a tag in it (in case of sequence, tag is the first element of sequence).
     ///
     /// Not public API.
     pub struct TaggedContentVisitor<T> {

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -997,7 +997,9 @@ fn test_internally_tagged_struct_variant_containing_unit_variant() {
             Token::Str("action"),
             Token::Str("Log"),
             Token::Str("level"),
+            Token::Enum { name: "Level" },
             Token::BorrowedStr("Info"),
+            Token::Unit,
             Token::StructEnd,
         ],
     );
@@ -1009,7 +1011,9 @@ fn test_internally_tagged_struct_variant_containing_unit_variant() {
             Token::Str("action"),
             Token::Str("Log"),
             Token::Str("level"),
+            Token::Enum { name: "Level" },
             Token::BorrowedStr("Info"),
+            Token::Unit,
             Token::MapEnd,
         ],
     );
@@ -1019,7 +1023,9 @@ fn test_internally_tagged_struct_variant_containing_unit_variant() {
         &[
             Token::Seq { len: Some(2) },
             Token::Str("Log"),
+            Token::Enum { name: "Level" },
             Token::BorrowedStr("Info"),
+            Token::Unit,
             Token::SeqEnd,
         ],
     );

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -987,6 +987,18 @@ fn test_internally_tagged_struct_variant_containing_unit_variant() {
         Log { level: Level },
     }
 
+    // Canary test that ensures that we use adequate enum representation that
+    // is possible to deserialize regardless of possible buffering in internally
+    // tagged enum implementation
+    assert_de_tokens(
+        &Level::Info,
+        &[
+            Token::Enum { name: "Level" },
+            Token::BorrowedStr("Info"),
+            Token::Unit,
+        ],
+    );
+
     assert_de_tokens(
         &Message::Log { level: Level::Info },
         &[


### PR DESCRIPTION
The test that is fixing by this PR was introduces in #933 and has a purpose to reach the `Content::Str` case here that was fixed by that PR:
https://github.com/serde-rs/serde/blob/05a5b7e3c6de502d45597cbc083f28bc1d4f4626/serde/src/private/de.rs#L1446

The `Content::Str` case here produced using `visit_borrowing_str` here (that the only case when `Content::Str` can be created):
https://github.com/serde-rs/serde/blob/05a5b7e3c6de502d45597cbc083f28bc1d4f4626/serde/src/private/de.rs#L424-L429

which is called as a response to `Token::BorrowedStr`:
https://github.com/serde-rs/test/blob/d1294b3ad549874d5035752ac62b4eb75cee5060/src/de.rs#L129

However, unit variants of externally tagged enum cannot be deserialized from the string token by itself. The one of following combinations of tokens should be used to correctly represent enum variant:
- `[xxxVariant { .. }]`
- `[Enum { .. }, xxxVariant { variant, .. }]`
- `[Enum { .. }, String(variant), <variant content>]`
- `[Enum { .. }, Str(variant), <variant content>]`
- `[Enum { .. }, BorrowedStr(variant), <variant content>]`

Because we want to reach `Content::Str` case, the only possible representation which we can use is `[Enum { name: "Level" }, BorrowedStr("Info"), Unit]` (other variants will be captured as `Content::String`).