### PR TITLE
Improve error message for using tag with alloc disabled

### DIFF
--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -182,6 +182,7 @@ mod lib {
     pub use self::core::cell::{Cell, RefCell};
     pub use self::core::clone;
     pub use self::core::cmp::Reverse;
+    pub use self::core::compile_error;
     pub use self::core::convert;
     pub use self::core::default;
     pub use self::core::fmt::{self, Debug, Display, Write as FmtWrite};

--- a/serde/src/private/mod.rs
+++ b/serde/src/private/mod.rs
@@ -7,6 +7,7 @@ pub mod ser;
 pub mod doc;
 
 pub use crate::lib::clone::Clone;
+pub use crate::lib::compile_error;
 pub use crate::lib::convert::{From, Into};
 pub use crate::lib::default::Default;
 pub use crate::lib::fmt::{self, Formatter};
@@ -45,4 +46,18 @@ mod string {
         // UTF-8.
         str::from_utf8(bytes).unwrap_or("\u{fffd}\u{fffd}\u{fffd}")
     }
+}
+
+#[cfg(any(feature = "std", feature = "alloc"))]
+#[macro_export]
+macro_rules! __require_alloc_or_std {
+    ($msg:tt) => {};
+}
+
+#[cfg(not(any(feature = "std", feature = "alloc")))]
+#[macro_export]
+macro_rules! __require_alloc_or_std {
+    ($msg:tt) => {
+        $crate::__private::compile_error!($msg);
+    };
 }


### PR DESCRIPTION
Closes #2668.

```rust
// [dependencies]
// serde = { version = "1", default-features = false }
// serde_derive = "1"

#[derive(serde_derive::Deserialize)]
#[serde(tag = "type")]
pub enum MyEnum {
    MyVariant
}

```

Error message before:

```console
error[E0433]: failed to resolve: could not find `TaggedContentVisitor` in `de`
  --> src/main.rs:5:10
   |
5  | #[derive(serde_derive::Deserialize)]
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^ could not find `TaggedContentVisitor` in `de`
   |
note: found an item that was configured out
  --> serde/src/private/de.rs:16:50
   |
16 |     TagOrContentField, TagOrContentFieldVisitor, TaggedContentVisitor, UntaggedUnitVisitor,
   |                                                  ^^^^^^^^^^^^^^^^^^^^
   = note: this error originates in the derive macro `serde_derive::Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0433]: failed to resolve: could not find `ContentDeserializer` in `de`
  --> src/main.rs:5:10
   |
5  | #[derive(serde_derive::Deserialize)]
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^ could not find `ContentDeserializer` in `de`
   |
note: found an item that was configured out
  --> serde/src/private/de.rs:14:14
   |
14 |     Content, ContentDeserializer, ContentRefDeserializer, EnumDeserializer,
   |              ^^^^^^^^^^^^^^^^^^^
   = note: this error originates in the derive macro `serde_derive::Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0433]: failed to resolve: could not find `InternallyTaggedUnitVisitor` in `de`
  --> src/main.rs:5:10
   |
5  | #[derive(serde_derive::Deserialize)]
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^ could not find `InternallyTaggedUnitVisitor` in `de`
   |
note: found an item that was configured out
  --> serde/src/private/de.rs:15:5
   |
15 |     InternallyTaggedUnitVisitor, TagContentOtherField, TagContentOtherFieldVisitor,
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   = note: this error originates in the derive macro `serde_derive::Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)
```

After:

```console
error: Serde's `tag` attribute requires either "alloc" or "std" feature to be enabled on the serde crate
 --> src/main.rs:5:10
  |
5 | #[derive(serde_derive::Deserialize)]
  |          ^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: this error originates in the macro `_serde::__require_alloc_or_std` which comes from the expansion of the derive macro `serde_derive::Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0433]: failed to resolve: could not find `TaggedContentVisitor` in `de`
  --> src/main.rs:5:10
   |
5  | #[derive(serde_derive::Deserialize)]
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^ could not find `TaggedContentVisitor` in `de`
   |
note: found an item that was configured out
  --> serde/src/private/de.rs:16:50
   |
16 |     TagOrContentField, TagOrContentFieldVisitor, TaggedContentVisitor, UntaggedUnitVisitor,
   |                                                  ^^^^^^^^^^^^^^^^^^^^
   = note: this error originates in the derive macro `serde_derive::Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0433]: failed to resolve: could not find `ContentDeserializer` in `de`
  --> src/main.rs:5:10
   |
5  | #[derive(serde_derive::Deserialize)]
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^ could not find `ContentDeserializer` in `de`
   |
note: found an item that was configured out
  --> serde/src/private/de.rs:14:14
   |
14 |     Content, ContentDeserializer, ContentRefDeserializer, EnumDeserializer,
   |              ^^^^^^^^^^^^^^^^^^^
   = note: this error originates in the derive macro `serde_derive::Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0433]: failed to resolve: could not find `InternallyTaggedUnitVisitor` in `de`
  --> src/main.rs:5:10
   |
5  | #[derive(serde_derive::Deserialize)]
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^ could not find `InternallyTaggedUnitVisitor` in `de`
   |
note: found an item that was configured out
  --> serde/src/private/de.rs:15:5
   |
15 |     InternallyTaggedUnitVisitor, TagContentOtherField, TagContentOtherFieldVisitor,
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   = note: this error originates in the derive macro `serde_derive::Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)
```