### PR TITLE
fix: ambiguous associated item in forward_to_deserialize_any!

### DIFF
--- a/serde/src/macros.rs
+++ b/serde/src/macros.rs
@@ -123,7 +123,7 @@ macro_rules! forward_to_deserialize_any {
 macro_rules! forward_to_deserialize_any_method {
     ($func:ident<$l:tt, $v:ident>($($arg:ident : $ty:ty),*)) => {
         #[inline]
-        fn $func<$v>(self, $($arg: $ty,)* visitor: $v) -> $crate::__private::Result<$v::Value, Self::Error>
+        fn $func<$v>(self, $($arg: $ty,)* visitor: $v) -> $crate::__private::Result<$v::Value, <Self as $crate::de::Deserializer<$l>>::Error>
         where
             $v: $crate::de::Visitor<$l>,
         {


### PR DESCRIPTION
Hit in [`serde-save`](https://docs.rs/serde-save), the following code fails to compile:

```rust
enum Value {
    Error,
}

impl<'de> serde::Deserializer<'de> for Value {
    type Error = serde::de::value::Error;
    fn deserialize_any<V>(self, _: V) -> Result<V::Value, serde::de::value::Error>
    where
        V: serde::de::Visitor<'de>,
    {
        todo!()
    }
    serde::forward_to_deserialize_any! {
        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
        bytes byte_buf option unit unit_struct newtype_struct seq tuple
        tuple_struct map struct enum identifier ignored_any
    }
}
```

```console
error: ambiguous associated item
   --> src/lib.rs:16:5
    |
16  | /     serde::forward_to_deserialize_any! {
17  | |         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
18  | |         bytes byte_buf option unit unit_struct newtype_struct seq tuple
19  | |         tuple_struct map struct enum identifier ignored_any
20  | |     }
    | |_____^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57644 <https://github.com/rust-lang/rust/issues/57644>
note: `Error` could refer to the variant defined here
   --> src/lib.rs:5:5
    |
5   |     Error,
    |     ^^^^^
note: `Error` could also refer to the associated type defined here
   --> /playground/.cargo/registry/src/index.crates.io-6f17d22bba15001f/serde-1.0.197/src/de/mod.rs:911:5
    |
911 |     type Error: Error;
    |     ^^^^^^^^^^^^^^^^^
    = note: `#[deny(ambiguous_associated_items)]` on by default
    = note: this error originates in the macro `forward_to_deserialize_any_method` which comes from the expansion of the macro `serde::forward_to_deserialize_any` (in Nightly builds, run with -Z macro-backtrace for more info)
```
[playground link](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=c5361ff0c39193a62ca079f708e68c55)
