### PR TITLE
"cannot infer type" from Deserialize derive macro with simple variants and untagged variants

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1737,7 +1737,6 @@ fn deserialize_untagged_enum_after(
                 quote!(__deserializer),
             ))
         });
-    let attempts = first_attempt.into_iter().chain(attempts);
     // TODO this message could be better by saving the errors from the failed
     // attempts. The heuristic used by TOML was to count the number of fields
     // processed before an error, and use the error that happened after the
@@ -1750,10 +1749,19 @@ fn deserialize_untagged_enum_after(
     );
     let fallthrough_msg = cattrs.expecting().unwrap_or(&fallthrough_msg);
 
+    // This may be infallible so we need to provide the error type.
+    let first_attempt = first_attempt.map(|expr| {
+        quote! {
+            if let _serde::__private::Result::<_, __D::Error>::Ok(__ok) = #expr {
+                return _serde::__private::Ok(__ok);
+            }
+        }
+    });
     quote_block! {
         let __content = <_serde::__private::de::Content as _serde::Deserialize>::deserialize(__deserializer)?;
         let __deserializer = _serde::__private::de::ContentRefDeserializer::<__D::Error>::new(&__content);
 
+        #first_attempt
         #(
             if let _serde::__private::Ok(__ok) = #attempts {
                 return _serde::__private::Ok(__ok);

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1749,10 +1749,14 @@ fn deserialize_untagged_enum_after(
     );
     let fallthrough_msg = cattrs.expecting().unwrap_or(&fallthrough_msg);
 
-    // This may be infallible so we need to provide the error type.
+    // Ignore any error associated with non-untagged deserialization so that we
+    // can fall through to the untagged variants. This may be infallible so we
+    // need to provide the error type.
     let first_attempt = first_attempt.map(|expr| {
         quote! {
-            if let _serde::__private::Result::<_, __D::Error>::Ok(__ok) = #expr {
+            if let _serde::__private::Result::<_, __D::Error>::Ok(__ok) = (|| {
+                #expr
+            })() {
                 return _serde::__private::Ok(__ok);
             }
         }

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -2381,7 +2381,7 @@ fn test_partially_untagged_enum_desugared() {
 }
 
 #[test]
-fn test_partially_untagged_tagged_enum() {
+fn test_partially_untagged_internally_tagged_enum() {
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
     #[serde(tag = "t")]
     enum Data {
@@ -2408,17 +2408,20 @@ fn test_partially_untagged_tagged_enum() {
     assert_de_tokens(&data, &[Token::U32(42)]);
 
     // TODO test error output
+}
 
+#[test]
+fn test_partially_untagged_adjacently_tagged_enum() {
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
     #[serde(tag = "t", content = "c")]
-    enum Data2 {
+    enum Data {
         A(u32),
         B,
         #[serde(untagged)]
         Var(u32),
     }
 
-    let data = Data2::A(7);
+    let data = Data::A(7);
 
     assert_de_tokens(
         &data,
@@ -2432,7 +2435,7 @@ fn test_partially_untagged_tagged_enum() {
         ],
     );
 
-    let data = Data2::Var(42);
+    let data = Data::Var(42);
 
     assert_de_tokens(&data, &[Token::U32(42)]);
 

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -2381,6 +2381,30 @@ fn test_partially_untagged_enum_desugared() {
 }
 
 #[test]
+fn test_partially_untagged_simple_enum() {
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    #[serde(tag = "tag")]
+    enum Data {
+        A,
+        #[serde(untagged)]
+        Var(u32),
+    }
+
+    let data = Data::A;
+    assert_tokens(
+        &data,
+        &[
+            Token::Map { len: None },
+            Token::Str("t"),
+            Token::Str("A"),
+            Token::Str("b"),
+            Token::I32(0),
+            Token::MapEnd,
+        ],
+    );
+}
+
+#[test]
 fn test_flatten_option() {
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
     struct Outer {

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -2381,11 +2381,12 @@ fn test_partially_untagged_enum_desugared() {
 }
 
 #[test]
-fn test_partially_untagged_simple_enum() {
+fn test_partially_untagged_tagged_enum() {
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
     #[serde(tag = "t")]
     enum Data {
         A,
+        B,
         #[serde(untagged)]
         Var(u32),
     }
@@ -2398,11 +2399,44 @@ fn test_partially_untagged_simple_enum() {
             Token::Map { len: None },
             Token::Str("t"),
             Token::Str("A"),
-            Token::Str("b"),
-            Token::I32(0),
             Token::MapEnd,
         ],
     );
+
+    let data = Data::Var(42);
+
+    assert_de_tokens(&data, &[Token::U32(42)]);
+
+    // TODO test error output
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    #[serde(tag = "t", content = "c")]
+    enum Data2 {
+        A(u32),
+        B,
+        #[serde(untagged)]
+        Var(u32),
+    }
+
+    let data = Data2::A(7);
+
+    assert_de_tokens(
+        &data,
+        &[
+            Token::Map { len: None },
+            Token::Str("t"),
+            Token::Str("A"),
+            Token::Str("c"),
+            Token::U32(7),
+            Token::MapEnd,
+        ],
+    );
+
+    let data = Data2::Var(42);
+
+    assert_de_tokens(&data, &[Token::U32(42)]);
+
+    // TODO test error output
 }
 
 #[test]

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -2383,7 +2383,7 @@ fn test_partially_untagged_enum_desugared() {
 #[test]
 fn test_partially_untagged_simple_enum() {
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
-    #[serde(tag = "tag")]
+    #[serde(tag = "t")]
     enum Data {
         A,
         #[serde(untagged)]
@@ -2391,7 +2391,8 @@ fn test_partially_untagged_simple_enum() {
     }
 
     let data = Data::A;
-    assert_tokens(
+
+    assert_de_tokens(
         &data,
         &[
             Token::Map { len: None },


### PR DESCRIPTION
This produces an error:

```rust
    #[derive(Deserialize)]
    #[serde(tag = "t")]
    enum Data {
        A,
        #[serde(untagged)]
        Var(u32),
    }
```

```
error[[E0282]](https://doc.rust-lang.org/stable/error_codes/E0282.html): type annotations needed
 --> src/lib.rs:3:10
  |
3 | #[derive(Deserialize)]
  |          ^^^^^^^^^^^ cannot infer type
  |
  = note: this error originates in the derive macro `Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0282`.
error: could not compile `playground` (lib) due to previous error
```

My proposed fix is intended to minimize changes to code unrelated to the changes from #2403.