### PR TITLE
Add helper CowStrVisitor and CowBytesVisitor types

### DIFF
--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -7,7 +7,7 @@ use crate::de::{
 };
 
 #[cfg(any(feature = "std", feature = "alloc"))]
-use crate::de::{MapAccess, Unexpected};
+use crate::de::MapAccess;
 
 #[cfg(any(feature = "std", feature = "alloc"))]
 pub use self::content::{
@@ -66,72 +66,9 @@ where
     D: Deserializer<'de>,
     R: From<Cow<'a, str>>,
 {
-    struct CowStrVisitor;
-
-    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
-    impl<'a> Visitor<'a> for CowStrVisitor {
-        type Value = Cow<'a, str>;
-
-        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-            formatter.write_str("a string")
-        }
-
-        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-        where
-            E: Error,
-        {
-            Ok(Cow::Owned(v.to_owned()))
-        }
-
-        fn visit_borrowed_str<E>(self, v: &'a str) -> Result<Self::Value, E>
-        where
-            E: Error,
-        {
-            Ok(Cow::Borrowed(v))
-        }
-
-        fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
-        where
-            E: Error,
-        {
-            Ok(Cow::Owned(v))
-        }
-
-        fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-        where
-            E: Error,
-        {
-            match str::from_utf8(v) {
-                Ok(s) => Ok(Cow::Owned(s.to_owned())),
-                Err(_) => Err(Error::invalid_value(Unexpected::Bytes(v), &self)),
-            }
-        }
-
-        fn visit_borrowed_bytes<E>(self, v: &'a [u8]) -> Result<Self::Value, E>
-        where
-            E: Error,
-        {
-            match str::from_utf8(v) {
-                Ok(s) => Ok(Cow::Borrowed(s)),
-                Err(_) => Err(Error::invalid_value(Unexpected::Bytes(v), &self)),
-            }
-        }
-
-        fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
-        where
-            E: Error,
-        {
-            match String::from_utf8(v) {
-                Ok(s) => Ok(Cow::Owned(s)),
-                Err(e) => Err(Error::invalid_value(
-                    Unexpected::Bytes(&e.into_bytes()),
-                    &self,
-                )),
-            }
-        }
-    }
-
-    deserializer.deserialize_str(CowStrVisitor).map(From::from)
+    deserializer
+        .deserialize_str(serde_core::de::value::CowStrVisitor)
+        .map(From::from)
 }
 
 #[cfg(any(feature = "std", feature = "alloc"))]
@@ -140,61 +77,8 @@ where
     D: Deserializer<'de>,
     R: From<Cow<'a, [u8]>>,
 {
-    struct CowBytesVisitor;
-
-    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
-    impl<'a> Visitor<'a> for CowBytesVisitor {
-        type Value = Cow<'a, [u8]>;
-
-        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-            formatter.write_str("a byte array")
-        }
-
-        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-        where
-            E: Error,
-        {
-            Ok(Cow::Owned(v.as_bytes().to_vec()))
-        }
-
-        fn visit_borrowed_str<E>(self, v: &'a str) -> Result<Self::Value, E>
-        where
-            E: Error,
-        {
-            Ok(Cow::Borrowed(v.as_bytes()))
-        }
-
-        fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
-        where
-            E: Error,
-        {
-            Ok(Cow::Owned(v.into_bytes()))
-        }
-
-        fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-        where
-            E: Error,
-        {
-            Ok(Cow::Owned(v.to_vec()))
-        }
-
-        fn visit_borrowed_bytes<E>(self, v: &'a [u8]) -> Result<Self::Value, E>
-        where
-            E: Error,
-        {
-            Ok(Cow::Borrowed(v))
-        }
-
-        fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
-        where
-            E: Error,
-        {
-            Ok(Cow::Owned(v))
-        }
-    }
-
     deserializer
-        .deserialize_bytes(CowBytesVisitor)
+        .deserialize_bytes(serde_core::de::value::CowBytesVisitor)
         .map(From::from)
 }
 


### PR DESCRIPTION
As all known, when you deserialize [`Cow`](https://doc.rust-lang.org/nightly/alloc/borrow/enum.Cow.html), it will always be deserialized as `Owned`, which makes it difficult to implement effective deserialization when you manually want to deserialize `Cow<str>` or `Cow<[u8]>`. This PR adds two helper types, `CowStrVisitor` and `CowBytesVisitor`, which both serves as a `Visitor` and a `DeserializeSeed` and allows you to read borrowed data from, for example, `MapAccess`:

```rust
use serde::de::{DeserializeSeed, Deserializer, MapAccess, Visitor};
use serde::de::value::CowStrVisitor;
use std::borrow::Cow;

/// A simple XML DOM node.
struct Element<'a> {
    name: Cow<'a, str>,
    children: Vec<Node<'a>>,
}
enum Node<'a> {
    Text(Cow<'a, str>),
    Element(Element<'a>),
}

impl<'de> Visitor<'de> for Element<'de> {
    type Value = Self;

    fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
        f.write_str("a map")
    }

    fn visit_map<A>(mut self, mut map: A) -> Result<Self::Value, A::Error>
    where
        A: MapAccess<'de>,
    {
        while let Some(key) = map.next_key_seed(CowStrVisitor)? {
            if "$text" == key {
                let text = map.next_value_seed(CowStrVisitor)?;
                self.children.push(Node::Text(text));
            } else {
                let elem = Element { name: key, children: Vec::new() };
                let elem = map.next_value_seed(elem)?;
                self.children.push(Node::Element(elem));
            }
        }
        Ok(self)
    }
}

impl<'de> DeserializeSeed<'de> for Element<'de> {
    type Value = Self;

    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
    where
        D: Deserializer<'de>,
    {
        deserializer.deserialize_map(self)
    }
}
```