### PR TITLE
A few minor `write_str` optimizations

### DIFF
--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -405,17 +405,17 @@ impl<'a> fmt::Display for Unexpected<'a> {
             Float(f) => write!(formatter, "floating point `{}`", WithDecimalPoint(f)),
             Char(c) => write!(formatter, "character `{}`", c),
             Str(s) => write!(formatter, "string {:?}", s),
-            Bytes(_) => write!(formatter, "byte array"),
-            Unit => write!(formatter, "unit value"),
-            Option => write!(formatter, "Option value"),
-            NewtypeStruct => write!(formatter, "newtype struct"),
-            Seq => write!(formatter, "sequence"),
-            Map => write!(formatter, "map"),
-            Enum => write!(formatter, "enum"),
-            UnitVariant => write!(formatter, "unit variant"),
-            NewtypeVariant => write!(formatter, "newtype variant"),
-            TupleVariant => write!(formatter, "tuple variant"),
-            StructVariant => write!(formatter, "struct variant"),
+            Bytes(_) => formatter.write_str("byte array"),
+            Unit => formatter.write_str("unit value"),
+            Option => formatter.write_str("Option value"),
+            NewtypeStruct => formatter.write_str("newtype struct"),
+            Seq => formatter.write_str("sequence"),
+            Map => formatter.write_str("map"),
+            Enum => formatter.write_str("enum"),
+            UnitVariant => formatter.write_str("unit variant"),
+            NewtypeVariant => formatter.write_str("newtype variant"),
+            TupleVariant => formatter.write_str("tuple variant"),
+            StructVariant => formatter.write_str("struct variant"),
             Other(other) => formatter.write_str(other),
         }
     }
@@ -2278,10 +2278,10 @@ impl Display for OneOf {
             1 => write!(formatter, "`{}`", self.names[0]),
             2 => write!(formatter, "`{}` or `{}`", self.names[0], self.names[1]),
             _ => {
-                tri!(write!(formatter, "one of "));
+                tri!(formatter.write_str("one of "));
                 for (i, alt) in self.names.iter().enumerate() {
                     if i > 0 {
-                        tri!(write!(formatter, ", "));
+                        tri!(formatter.write_str(", "));
                     }
                     tri!(write!(formatter, "`{}`", alt));
                 }

--- a/serde/src/de/value.rs
+++ b/serde/src/de/value.rs
@@ -983,7 +983,7 @@ struct ExpectedInSeq(usize);
 impl Expected for ExpectedInSeq {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         if self.0 == 1 {
-            write!(formatter, "1 element in sequence")
+            formatter.write_str("1 element in sequence")
         } else {
             write!(formatter, "{} elements in sequence", self.0)
         }
@@ -1411,7 +1411,7 @@ struct ExpectedInMap(usize);
 impl Expected for ExpectedInMap {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         if self.0 == 1 {
-            write!(formatter, "1 element in map")
+            formatter.write_str("1 element in map")
         } else {
             write!(formatter, "{} elements in map", self.0)
         }

--- a/test_suite/tests/test_value.rs
+++ b/test_suite/tests/test_value.rs
@@ -63,7 +63,7 @@ fn test_map_access_to_enum() {
                 type Value = Potential;
 
                 fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                    write!(formatter, "a map")
+                    formatter.write_str("a map")
                 }
 
                 fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>


### PR DESCRIPTION
Apparently `write!` generates more code than `write_str` when used with a simple string, so optimizing it.