### PR TITLE
Document that `len` does not include skipped struct fields

### DIFF
--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -1170,7 +1170,8 @@ pub trait Serializer: Sized {
     /// then a call to `end`.
     ///
     /// The `name` is the name of the struct and the `len` is the number of
-    /// data fields that will be serialized.
+    /// data fields that will be serialized. `len` does not include fields
+    /// which are skipped with [`SerializeStruct::skip_field`].
     ///
     /// ```edition2021
     /// use serde::ser::{Serialize, SerializeStruct, Serializer};
@@ -1207,6 +1208,8 @@ pub trait Serializer: Sized {
     /// The `name` is the name of the enum, the `variant_index` is the index of
     /// this variant within the enum, the `variant` is the name of the variant,
     /// and the `len` is the number of data fields that will be serialized.
+    /// `len` does not include fields which are skipped with
+    /// [`SerializeStructVariant::skip_field`].
     ///
     /// ```edition2021
     /// use serde::ser::{Serialize, SerializeStructVariant, Serializer};
@@ -1857,6 +1860,8 @@ pub trait SerializeStruct {
         T: ?Sized + Serialize;
 
     /// Indicate that a struct field has been skipped.
+    ///
+    /// The default implementation does nothing.
     #[inline]
     fn skip_field(&mut self, key: &'static str) -> Result<(), Self::Error> {
         let _ = key;
@@ -1919,6 +1924,8 @@ pub trait SerializeStructVariant {
         T: ?Sized + Serialize;
 
     /// Indicate that a struct variant field has been skipped.
+    ///
+    /// The default implementation does nothing.
     #[inline]
     fn skip_field(&mut self, key: &'static str) -> Result<(), Self::Error> {
         let _ = key;


### PR DESCRIPTION
At least this seems to be how serde_derive behaves:
https://github.com/serde-rs/serde/blob/3f43fca90dfff4a8728765867cea85865843c337/serde_derive/src/ser.rs#L335-L341

Explicitly documenting this makes it easier for custom `Serializer` implementations to know what to expect from the `len` value, and makes it clearer for custom `Serialize` implementations to know what to provide as value.