### PR TITLE
Add "space case" & "SCREAMING SPACE CASE" rename rules

### DIFF
--- a/serde_derive/src/internals/case.rs
+++ b/serde_derive/src/internals/case.rs
@@ -28,6 +28,8 @@ pub enum RenameRule {
     KebabCase,
     /// Rename direct children to "SCREAMING-KEBAB-CASE" style.
     ScreamingKebabCase,
+    /// Rename direct children to "SCREAMING SPACE CASE" style.
+    ScreamingSpaceCase,
 }
 
 static RENAME_RULES: &[(&str, RenameRule)] = &[
@@ -39,6 +41,7 @@ static RENAME_RULES: &[(&str, RenameRule)] = &[
     ("SCREAMING_SNAKE_CASE", ScreamingSnakeCase),
     ("kebab-case", KebabCase),
     ("SCREAMING-KEBAB-CASE", ScreamingKebabCase),
+    ("SCREAMING SPACE CASE", ScreamingSpaceCase),
 ];
 
 impl RenameRule {
@@ -75,6 +78,9 @@ impl RenameRule {
             ScreamingKebabCase => ScreamingSnakeCase
                 .apply_to_variant(variant)
                 .replace('_', "-"),
+            ScreamingSpaceCase => ScreamingSnakeCase
+                .apply_to_variant(variant)
+                .replace('_', " "),
         }
     }
 
@@ -105,6 +111,7 @@ impl RenameRule {
             ScreamingSnakeCase => field.to_ascii_uppercase(),
             KebabCase => field.replace('_', "-"),
             ScreamingKebabCase => ScreamingSnakeCase.apply_to_field(field).replace('_', "-"),
+            ScreamingSpaceCase => ScreamingSnakeCase.apply_to_field(field).replace('_', " "),
         }
     }
 
@@ -138,9 +145,20 @@ impl<'a> Display for ParseError<'a> {
 
 #[test]
 fn rename_variants() {
-    for &(original, lower, upper, camel, snake, screaming, kebab, screaming_kebab) in &[
+    for &(
+        original,
+        lower,
+        upper,
+        camel,
+        snake,
+        screaming,
+        kebab,
+        screaming_kebab,
+        screaming_space,
+    ) in &[
         (
             "Outcome", "outcome", "OUTCOME", "outcome", "outcome", "OUTCOME", "outcome", "OUTCOME",
+            "OUTCOME",
         ),
         (
             "VeryTasty",
@@ -151,9 +169,12 @@ fn rename_variants() {
             "VERY_TASTY",
             "very-tasty",
             "VERY-TASTY",
+            "VERY TASTY",
         ),
-        ("A", "a", "A", "a", "a", "A", "a", "A"),
-        ("Z42", "z42", "Z42", "z42", "z42", "Z42", "z42", "Z42"),
+        ("A", "a", "A", "a", "a", "A", "a", "A", "A"),
+        (
+            "Z42", "z42", "Z42", "z42", "z42", "Z42", "z42", "Z42", "Z42",
+        ),
     ] {
         assert_eq!(None.apply_to_variant(original), original);
         assert_eq!(LowerCase.apply_to_variant(original), lower);
@@ -167,14 +188,18 @@ fn rename_variants() {
             ScreamingKebabCase.apply_to_variant(original),
             screaming_kebab
         );
+        assert_eq!(
+            ScreamingSpaceCase.apply_to_variant(original),
+            screaming_space
+        );
     }
 }
 
 #[test]
 fn rename_fields() {
-    for &(original, upper, pascal, camel, screaming, kebab, screaming_kebab) in &[
+    for &(original, upper, pascal, camel, screaming, kebab, screaming_kebab, screaming_space) in &[
         (
-            "outcome", "OUTCOME", "Outcome", "outcome", "OUTCOME", "outcome", "OUTCOME",
+            "outcome", "OUTCOME", "Outcome", "outcome", "OUTCOME", "outcome", "OUTCOME", "OUTCOME",
         ),
         (
             "very_tasty",
@@ -184,9 +209,10 @@ fn rename_fields() {
             "VERY_TASTY",
             "very-tasty",
             "VERY-TASTY",
+            "VERY TASTY",
         ),
-        ("a", "A", "A", "a", "A", "a", "A"),
-        ("z42", "Z42", "Z42", "z42", "Z42", "z42", "Z42"),
+        ("a", "A", "A", "a", "A", "a", "A", "A"),
+        ("z42", "Z42", "Z42", "z42", "Z42", "z42", "Z42", "Z42"),
     ] {
         assert_eq!(None.apply_to_field(original), original);
         assert_eq!(UpperCase.apply_to_field(original), upper);
@@ -196,5 +222,6 @@ fn rename_fields() {
         assert_eq!(ScreamingSnakeCase.apply_to_field(original), screaming);
         assert_eq!(KebabCase.apply_to_field(original), kebab);
         assert_eq!(ScreamingKebabCase.apply_to_field(original), screaming_kebab);
+        assert_eq!(ScreamingSpaceCase.apply_to_field(original), screaming_space);
     }
 }

--- a/serde_derive/src/internals/case.rs
+++ b/serde_derive/src/internals/case.rs
@@ -28,6 +28,8 @@ pub enum RenameRule {
     KebabCase,
     /// Rename direct children to "SCREAMING-KEBAB-CASE" style.
     ScreamingKebabCase,
+    /// Rename direct children to "space case" style.
+    SpaceCase,
     /// Rename direct children to "SCREAMING SPACE CASE" style.
     ScreamingSpaceCase,
 }
@@ -41,6 +43,7 @@ static RENAME_RULES: &[(&str, RenameRule)] = &[
     ("SCREAMING_SNAKE_CASE", ScreamingSnakeCase),
     ("kebab-case", KebabCase),
     ("SCREAMING-KEBAB-CASE", ScreamingKebabCase),
+    ("space case", SpaceCase),
     ("SCREAMING SPACE CASE", ScreamingSpaceCase),
 ];
 
@@ -78,6 +81,7 @@ impl RenameRule {
             ScreamingKebabCase => ScreamingSnakeCase
                 .apply_to_variant(variant)
                 .replace('_', "-"),
+            SpaceCase => SnakeCase.apply_to_variant(variant).replace('_', " "),
             ScreamingSpaceCase => ScreamingSnakeCase
                 .apply_to_variant(variant)
                 .replace('_', " "),
@@ -111,6 +115,7 @@ impl RenameRule {
             ScreamingSnakeCase => field.to_ascii_uppercase(),
             KebabCase => field.replace('_', "-"),
             ScreamingKebabCase => ScreamingSnakeCase.apply_to_field(field).replace('_', "-"),
+            SpaceCase => SnakeCase.apply_to_field(field).replace('_', " "),
             ScreamingSpaceCase => ScreamingSnakeCase.apply_to_field(field).replace('_', " "),
         }
     }
@@ -154,11 +159,12 @@ fn rename_variants() {
         screaming,
         kebab,
         screaming_kebab,
+        space,
         screaming_space,
     ) in &[
         (
             "Outcome", "outcome", "OUTCOME", "outcome", "outcome", "OUTCOME", "outcome", "OUTCOME",
-            "OUTCOME",
+            "outcome", "OUTCOME",
         ),
         (
             "VeryTasty",
@@ -169,11 +175,12 @@ fn rename_variants() {
             "VERY_TASTY",
             "very-tasty",
             "VERY-TASTY",
+            "very tasty",
             "VERY TASTY",
         ),
-        ("A", "a", "A", "a", "a", "A", "a", "A", "A"),
+        ("A", "a", "A", "a", "a", "A", "a", "A", "a", "A"),
         (
-            "Z42", "z42", "Z42", "z42", "z42", "Z42", "z42", "Z42", "Z42",
+            "Z42", "z42", "Z42", "z42", "z42", "Z42", "z42", "Z42", "Z42", "Z42",
         ),
     ] {
         assert_eq!(None.apply_to_variant(original), original);
@@ -188,6 +195,7 @@ fn rename_variants() {
             ScreamingKebabCase.apply_to_variant(original),
             screaming_kebab
         );
+        assert_eq!(SpaceCase.apply_to_variant(original), space);
         assert_eq!(
             ScreamingSpaceCase.apply_to_variant(original),
             screaming_space
@@ -197,9 +205,20 @@ fn rename_variants() {
 
 #[test]
 fn rename_fields() {
-    for &(original, upper, pascal, camel, screaming, kebab, screaming_kebab, screaming_space) in &[
+    for &(
+        original,
+        upper,
+        pascal,
+        camel,
+        screaming,
+        kebab,
+        screaming_kebab,
+        space,
+        screaming_space,
+    ) in &[
         (
-            "outcome", "OUTCOME", "Outcome", "outcome", "OUTCOME", "outcome", "OUTCOME", "OUTCOME",
+            "outcome", "OUTCOME", "Outcome", "outcome", "OUTCOME", "outcome", "OUTCOME", "outcome",
+            "OUTCOME",
         ),
         (
             "very_tasty",
@@ -209,10 +228,13 @@ fn rename_fields() {
             "VERY_TASTY",
             "very-tasty",
             "VERY-TASTY",
+            "very tasty",
             "VERY TASTY",
         ),
-        ("a", "A", "A", "a", "A", "a", "A", "A"),
-        ("z42", "Z42", "Z42", "z42", "Z42", "z42", "Z42", "Z42"),
+        ("a", "A", "A", "a", "A", "a", "A", "a", "A"),
+        (
+            "z42", "Z42", "Z42", "z42", "Z42", "z42", "Z42", "Z42", "Z42",
+        ),
     ] {
         assert_eq!(None.apply_to_field(original), original);
         assert_eq!(UpperCase.apply_to_field(original), upper);
@@ -222,6 +244,7 @@ fn rename_fields() {
         assert_eq!(ScreamingSnakeCase.apply_to_field(original), screaming);
         assert_eq!(KebabCase.apply_to_field(original), kebab);
         assert_eq!(ScreamingKebabCase.apply_to_field(original), screaming_kebab);
+        assert_eq!(SpaceCase.apply_to_field(original), space);
         assert_eq!(ScreamingSpaceCase.apply_to_field(original), screaming_space);
     }
 }

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -2006,6 +2006,20 @@ fn test_rename_all() {
         serialize_seq: bool,
     }
 
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    #[serde(rename_all = "space case")]
+    struct Space {
+        serialize: bool,
+        serialize_seq: bool,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    #[serde(rename_all = "SCREAMING SPACE CASE")]
+    struct ScreamingSpace {
+        serialize: bool,
+        serialize_seq: bool,
+    }
+
     assert_tokens(
         &E::Serialize {
             serialize: true,
@@ -2091,6 +2105,42 @@ fn test_rename_all() {
             Token::Str("SERIALIZE"),
             Token::Bool(true),
             Token::Str("SERIALIZE-SEQ"),
+            Token::Bool(true),
+            Token::StructEnd,
+        ],
+    );
+
+    assert_tokens(
+        &Space {
+            serialize: true,
+            serialize_seq: true,
+        },
+        &[
+            Token::Struct {
+                name: "Space",
+                len: 2,
+            },
+            Token::Str("serialize"),
+            Token::Bool(true),
+            Token::Str("serialize seq"),
+            Token::Bool(true),
+            Token::StructEnd,
+        ],
+    );
+
+    assert_tokens(
+        &ScreamingSpace {
+            serialize: true,
+            serialize_seq: true,
+        },
+        &[
+            Token::Struct {
+                name: "ScreamingSpace",
+                len: 2,
+            },
+            Token::Str("SERIALIZE"),
+            Token::Bool(true),
+            Token::Str("SERIALIZE SEQ"),
             Token::Bool(true),
             Token::StructEnd,
         ],

--- a/test_suite/tests/ui/rename/container_unknown_rename_rule.stderr
+++ b/test_suite/tests/ui/rename/container_unknown_rename_rule.stderr
@@ -1,4 +1,4 @@
-error: unknown rename rule `rename_all = "abc"`, expected one of "lowercase", "UPPERCASE", "PascalCase", "camelCase", "snake_case", "SCREAMING_SNAKE_CASE", "kebab-case", "SCREAMING-KEBAB-CASE", "SCREAMING SPACE CASE"
+error: unknown rename rule `rename_all = "abc"`, expected one of "lowercase", "UPPERCASE", "PascalCase", "camelCase", "snake_case", "SCREAMING_SNAKE_CASE", "kebab-case", "SCREAMING-KEBAB-CASE", "space case", "SCREAMING SPACE CASE"
  --> tests/ui/rename/container_unknown_rename_rule.rs:4:22
   |
 4 | #[serde(rename_all = "abc")]

--- a/test_suite/tests/ui/rename/container_unknown_rename_rule.stderr
+++ b/test_suite/tests/ui/rename/container_unknown_rename_rule.stderr
@@ -1,4 +1,4 @@
-error: unknown rename rule `rename_all = "abc"`, expected one of "lowercase", "UPPERCASE", "PascalCase", "camelCase", "snake_case", "SCREAMING_SNAKE_CASE", "kebab-case", "SCREAMING-KEBAB-CASE"
+error: unknown rename rule `rename_all = "abc"`, expected one of "lowercase", "UPPERCASE", "PascalCase", "camelCase", "snake_case", "SCREAMING_SNAKE_CASE", "kebab-case", "SCREAMING-KEBAB-CASE", "SCREAMING SPACE CASE"
  --> tests/ui/rename/container_unknown_rename_rule.rs:4:22
   |
 4 | #[serde(rename_all = "abc")]

--- a/test_suite/tests/ui/rename/variant_unknown_rename_rule.stderr
+++ b/test_suite/tests/ui/rename/variant_unknown_rename_rule.stderr
@@ -1,4 +1,4 @@
-error: unknown rename rule `rename_all = "abc"`, expected one of "lowercase", "UPPERCASE", "PascalCase", "camelCase", "snake_case", "SCREAMING_SNAKE_CASE", "kebab-case", "SCREAMING-KEBAB-CASE"
+error: unknown rename rule `rename_all = "abc"`, expected one of "lowercase", "UPPERCASE", "PascalCase", "camelCase", "snake_case", "SCREAMING_SNAKE_CASE", "kebab-case", "SCREAMING-KEBAB-CASE", "SCREAMING SPACE CASE"
  --> tests/ui/rename/variant_unknown_rename_rule.rs:5:26
   |
 5 |     #[serde(rename_all = "abc")]

--- a/test_suite/tests/ui/rename/variant_unknown_rename_rule.stderr
+++ b/test_suite/tests/ui/rename/variant_unknown_rename_rule.stderr
@@ -1,4 +1,4 @@
-error: unknown rename rule `rename_all = "abc"`, expected one of "lowercase", "UPPERCASE", "PascalCase", "camelCase", "snake_case", "SCREAMING_SNAKE_CASE", "kebab-case", "SCREAMING-KEBAB-CASE", "SCREAMING SPACE CASE"
+error: unknown rename rule `rename_all = "abc"`, expected one of "lowercase", "UPPERCASE", "PascalCase", "camelCase", "snake_case", "SCREAMING_SNAKE_CASE", "kebab-case", "SCREAMING-KEBAB-CASE", "space case", "SCREAMING SPACE CASE"
  --> tests/ui/rename/variant_unknown_rename_rule.rs:5:26
   |
 5 |     #[serde(rename_all = "abc")]


### PR DESCRIPTION
Add a two new `RenameRule` variants to handle "space case" and "SCREAMING SPACE CASE".