### PR TITLE
Ignore needless_lifetimes clippy lint in generated code

### DIFF
--- a/serde_derive/src/dummy.rs
+++ b/serde_derive/src/dummy.rs
@@ -14,7 +14,12 @@ pub fn wrap_in_const(serde_path: Option<&syn::Path>, code: TokenStream) -> Token
 
     quote! {
         #[doc(hidden)]
-        #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
+        #[allow(
+            clippy::needless_lifetimes,
+            non_upper_case_globals,
+            unused_attributes,
+            unused_qualifications,
+        )]
         const _: () = {
             #use_serde
             #code


### PR DESCRIPTION
Clippy is reporting warnings in serde_derive-generated code in master because https://github.com/serde-rs/serde/pull/2558 interferes with clippy's `is_from_proc_macro` logic. The generated code is the same before and after that PR, but the PR makes it use spans that hide that particular tokens are generated. For example in the case of:

```rust
use serde::{Serialize, Serializer};

#[derive(Serialize)]
pub struct Struct {
    #[serde(serialize_with = "serialize_string")]
    pub i: i32,
}

fn serialize_string<S>(i: &i32, serializer: S) -> Result<S::Ok, S::Error>
where
    S: Serializer,
{
    serializer.collect_str(i)
}
```

```console
$ cargo clippy
warning: the following explicit lifetimes could be elided: '__a
 --> src/main.rs:3:10
  |
3 | #[derive(Serialize)]
  |          ^^^^^^^^^
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
  = note: `#[warn(clippy::needless_lifetimes)]` on by default
  = note: this warning originates in the derive macro `Serialize` (in Nightly builds, run with -Z macro-backtrace for more info)
```

The generated code is:

```rust
#[doc(hidden)]
#[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
const _: () = {
    #[allow(unused_extern_crates, clippy::useless_attribute)]
    extern crate serde as _serde;
    #[automatically_derived]
    impl _serde::Serialize for Struct {
        fn serialize<__S>(
            &self,
            __serializer: __S,
        ) -> _serde::__private::Result<__S::Ok, __S::Error>
        where
            __S: _serde::Serializer,
        {
            let mut __serde_state = _serde::Serializer::serialize_struct(
                __serializer,
                "Struct",
                false as usize + 1,
            )?;
            _serde::ser::SerializeStruct::serialize_field(
                &mut __serde_state,
                "i",
                {
                    #[doc(hidden)]
                    struct __SerializeWith<'__a> {
                        #[allow(dead_code)]
                        values: (&'__a i32,),
                        phantom: _serde::__private::PhantomData<Struct>,
                    }
                    impl<'__a> _serde::Serialize for __SerializeWith<'__a> {
                        fn serialize<__S>(
                            &self,
                            __s: __S,
                        ) -> _serde::__private::Result<__S::Ok, __S::Error>
                        where
                            __S: _serde::Serializer,
                        {
                            serialize_string(self.values.0, __s)
                        }
                    }
                    &__SerializeWith {
                        values: (&self.i,),
                        phantom: _serde::__private::PhantomData::<Struct>,
                    }
                },
            )?;
            _serde::ser::SerializeStruct::end(__serde_state)
        }
    }
};
```

with the `clippy::needless_lifetimes` warning originating from this part:

```console
warning: the following explicit lifetimes could be elided: '__a
  --> src/main.rs:45:26
   |
45 |                     impl<'__a> _serde::Serialize for __SerializeWith<'__a> {
   |                          ^^^^                                        ^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
   = note: `#[warn(clippy::needless_lifetimes)]` on by default
help: elide the lifetimes
   |
45 -                     impl<'__a> _serde::Serialize for __SerializeWith<'__a> {
45 +                     impl _serde::Serialize for __SerializeWith<'_> {
   |
```