### PR TITLE
Update a Rust edition to 2021 across project files

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You may be looking for:
 <details>
 <summary>
 Click to show Cargo.toml.
-<a href="https://play.rust-lang.org/?edition=2018&gist=72755f28f99afc95e01d63174b28c1f5" target="_blank">Run this code in the playground.</a>
+<a href="https://play.rust-lang.org/?edition=2021&gist=72755f28f99afc95e01d63174b28c1f5" target="_blank">Run this code in the playground.</a>
 </summary>
 
 ```toml

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -2,7 +2,7 @@
 name = "serde_test_suite"
 version = "0.0.0"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>", "David Tolnay <dtolnay@gmail.com>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/test_suite/no_std/Cargo.toml
+++ b/test_suite/no_std/Cargo.toml
@@ -2,7 +2,7 @@
 name = "serde_derive_tests_no_std"
 version = "0.0.0"
 authors = ["David Tolnay <dtolnay@gmail.com>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]


### PR DESCRIPTION
Updated the Cargo.toml files for test suites and a link in the README to use Rust edition 2021 instead of 2018. This ensures compatibility with the 2021 Rust features and standards.