### PR TITLE
Update ui tests from PR 2558

### DIFF
--- a/test_suite/tests/ui/with/incorrect_type.stderr
+++ b/test_suite/tests/ui/with/incorrect_type.stderr
@@ -7,7 +7,7 @@ error[E0277]: the trait bound `&u8: Serializer` is not satisfied
    |                         --- required by a bound introduced by this call
    |
    = help: the following other types implement trait `Serializer`:
-             &'a mut Formatter<'b>
+             &mut Formatter<'a>
              FlatMapSerializer<'a, M>
              _::_serde::__private::ser::content::ContentSerializer<E>
 note: required by a bound in `w::serialize`
@@ -35,7 +35,7 @@ error[E0277]: the trait bound `&u8: Serializer` is not satisfied
    |                         ^^^ the trait `Serializer` is not implemented for `&u8`
    |
    = help: the following other types implement trait `Serializer`:
-             &'a mut Formatter<'b>
+             &mut Formatter<'a>
              FlatMapSerializer<'a, M>
              _::_serde::__private::ser::content::ContentSerializer<E>
 
@@ -56,7 +56,7 @@ error[E0277]: the trait bound `&u8: Serializer` is not satisfied
    |                                   -------------- required by a bound introduced by this call
    |
    = help: the following other types implement trait `Serializer`:
-             &'a mut Formatter<'b>
+             &mut Formatter<'a>
              FlatMapSerializer<'a, M>
              _::_serde::__private::ser::content::ContentSerializer<E>
 note: required by a bound in `w::serialize`
@@ -84,7 +84,7 @@ error[E0277]: the trait bound `&u8: Serializer` is not satisfied
    |                                   ^^^^^^^^^^^^^^ the trait `Serializer` is not implemented for `&u8`
    |
    = help: the following other types implement trait `Serializer`:
-             &'a mut Formatter<'b>
+             &mut Formatter<'a>
              FlatMapSerializer<'a, M>
              _::_serde::__private::ser::content::ContentSerializer<E>
 


### PR DESCRIPTION
This test was failing on master since the stderr in #2558 had been generated prior to 8e1ae68569db46251a88997e5e212392d4ad83ea.

https://github.com/serde-rs/serde/pull/2558#issuecomment-2427872479