### PR TITLE
fix clippy absolute paths warning

### DIFF
--- a/serde_derive/src/dummy.rs
+++ b/serde_derive/src/dummy.rs
@@ -14,7 +14,7 @@ pub fn wrap_in_const(serde_path: Option<&syn::Path>, code: TokenStream) -> Token
 
     quote! {
         #[doc(hidden)]
-        #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
+        #[allow(non_upper_case_globals, unused_attributes, unused_qualifications, clippy::absolute_paths)]
         const _: () = {
             #use_serde
             #code


### PR DESCRIPTION
First attempt https://github.com/serde-rs/serde/pull/2905 failed because [this](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=71f25171e7d282a7073985c1f34eb6ef) pattern apparently doesn't work. Alternatively one could replace `_serde` with a runtime `#path`

Fixes https://github.com/serde-rs/serde/issues/2904