### PR TITLE
Format invalid float message to show at least one decimal place

### DIFF
--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -402,7 +402,7 @@ impl<'a> fmt::Display for Unexpected<'a> {
             Bool(b) => write!(formatter, "boolean `{}`", b),
             Unsigned(i) => write!(formatter, "integer `{}`", i),
             Signed(i) => write!(formatter, "integer `{}`", i),
-            Float(f) => write!(formatter, "floating point `{}`", f),
+            Float(f) => write!(formatter, "floating point `{:.1}`", f),
             Char(c) => write!(formatter, "character `{}`", c),
             Str(s) => write!(formatter, "string {:?}", s),
             Bytes(_) => write!(formatter, "byte array"),

--- a/test_suite/tests/test_de_error.rs
+++ b/test_suite/tests/test_de_error.rs
@@ -1434,7 +1434,7 @@ fn test_number_from_string() {
 fn test_integer_from_float() {
     assert_de_tokens_error::<isize>(
         &[Token::F32(0.0)],
-        "invalid type: floating point `0`, expected isize",
+        "invalid type: floating point `0.0`, expected isize",
     );
 }
 


### PR DESCRIPTION
It can be confusing at first when deserializing (e.g. JSON) and getting an error like:

> invalid type: floating point `3`, expected u32

It shows a valid integer but it is actually a float.

Changes the error to always show at least one decimal place to avoid confusion.