### PR TITLE
Correctly process flatten fields in enum variants

### DIFF
--- a/serde_derive/src/internals/ast.rs
+++ b/serde_derive/src/internals/ast.rs
@@ -85,6 +85,7 @@ impl<'a> Container<'a> {
                     for field in &mut variant.fields {
                         if field.attrs.flatten() {
                             has_flatten = true;
+                            variant.attrs.mark_has_flatten();
                         }
                         field.attrs.rename_by_rules(
                             variant

--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -216,6 +216,22 @@ pub struct Container {
     type_into: Option<syn::Type>,
     remote: Option<syn::Path>,
     identifier: Identifier,
+    /// `true` if container is a `struct` and it has a field with `#[serde(flatten)]`
+    /// attribute or it is an `enum` with a struct variant which has a field with
+    /// `#[serde(flatten)]` attribute. Examples:
+    ///
+    /// ```ignore
+    /// struct Container {
+    ///     #[serde(flatten)]
+    ///     some_field: (),
+    /// }
+    /// enum Container {
+    ///     Variant {
+    ///         #[serde(flatten)]
+    ///         some_field: (),
+    ///     },
+    /// }
+    /// ```
     has_flatten: bool,
     serde_path: Option<syn::Path>,
     is_packed: bool,
@@ -794,6 +810,18 @@ pub struct Variant {
     rename_all_rules: RenameAllRules,
     ser_bound: Option<Vec<syn::WherePredicate>>,
     de_bound: Option<Vec<syn::WherePredicate>>,
+    /// `true` if variant is a struct variant which contains a field with `#[serde(flatten)]`
+    /// attribute. Examples:
+    ///
+    /// ```ignore
+    /// enum Enum {
+    ///     Variant {
+    ///         #[serde(flatten)]
+    ///         some_field: (),
+    ///     },
+    /// }
+    /// ```
+    has_flatten: bool,
     skip_deserializing: bool,
     skip_serializing: bool,
     other: bool,
@@ -963,6 +991,7 @@ impl Variant {
             },
             ser_bound: ser_bound.get(),
             de_bound: de_bound.get(),
+            has_flatten: false,
             skip_deserializing: skip_deserializing.get(),
             skip_serializing: skip_serializing.get(),
             other: other.get(),
@@ -1003,6 +1032,14 @@ impl Variant {
 
     pub fn de_bound(&self) -> Option<&[syn::WherePredicate]> {
         self.de_bound.as_ref().map(|vec| &vec[..])
+    }
+
+    pub fn has_flatten(&self) -> bool {
+        self.has_flatten
+    }
+
+    pub fn mark_has_flatten(&mut self) {
+        self.has_flatten = true;
     }
 
     pub fn skip_deserializing(&self) -> bool {

--- a/test_suite/tests/regression/issue1904.rs
+++ b/test_suite/tests/regression/issue1904.rs
@@ -1,0 +1,65 @@
+#![allow(dead_code)] // we do not read enum fields
+use serde_derive::Deserialize;
+
+#[derive(Deserialize)]
+pub struct Nested;
+
+#[derive(Deserialize)]
+pub enum ExternallyTagged1 {
+    Tuple(f64, String),
+    Flatten {
+        #[serde(flatten)]
+        nested: Nested,
+    },
+}
+
+#[derive(Deserialize)]
+pub enum ExternallyTagged2 {
+    Flatten {
+        #[serde(flatten)]
+        nested: Nested,
+    },
+    Tuple(f64, String),
+}
+
+// Internally tagged enums cannot contain tuple variants so not tested here
+
+#[derive(Deserialize)]
+#[serde(tag = "tag", content = "content")]
+pub enum AdjacentlyTagged1 {
+    Tuple(f64, String),
+    Flatten {
+        #[serde(flatten)]
+        nested: Nested,
+    },
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "tag", content = "content")]
+pub enum AdjacentlyTagged2 {
+    Flatten {
+        #[serde(flatten)]
+        nested: Nested,
+    },
+    Tuple(f64, String),
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+pub enum Untagged1 {
+    Tuple(f64, String),
+    Flatten {
+        #[serde(flatten)]
+        nested: Nested,
+    },
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+pub enum Untagged2 {
+    Flatten {
+        #[serde(flatten)]
+        nested: Nested,
+    },
+    Tuple(f64, String),
+}

--- a/test_suite/tests/regression/issue2565.rs
+++ b/test_suite/tests/regression/issue2565.rs
@@ -1,0 +1,41 @@
+use serde_derive::{Serialize, Deserialize};
+use serde_test::{assert_tokens, Token};
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+enum Enum {
+    Simple {
+        a: i32,
+    },
+    Flatten {
+        #[serde(flatten)]
+        flatten: (),
+        a: i32,
+    },
+}
+
+#[test]
+fn simple_variant() {
+    assert_tokens(
+        &Enum::Simple { a: 42 },
+        &[
+            Token::StructVariant { name: "Enum", variant: "Simple", len: 1 },
+            Token::Str("a"),
+            Token::I32(42),
+            Token::StructVariantEnd,
+        ]
+    );
+}
+
+#[test]
+fn flatten_variant() {
+    assert_tokens(
+        &Enum::Flatten { flatten: (), a: 42 },
+        &[
+            Token::NewtypeVariant { name: "Enum", variant: "Flatten" },
+            Token::Map { len: None },
+            Token::Str("a"),
+            Token::I32(42),
+            Token::MapEnd,
+        ]
+    );
+}

--- a/test_suite/tests/regression/issue2792.rs
+++ b/test_suite/tests/regression/issue2792.rs
@@ -1,0 +1,16 @@
+#![allow(dead_code)] // we do not read enum fields
+use serde_derive::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub enum A {
+    B {
+        c: String,
+    },
+    D {
+        #[serde(flatten)]
+        e: E,
+    },
+}
+#[derive(Deserialize)]
+pub struct E {}

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -2380,6 +2380,56 @@ fn test_partially_untagged_enum_desugared() {
     );
 }
 
+/// Regression test for https://github.com/serde-rs/serde/issues/1904
+#[test]
+fn test_enum_tuple_and_struct_with_flatten() {
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    enum Outer {
+        Tuple(f64, i32),
+        Flatten {
+            #[serde(flatten)]
+            nested: Nested,
+        },
+    }
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct Nested {
+        a: i32,
+        b: i32,
+    }
+
+    assert_tokens(
+        &Outer::Tuple(1.2, 3),
+        &[
+            Token::TupleVariant {
+                name: "Outer",
+                variant: "Tuple",
+                len: 2,
+            },
+            Token::F64(1.2),
+            Token::I32(3),
+            Token::TupleVariantEnd,
+        ],
+    );
+    assert_tokens(
+        &Outer::Flatten {
+            nested: Nested { a: 1, b: 2 },
+        },
+        &[
+            Token::NewtypeVariant {
+                name: "Outer",
+                variant: "Flatten",
+            },
+            Token::Map { len: None },
+            Token::Str("a"),
+            Token::I32(1),
+            Token::Str("b"),
+            Token::I32(2),
+            Token::MapEnd,
+        ],
+    );
+}
+
 #[test]
 fn test_partially_untagged_internally_tagged_enum() {
     #[derive(Serialize, Deserialize, PartialEq, Debug)]


### PR DESCRIPTION
Store `has_flatten` mark in the `Variant` attributes and use it instead of `attr::Container::has_flatten()` in methods that can be called for variants.

Fixes #1904, fixes #2565, fixes #2792