### PR TITLE
Remove 'useless' unsafe?

### DIFF
--- a/serde/src/format.rs
+++ b/serde/src/format.rs
@@ -13,7 +13,10 @@ impl<'a> Buf<'a> {
 
     pub fn as_str(&self) -> &str {
         let slice = &self.bytes[..self.offset];
-        unsafe { str::from_utf8_unchecked(slice) }
+        return match str::from_utf8(slice) {
+            Ok(slice) => slice,
+            Err(_) => "",
+        };
     }
 }
 

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -869,7 +869,10 @@ impl Serialize for net::Ipv4Addr {
                 written += format_u8(*oct, &mut buf[written + 1..]) + 1;
             }
             // Safety: We've only written ASCII bytes to the buffer, so it is valid UTF-8
-            let buf = unsafe { str::from_utf8_unchecked(&buf[..written]) };
+            let buf = match str::from_utf8(&buf[..written]) {
+                Ok(buffer) => buffer,
+                Err(_) => "",
+            };
             serializer.serialize_str(buf)
         } else {
             self.octets().serialize(serializer)


### PR DESCRIPTION
Hello ?

Sorry, I just don't understand the use of the `std::from_utf8_unchecked` function when you can simply use str::from_utf8. Which doesn't break serde (even with a `cargo test` everything looks ok.
