### PR TITLE
Expanded #[serder(default = ...)] capabilities.

### DIFF
--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde"
-version = "1.0.197"
+version = "1.0.198"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>", "David Tolnay <dtolnay@gmail.com>"]
 build = "build.rs"
 categories = ["encoding", "no-std", "no-std::no-alloc"]

--- a/serde_derive/Cargo.toml
+++ b/serde_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.198"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>", "David Tolnay <dtolnay@gmail.com>"]
 categories = ["no-std", "no-std::no-alloc"]
 description = "Macros 1.1 implementation of #[derive(Serialize, Deserialize)]"

--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -396,24 +396,21 @@ impl Container {
                     deny_unknown_fields.set_true(meta.path);
                 } else if meta.path == DEFAULT {
                     if meta.input.peek(Token![=]) {
-                        // #[serde(default = "...")]
-                        if let Some(path) = parse_lit_into_expr_path(cx, DEFAULT, &meta)? {
+                        // #[serde(default = ...)]
+                        if let Some(dflt) = parse_default(cx, &meta)? {
                             match &item.data {
                                 syn::Data::Struct(syn::DataStruct { fields, .. }) => match fields {
                                     syn::Fields::Named(_) | syn::Fields::Unnamed(_) => {
-                                        default.set(&meta.path, Default::Path(path));
+                                        default.set(&meta.path, dflt);
                                     }
                                     syn::Fields::Unit => {
-                                        let msg = "#[serde(default = \"...\")] can only be used on structs that have fields";
+                                        let msg = "#[serde(default = ...)] can only be used on structs that have fields";
                                         cx.syn_error(meta.error(msg));
                                     }
                                 },
-                                syn::Data::Enum(_) => {
-                                    let msg = "#[serde(default = \"...\")] can only be used on structs";
-                                    cx.syn_error(meta.error(msg));
-                                }
+                                syn::Data::Enum(_) |
                                 syn::Data::Union(_) => {
-                                    let msg = "#[serde(default = \"...\")] can only be used on structs";
+                                    let msg = "#[serde(default = ...)] can only be used on structs";
                                     cx.syn_error(meta.error(msg));
                                 }
                             }
@@ -1055,13 +1052,17 @@ pub enum Default {
     Default,
     /// The default is given by this function.
     Path(syn::ExprPath),
+    /// The default is a literal value
+    Expr(Box<syn::Expr>),
 }
 
 impl Default {
     pub fn is_none(&self) -> bool {
         match self {
             Default::None => true,
-            Default::Default | Default::Path(_) => false,
+            Default::Default |
+            Default::Path(_) |
+            Default::Expr(_) => false,
         }
     }
 }
@@ -1140,9 +1141,9 @@ impl Field {
                     }
                 } else if meta.path == DEFAULT {
                     if meta.input.peek(Token![=]) {
-                        // #[serde(default = "...")]
-                        if let Some(path) = parse_lit_into_expr_path(cx, DEFAULT, &meta)? {
-                            default.set(&meta.path, Default::Path(path));
+                        // #[serde(default = ...)]
+                        if let Some(default_value) = parse_default(cx, &meta)? {
+                            default.set(&meta.path, default_value)
                         }
                     } else {
                         // #[serde(default)]
@@ -1546,6 +1547,54 @@ fn parse_lit_into_expr_path(
             None
         }
     })
+}
+
+/// Parses either an [`ExprPath`](syn::ExprPath) to a `fn` which will return the 
+/// default value for a field, or an [`Expr`](syn::ExprParen) wrapped in parenthesies
+/// which is a valid value for a field. 
+/// 
+/// ```no_run
+/// use serde::{Serialize, Deserialize};
+/// 
+/// #[derive(Clone, Default, Serialize, Deserialize)]
+/// pub struct DemoStruct {
+///     #[serde(default = "my_fn")]
+///     a: i32,
+///     #[serde(default = (12))]
+///     b: i32,
+/// }
+/// 
+/// fn my_fn() -> i32 { 16 }
+/// ```
+fn parse_default(
+    cx: &Ctxt,
+    meta: &ParseNestedMeta,
+) -> syn::Result<Option<Default>> {
+
+    let expr: syn::Expr = meta.value()?.parse()?;
+    match expr {
+        // #[serde(default = "...")]
+        syn::Expr::Lit(syn::ExprLit { lit: syn::Lit::Str(lit_str), .. }) => {
+            match lit_str.parse::<syn::ExprPath>() {
+                Ok(path) => Ok(Some(Default::Path(path))),
+                _ => {
+                    let msg = format!("failed to parse path: {:?}", lit_str.value());
+                    cx.error_spanned_by(&lit_str, msg);
+                    Ok(None)
+                }
+            }
+        },
+
+        // #[serde(default = (...))]
+        syn::Expr::Paren(paren) => {
+            Ok(Some(Default::Expr(paren.expr)))
+        },
+        _ => {
+            let msg = format!("failed to parse literal or fn path: {:?}", expr.to_token_stream());
+            cx.error_spanned_by(&expr, msg);
+            Ok(None)
+        }
+    }
 }
 
 fn parse_lit_into_where(

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -95,6 +95,8 @@ where
     a4: D,
     #[serde(skip_deserializing, default = "MyDefault::my_default")]
     a5: E,
+    #[serde(skip_deserializing, default = (12.3))]
+    a6: f32
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -123,6 +125,7 @@ fn test_default_struct() {
             a3: 3,
             a4: 0,
             a5: 123,
+            a6: 12.3,
         },
         &[
             Token::Struct {
@@ -139,6 +142,8 @@ fn test_default_struct() {
             Token::I32(4),
             Token::Str("a5"),
             Token::I32(5),
+            Token::Str("a6"),
+            Token::F32(12.3),
             Token::StructEnd,
         ],
     );
@@ -150,14 +155,17 @@ fn test_default_struct() {
             a3: 123,
             a4: 0,
             a5: 123,
+            a6: 12.3
         },
         &[
             Token::Struct {
                 name: "DefaultStruct",
-                len: 3,
+                len: 6,
             },
             Token::Str("a1"),
             Token::I32(1),
+            Token::Str("a6"),
+            Token::F32(12.3),
             Token::StructEnd,
         ],
     );
@@ -436,6 +444,7 @@ fn test_ignore_unknown() {
             a3: 3,
             a4: 0,
             a5: 123,
+            a6: 12.3
         },
         &[
             Token::Struct {

--- a/test_suite/tests/ui/default-attribute/enum_path.stderr
+++ b/test_suite/tests/ui/default-attribute/enum_path.stderr
@@ -1,4 +1,4 @@
-error: #[serde(default = "...")] can only be used on structs
+error: #[serde(default = ...)] can only be used on structs
  --> tests/ui/default-attribute/enum_path.rs:4:9
   |
 4 | #[serde(default = "default_e")]


### PR DESCRIPTION
### Before
Giving a field a default value that isn't the same as that type's `Default` required users to define a function for each field.
```
#[derive(Serialize, Deserialize)]
pub struct MyStruct {
    #[serde(default = "my_struct_a_default")]
    a: i32,
    #[serde(default = "my_struct_b_default")]
    b: i32,
}

fn my_struct_a_default() -> i32 {
    12
}
fn my_struct_b_default() -> i32 {
    16
}
```
### Now
Constant expressions may also be used, so long as they are wrapped in parenthesis
```
#[derive(Serialize, Deserialize)]
pub struct MyStruct {
    #[serde(default = (12))]
    a: i32,
    #[serde(default = (16))]
    b: i32,
}
```
The requirement of wrapping expressions in parenthesis is to ensure string values are not mistaken for a path to a function. This ensures full backwards compatibility.

I have also modified some of the tests to verify this new capability, and incremented the version number