### PR TITLE
Use the `#[diagnostic::on_unimplemented]` attribute when possible

### DIFF
--- a/serde/build.rs
+++ b/serde/build.rs
@@ -25,6 +25,7 @@ fn main() {
         println!("cargo:rustc-check-cfg=cfg(no_std_atomic64)");
         println!("cargo:rustc-check-cfg=cfg(no_systemtime_checked_add)");
         println!("cargo:rustc-check-cfg=cfg(no_target_has_atomic)");
+        println!("cargo:rustc-check-cfg=cfg(no_diagnostic_namespace)");
     }
 
     let target = env::var("TARGET").unwrap();
@@ -83,6 +84,12 @@ fn main() {
     // https://blog.rust-lang.org/2023/11/16/Rust-1.74.0.html#stabilized-apis
     if minor < 74 {
         println!("cargo:rustc-cfg=no_core_num_saturating");
+    }
+
+    // Support for the `#[diagnostic]` tool attribute namespace
+    // https://blog.rust-lang.org/2024/05/02/Rust-1.78.0.html#diagnostic-attributes
+    if minor < 78 {
+        println!("cargo:rustc-cfg=no_diagnostic_namespace");
     }
 }
 

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -532,6 +532,13 @@ impl<'a> Display for Expected + 'a {
 /// deserializer lifetimes] for a more detailed explanation of these lifetimes.
 ///
 /// [Understanding deserializer lifetimes]: https://serde.rs/lifetimes.html
+#[cfg_attr(
+    not(no_diagnostic_namespace),
+    diagnostic::on_unimplemented(
+        note = "for local types consider adding `#[derive(serde::Deserialize)]` to your `{Self}` type",
+        note = "for types from other crates check whether the crate offers a `serde` feature flag",
+    )
+)]
 pub trait Deserialize<'de>: Sized {
     /// Deserialize this value from the given Serde deserializer.
     ///

--- a/serde/src/ser/mod.rs
+++ b/serde/src/ser/mod.rs
@@ -215,6 +215,13 @@ declare_error_trait!(Error: Sized + Debug + Display);
 /// [`linked-hash-map`]: https://crates.io/crates/linked-hash-map
 /// [`serde_derive`]: https://crates.io/crates/serde_derive
 /// [derive section of the manual]: https://serde.rs/derive.html
+#[cfg_attr(
+    not(no_diagnostic_namespace),
+    diagnostic::on_unimplemented(
+        note = "for local types consider adding `#[derive(serde::Serialize)]` to your `{Self}` type",
+        note = "for types from other crates check whether the crate offers a `serde` feature flag",
+    )
+)]
 pub trait Serialize {
     /// Serialize this value into the given Serde serializer.
     ///


### PR DESCRIPTION
This change enables the `#[diagnostic::on_unimplemented]` attribute for the `Serialize` and `Deserialize` trait to point the user to the relevant derives and point out that they might want to check crates features for external types by adding the relevant hints an note.


The help text is up for discussion, but I feel that this might help quite a lot of users that struggle why external crates do not implement the serde traits. 