### PR TITLE
Implement `#[key = ...]`

### DIFF
--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -1871,6 +1871,25 @@ pub trait SerializeStruct {
         Ok(())
     }
 
+    /// Serialize a struct field consisting of a typed key and value.
+    ///
+    /// This method is similar to `serialize_field`, but it allows the key to be
+    /// a type that is not a string. This is useful for formats that support
+    /// non-string keys such as CBOR.
+    fn serialize_typed_field<K: ?Sized, V: ?Sized>(
+        &mut self,
+        key: &K,
+        value: &V,
+    ) -> Result<(), Self::Error>
+    where
+        K: Serialize,
+        V: Serialize,
+    {
+        let _ = key;
+        let _ = value;
+        Ok(())
+    }
+
     /// Finish serializing a struct.
     fn end(self) -> Result<Self::Ok, Self::Error>;
 }

--- a/serde_derive/src/internals/symbol.rs
+++ b/serde_derive/src/internals/symbol.rs
@@ -19,6 +19,7 @@ pub const FLATTEN: Symbol = Symbol("flatten");
 pub const FROM: Symbol = Symbol("from");
 pub const GETTER: Symbol = Symbol("getter");
 pub const INTO: Symbol = Symbol("into");
+pub const KEY: Symbol = Symbol("key");
 pub const NON_EXHAUSTIVE: Symbol = Symbol("non_exhaustive");
 pub const OTHER: Symbol = Symbol("other");
 pub const REMOTE: Symbol = Symbol("remote");

--- a/test_suite/tests/test_gen.rs
+++ b/test_suite/tests/test_gen.rs
@@ -769,6 +769,18 @@ fn test_gen() {
     #[derive(Deserialize)]
     #[serde(bound(deserialize = "[&'de str; N]: Copy"))]
     struct GenericUnitStruct<const N: usize>;
+
+    #[derive(Serialize, Deserialize)]
+    struct KeyedStruct<'se> {
+        #[serde(key = b'a')]
+        a: &'se str,
+        #[serde(key = 8)]
+        b: u16,
+        #[serde(key = 8i16)]
+        c: u32,
+        #[serde(key = 'c')]
+        d: u64,
+    }
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/test_suite/tests/ui/key/float.rs
+++ b/test_suite/tests/ui/key/float.rs
@@ -1,0 +1,9 @@
+use serde_derive::Serialize;
+
+#[derive(Serialize)]
+struct S {
+    #[serde(key = 1.1)]
+    x: (),
+}
+
+fn main() {}

--- a/test_suite/tests/ui/key/float.stderr
+++ b/test_suite/tests/ui/key/float.stderr
@@ -1,0 +1,5 @@
+error: serde key attribute cannot be a float
+ --> tests/ui/key/float.rs:5:19
+  |
+5 |     #[serde(key = 1.1)]
+  |                   ^^^

--- a/test_suite/tests/ui/key/string.rs
+++ b/test_suite/tests/ui/key/string.rs
@@ -1,0 +1,9 @@
+use serde_derive::Serialize;
+
+#[derive(Serialize)]
+struct S {
+    #[serde(key = "a")]
+    x: (),
+}
+
+fn main() {}

--- a/test_suite/tests/ui/key/string.stderr
+++ b/test_suite/tests/ui/key/string.stderr
@@ -1,0 +1,5 @@
+error: use the serde rename attribute instead
+ --> tests/ui/key/string.rs:5:19
+  |
+5 |     #[serde(key = "a")]
+  |                   ^^^

--- a/test_suite/tests/ui/key/unknown.rs
+++ b/test_suite/tests/ui/key/unknown.rs
@@ -1,0 +1,9 @@
+use serde_derive::Serialize;
+
+#[derive(Serialize)]
+struct S {
+    #[serde(key = g)]
+    x: (),
+}
+
+fn main() {}

--- a/test_suite/tests/ui/key/unknown.stderr
+++ b/test_suite/tests/ui/key/unknown.stderr
@@ -1,0 +1,5 @@
+error: expected serde key attribute to be a literal
+ --> tests/ui/key/unknown.rs:5:19
+  |
+5 |     #[serde(key = g)]
+  |                   ^


### PR DESCRIPTION
This PR implements the ability to use a limited set of literals for keys when serializing and deserializing structs. The motivation is written in https://github.com/serde-rs/serde/issues/2695.

Closes https://github.com/serde-rs/serde/issues/2695

## Limitations

 - We purposefully error for string keys since this is already supported using `rename`.
 - Floats are not supported (Rust doesn't support them for match statements and in practice, this is not done).
 - Negative keys are not supported for the time being.
 - Keys can clash if the user wants to. (Footgun?)