### PR TITLE
Emit an error if a variant of an untagged enum is annoted with `#[serde(rename)]` or `#[serde(alias)]`

### DIFF
--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -177,6 +177,11 @@ impl Name {
     pub fn deserialize_name(&self) -> &str {
         &self.deserialize
     }
+    
+    /// Return whether the container name was changed for serialization or deserialization.
+    pub fn renamed(&self) -> bool {
+		self.serialize_renamed || self.deserialize_renamed || !self.deserialize_aliases.is_empty()
+	}
 
     fn deserialize_aliases(&self) -> &BTreeSet<String> {
         &self.deserialize_aliases
@@ -241,6 +246,7 @@ pub struct Container {
 }
 
 /// Styles of representing an enum.
+#[derive(PartialEq)]
 pub enum TagType {
     /// The default.
     ///


### PR DESCRIPTION
Fixes #2787.