### PR TITLE
Fix workspace.dependencies default-features future compat warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,6 @@ members = [
 serde = { path = "serde" }
 
 [workspace.dependencies]
-proc-macro2 = "1.0.74"
-quote = "1.0.35"
-syn = "2.0.46"
+proc-macro2 = { version = "1.0.74", default-features = false }
+quote = { version = "1.0.35", default-features = false }
+syn = { version = "2.0.46", default-features = false }

--- a/serde_derive/Cargo.toml
+++ b/serde_derive/Cargo.toml
@@ -21,9 +21,9 @@ name = "serde_derive"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = { workspace = true }
-quote = { workspace = true }
-syn = { workspace = true }
+proc-macro2 = { workspace = true, features = ["proc-macro"] }
+quote = { workspace = true, features = ["proc-macro"] }
+syn = { workspace = true, features = ["clone-impls", "derive", "parsing", "printing", "proc-macro"] }
 
 [dev-dependencies]
 serde = { version = "1", path = "../serde" }

--- a/serde_derive_internals/Cargo.toml
+++ b/serde_derive_internals/Cargo.toml
@@ -17,7 +17,7 @@ path = "lib.rs"
 [dependencies]
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
-syn = { workspace = true, default-features = false, features = ["clone-impls", "derive", "parsing", "printing"] }
+syn = { workspace = true, features = ["clone-impls", "derive", "parsing", "printing"] }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
Since #2678 all Cargo commands have been reporting this warning:

```console
warning: serde_derive_internals/Cargo.toml: `default-features` is ignored for syn,
since `default-features` was not specified for `workspace.dependencies.syn`, this
could become a hard error in the future
```