### PR TITLE
Fix: Use `&[T]` instead of `&Vec<T>` wherever possible

### DIFF
--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -710,7 +710,7 @@ fn serialize_adjacently_tagged_variant(
     });
 
     let fields_ty = variant.fields.iter().map(|f| &f.ty);
-    let fields_ident: &Vec<_> = &match variant.style {
+    let fields_ident: &[_] = &match variant.style {
         Style::Unit => {
             if variant.attrs.serialize_with().is_some() {
                 vec![]

--- a/test_suite/tests/test_gen.rs
+++ b/test_suite/tests/test_gen.rs
@@ -843,7 +843,7 @@ pub fn is_zero(n: &u8) -> bool {
     *n == 0
 }
 
-fn vec_first_element<T, S>(vec: &Vec<T>, serializer: S) -> StdResult<S::Ok, S::Error>
+fn vec_first_element<T, S>(vec: &[T], serializer: S) -> StdResult<S::Ok, S::Error>
 where
     T: Serialize,
     S: Serializer,


### PR DESCRIPTION
Found a few places where `&Vec<T>` is used and could be swapped with `&[T]`.
