### PR TITLE
add `#[allow(deprecated)]` to derive implementations

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -34,6 +34,7 @@ pub fn expand_derive_deserialize(input: &mut syn::DeriveInput) -> syn::Result<To
         let used = pretend::pretend_used(&cont, params.is_packed);
         quote! {
             #[automatically_derived]
+            #[allow(deprecated)]
             impl #de_impl_generics #ident #ty_generics #where_clause {
                 #vis fn deserialize<__D>(__deserializer: __D) -> #serde::__private::Result<#remote #ty_generics, __D::Error>
                 where
@@ -49,6 +50,7 @@ pub fn expand_derive_deserialize(input: &mut syn::DeriveInput) -> syn::Result<To
 
         quote! {
             #[automatically_derived]
+            #[allow(deprecated)]
             impl #de_impl_generics #serde::Deserialize<#delife> for #ident #ty_generics #where_clause {
                 fn deserialize<__D>(__deserializer: __D) -> #serde::__private::Result<Self, __D::Error>
                 where

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -30,6 +30,7 @@ pub fn expand_derive_serialize(input: &mut syn::DeriveInput) -> syn::Result<Toke
         let used = pretend::pretend_used(&cont, params.is_packed);
         quote! {
             #[automatically_derived]
+            #[allow(deprecated)]
             impl #impl_generics #ident #ty_generics #where_clause {
                 #vis fn serialize<__S>(__self: &#remote #ty_generics, __serializer: __S) -> #serde::__private::Result<__S::Ok, __S::Error>
                 where
@@ -43,6 +44,7 @@ pub fn expand_derive_serialize(input: &mut syn::DeriveInput) -> syn::Result<Toke
     } else {
         quote! {
             #[automatically_derived]
+            #[allow(deprecated)]
             impl #impl_generics #serde::Serialize for #ident #ty_generics #where_clause {
                 fn serialize<__S>(&self, __serializer: __S) -> #serde::__private::Result<__S::Ok, __S::Error>
                 where

--- a/test_suite/tests/deprecated.rs
+++ b/test_suite/tests/deprecated.rs
@@ -1,0 +1,35 @@
+#![deny(deprecated)]
+#![allow(dead_code)]
+
+use serde_derive::{Deserialize, Serialize};
+
+/// deprecated enum
+#[derive(Serialize, Deserialize)]
+#[deprecated]
+enum E1 {
+    A,
+    B,
+}
+
+/// deprecated struct
+#[derive(Serialize, Deserialize)]
+#[deprecated]
+struct S1 {
+    a: bool,
+}
+
+/// deprecated enum variant
+#[derive(Serialize, Deserialize)]
+enum E2 {
+    A,
+    #[deprecated]
+    B,
+}
+
+/// deprecated struct field
+#[derive(Serialize, Deserialize)]
+#[deprecated]
+struct S2 {
+    #[deprecated]
+    a: bool,
+}


### PR DESCRIPTION
Allow deprecated in the `Serialize`/`Deserialize` derive implementations. This allows you to deprecate structs, enums, struct fields, or enum variants and not get compiler warnings/errors about use of deprecated thing.

Resolves #2195