### PR TITLE
Drop trailing whitespace from CI job name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - run: cd test_suite/no_std && cargo build
 
   nightly:
-    name: Rust nightly ${{matrix.os == 'windows' && '(windows)' || ''}}
+    name: Rust nightly${{matrix.os == 'windows' && ' (windows)' || ''}}
     runs-on: ${{matrix.os}}-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
I am blindly guessing that this whitespace is what is causing PRs to bounce from the merge queue despite all checks passing.

<p align="center"><img src="https://github.com/user-attachments/assets/f3760a3d-e4bf-4876-bd8b-8dc35bfb6c81" width="700"></p>
