### PR TITLE
Temporarily ignore collection_is_never_read on FlattenSkipDeserializing

### DIFF
--- a/test_suite/tests/test_gen.rs
+++ b/test_suite/tests/test_gen.rs
@@ -720,11 +720,14 @@ fn test_gen() {
         flat: StdOption<T>,
     }
 
-    #[derive(Serialize, Deserialize)]
-    pub struct FlattenSkipDeserializing<T> {
-        #[serde(flatten, skip_deserializing)]
-        flat: T,
-    }
+    #[allow(clippy::collection_is_never_read)] // FIXME
+    const _: () = {
+        #[derive(Serialize, Deserialize)]
+        pub struct FlattenSkipDeserializing<T> {
+            #[serde(flatten, skip_deserializing)]
+            flat: T,
+        }
+    };
 
     #[derive(Serialize, Deserialize)]
     #[serde(untagged)]


### PR DESCRIPTION
@Mingun, this lint fires since #2567. Could you take a look at what should be generated for such a struct?

https://github.com/serde-rs/serde/blob/fc55ac70d34221b38672b1583e496011fbae92aa/test_suite/tests/test_gen.rs#L723-L727

```console
error: collection is never read
   --> test_suite/tests/test_gen.rs:723:25
    |
723 |     #[derive(Serialize, Deserialize)]
    |                         ^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#collection_is_never_read
note: the lint level is defined here
   --> test_suite/tests/test_gen.rs:23:9
    |
23  | #![deny(clippy::collection_is_never_read)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)
```