### PR TITLE
Show variant aliases in error message

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1259,7 +1259,7 @@ fn prepare_enum_variant_enum(variants: &[Variant]) -> (TokenStream, Stmts) {
         });
 
     let variants_stmt = {
-        let variant_names = variant_names_idents.iter().map(|(name, _, _)| name);
+        let variant_names = variant_names_idents.iter().flat_map(|&(_, _, aliases)| aliases);
         quote! {
             #[doc(hidden)]
             const VARIANTS: &'static [&'static str] = &[ #(#variant_names),* ];

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -782,7 +782,7 @@ fn test_unknown_field_rename_enum() {
             variant: "SailorMoon",
             len: 3,
         }],
-        "unknown variant `SailorMoon`, expected `sailor_moon`",
+        "unknown variant `SailorMoon`, expected `sailor_moon` or `usagi_tsukino`",
     );
 
     assert_de_tokens_error::<AliasEnum>(


### PR DESCRIPTION
Before that PR an error message of such enum did not include aliases of possible variants:
```rust
#[derive(Deserialize)]
enum Enum {
  #[serde(alias = "C")]
  A,
  B
}
```
Now the error message will mention `C`