### PR TITLE
Support deserializing enum values in internally/untagged enums

### DIFF
--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -206,6 +206,7 @@ mod content {
     // This issue is tracking making some of this stuff public:
     // https://github.com/serde-rs/serde/issues/741
 
+    use crate::de::VariantAccess;
     use crate::lib::*;
 
     use crate::actually_private;
@@ -249,6 +250,7 @@ mod content {
         Newtype(Box<Content<'de>>),
         Seq(Vec<Content<'de>>),
         Map(Vec<(Content<'de>, Content<'de>)>),
+        Enum(Box<(Content<'de>, Content<'de>)>),
     }
 
     impl<'de> Content<'de> {
@@ -286,6 +288,7 @@ mod content {
                 Content::Newtype(_) => Unexpected::NewtypeStruct,
                 Content::Seq(_) => Unexpected::Seq,
                 Content::Map(_) => Unexpected::Map,
+                Content::Enum(_) => Unexpected::Enum,
             }
         }
     }
@@ -510,13 +513,13 @@ mod content {
             Ok(Content::Map(vec))
         }
 
-        fn visit_enum<V>(self, _visitor: V) -> Result<Self::Value, V::Error>
+        fn visit_enum<V>(self, visitor: V) -> Result<Self::Value, V::Error>
         where
             V: EnumAccess<'de>,
         {
-            Err(de::Error::custom(
-                "untagged and internally tagged enums do not support enum input",
-            ))
+            let (variant, access) = tri!(visitor.variant());
+            let value = tri!(access.newtype_variant());
+            Ok(Content::Enum(Box::new((variant, value))))
         }
     }
 
@@ -1146,6 +1149,7 @@ mod content {
                 Content::Newtype(v) => visitor.visit_newtype_struct(ContentDeserializer::new(*v)),
                 Content::Seq(v) => visit_content_seq(v, visitor),
                 Content::Map(v) => visit_content_map(v, visitor),
+                Content::Enum(v) => visitor.visit_enum(EnumDeserializer::new(v.0, Some(v.1))),
             }
         }
 
@@ -1747,6 +1751,9 @@ mod content {
                 }
                 Content::Seq(ref v) => visit_content_seq_ref(v, visitor),
                 Content::Map(ref v) => visit_content_map_ref(v, visitor),
+                Content::Enum(ref v) => {
+                    visitor.visit_enum(EnumRefDeserializer::new(&v.0, Some(&v.1)))
+                }
             }
         }
 
@@ -2089,6 +2096,19 @@ mod content {
         variant: &'a Content<'de>,
         value: Option<&'a Content<'de>>,
         err: PhantomData<E>,
+    }
+
+    impl<'a, 'de: 'a, E> EnumRefDeserializer<'a, 'de, E>
+    where
+        E: de::Error,
+    {
+        fn new(variant: &'a Content<'de>, value: Option<&'a Content<'de>>) -> Self {
+            Self {
+                variant,
+                value,
+                err: PhantomData,
+            }
+        }
     }
 
     impl<'de, 'a, E> de::EnumAccess<'de> for EnumRefDeserializer<'a, 'de, E>


### PR DESCRIPTION
This patch adds support for deserializing enum values in internally/untagged enums. E.g.:

```rust
#[derive(Debug, Deserialize, PartialEq)]
pub enum Inner {
    A, B, C
}
#[derive(Debug, Deserialize, PartialEq)]
#[serde(tag = "type")]
pub enum Internally {
    Variant { inner: Inner },
}
```

At the moment, if the `Deserializer` _knows_ that `Inner` is an enum and calls `visit_enum` (e.g., a self-describing format that understands enums),  this error will be triggered:

https://github.com/serde-rs/serde/blob/ede9762a583c3cc3b87c10a53551828fad339525/serde/src/private/de.rs#L517-L519

I'm working around this issue by serializing the variant as a `Content` and visiting the value with `EnumAccess::newtype_variant::<Content>`.

There is no perfect solution here as the enum value could be a map, tuple, unit, etc. However, given that we're trying to deserialize arbitrary values, deserializing as a "newtype" actually makes a lot of sense:

1. Deserializers can opt-in to this fairly easily by implementing `EnumAccess::newtype_variant_seed`.
2. Types (implementing `Deserialize`) should "just work" as expected because maps, tuples, etc. are preserved.

If you're interested in this change, I can add some tests. Unfortunately, the token test logic never calls `visit_enum` from `deserialize_any`, so testing will either require implementing a custom `Deserializer` and/or modifying the token deserializer.