### PR TITLE
Delete doc(cfg) attribute from impls that are supported in no-std

### DIFF
--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -1717,7 +1717,6 @@ macro_rules! deserialize_enum {
 }
 
 #[cfg(any(feature = "std", not(no_core_net)))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "std", not(no_core_net)))))]
 impl<'de> Deserialize<'de> for net::IpAddr {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -1738,13 +1737,11 @@ impl<'de> Deserialize<'de> for net::IpAddr {
 
 parse_ip_impl! {
     #[cfg(any(feature = "std", not(no_core_net)))]
-    #[cfg_attr(docsrs, doc(cfg(any(feature = "std", not(no_core_net)))))]
     net::Ipv4Addr, "IPv4 address", 4
 }
 
 parse_ip_impl! {
     #[cfg(any(feature = "std", not(no_core_net)))]
-    #[cfg_attr(docsrs, doc(cfg(any(feature = "std", not(no_core_net)))))]
     net::Ipv6Addr, "IPv6 address", 16
 }
 
@@ -1771,7 +1768,6 @@ macro_rules! parse_socket_impl {
 }
 
 #[cfg(any(feature = "std", not(no_core_net)))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "std", not(no_core_net)))))]
 impl<'de> Deserialize<'de> for net::SocketAddr {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -1792,14 +1788,12 @@ impl<'de> Deserialize<'de> for net::SocketAddr {
 
 parse_socket_impl! {
     #[cfg(any(feature = "std", not(no_core_net)))]
-    #[cfg_attr(docsrs, doc(cfg(any(feature = "std", not(no_core_net)))))]
     net::SocketAddrV4, "IPv4 socket address",
     |(ip, port)| net::SocketAddrV4::new(ip, port),
 }
 
 parse_socket_impl! {
     #[cfg(any(feature = "std", not(no_core_net)))]
-    #[cfg_attr(docsrs, doc(cfg(any(feature = "std", not(no_core_net)))))]
     net::SocketAddrV6, "IPv6 socket address",
     |(ip, port)| net::SocketAddrV6::new(ip, port, 0, 0),
 }

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -784,7 +784,6 @@ macro_rules! serialize_display_bounded_length {
 }
 
 #[cfg(any(feature = "std", not(no_core_net)))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "std", not(no_core_net)))))]
 impl Serialize for net::IpAddr {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -855,7 +854,6 @@ fn test_format_u8() {
 }
 
 #[cfg(any(feature = "std", not(no_core_net)))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "std", not(no_core_net)))))]
 impl Serialize for net::Ipv4Addr {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -880,7 +878,6 @@ impl Serialize for net::Ipv4Addr {
 }
 
 #[cfg(any(feature = "std", not(no_core_net)))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "std", not(no_core_net)))))]
 impl Serialize for net::Ipv6Addr {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -897,7 +894,6 @@ impl Serialize for net::Ipv6Addr {
 }
 
 #[cfg(any(feature = "std", not(no_core_net)))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "std", not(no_core_net)))))]
 impl Serialize for net::SocketAddr {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -922,7 +918,6 @@ impl Serialize for net::SocketAddr {
 }
 
 #[cfg(any(feature = "std", not(no_core_net)))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "std", not(no_core_net)))))]
 impl Serialize for net::SocketAddrV4 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -939,7 +934,6 @@ impl Serialize for net::SocketAddrV4 {
 }
 
 #[cfg(any(feature = "std", not(no_core_net)))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "std", not(no_core_net)))))]
 impl Serialize for net::SocketAddrV6 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
Followup to #2816. These impls no longer need a cfg banner on docs.rs.