### PR TITLE
Remove option_if_let_else clippy suppression

### DIFF
--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -122,7 +122,6 @@
     // things are often more readable this way
     clippy::cast_lossless,
     clippy::module_name_repetitions,
-    clippy::option_if_let_else,
     clippy::single_match_else,
     clippy::type_complexity,
     clippy::use_self,

--- a/serde_derive/src/lib.rs
+++ b/serde_derive/src/lib.rs
@@ -50,7 +50,6 @@
     clippy::match_wildcard_for_single_variants,
     clippy::module_name_repetitions,
     clippy::must_use_candidate,
-    clippy::option_if_let_else,
     clippy::similar_names,
     clippy::single_match_else,
     clippy::struct_excessive_bools,


### PR DESCRIPTION
This lint got downgraded from `pedantic` to `nursery` by https://github.com/rust-lang/rust-clippy/pull/7568 so we no longer run it.