### PR TITLE
Skip collecting unmatched fields in variants that do not use flatten

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -2480,7 +2480,10 @@ fn deserialize_map(
         });
 
     // Collect contents for flatten fields into a buffer
-    let let_collect = if cattrs.has_flatten() {
+    let has_flatten = fields
+        .iter()
+        .any(|field| field.attrs.flatten() && !field.attrs.skip_deserializing());
+    let let_collect = if has_flatten {
         Some(quote! {
             let mut __collect = _serde::__private::Vec::<_serde::__private::Option<(
                 _serde::__private::de::Content,
@@ -2532,7 +2535,7 @@ fn deserialize_map(
         });
 
     // Visit ignored values to consume them
-    let ignored_arm = if cattrs.has_flatten() {
+    let ignored_arm = if has_flatten {
         Some(quote! {
             __Field::__other(__name) => {
                 __collect.push(_serde::__private::Some((
@@ -2602,7 +2605,7 @@ fn deserialize_map(
             }
         });
 
-    let collected_deny_unknown_fields = if cattrs.has_flatten() && cattrs.deny_unknown_fields() {
+    let collected_deny_unknown_fields = if has_flatten && cattrs.deny_unknown_fields() {
         Some(quote! {
             if let _serde::__private::Some(_serde::__private::Some((__key, _))) =
                 __collect.into_iter().filter(_serde::__private::Option::is_some).next()

--- a/test_suite/tests/test_gen.rs
+++ b/test_suite/tests/test_gen.rs
@@ -4,6 +4,7 @@
 
 #![deny(warnings)]
 #![allow(
+    confusable_idents,
     unknown_lints,
     mixed_script_confusables,
     clippy::derive_partial_eq_without_eq,

--- a/test_suite/tests/test_gen.rs
+++ b/test_suite/tests/test_gen.rs
@@ -19,6 +19,7 @@
     clippy::trivially_copy_pass_by_ref,
     clippy::type_repetition_in_bounds
 )]
+#![deny(clippy::collection_is_never_read)]
 
 use serde::de::{Deserialize, DeserializeOwned, Deserializer};
 use serde::ser::{Serialize, Serializer};

--- a/test_suite/tests/test_gen.rs
+++ b/test_suite/tests/test_gen.rs
@@ -725,6 +725,19 @@ fn test_gen() {
         flat: T,
     }
 
+    #[derive(Serialize, Deserialize)]
+    #[serde(untagged)]
+    pub enum Inner<T> {
+        Builder {
+            s: T,
+            #[serde(flatten)]
+            o: T,
+        },
+        Default {
+            s: T,
+        },
+    }
+
     // https://github.com/serde-rs/serde/issues/1804
     #[derive(Serialize, Deserialize)]
     pub enum Message {


### PR DESCRIPTION
Fixes #2789.

For the enum in the repro:

```rust
#[derive(Deserialize)]
#[serde(untagged)]
enum Inner<'a> {
    Default {
        s: &'a str,
    },
    Builder {
        s: &'a str,
        #[serde(flatten)]
        o: Options,
    },
}
```

we would previously collect a `Vec<Option<(Content, Content)>>` of the unrecognized keys and values in the input. These would be used for deserializing `o` inside `Builder`, but when deserializing `Default`, the vector would not be used and would correctly trigger the _"collection is never read"_ warning.