### PR TITLE
Add CSV to the formats list

### DIFF
--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -63,6 +63,7 @@
 //!   and from DynamoDB.
 //! - [Hjson], a syntax extension to JSON designed around human reading and
 //!   editing. *(deserialization only)*
+//! - [CSV], Comma-separated values is a tabular text file format.
 //!
 //! [JSON]: https://github.com/serde-rs/json
 //! [Postcard]: https://github.com/jamesmunns/postcard
@@ -89,6 +90,7 @@
 //! [DynamoDB Items]: https://docs.rs/serde_dynamo
 //! [rusoto_dynamodb]: https://docs.rs/rusoto_dynamodb
 //! [Hjson]: https://github.com/Canop/deser-hjson
+//! [CSV]: https://docs.rs/csv
 
 ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
The `csv` crate is from BurntSushi.