### PR TITLE
Fix roundtrip of flatten externally tagged enum unit variant

### DIFF
--- a/serde/src/private/ser.rs
+++ b/serde/src/private/ser.rs
@@ -54,6 +54,7 @@ enum Unsupported {
     Sequence,
     Tuple,
     TupleStruct,
+    #[cfg(not(any(feature = "std", feature = "alloc")))]
     Enum,
 }
 
@@ -70,6 +71,7 @@ impl Display for Unsupported {
             Unsupported::Sequence => formatter.write_str("a sequence"),
             Unsupported::Tuple => formatter.write_str("a tuple"),
             Unsupported::TupleStruct => formatter.write_str("a tuple struct"),
+            #[cfg(not(any(feature = "std", feature = "alloc")))]
             Unsupported::Enum => formatter.write_str("an enum"),
         }
     }
@@ -1095,9 +1097,9 @@ where
         self,
         _: &'static str,
         _: u32,
-        _: &'static str,
+        variant: &'static str,
     ) -> Result<Self::Ok, Self::Error> {
-        Err(Self::bad_type(Unsupported::Enum))
+        self.0.serialize_entry(variant, &())
     }
 
     fn serialize_newtype_struct<T>(

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -2655,9 +2655,44 @@ mod flatten {
 
             #[derive(Debug, PartialEq, Serialize, Deserialize)]
             enum Enum {
+                Unit,
                 Newtype(HashMap<String, String>),
                 Tuple(u32, u32),
                 Struct { index: u32, value: u32 },
+            }
+
+            #[test]
+            fn unit() {
+                let value = Flatten {
+                    data: Enum::Unit,
+                    extra: HashMap::from_iter([("extra_key".into(), "extra value".into())]),
+                };
+                assert_tokens(
+                    &value,
+                    &[
+                        Token::Map { len: None },
+                        // data
+                        Token::Str("Unit"), // variant
+                        Token::Unit,
+                        // extra
+                        Token::Str("extra_key"),
+                        Token::Str("extra value"),
+                        Token::MapEnd,
+                    ],
+                );
+                assert_de_tokens(
+                    &value,
+                    &[
+                        Token::Map { len: None },
+                        // extra
+                        Token::Str("extra_key"),
+                        Token::Str("extra value"),
+                        // data
+                        Token::Str("Unit"), // variant
+                        Token::Unit,
+                        Token::MapEnd,
+                    ],
+                );
             }
 
             #[test]


### PR DESCRIPTION
Unit variant of externally tagged enum can be deserialized when enum is flatten, [but cannot be serialized](
https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=67545ca025699ac9894f464ad1dc2405) -- `ser` test failed:
```rust
#![cfg(test)]

use serde::{Deserialize, Serialize}; // 1.0.204;
use serde_json::{from_str, to_string}; // 1.0.121

#[derive(Debug, PartialEq, Serialize, Deserialize)]
struct Flatten {
    #[serde(flatten)]
    data: Enum,
}

#[derive(Debug, PartialEq, Serialize, Deserialize)]
enum Enum {
    Unit,
}

const JSON: &str = r#"{"Unit":null}"#;

#[test]
fn de() {
    // ok
    assert_eq!(from_str::<Flatten>(JSON).unwrap(), Flatten { data: Enum::Unit });
}

#[test]
fn ser() {
    // called `Result::unwrap()` on an `Err` value: Error("can only flatten structs and maps (got an enum)", line: 0, column: 0)
    assert_eq!(to_string(&Flatten { data: Enum::Unit }).unwrap(), JSON);
}
```

This PR fixes this inconsistency