### PR TITLE
Use serialize_entry instead of serialize_key + serialize_value when serialize flatten newtype enum variant

### DIFF
--- a/serde/src/private/ser.rs
+++ b/serde/src/private/ser.rs
@@ -1125,8 +1125,7 @@ where
     where
         T: ?Sized + Serialize,
     {
-        tri!(self.0.serialize_key(variant));
-        self.0.serialize_value(value)
+        self.0.serialize_entry(variant, value)
     }
 
     fn serialize_seq(self, _: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {


### PR DESCRIPTION
Serializers that reimplements serialize_entry will get benefits from that