### PR TITLE
Produce unreachable_patterns warning when deserialization names collide

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1,5 +1,6 @@
 use crate::fragment::{Expr, Fragment, Match, Stmts};
 use crate::internals::ast::{Container, Data, Field, Style, Variant};
+use crate::internals::name::Name;
 use crate::internals::{attr, replace_receiver, ungroup, Ctxt, Derive};
 use crate::{bound, dummy, pretend, this};
 use proc_macro2::{Literal, Span, TokenStream};
@@ -2002,7 +2003,7 @@ fn deserialize_untagged_newtype_variant(
 
 struct FieldWithAliases<'a> {
     ident: Ident,
-    aliases: &'a BTreeSet<String>,
+    aliases: &'a BTreeSet<Name>,
 }
 
 fn deserialize_generated_identifier(
@@ -2224,7 +2225,7 @@ fn deserialize_identifier(
         let aliases = field
             .aliases
             .iter()
-            .map(|alias| Literal::byte_string(alias.as_bytes()));
+            .map(|alias| Literal::byte_string(alias.value.as_bytes()));
         quote!(#(#aliases)|* => _serde::__private::Ok(#this_value::#ident))
     });
 

--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -130,7 +130,7 @@ impl<'c, T> VecAttr<'c, T> {
     }
 }
 
-pub struct Name {
+pub struct MultiName {
     serialize: String,
     serialize_renamed: bool,
     deserialize: String,
@@ -142,13 +142,13 @@ fn unraw(ident: &Ident) -> String {
     ident.to_string().trim_start_matches("r#").to_owned()
 }
 
-impl Name {
+impl MultiName {
     fn from_attrs(
         source_name: String,
         ser_name: Attr<String>,
         de_name: Attr<String>,
         de_aliases: Option<VecAttr<String>>,
-    ) -> Name {
+    ) -> Self {
         let mut alias_set = BTreeSet::new();
         if let Some(de_aliases) = de_aliases {
             for alias_name in de_aliases.get() {
@@ -160,7 +160,7 @@ impl Name {
         let ser_renamed = ser_name.is_some();
         let de_name = de_name.get();
         let de_renamed = de_name.is_some();
-        Name {
+        MultiName {
             serialize: ser_name.unwrap_or_else(|| source_name.clone()),
             serialize_renamed: ser_renamed,
             deserialize: de_name.unwrap_or(source_name),
@@ -203,7 +203,7 @@ impl RenameAllRules {
 
 /// Represents struct or enum attribute information.
 pub struct Container {
-    name: Name,
+    name: MultiName,
     transparent: bool,
     deny_unknown_fields: bool,
     default: Default,
@@ -567,7 +567,7 @@ impl Container {
         }
 
         Container {
-            name: Name::from_attrs(unraw(&item.ident), ser_name, de_name, None),
+            name: MultiName::from_attrs(unraw(&item.ident), ser_name, de_name, None),
             transparent: transparent.get(),
             deny_unknown_fields: deny_unknown_fields.get(),
             default: default.get().unwrap_or(Default::None),
@@ -594,7 +594,7 @@ impl Container {
         }
     }
 
-    pub fn name(&self) -> &Name {
+    pub fn name(&self) -> &MultiName {
         &self.name
     }
 
@@ -781,7 +781,7 @@ fn decide_identifier(
 
 /// Represents variant attribute information
 pub struct Variant {
-    name: Name,
+    name: MultiName,
     rename_all_rules: RenameAllRules,
     ser_bound: Option<Vec<syn::WherePredicate>>,
     de_bound: Option<Vec<syn::WherePredicate>>,
@@ -947,7 +947,7 @@ impl Variant {
         }
 
         Variant {
-            name: Name::from_attrs(unraw(&variant.ident), ser_name, de_name, Some(de_aliases)),
+            name: MultiName::from_attrs(unraw(&variant.ident), ser_name, de_name, Some(de_aliases)),
             rename_all_rules: RenameAllRules {
                 serialize: rename_all_ser_rule.get().unwrap_or(RenameRule::None),
                 deserialize: rename_all_de_rule.get().unwrap_or(RenameRule::None),
@@ -964,7 +964,7 @@ impl Variant {
         }
     }
 
-    pub fn name(&self) -> &Name {
+    pub fn name(&self) -> &MultiName {
         &self.name
     }
 
@@ -1023,7 +1023,7 @@ impl Variant {
 
 /// Represents field attribute information
 pub struct Field {
-    name: Name,
+    name: MultiName,
     skip_serializing: bool,
     skip_deserializing: bool,
     skip_serializing_if: Option<syn::ExprPath>,
@@ -1290,7 +1290,7 @@ impl Field {
         }
 
         Field {
-            name: Name::from_attrs(ident, ser_name, de_name, Some(de_aliases)),
+            name: MultiName::from_attrs(ident, ser_name, de_name, Some(de_aliases)),
             skip_serializing: skip_serializing.get(),
             skip_deserializing: skip_deserializing.get(),
             skip_serializing_if: skip_serializing_if.get(),
@@ -1306,7 +1306,7 @@ impl Field {
         }
     }
 
-    pub fn name(&self) -> &Name {
+    pub fn name(&self) -> &MultiName {
         &self.name
     }
 

--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -1,3 +1,4 @@
+use crate::internals::name::MultiName;
 use crate::internals::symbol::*;
 use crate::internals::{ungroup, Ctxt};
 use proc_macro2::{Spacing, Span, TokenStream, TokenTree};
@@ -21,7 +22,7 @@ use syn::{parse_quote, token, Ident, Lifetime, Token};
 
 pub use crate::internals::case::RenameRule;
 
-struct Attr<'c, T> {
+pub(crate) struct Attr<'c, T> {
     cx: &'c Ctxt,
     name: Symbol,
     tokens: TokenStream,
@@ -62,7 +63,7 @@ impl<'c, T> Attr<'c, T> {
         }
     }
 
-    fn get(self) -> Option<T> {
+    pub(crate) fn get(self) -> Option<T> {
         self.value
     }
 
@@ -90,7 +91,7 @@ impl<'c> BoolAttr<'c> {
     }
 }
 
-struct VecAttr<'c, T> {
+pub(crate) struct VecAttr<'c, T> {
     cx: &'c Ctxt,
     name: Symbol,
     first_dup_tokens: TokenStream,
@@ -125,63 +126,13 @@ impl<'c, T> VecAttr<'c, T> {
         }
     }
 
-    fn get(self) -> Vec<T> {
+    pub(crate) fn get(self) -> Vec<T> {
         self.values
     }
 }
 
-pub struct MultiName {
-    serialize: String,
-    serialize_renamed: bool,
-    deserialize: String,
-    deserialize_renamed: bool,
-    deserialize_aliases: BTreeSet<String>,
-}
-
 fn unraw(ident: &Ident) -> String {
     ident.to_string().trim_start_matches("r#").to_owned()
-}
-
-impl MultiName {
-    fn from_attrs(
-        source_name: String,
-        ser_name: Attr<String>,
-        de_name: Attr<String>,
-        de_aliases: Option<VecAttr<String>>,
-    ) -> Self {
-        let mut alias_set = BTreeSet::new();
-        if let Some(de_aliases) = de_aliases {
-            for alias_name in de_aliases.get() {
-                alias_set.insert(alias_name);
-            }
-        }
-
-        let ser_name = ser_name.get();
-        let ser_renamed = ser_name.is_some();
-        let de_name = de_name.get();
-        let de_renamed = de_name.is_some();
-        MultiName {
-            serialize: ser_name.unwrap_or_else(|| source_name.clone()),
-            serialize_renamed: ser_renamed,
-            deserialize: de_name.unwrap_or(source_name),
-            deserialize_renamed: de_renamed,
-            deserialize_aliases: alias_set,
-        }
-    }
-
-    /// Return the container name for the container when serializing.
-    pub fn serialize_name(&self) -> &str {
-        &self.serialize
-    }
-
-    /// Return the container name for the container when deserializing.
-    pub fn deserialize_name(&self) -> &str {
-        &self.deserialize
-    }
-
-    fn deserialize_aliases(&self) -> &BTreeSet<String> {
-        &self.deserialize_aliases
-    }
 }
 
 #[derive(Copy, Clone)]

--- a/serde_derive/src/internals/check.rs
+++ b/serde_derive/src/internals/check.rs
@@ -332,13 +332,13 @@ fn check_internal_tag_field_name_conflict(cx: &Ctxt, cont: &Container) {
                     let name = field.attrs.name();
                     let ser_name = name.serialize_name();
 
-                    if check_ser && ser_name == tag {
+                    if check_ser && ser_name.value == tag {
                         diagnose_conflict();
                         return;
                     }
 
                     for de_name in field.attrs.aliases() {
-                        if check_de && de_name == tag {
+                        if check_de && de_name.value == tag {
                             diagnose_conflict();
                             return;
                         }

--- a/serde_derive/src/internals/mod.rs
+++ b/serde_derive/src/internals/mod.rs
@@ -1,10 +1,10 @@
 pub mod ast;
 pub mod attr;
+pub mod name;
 
 mod case;
 mod check;
 mod ctxt;
-mod name;
 mod receiver;
 mod respan;
 mod symbol;

--- a/serde_derive/src/internals/mod.rs
+++ b/serde_derive/src/internals/mod.rs
@@ -4,6 +4,7 @@ pub mod attr;
 mod case;
 mod check;
 mod ctxt;
+mod name;
 mod receiver;
 mod respan;
 mod symbol;

--- a/serde_derive/src/internals/name.rs
+++ b/serde_derive/src/internals/name.rs
@@ -1,0 +1,52 @@
+use crate::internals::attr::{Attr, VecAttr};
+use std::collections::BTreeSet;
+
+pub struct MultiName {
+    pub(crate) serialize: String,
+    pub(crate) serialize_renamed: bool,
+    pub(crate) deserialize: String,
+    pub(crate) deserialize_renamed: bool,
+    pub(crate) deserialize_aliases: BTreeSet<String>,
+}
+
+impl MultiName {
+    pub(crate) fn from_attrs(
+        source_name: String,
+        ser_name: Attr<String>,
+        de_name: Attr<String>,
+        de_aliases: Option<VecAttr<String>>,
+    ) -> Self {
+        let mut alias_set = BTreeSet::new();
+        if let Some(de_aliases) = de_aliases {
+            for alias_name in de_aliases.get() {
+                alias_set.insert(alias_name);
+            }
+        }
+
+        let ser_name = ser_name.get();
+        let ser_renamed = ser_name.is_some();
+        let de_name = de_name.get();
+        let de_renamed = de_name.is_some();
+        MultiName {
+            serialize: ser_name.unwrap_or_else(|| source_name.clone()),
+            serialize_renamed: ser_renamed,
+            deserialize: de_name.unwrap_or(source_name),
+            deserialize_renamed: de_renamed,
+            deserialize_aliases: alias_set,
+        }
+    }
+
+    /// Return the container name for the container when serializing.
+    pub fn serialize_name(&self) -> &str {
+        &self.serialize
+    }
+
+    /// Return the container name for the container when deserializing.
+    pub fn deserialize_name(&self) -> &str {
+        &self.deserialize
+    }
+
+    pub(crate) fn deserialize_aliases(&self) -> &BTreeSet<String> {
+        &self.deserialize_aliases
+    }
+}

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -1,5 +1,6 @@
 use crate::fragment::{Fragment, Match, Stmts};
 use crate::internals::ast::{Container, Data, Field, Style, Variant};
+use crate::internals::name::Name;
 use crate::internals::{attr, replace_receiver, Ctxt, Derive};
 use crate::{bound, dummy, pretend, this};
 use proc_macro2::{Span, TokenStream};
@@ -798,9 +799,9 @@ fn serialize_untagged_variant(
 
 enum TupleVariant<'a> {
     ExternallyTagged {
-        type_name: &'a str,
+        type_name: &'a Name,
         variant_index: u32,
-        variant_name: &'a str,
+        variant_name: &'a Name,
     },
     Untagged,
 }
@@ -867,11 +868,11 @@ fn serialize_tuple_variant(
 enum StructVariant<'a> {
     ExternallyTagged {
         variant_index: u32,
-        variant_name: &'a str,
+        variant_name: &'a Name,
     },
     InternallyTagged {
         tag: &'a str,
-        variant_name: &'a str,
+        variant_name: &'a Name,
     },
     Untagged,
 }
@@ -880,7 +881,7 @@ fn serialize_struct_variant(
     context: StructVariant,
     params: &Parameters,
     fields: &[Field],
-    name: &str,
+    name: &Name,
 ) -> Fragment {
     if fields.iter().any(|field| field.attrs.flatten()) {
         return serialize_struct_variant_with_flatten(context, params, fields, name);
@@ -964,7 +965,7 @@ fn serialize_struct_variant_with_flatten(
     context: StructVariant,
     params: &Parameters,
     fields: &[Field],
-    name: &str,
+    name: &Name,
 ) -> Fragment {
     let struct_trait = StructTrait::SerializeMap;
     let serialize_fields = serialize_struct_visitor(fields, params, true, &struct_trait);


### PR DESCRIPTION
Closes #2308.

```console
warning: unreachable pattern
 --> src/main.rs:7:22
  |
5 |     #[serde(rename = "Response")]
  |                      ---------- matches all the relevant values
6 |     Request { id: String},
7 |     #[serde(rename = "Response")]
  |                      ^^^^^^^^^^ no value can reach this
  |
  = note: `#[warn(unreachable_patterns)]` on by default
```