### PR TITLE
Adopt new Cargo feature resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "serde_derive_internals",
     "test_suite",
 ]
+resolver = "2"
 
 [patch.crates-io]
 serde = { path = "serde" }


### PR DESCRIPTION
This makes the git repository incompatible with Rust 1.45 through 1.50, as `resolver` was introduced unstably in 1.45 and stabilized in 1.51. But that's fine and the published serde crate won't be affected.