### PR TITLE
Make it possible to offer roundtrip guarantees for formats that need it

### DIFF
--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -1641,6 +1641,25 @@ pub trait Visitor<'de>: Sized {
         self.visit_unit()
     }
 
+    /// The input contains a unit variant.
+    ///
+    /// The default implementation forwards to `visit_enum`.
+    fn visit_unit_variant<A>(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        data: A,
+    ) -> Result<Self::Value, A::Error>
+    where
+        A: EnumAccess<'de>,
+    {
+        let _ = name;
+        let _ = variant_index;
+        let _ = variant;
+        self.visit_enum(data)
+    }
+
     /// The input contains a newtype struct.
     ///
     /// The content of the newtype struct may be read from the given
@@ -1671,6 +1690,25 @@ pub trait Visitor<'de>: Sized {
     {
         let _ = name;
         self.visit_newtype_struct(deserializer)
+    }
+
+    /// The input contains a newtype variant.
+    ///
+    /// The default implementation forwards to `visit_enum`.
+    fn visit_newtype_variant<A>(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        data: A,
+    ) -> Result<Self::Value, A::Error>
+    where
+        A: EnumAccess<'de>,
+    {
+        let _ = name;
+        let _ = variant_index;
+        let _ = variant;
+        self.visit_enum(data)
     }
 
     /// The input contains a sequence of elements.
@@ -1705,6 +1743,27 @@ pub trait Visitor<'de>: Sized {
         self.visit_seq(tup)
     }
 
+    /// The input contains a tuple variant.
+    ///
+    /// The default implementation forwards to `visit_enum`.
+    fn visit_tuple_variant<A>(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        len: usize,
+        data: A,
+    ) -> Result<Self::Value, A::Error>
+    where
+        A: EnumAccess<'de>,
+    {
+        let _ = name;
+        let _ = variant_index;
+        let _ = variant;
+        let _ = len;
+        self.visit_enum(data)
+    }
+
     /// The input contains a key-value map.
     ///
     /// The default implementation fails with a type error.
@@ -1731,6 +1790,27 @@ pub trait Visitor<'de>: Sized {
         let _ = name;
         let _ = fields;
         self.visit_map(data)
+    }
+
+    /// The input contains a struct variant.
+    ///
+    /// The default implementation forwards to `visit_enum`.
+    fn visit_struct_variant<A>(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        fields: &[&'static str],
+        data: A,
+    ) -> Result<Self::Value, A::Error>
+    where
+        A: EnumAccess<'de>,
+    {
+        let _ = name;
+        let _ = variant_index;
+        let _ = variant;
+        let _ = fields;
+        self.visit_enum(data)
     }
 
     /// The input contains an enum.

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -1630,6 +1630,17 @@ pub trait Visitor<'de>: Sized {
         Err(Error::invalid_type(Unexpected::Unit, &self))
     }
 
+    /// The input contains a unit struct.
+    ///
+    /// The default implementation forwards to `visit_unit`.
+    fn visit_unit_struct<E>(self, name: &'static str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        let _ = name;
+        self.visit_unit()
+    }
+
     /// The input contains a newtype struct.
     ///
     /// The content of the newtype struct may be read from the given
@@ -1655,6 +1666,27 @@ pub trait Visitor<'de>: Sized {
         Err(Error::invalid_type(Unexpected::Seq, &self))
     }
 
+    /// The input contains a tuple.
+    ///
+    /// The default implementation forwards to `visit_seq`.
+    fn visit_tuple<A>(self, tup: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        self.visit_seq(tup)
+    }
+
+    /// The input contains a tuple struct.
+    ///
+    /// The default implementation forwards to `visit_seq`.
+    fn visit_tuple_struct<A>(self, name: &'static str, tup: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let _ = name;
+        self.visit_seq(tup)
+    }
+
     /// The input contains a key-value map.
     ///
     /// The default implementation fails with a type error.
@@ -1664,6 +1696,23 @@ pub trait Visitor<'de>: Sized {
     {
         let _ = map;
         Err(Error::invalid_type(Unexpected::Map, &self))
+    }
+
+    /// The input contains a struct.
+    ///
+    /// The default implementation forwards to `visit_map`.
+    fn visit_struct<A>(
+        self,
+        name: &'static str,
+        fields: &[&'static str],
+        data: A,
+    ) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let _ = name;
+        let _ = fields;
+        self.visit_map(data)
     }
 
     /// The input contains an enum.

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -1655,6 +1655,24 @@ pub trait Visitor<'de>: Sized {
         Err(Error::invalid_type(Unexpected::NewtypeStruct, &self))
     }
 
+    /// The input contains a newtype struct.
+    ///
+    /// `name` is the name of the struct. The content of the newtype struct may
+    /// be read from the given `Deserializer`.
+    ///
+    /// The default implementation forwards to `visit_newtype_struct`.
+    fn visit_newtype_struct_with_name<D>(
+        self,
+        name: &'static str,
+        deserializer: D,
+    ) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let _ = name;
+        self.visit_newtype_struct(deserializer)
+    }
+
     /// The input contains a sequence of elements.
     ///
     /// The default implementation fails with a type error.


### PR DESCRIPTION
The `Serializer` and `Deserializer` traits have a nice symmetry in their methods. In theory, that means it should be possible to write serialisers and deserialisers that offer round trip guarantees across its entire data model. In practice this is not possible, however, because the `Visitor` trait does not have a one to one translation with deserialisers. Unlike deserialisers, for example, it makes no distinction between structs and maps.

This PR adds additional methods to the Visitor trait to ensure that symmetry is kept. It also adds default implementations that maintain the current behaviour to ensure backwards compatibility. This allows formats that need it to offer round trip guarantees across the entire Serde data model without affecting existing formats. This behaviour is [tested in this PR](https://github.com/rushmorem/serde-content/pull/1).