### PR TITLE
Disallow deserialization of struct and struct variant with named fields from sequence

### DIFF
--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -2963,33 +2963,6 @@ mod flatten {
             }
 
             // Reaches crate::private::de::content::VariantDeserializer::struct_variant
-            // Content::Seq case
-            // via FlatMapDeserializer::deserialize_enum
-            #[test]
-            fn struct_from_seq() {
-                assert_de_tokens(
-                    &Flatten {
-                        data: Enum::Struct {
-                            index: 0,
-                            value: 42,
-                        },
-                        extra: HashMap::from_iter([("extra_key".into(), "extra value".into())]),
-                    },
-                    &[
-                        Token::Map { len: None },
-                        Token::Str("Struct"), // variant
-                        Token::Seq { len: Some(2) },
-                        Token::U32(0),  // index
-                        Token::U32(42), // value
-                        Token::SeqEnd,
-                        Token::Str("extra_key"),
-                        Token::Str("extra value"),
-                        Token::MapEnd,
-                    ],
-                );
-            }
-
-            // Reaches crate::private::de::content::VariantDeserializer::struct_variant
             // Content::Map case
             // via FlatMapDeserializer::deserialize_enum
             #[test]

--- a/test_suite/tests/test_de.rs
+++ b/test_suite/tests/test_de.rs
@@ -1381,15 +1381,6 @@ fn test_struct() {
             Token::StructEnd,
         ],
     );
-    test(
-        Struct { a: 1, b: 2, c: 0 },
-        &[
-            Token::Seq { len: Some(3) },
-            Token::I32(1),
-            Token::I32(2),
-            Token::SeqEnd,
-        ],
-    );
 }
 
 #[test]

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -714,16 +714,6 @@ fn test_internally_tagged_enum() {
         ],
     );
 
-    assert_de_tokens(
-        &InternallyTagged::A { a: 1 },
-        &[
-            Token::Seq { len: Some(2) },
-            Token::Str("A"),
-            Token::U8(1),
-            Token::SeqEnd,
-        ],
-    );
-
     assert_tokens(
         &InternallyTagged::B,
         &[
@@ -785,16 +775,6 @@ fn test_internally_tagged_enum() {
             Token::Str("f"),
             Token::U8(6),
             Token::StructEnd,
-        ],
-    );
-
-    assert_de_tokens(
-        &InternallyTagged::E(Struct { f: 6 }),
-        &[
-            Token::Seq { len: Some(2) },
-            Token::Str("E"),
-            Token::U8(6),
-            Token::SeqEnd,
         ],
     );
 
@@ -1011,16 +991,6 @@ fn test_internally_tagged_struct_variant_containing_unit_variant() {
             Token::Str("level"),
             Token::BorrowedStr("Info"),
             Token::MapEnd,
-        ],
-    );
-
-    assert_de_tokens(
-        &Message::Log { level: Level::Info },
-        &[
-            Token::Seq { len: Some(2) },
-            Token::Str("Log"),
-            Token::BorrowedStr("Info"),
-            Token::SeqEnd,
         ],
     );
 }
@@ -1521,23 +1491,6 @@ fn test_enum_in_internally_tagged_enum() {
             Token::Str("f"),
             Token::U8(1),
             Token::StructEnd,
-            Token::MapEnd,
-        ],
-    );
-
-    // Reaches crate::private::de::content::VariantDeserializer::struct_variant
-    // Content::Seq case
-    // via ContentDeserializer::deserialize_enum
-    assert_de_tokens(
-        &Outer::Inner(Inner::Struct { f: 1 }),
-        &[
-            Token::Map { len: Some(2) },
-            Token::Str("type"),
-            Token::Str("Inner"),
-            Token::Str("Struct"),
-            Token::Seq { len: Some(1) },
-            Token::U8(1), // f
-            Token::SeqEnd,
             Token::MapEnd,
         ],
     );


### PR DESCRIPTION
Fixes #1587. In contrast to #2639, this PR includes breaking changes and would need a new major version.