### PR TITLE
Hygiene for macro-generated newtype struct deserialization with `with` attr

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -875,13 +875,14 @@ fn deserialize_newtype_struct(
 ) -> TokenStream {
     let delife = params.borrowed.de_lifetime();
     let field_ty = field.ty;
+    let deserializer_var = quote!(__e);
 
     let value = match field.attrs.deserialize_with() {
         None => {
             let span = field.original.span();
             let func = quote_spanned!(span=> <#field_ty as _serde::Deserialize>::deserialize);
             quote! {
-                #func(__e)?
+                #func(#deserializer_var)?
             }
         }
         Some(path) => {
@@ -890,7 +891,7 @@ fn deserialize_newtype_struct(
             // on the #[serde(with = "...")]
             //                       ^^^^^
             quote_spanned! {path.span()=>
-                #path(__e)?
+                #path(#deserializer_var)?
             }
         }
     };
@@ -906,7 +907,7 @@ fn deserialize_newtype_struct(
 
     quote! {
         #[inline]
-        fn visit_newtype_struct<__E>(self, __e: __E) -> _serde::__private::Result<Self::Value, __E::Error>
+        fn visit_newtype_struct<__E>(self, #deserializer_var: __E) -> _serde::__private::Result<Self::Value, __E::Error>
         where
             __E: _serde::Deserializer<#delife>,
         {

--- a/test_suite/tests/regression/issue2846.rs
+++ b/test_suite/tests/regression/issue2846.rs
@@ -5,7 +5,11 @@ use serde_derive::Deserialize;
 macro_rules! declare_in_macro {
     ($with:literal) => {
         #[derive(Deserialize)]
-        pub struct S(#[serde(with = $with)] i32);
+        pub struct S(
+            #[serde(with = $with)]
+            #[allow(dead_code)]
+            i32,
+        );
     };
 }
 

--- a/test_suite/tests/regression/issue2846.rs
+++ b/test_suite/tests/regression/issue2846.rs
@@ -1,0 +1,23 @@
+#![allow(clippy::trivially_copy_pass_by_ref)]
+
+use serde_derive::Deserialize;
+
+macro_rules! declare_in_macro {
+    ($with:literal) => {
+        #[derive(Deserialize)]
+        pub struct S(#[serde(with = $with)] i32);
+    };
+}
+
+declare_in_macro!("with");
+
+mod with {
+    use serde::Deserializer;
+
+    pub fn deserialize<'de, D>(_: D) -> Result<i32, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        unimplemented!()
+    }
+}


### PR DESCRIPTION
Fixes #2846.