### PR TITLE
Produce a separate warning for every colliding name

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -2217,7 +2217,11 @@ fn deserialize_identifier(
         let ident = &field.ident;
         let aliases = field.aliases;
         // `aliases` also contains a main name
-        quote!(#(#aliases)|* => _serde::__private::Ok(#this_value::#ident))
+        quote! {
+            #(
+                #aliases => _serde::__private::Ok(#this_value::#ident),
+            )*
+        }
     });
     let bytes_mapping = deserialized_fields.iter().map(|field| {
         let ident = &field.ident;
@@ -2226,7 +2230,11 @@ fn deserialize_identifier(
             .aliases
             .iter()
             .map(|alias| Literal::byte_string(alias.value.as_bytes()));
-        quote!(#(#aliases)|* => _serde::__private::Ok(#this_value::#ident))
+        quote! {
+            #(
+                #aliases => _serde::__private::Ok(#this_value::#ident),
+            )*
+        }
     });
 
     let expecting = expecting.unwrap_or(if is_variant {
@@ -2424,7 +2432,7 @@ fn deserialize_identifier(
                 __E: _serde::de::Error,
             {
                 match __value {
-                    #(#str_mapping,)*
+                    #(#str_mapping)*
                     _ => {
                         #value_as_borrowed_str_content
                         #fallthrough_borrowed_arm
@@ -2437,7 +2445,7 @@ fn deserialize_identifier(
                 __E: _serde::de::Error,
             {
                 match __value {
-                    #(#bytes_mapping,)*
+                    #(#bytes_mapping)*
                     _ => {
                         #bytes_to_str
                         #value_as_borrowed_bytes_content
@@ -2462,7 +2470,7 @@ fn deserialize_identifier(
             __E: _serde::de::Error,
         {
             match __value {
-                #(#str_mapping,)*
+                #(#str_mapping)*
                 _ => {
                     #value_as_str_content
                     #fallthrough_arm
@@ -2475,7 +2483,7 @@ fn deserialize_identifier(
             __E: _serde::de::Error,
         {
             match __value {
-                #(#bytes_mapping,)*
+                #(#bytes_mapping)*
                 _ => {
                     #bytes_to_str
                     #value_as_bytes_content


### PR DESCRIPTION
Before:

```console
warning: unreachable pattern
  --> tests/ui/conflict/alias.rs:12:21
   |
8  |       #[serde(alias = "a", alias = "b", alias = "c")]
   |                       ----------------------------- matches all the relevant values
...
12 |       #[serde(alias = "c")]
   |  _____________________^
13 | |     b: (),
   | |_____^ no value can reach this
   |
   = note: `#[warn(unreachable_patterns)]` on by default
```

After:

```console
warning: unreachable pattern
  --> tests/ui/conflict/alias.rs:13:5
   |
8  |     #[serde(alias = "a", alias = "b", alias = "c")]
   |                                  --- matches all the relevant values
...
13 |     b: (),
   |     ^ no value can reach this
   |
   = note: `#[warn(unreachable_patterns)]` on by default

warning: unreachable pattern
  --> tests/ui/conflict/alias.rs:12:21
   |
8  |     #[serde(alias = "a", alias = "b", alias = "c")]
   |                                               --- matches all the relevant values
...
12 |     #[serde(alias = "c")]
   |                     ^^^ no value can reach this
```

The diagnostic in the "Before" is a confusingly rendered consequence of a warning that looks like this in the underlying macro-expanded code:

```console
warning: unreachable pattern
  --> src/main.rs:74:25
   |
73 |                         "a" | "b" | "c" => _serde::__private::Ok(__Field::__field0),
   |                         --------------- matches all the relevant values
74 |                         "b" | "c" => _serde::__private::Ok(__Field::__field1),
   |                         ^^^^^^^^^ no value can reach this
   |
   = note: `#[warn(unreachable_patterns)]` on by default
```