### PR TITLE
Only format Unexpected::Float with decimal point if it is finite

### DIFF
--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -2312,13 +2312,17 @@ impl Display for WithDecimalPoint {
             }
         }
 
-        let mut writer = LookForDecimalPoint {
-            formatter,
-            has_decimal_point: false,
-        };
-        tri!(write!(writer, "{}", self.0));
-        if !writer.has_decimal_point {
-            tri!(formatter.write_str(".0"));
+        if self.0.is_finite() {
+            let mut writer = LookForDecimalPoint {
+                formatter,
+                has_decimal_point: false,
+            };
+            tri!(write!(writer, "{}", self.0));
+            if !writer.has_decimal_point {
+                tri!(formatter.write_str(".0"));
+            }
+        } else {
+            tri!(write!(formatter, "{}", self.0));
         }
         Ok(())
     }

--- a/test_suite/tests/test_de_error.rs
+++ b/test_suite/tests/test_de_error.rs
@@ -1439,6 +1439,14 @@ fn test_integer_from_float() {
 }
 
 #[test]
+fn test_nan_no_decimal_point() {
+    assert_de_tokens_error::<isize>(
+        &[Token::F32(f32::NAN)],
+        "invalid type: floating point `NaN`, expected isize",
+    );
+}
+
+#[test]
 fn test_unit_struct_from_seq() {
     assert_de_tokens_error::<UnitStruct>(
         &[Token::Seq { len: Some(0) }, Token::SeqEnd],


### PR DESCRIPTION
bef110b92a1 changed the display for unexpected floats to always append a
".0" if there was no decimal point found in the formatting of the float.

However, this should only be relevant for finite (i.e., not NaN or inf)
values.  The change introduced a test failure in the ordered-float
crate due to this:

     ---- impl_serde::test_fail_on_nan stdout ----
     thread 'impl_serde::test_fail_on_nan' panicked at 'assertion failed: `(left == right)`
       left: `Error { msg: "invalid value: floating point `NaN.0`, expected float (but not NaN)" }`,
      right: `"invalid value: floating point `NaN`, expected float (but not NaN)"`', src/lib.rs:1554:9
     stack backtrace:
        0: rust_begin_unwind
                  at /usr/src/rustc-1.70.0/library/std/src/panicking.rs:578:5
        1: core::panicking::panic_fmt
                  at /usr/src/rustc-1.70.0/library/core/src/panicking.rs:67:14
        2: core::panicking::assert_failed_inner
        3: core::panicking::assert_failed
                  at /usr/src/rustc-1.70.0/library/core/src/panicking.rs:228:5
        4: serde_test::assert::assert_de_tokens_error
                  at /usr/share/cargo/registry/serde_test-1.0.171/src/assert.rs:228:19
        5: ordered_float::impl_serde::test_fail_on_nan
                  at ./src/lib.rs:1554:9
        6: ordered_float::impl_serde::test_fail_on_nan::{{closure}}
                  at ./src/lib.rs:1553:27
        7: core::ops::function::FnOnce::call_once
                  at /usr/src/rustc-1.70.0/library/core/src/ops/function.rs:250:5
        8: core::ops::function::FnOnce::call_once
                  at /usr/src/rustc-1.70.0/library/core/src/ops/function.rs:250:5
     note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.