### PR TITLE
`has_flatten` rework

### DIFF
--- a/serde_derive/src/internals/ast.rs
+++ b/serde_derive/src/internals/ast.rs
@@ -63,7 +63,7 @@ impl<'a> Container<'a> {
         item: &'a syn::DeriveInput,
         derive: Derive,
     ) -> Option<Container<'a>> {
-        let mut attrs = attr::Container::from_ast(cx, item);
+        let attrs = attr::Container::from_ast(cx, item);
 
         let mut data = match &item.data {
             syn::Data::Enum(data) => Data::Enum(enum_from_ast(cx, &data.variants, attrs.default())),
@@ -77,15 +77,11 @@ impl<'a> Container<'a> {
             }
         };
 
-        let mut has_flatten = false;
         match &mut data {
             Data::Enum(variants) => {
                 for variant in variants {
                     variant.attrs.rename_by_rules(attrs.rename_all_rules());
                     for field in &mut variant.fields {
-                        if field.attrs.flatten() {
-                            has_flatten = true;
-                        }
                         field.attrs.rename_by_rules(
                             variant
                                 .attrs
@@ -97,16 +93,9 @@ impl<'a> Container<'a> {
             }
             Data::Struct(_, fields) => {
                 for field in fields {
-                    if field.attrs.flatten() {
-                        has_flatten = true;
-                    }
                     field.attrs.rename_by_rules(attrs.rename_all_rules());
                 }
             }
-        }
-
-        if has_flatten {
-            attrs.mark_has_flatten();
         }
 
         let mut item = Container {

--- a/serde_derive/src/internals/ast.rs
+++ b/serde_derive/src/internals/ast.rs
@@ -85,7 +85,6 @@ impl<'a> Container<'a> {
                     for field in &mut variant.fields {
                         if field.attrs.flatten() {
                             has_flatten = true;
-                            variant.attrs.mark_has_flatten();
                         }
                         field.attrs.rename_by_rules(
                             variant

--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -216,23 +216,6 @@ pub struct Container {
     type_into: Option<syn::Type>,
     remote: Option<syn::Path>,
     identifier: Identifier,
-    /// True if container is a struct and has a field with `#[serde(flatten)]`,
-    /// or is an enum with a struct variant which has a field with
-    /// `#[serde(flatten)]`.
-    ///
-    /// ```ignore
-    /// struct Container {
-    ///     #[serde(flatten)]
-    ///     some_field: (),
-    /// }
-    /// enum Container {
-    ///     Variant {
-    ///         #[serde(flatten)]
-    ///         some_field: (),
-    ///     },
-    /// }
-    /// ```
-    has_flatten: bool,
     serde_path: Option<syn::Path>,
     is_packed: bool,
     /// Error message generated when type can't be deserialized
@@ -603,7 +586,6 @@ impl Container {
             type_into: type_into.get(),
             remote: remote.get(),
             identifier: decide_identifier(cx, item, field_identifier, variant_identifier),
-            has_flatten: false,
             serde_path: serde_path.get(),
             is_packed,
             expecting: expecting.get(),
@@ -669,14 +651,6 @@ impl Container {
 
     pub fn identifier(&self) -> Identifier {
         self.identifier
-    }
-
-    pub fn has_flatten(&self) -> bool {
-        self.has_flatten
-    }
-
-    pub fn mark_has_flatten(&mut self) {
-        self.has_flatten = true;
     }
 
     pub fn custom_serde_path(&self) -> Option<&syn::Path> {

--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -810,18 +810,6 @@ pub struct Variant {
     rename_all_rules: RenameAllRules,
     ser_bound: Option<Vec<syn::WherePredicate>>,
     de_bound: Option<Vec<syn::WherePredicate>>,
-    /// True if variant is a struct variant which contains a field with
-    /// `#[serde(flatten)]`.
-    ///
-    /// ```ignore
-    /// enum Enum {
-    ///     Variant {
-    ///         #[serde(flatten)]
-    ///         some_field: (),
-    ///     },
-    /// }
-    /// ```
-    has_flatten: bool,
     skip_deserializing: bool,
     skip_serializing: bool,
     other: bool,
@@ -991,7 +979,6 @@ impl Variant {
             },
             ser_bound: ser_bound.get(),
             de_bound: de_bound.get(),
-            has_flatten: false,
             skip_deserializing: skip_deserializing.get(),
             skip_serializing: skip_serializing.get(),
             other: other.get(),
@@ -1032,14 +1019,6 @@ impl Variant {
 
     pub fn de_bound(&self) -> Option<&[syn::WherePredicate]> {
         self.de_bound.as_ref().map(|vec| &vec[..])
-    }
-
-    pub fn has_flatten(&self) -> bool {
-        self.has_flatten
-    }
-
-    pub fn mark_has_flatten(&mut self) {
-        self.has_flatten = true;
     }
 
     pub fn skip_deserializing(&self) -> bool {

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -376,26 +376,8 @@ fn serialize_struct_as_map(
 
     let let_mut = mut_if(serialized_fields.peek().is_some() || tag_field_exists);
 
-    let len = if cattrs.has_flatten() {
-        quote!(_serde::__private::None)
-    } else {
-        let len = serialized_fields
-            .map(|field| match field.attrs.skip_serializing_if() {
-                None => quote!(1),
-                Some(path) => {
-                    let field_expr = get_member(params, field, &field.member);
-                    quote!(if #path(#field_expr) { 0 } else { 1 })
-                }
-            })
-            .fold(
-                quote!(#tag_field_exists as usize),
-                |sum, expr| quote!(#sum + #expr),
-            );
-        quote!(_serde::__private::Some(#len))
-    };
-
     quote_block! {
-        let #let_mut __serde_state = _serde::Serializer::serialize_map(__serializer, #len)?;
+        let #let_mut __serde_state = _serde::Serializer::serialize_map(__serializer, _serde::__private::None)?;
         #tag_field
         #(#serialize_fields)*
         _serde::ser::SerializeMap::end(__serde_state)

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -297,7 +297,10 @@ fn serialize_struct(params: &Parameters, fields: &[Field], cattrs: &attr::Contai
         u32::MAX
     );
 
-    if cattrs.has_flatten() {
+    let has_non_skipped_flatten = fields
+        .iter()
+        .any(|field| field.attrs.flatten() && !field.attrs.skip_serializing());
+    if has_non_skipped_flatten {
         serialize_struct_as_map(params, fields, cattrs)
     } else {
         serialize_struct_as_struct(params, fields, cattrs)

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -289,7 +289,13 @@ fn serialize_tuple_struct(
 }
 
 fn serialize_struct(params: &Parameters, fields: &[Field], cattrs: &attr::Container) -> Fragment {
-    assert!(fields.len() as u64 <= u64::from(u32::MAX));
+    assert!(
+        fields.len() as u64 <= u64::from(u32::MAX),
+        "too many fields in {}: {}, maximum supported count is {}",
+        cattrs.name().serialize_name(),
+        fields.len(),
+        u32::MAX
+    );
 
     if cattrs.has_flatten() {
         serialize_struct_as_map(params, fields, cattrs)

--- a/test_suite/tests/test_gen.rs
+++ b/test_suite/tests/test_gen.rs
@@ -548,10 +548,29 @@ fn test_gen() {
     assert::<FlattenWith>();
 
     #[derive(Serialize, Deserialize)]
+    pub struct Flatten<T> {
+        #[serde(flatten)]
+        t: T,
+    }
+
+    #[derive(Serialize, Deserialize)]
     #[serde(deny_unknown_fields)]
     pub struct FlattenDenyUnknown<T> {
         #[serde(flatten)]
         t: T,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    pub struct SkipDeserializing<T> {
+        #[serde(skip_deserializing)]
+        flat: T,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct SkipDeserializingDenyUnknown<T> {
+        #[serde(skip_deserializing)]
+        flat: T,
     }
 
     #[derive(Serialize, Deserialize)]
@@ -720,14 +739,11 @@ fn test_gen() {
         flat: StdOption<T>,
     }
 
-    #[allow(clippy::collection_is_never_read)] // FIXME
-    const _: () = {
-        #[derive(Serialize, Deserialize)]
-        pub struct FlattenSkipDeserializing<T> {
-            #[serde(flatten, skip_deserializing)]
-            flat: T,
-        }
-    };
+    #[derive(Serialize, Deserialize)]
+    pub struct FlattenSkipDeserializing<T> {
+        #[serde(flatten, skip_deserializing)]
+        flat: T,
+    }
 
     #[derive(Serialize, Deserialize)]
     #[serde(untagged)]


### PR DESCRIPTION
This PR removes workaround from #2794 in the first commit.

The 2nd commit unifies behaviour for all cases where flatten fields processed in the deserializer. Consequence of that commit: `FlattenSkipDeserializing[DenyUnknown]`
- does not collect data in `Field`, because do not read them anyway
- gets `deserialize_in_place` method
- gets ability to deserialize from sequence (`visit_seq` method)
- uses `deserialize_struct` instead of `deserialize_map`

The 3rd commit gives understandable message when derive failed due to assertion.

The 4th commit removed dead code that here since 2018.

The last commit does the unification of `has_flatten` behaviour for the serializer side. Consequence of that commit: `FlattenSkipSerializing`
- uses `serialize_struct` instead of `serialize_map`
