### PR TITLE
Provide public access to RenameAllRules in serde_derive_internals

### DIFF
--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -185,8 +185,8 @@ impl Name {
 
 #[derive(Copy, Clone)]
 pub struct RenameAllRules {
-    serialize: RenameRule,
-    deserialize: RenameRule,
+    pub serialize: RenameRule,
+    pub deserialize: RenameRule,
 }
 
 impl RenameAllRules {


### PR DESCRIPTION
Closes #2237. Closes #2238.