### PR TITLE
SERDE-1 - Warning on unused attributes

### DIFF
--- a/serde_derive/Cargo.toml
+++ b/serde_derive/Cargo.toml
@@ -15,6 +15,8 @@ rust-version = "1.56"
 [features]
 default = []
 deserialize_in_place = []
+# Provide impls for types that require unstable functionality e.g compile warnings
+unstable = []
 
 [lib]
 name = "serde_derive"

--- a/serde_derive/src/internals/ast.rs
+++ b/serde_derive/src/internals/ast.rs
@@ -65,6 +65,7 @@ impl<'a> Container<'a> {
     ) -> Option<Container<'a>> {
         let mut attrs = attr::Container::from_ast(cx, item);
 
+        #[cfg(feature = "unstable")]
         let into_used = if let Some(_) = attrs.type_into() {
             true
         } else {
@@ -76,12 +77,13 @@ impl<'a> Container<'a> {
             syn::Data::Struct(data) => {
                 let (style, fields) = struct_from_ast(cx, &data.fields, None, attrs.default());
 
+                #[cfg(feature = "unstable")]
                 if into_used == true {
                     for field in fields.iter() {
                         if !field.original.attrs.is_empty() {
                             field.original.ident.clone().unwrap().span().unwrap()
-                            .warning("#[serde(into)] container attribute will invalidate all field attributes")
-                            .emit();
+                                .warning("#[serde(into)] container attribute will invalidate all field attributes")
+                                .emit();
                         }
                     }
                 }

--- a/serde_derive/src/lib.rs
+++ b/serde_derive/src/lib.rs
@@ -61,7 +61,7 @@
     clippy::wildcard_imports
 )]
 #![cfg_attr(all(test, exhaustive), feature(non_exhaustive_omitted_patterns_lint))]
-#![feature(proc_macro_diagnostic)]
+#![cfg_attr(feature = "unstable", feature(proc_macro_diagnostic))]
 extern crate proc_macro2;
 extern crate quote;
 extern crate syn;

--- a/serde_derive/src/lib.rs
+++ b/serde_derive/src/lib.rs
@@ -61,7 +61,7 @@
     clippy::wildcard_imports
 )]
 #![cfg_attr(all(test, exhaustive), feature(non_exhaustive_omitted_patterns_lint))]
-
+#![feature(proc_macro_diagnostic)]
 extern crate proc_macro2;
 extern crate quote;
 extern crate syn;

--- a/serde_derive_internals/Cargo.toml
+++ b/serde_derive_internals/Cargo.toml
@@ -15,7 +15,8 @@ rust-version = "1.56"
 path = "lib.rs"
 
 [dependencies]
-proc-macro2 = "1.0"
+# nightly version supports #![feature(proc_macro_diagnostic)]
+proc-macro2 = { version = "1.0", features = ["nightly"] }
 quote = "1.0"
 syn = { version = "2.0.28", default-features = false, features = ["clone-impls", "derive", "parsing", "printing"] }
 

--- a/serde_derive_internals/Cargo.toml
+++ b/serde_derive_internals/Cargo.toml
@@ -15,8 +15,7 @@ rust-version = "1.56"
 path = "lib.rs"
 
 [dependencies]
-# nightly version supports #![feature(proc_macro_diagnostic)]
-proc-macro2 = { version = "1.0", features = ["nightly"] }
+proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0.28", default-features = false, features = ["clone-impls", "derive", "parsing", "printing"] }
 

--- a/serde_derive_internals/lib.rs
+++ b/serde_derive_internals/lib.rs
@@ -37,7 +37,7 @@
     clippy::unused_self,
     clippy::wildcard_imports
 )]
-
+#![feature(proc_macro_diagnostic)]
 extern crate proc_macro2;
 extern crate quote;
 extern crate syn;

--- a/serde_derive_internals/lib.rs
+++ b/serde_derive_internals/lib.rs
@@ -37,7 +37,7 @@
     clippy::unused_self,
     clippy::wildcard_imports
 )]
-#![feature(proc_macro_diagnostic)]
+#![cfg_attr(feature = "unstable", feature(proc_macro_diagnostic))]
 extern crate proc_macro2;
 extern crate quote;
 extern crate syn;


### PR DESCRIPTION
Closes #2491 

## Fix: Added a compile time warning.
A compile-time warning is displayed when the `into` container attribute is used with other field attributes. [Link to a test program](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=b0b05ac54f3065e553d425a3277ae405).

In order to emit a compile-time warning, the `#![feature(proc_macro_diagnostic)]` was added to the `lib.rs` files. This required the use of `proc-macro2` nightly features.
```xml
[dependencies]
# nightly version supports #![feature(proc_macro_diagnostic)]
proc-macro2 = { version = "1.0", features = ["nightly"] }
```

Sample of warning issued:
```rust
warning: #[serde(into)] container attribute will invalidate all field attributes
 --> demo\src\main.rs:8:5
  |
8 |     field_1: usize,
  |     ^^^^^^^

warning: `demo` (bin "demo") generated 1 warning
```

___

Do we need test for this?
