### PR TITLE
Also link to stable proc_macro

### DIFF
--- a/serde_derive/Cargo.toml
+++ b/serde_derive/Cargo.toml
@@ -37,4 +37,5 @@ rustdoc-args = [
     "--extern-html-root-url=core=https://doc.rust-lang.org",
     "--extern-html-root-url=alloc=https://doc.rust-lang.org",
     "--extern-html-root-url=std=https://doc.rust-lang.org",
+    "--extern-html-root-url=proc_macro=https://doc.rust-lang.org",
 ]

--- a/serde_derive_internals/Cargo.toml
+++ b/serde_derive_internals/Cargo.toml
@@ -27,4 +27,5 @@ rustdoc-args = [
     "--extern-html-root-url=core=https://doc.rust-lang.org",
     "--extern-html-root-url=alloc=https://doc.rust-lang.org",
     "--extern-html-root-url=std=https://doc.rust-lang.org",
+    "--extern-html-root-url=proc_macro=https://doc.rust-lang.org",
 ]


### PR DESCRIPTION
I missed this in #2895.

https://docs.rs/serde_derive/1.0.218/src/serde_derive/lib.rs.html#91