### PR TITLE
Customizable buffer type (proof of concept)

### DIFF
--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -1223,6 +1223,12 @@ pub trait Deserializer<'de>: Sized {
         true
     }
 
+    ///
+    fn deserialize_buffer(self) -> Result<impl Buffer<'de, Error = Self::Error>, Self::Error> {
+        let content = crate::__private::de::Content::deserialize(self)?;
+        Ok(crate::__private::de::ContentDeserializer::new(content))
+    }
+
     // Not public API.
     #[cfg(all(not(no_serde_derive), any(feature = "std", feature = "alloc")))]
     #[doc(hidden)]
@@ -1236,6 +1242,29 @@ pub trait Deserializer<'de>: Sized {
     {
         self.deserialize_any(visitor)
     }
+}
+
+///
+pub trait Buffer<'de> {
+    ///
+    type Error: Error;
+
+    ///
+    type OwnedDeserializer: Deserializer<'de, Error = Self::Error>;
+
+    ///
+    type RefDeserializer<'a>: Deserializer<'de, Error = Self::Error> + Copy
+    where
+        'de: 'a,
+        Self: 'a;
+
+    ///
+    fn owned_deserializer(self) -> Self::OwnedDeserializer;
+
+    ///
+    fn ref_deserializer<'a>(&'a self) -> Self::RefDeserializer<'a>
+    where
+        'de: 'a;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1891,6 +1920,14 @@ pub trait MapAccess<'de> {
     #[inline]
     fn size_hint(&self) -> Option<usize> {
         None
+    }
+
+    ///
+    fn next_value_buffer(
+        &mut self,
+    ) -> Result<impl Buffer<'de, Error = Self::Error> + use<'de, Self>, Self::Error> {
+        let content = self.next_value::<crate::__private::de::Content>()?;
+        Ok(crate::__private::de::ContentDeserializer::new(content))
     }
 }
 

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -94,6 +94,7 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
+#![feature(precise_capturing_in_traits)]
 // Serde types in rustdoc of other crates get linked to here.
 #![doc(html_root_url = "https://docs.rs/serde/1.0.219")]
 // Support using Serde without the standard library!

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -211,7 +211,7 @@ mod content {
     use crate::actually_private;
     use crate::de::value::{MapDeserializer, SeqDeserializer};
     use crate::de::{
-        self, size_hint, Deserialize, DeserializeSeed, Deserializer, EnumAccess, Expected,
+        self, size_hint, Buffer, Deserialize, DeserializeSeed, Deserializer, EnumAccess, Expected,
         IgnoredAny, MapAccess, SeqAccess, Unexpected, Visitor,
     };
 
@@ -321,6 +321,32 @@ mod content {
 
         fn into_deserializer(self) -> Self::Deserializer {
             ContentRefDeserializer::new(self)
+        }
+    }
+
+    impl<'de, E> Buffer<'de> for ContentDeserializer<'de, E>
+    where
+        E: de::Error,
+    {
+        type Error = E;
+
+        type OwnedDeserializer = Self;
+
+        type RefDeserializer<'a>
+            = ContentRefDeserializer<'a, 'de, E>
+        where
+            'de: 'a,
+            E: 'a;
+
+        fn owned_deserializer(self) -> Self::OwnedDeserializer {
+            self
+        }
+
+        fn ref_deserializer<'a>(&'a self) -> Self::RefDeserializer<'a>
+        where
+            'de: 'a,
+        {
+            ContentRefDeserializer::new(&self.content)
         }
     }
 

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1669,12 +1669,12 @@ fn deserialize_adjacently_tagged_enum(
                     // First key is the content.
                     _serde::__private::Some(_serde::__private::de::TagOrContentField::Content) => {
                         // Buffer up the content.
-                        let __content = _serde::de::MapAccess::next_value::<_serde::__private::de::Content>(&mut __map)?;
+                        let __content = _serde::de::MapAccess::next_value_buffer(&mut __map)?;
                         // Visit the second key.
                         match #next_relevant_key {
                             // Second key is the tag.
                             _serde::__private::Some(_serde::__private::de::TagOrContentField::Tag) => {
-                                let __deserializer = _serde::__private::de::ContentDeserializer::<__A::Error>::new(__content);
+                                let __deserializer = _serde::de::Buffer::owned_deserializer(__content);
                                 #finish_content_then_tag
                             }
                             // Second key is a duplicate of the content.
@@ -1789,8 +1789,8 @@ fn deserialize_untagged_enum_after(
     });
 
     quote_block! {
-        let __content = <_serde::__private::de::Content as _serde::Deserialize>::deserialize(__deserializer)?;
-        let __deserializer = _serde::__private::de::ContentRefDeserializer::<__D::Error>::new(&__content);
+        let __content = _serde::Deserializer::deserialize_buffer(__deserializer)?;
+        let __deserializer = _serde::de::Buffer::ref_deserializer(&__content);
 
         #first_attempt
 


### PR DESCRIPTION
This demonstrates a backward compatible way that a format such as serde_json could use its own serde_json::Value as its buffer type for untagged enums and flatten, instead of "Content", solving https://github.com/serde-rs/serde/issues/1183. Uses "return position impl trait in traits" (stabilized in Rust 1.75 by https://github.com/rust-lang/rust/pull/115822) and "precise capturing in traits" (stabilizing in the near future by https://github.com/rust-lang/rust/pull/138128).