### PR TITLE
Adding workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,8 @@ members = [
 
 [patch.crates-io]
 serde = { path = "serde" }
+
+[workspace.dependencies]
+syn = "2.0.46"
+quote = "1.0.35"
+proc-macro2 = "1.0.74"

--- a/serde_derive/Cargo.toml
+++ b/serde_derive/Cargo.toml
@@ -21,9 +21,9 @@ name = "serde_derive"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.74"
-quote = "1.0.35"
-syn = "2.0.46"
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }
 
 [dev-dependencies]
 serde = { version = "1", path = "../serde" }

--- a/serde_derive_internals/Cargo.toml
+++ b/serde_derive_internals/Cargo.toml
@@ -15,9 +15,9 @@ rust-version = "1.56"
 path = "lib.rs"
 
 [dependencies]
-proc-macro2 = "1.0.74"
-quote = "1.0.35"
-syn = { version = "2.0.46", default-features = false, features = ["clone-impls", "derive", "parsing", "printing"] }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true, default-features = false, features = ["clone-impls", "derive", "parsing", "printing"] }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
I've only added the dependencies as workspace dependencies to make it easier to maintain from now on.

I've executed in the `serde` directory.
```sh
$ cargo test --features derive
```

And in the `test_suite`:
```sh
cargo +nightly test --features unstable
```

Both worked fine.

As required in the https://github.com/serde-rs/serde/blob/111803ab0768d010c606f2fc0d0add12750d5eef/CONTRIBUTING.md