### PR TITLE
Propagate parse errors inside a flattened Option struct

### DIFF
--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -916,11 +916,12 @@ where
         T::deserialize(deserializer).map(Some)
     }
 
-    fn __private_visit_untagged_option<D>(self, deserializer: D) -> Result<Self::Value, ()>
+    #[doc(hidden)]
+    fn __private_make_none<E>() -> Result<Self::Value, E>
     where
-        D: Deserializer<'de>,
+        E: Error,
     {
-        Ok(T::deserialize(deserializer).ok())
+        Ok(None)
     }
 }
 

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -1672,11 +1672,11 @@ pub trait Visitor<'de>: Sized {
 
     // Used when deserializing a flattened Option field. Not public API.
     #[doc(hidden)]
-    fn __private_visit_untagged_option<D>(self, _: D) -> Result<Self::Value, ()>
+    fn __private_make_none<E>() -> Result<Self::Value, E>
     where
-        D: Deserializer<'de>,
+        E: Error,
     {
-        Err(())
+        Err(Error::custom(""))
     }
 }
 


### PR DESCRIPTION
This is an attempt to address https://github.com/serde-rs/json/issues/644

The idea is to go through a proxy type `OptionFlatMapDeserializer` when calling `deserialize_option` in `FlatMapDeserializer`. Such proxy type provides a custom error type `FlatStructError` which only catches `missing_field` error during the immediate struct deserialization. All the errors happening nested will be preserved in another variant. In this way, we could propagate error inside a flattened struct.

I guess some more tests and comments are needed, but I want to put this work forward for preliminary test.
