### PR TITLE
Treat unmatched non-exhaustive remote variant as serde(skip)

### DIFF
--- a/serde/src/private/ser.rs
+++ b/serde/src/private/ser.rs
@@ -1370,3 +1370,16 @@ impl Serialize for AdjacentlyTaggedEnumVariant {
         serializer.serialize_unit_variant(self.enum_name, self.variant_index, self.variant_name)
     }
 }
+
+// Error when Serialize for a non_exhaustive remote enum encounters a variant
+// that is not recognized.
+pub struct CannotSerializeVariant<T>(pub T);
+
+impl<T> Display for CannotSerializeVariant<T>
+where
+    T: Debug,
+{
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "enum variant cannot be serialized: {:?}", self.0)
+    }
+}

--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -221,6 +221,7 @@ pub struct Container {
     is_packed: bool,
     /// Error message generated when type can't be deserialized
     expecting: Option<String>,
+    non_exhaustive: bool,
 }
 
 /// Styles of representing an enum.
@@ -306,9 +307,12 @@ impl Container {
         let mut variant_identifier = BoolAttr::none(cx, VARIANT_IDENTIFIER);
         let mut serde_path = Attr::none(cx, CRATE);
         let mut expecting = Attr::none(cx, EXPECTING);
+        let mut non_exhaustive = false;
 
         for attr in &item.attrs {
             if attr.path() != SERDE {
+                non_exhaustive |=
+                    matches!(&attr.meta, syn::Meta::Path(path) if path == NON_EXHAUSTIVE);
                 continue;
             }
 
@@ -587,6 +591,7 @@ impl Container {
             serde_path: serde_path.get(),
             is_packed,
             expecting: expecting.get(),
+            non_exhaustive,
         }
     }
 
@@ -671,6 +676,10 @@ impl Container {
     /// If `None`, default message will be used
     pub fn expecting(&self) -> Option<&str> {
         self.expecting.as_ref().map(String::as_ref)
+    }
+
+    pub fn non_exhaustive(&self) -> bool {
+        self.non_exhaustive
     }
 }
 

--- a/serde_derive/src/internals/symbol.rs
+++ b/serde_derive/src/internals/symbol.rs
@@ -19,6 +19,7 @@ pub const FLATTEN: Symbol = Symbol("flatten");
 pub const FROM: Symbol = Symbol("from");
 pub const GETTER: Symbol = Symbol("getter");
 pub const INTO: Symbol = Symbol("into");
+pub const NON_EXHAUSTIVE: Symbol = Symbol("non_exhaustive");
 pub const OTHER: Symbol = Symbol("other");
 pub const REMOTE: Symbol = Symbol("remote");
 pub const RENAME: Symbol = Symbol("rename");

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -401,13 +401,19 @@ fn serialize_enum(params: &Parameters, variants: &[Variant], cattrs: &attr::Cont
 
     let self_var = &params.self_var;
 
-    let arms: Vec<_> = variants
+    let mut arms: Vec<_> = variants
         .iter()
         .enumerate()
         .map(|(variant_index, variant)| {
             serialize_variant(params, variant, variant_index as u32, cattrs)
         })
         .collect();
+
+    if cattrs.non_exhaustive() {
+        arms.push(quote! {
+            unrecognized => _serde::__private::Err(_serde::ser::Error::custom(_serde::__private::ser::CannotSerializeVariant(unrecognized))),
+        });
+    }
 
     quote_expr! {
         match *#self_var {

--- a/test_suite/tests/test_remote.rs
+++ b/test_suite/tests/test_remote.rs
@@ -125,6 +125,9 @@ struct Test {
 
     #[serde(with = "EnumConcrete")]
     enum_concrete: remote::EnumGeneric<u8>,
+
+    #[serde(with = "ErrorKindDef")]
+    io_error_kind: std::io::ErrorKind,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -195,6 +198,15 @@ struct StructConcrete {
 #[serde(remote = "remote::EnumGeneric<u8>")]
 enum EnumConcrete {
     Variant(u8),
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "std::io::ErrorKind")]
+#[non_exhaustive]
+enum ErrorKindDef {
+    NotFound,
+    PermissionDenied,
+    // ...
 }
 
 impl From<PrimitivePrivDef> for remote::PrimitivePriv {


### PR DESCRIPTION
Serde already supports a `serde(skip)` attribute to not serialize a particular variant, returning an error instead.

```rust
#[derive(Serialize)]
enum Enum {
    Foo,
    #[serde(skip)]
    Bar,
}
```

This PR gives equivalent behavior to #\[non_exhaustive\] remote enums: it's as if every other possible variant were listed with a `serde(skip)` on it.

```rust
#[derive(Serialize, Deserialize)]
#[serde(remote = "std::io::ErrorKind")]
#[non_exhaustive]
enum ErrorKindDef {
    NotFound,
    PermissionDenied,
    // ...
}
```

```rust
assert!(ErrorKindDef::serialize(&ErrorKind::OutOfMemory, serializer).is_err());
```

Closes #2360. Closes #2361.