### PR TITLE
Implement `IntoDeserializer` for all `Deserializer`s in `serde::de::value` module

### DIFF
--- a/serde/src/de/value.rs
+++ b/serde/src/de/value.rs
@@ -175,6 +175,17 @@ where
     }
 }
 
+impl<'de, E> IntoDeserializer<'de, E> for UnitDeserializer<E>
+where
+    E: de::Error,
+{
+    type Deserializer = Self;
+
+    fn into_deserializer(self) -> Self {
+        self
+    }
+}
+
 impl<E> Debug for UnitDeserializer<E> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.debug_struct("UnitDeserializer").finish()
@@ -222,6 +233,18 @@ where
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
         bytes byte_buf option unit unit_struct newtype_struct seq tuple
         tuple_struct map struct enum identifier ignored_any
+    }
+}
+
+#[cfg(feature = "unstable")]
+impl<'de, E> IntoDeserializer<'de, E> for NeverDeserializer<E>
+where
+    E: de::Error,
+{
+    type Deserializer = Self;
+
+    fn into_deserializer(self) -> Self {
+        self
     }
 }
 
@@ -276,6 +299,17 @@ macro_rules! primitive_deserializer {
                 V: de::Visitor<'de>,
             {
                 visitor.$method(self.value $($cast)*)
+            }
+        }
+
+        impl<'de, E> IntoDeserializer<'de, E> for $name<E>
+        where
+            E: de::Error,
+        {
+            type Deserializer = Self;
+
+            fn into_deserializer(self) -> Self {
+                self
             }
         }
 
@@ -369,6 +403,17 @@ where
     }
 }
 
+impl<'de, E> IntoDeserializer<'de, E> for U32Deserializer<E>
+where
+    E: de::Error,
+{
+    type Deserializer = Self;
+
+    fn into_deserializer(self) -> Self {
+        self
+    }
+}
+
 impl<'de, E> de::EnumAccess<'de> for U32Deserializer<E>
 where
     E: de::Error,
@@ -458,6 +503,17 @@ where
     }
 }
 
+impl<'de, 'a, E> IntoDeserializer<'de, E> for StrDeserializer<'a, E>
+where
+    E: de::Error,
+{
+    type Deserializer = Self;
+
+    fn into_deserializer(self) -> Self {
+        self
+    }
+}
+
 impl<'de, 'a, E> de::EnumAccess<'de> for StrDeserializer<'a, E>
 where
     E: de::Error,
@@ -534,6 +590,17 @@ where
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
         bytes byte_buf option unit unit_struct newtype_struct seq tuple
         tuple_struct map struct identifier ignored_any
+    }
+}
+
+impl<'de, E> IntoDeserializer<'de, E> for BorrowedStrDeserializer<'de, E>
+where
+    E: de::Error,
+{
+    type Deserializer = Self;
+
+    fn into_deserializer(self) -> Self {
+        self
     }
 }
 
@@ -637,6 +704,18 @@ where
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
         bytes byte_buf option unit unit_struct newtype_struct seq tuple
         tuple_struct map struct identifier ignored_any
+    }
+}
+
+#[cfg(any(feature = "std", feature = "alloc"))]
+impl<'de, E> IntoDeserializer<'de, E> for StringDeserializer<E>
+where
+    E: de::Error,
+{
+    type Deserializer = Self;
+
+    fn into_deserializer(self) -> Self {
+        self
     }
 }
 
@@ -749,6 +828,18 @@ where
 }
 
 #[cfg(any(feature = "std", feature = "alloc"))]
+impl<'de, 'a, E> IntoDeserializer<'de, E> for CowStrDeserializer<'a, E>
+where
+    E: de::Error,
+{
+    type Deserializer = Self;
+
+    fn into_deserializer(self) -> Self {
+        self
+    }
+}
+
+#[cfg(any(feature = "std", feature = "alloc"))]
 impl<'de, 'a, E> de::EnumAccess<'de> for CowStrDeserializer<'a, E>
 where
     E: de::Error,
@@ -825,6 +916,17 @@ where
     }
 }
 
+impl<'de, 'a, E> IntoDeserializer<'de, E> for BytesDeserializer<'a, E>
+where
+    E: de::Error,
+{
+    type Deserializer = Self;
+
+    fn into_deserializer(self) -> Self {
+        self
+    }
+}
+
 impl<'a, E> Debug for BytesDeserializer<'a, E> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter
@@ -870,6 +972,17 @@ where
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
         bytes byte_buf option unit unit_struct newtype_struct seq tuple
         tuple_struct map struct enum identifier ignored_any
+    }
+}
+
+impl<'de, E> IntoDeserializer<'de, E> for BorrowedBytesDeserializer<'de, E>
+where
+    E: de::Error,
+{
+    type Deserializer = Self;
+
+    fn into_deserializer(self) -> Self {
+        self
     }
 }
 
@@ -949,6 +1062,19 @@ where
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
         bytes byte_buf option unit unit_struct newtype_struct seq tuple
         tuple_struct map struct enum identifier ignored_any
+    }
+}
+
+impl<'de, I, T, E> IntoDeserializer<'de, E> for SeqDeserializer<I, E>
+where
+    I: Iterator<Item = T>,
+    T: IntoDeserializer<'de, E>,
+    E: de::Error,
+{
+    type Deserializer = Self;
+
+    fn into_deserializer(self) -> Self {
+        self
     }
 }
 
@@ -1083,6 +1209,17 @@ where
     }
 }
 
+impl<'de, A> IntoDeserializer<'de, A::Error> for SeqAccessDeserializer<A>
+where
+    A: de::SeqAccess<'de>,
+{
+    type Deserializer = Self;
+
+    fn into_deserializer(self) -> Self {
+        self
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 /// A deserializer that iterates over a map.
@@ -1194,6 +1331,21 @@ where
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
         bytes byte_buf option unit unit_struct newtype_struct tuple_struct map
         struct enum identifier ignored_any
+    }
+}
+
+impl<'de, I, E> IntoDeserializer<'de, E> for MapDeserializer<'de, I, E>
+where
+    I: Iterator,
+    I::Item: private::Pair,
+    First<I::Item>: IntoDeserializer<'de, E>,
+    Second<I::Item>: IntoDeserializer<'de, E>,
+    E: de::Error,
+{
+    type Deserializer = Self;
+
+    fn into_deserializer(self) -> Self {
+        self
     }
 }
 
@@ -1498,6 +1650,17 @@ where
     }
 }
 
+impl<'de, A> IntoDeserializer<'de, A::Error> for MapAccessDeserializer<A>
+where
+    A: de::MapAccess<'de>,
+{
+    type Deserializer = Self;
+
+    fn into_deserializer(self) -> Self {
+        self
+    }
+}
+
 impl<'de, A> de::EnumAccess<'de> for MapAccessDeserializer<A>
 where
     A: de::MapAccess<'de>,
@@ -1548,6 +1711,17 @@ where
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
         bytes byte_buf option unit unit_struct newtype_struct seq tuple
         tuple_struct map struct enum identifier ignored_any
+    }
+}
+
+impl<'de, A> IntoDeserializer<'de, A::Error> for EnumAccessDeserializer<A>
+where
+    A: de::EnumAccess<'de>,
+{
+    type Deserializer = Self;
+
+    fn into_deserializer(self) -> Self {
+        self
     }
 }
 


### PR DESCRIPTION
Unfortunately, blanket implementation `IntoDeserializer for Deserializer` is impossible right now because this would be a breaking change. External crates may have this such implementation (and serde_json actually have it for `Value`).

Closes #2498