### PR TITLE
Duplicate the serde_derive dependency version in one fewer place

### DIFF
--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/serde-rs/serde"
 rust-version = "1.31"
 
 [dependencies]
-serde_derive = { version = "=1.0.185", optional = true, path = "../serde_derive" }
+serde_derive = { version = "1", optional = true, path = "../serde_derive" }
 
 [dev-dependencies]
 serde_derive = { version = "1", path = "../serde_derive" }


### PR DESCRIPTION
Followup to #2588.

The "=1.0.185" under `target.'cfg(any())'.dependencies` should be enough to constrain the versions.