### PR TITLE
Add derive_compiled feature to force compilation of serde_derive

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ fn main() {
 }
 ```
 
+## Note about serde_derive Binary
+
+When using `serde_derive` either directly or via `serde` with `derive` feature it
+may be distributed from within pre-compiled binary (currently only on `x86_64-linux-gnu` target)
+
+To force building `serde_derive` from source, an override is provided via:
+
+- `derive_compiled` feature in `serde`
+- `compiled` feature in `serde_derive`
+
 ## Getting help
 
 Serde is one of the most widely used Rust libraries so any place that Rustaceans

--- a/precompiled/serde_derive/Cargo.toml
+++ b/precompiled/serde_derive/Cargo.toml
@@ -17,6 +17,7 @@ rust-version = "1.56"
 [features]
 default = []
 deserialize_in_place = []
+compiled = ["proc-macro2", "quote", "syn"]
 
 [lib]
 proc-macro = true
@@ -25,6 +26,11 @@ proc-macro = true
 proc-macro2 = "1"
 quote = "1"
 syn = "2.0.28"
+
+[dependencies]
+proc-macro2 = { version = "1", optional = true }
+quote = { version = "1", optional = true }
+syn = { version = "2.0.28", optional = true }
 
 [dev-dependencies]
 serde = { version = "1", path = "../../serde" }

--- a/precompiled/serde_derive/src/lib.rs
+++ b/precompiled/serde_derive/src/lib.rs
@@ -15,8 +15,14 @@
 
 #![doc(html_root_url = "https://docs.rs/serde_derive/1.0.183")]
 
-#[cfg(not(all(target_arch = "x86_64", target_os = "linux", target_env = "gnu")))]
+#[cfg(any(
+    feature = "compiled",
+    not(all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"))
+))]
 include!("lib_from_source.rs");
 
-#[cfg(all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"))]
+#[cfg(not(any(
+    feature = "compiled",
+    not(all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"))
+)))]
 include!("lib_precompiled.rs");

--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -40,6 +40,9 @@ default = ["std"]
 # Provide derive(Serialize, Deserialize) macros.
 derive = ["serde_derive"]
 
+# Force full compilation of serde_derive
+derive_compiled = ["serde_derive/compiled"]
+
 # Provide impls for common standard library types like Vec<T> and HashMap<K, V>.
 # Requires a dependency on the Rust standard library.
 std = []

--- a/serde_derive/Cargo.toml
+++ b/serde_derive/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = "1.56"
 [features]
 default = []
 deserialize_in_place = []
+compiled = []
 
 [lib]
 name = "serde_derive"


### PR DESCRIPTION
I love idea of [watt](https://github.com/dtolnay/watt) and I believe it would be good addition to cargo/crate.io, but we are not there yet. So until then let's make everybody happy and provide non-default option for full compilation of serde_derive for those who want/need it.

Resolves https://github.com/serde-rs/serde/issues/2538

#### Deprecation plan

When this feature becomes obsolete (when cargo introduces precompiled macros) it should become nop to prevent SemVer breakage. 