### PR TITLE
fix: refine feature flag conditions for Arc and Rc implementations to include target_has_atomic checks

### DIFF
--- a/serde/src/de/impls.rs
+++ b/serde/src/de/impls.rs
@@ -2020,10 +2020,10 @@ where
 /// `Weak<T>` has a reference count of 0 and cannot be upgraded.
 ///
 /// [`"rc"`]: https://serde.rs/feature-flags.html#-features-rc
-#[cfg(all(feature = "rc", any(feature = "std", feature = "alloc")))]
+#[cfg(all(feature = "rc", any(feature = "std", all(feature = "alloc", target_has_atomic = "ptr"))))]
 #[cfg_attr(
     docsrs,
-    doc(cfg(all(feature = "rc", any(feature = "std", feature = "alloc"))))
+    doc(cfg(all(feature = "rc", any(feature = "std", all(feature = "alloc", target_has_atomic = "ptr")))))
 )]
 impl<'de, T> Deserialize<'de> for ArcWeak<T>
 where
@@ -2082,8 +2082,8 @@ box_forwarded_impl! {
     /// will end up with a strong count of 1.
     ///
     /// [`"rc"`]: https://serde.rs/feature-flags.html#-features-rc
-    #[cfg(all(feature = "rc", any(feature = "std", feature = "alloc")))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "rc", any(feature = "std", feature = "alloc")))))]
+    #[cfg(all(feature = "rc", any(feature = "std", all(feature = "alloc", target_has_atomic = "ptr"))))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "rc", any(feature = "std", all(feature = "alloc", target_has_atomic = "ptr"))))))]
     Arc
 }
 

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -218,7 +218,7 @@ mod lib {
     #[cfg(all(feature = "rc", feature = "std"))]
     pub use std::rc::{Rc, Weak as RcWeak};
 
-    #[cfg(all(feature = "rc", feature = "alloc", not(feature = "std")))]
+    #[cfg(all(feature = "rc", all(feature = "alloc", target_has_atomic = "ptr"), not(feature = "std")))]
     pub use alloc::sync::{Arc, Weak as ArcWeak};
     #[cfg(all(feature = "rc", feature = "std"))]
     pub use std::sync::{Arc, Weak as ArcWeak};

--- a/serde/src/ser/impls.rs
+++ b/serde/src/ser/impls.rs
@@ -512,14 +512,14 @@ deref_impl! {
     /// repeated data.
     ///
     /// [`"rc"`]: https://serde.rs/feature-flags.html#-features-rc
-    #[cfg(all(feature = "rc", any(feature = "std", feature = "alloc")))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "rc", any(feature = "std", feature = "alloc")))))]
+    #[cfg(all(feature = "rc", any(feature = "std", all(feature = "alloc", target_has_atomic = "ptr"))))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "rc", any(feature = "std", all(feature = "alloc", target_has_atomic = "ptr"))))))]
     <T> Serialize for Arc<T> where T: ?Sized + Serialize
 }
 
 deref_impl! {
-    #[cfg(any(feature = "std", feature = "alloc"))]
-    #[cfg_attr(docsrs, doc(cfg(any(feature = "std", feature = "alloc"))))]
+    #[cfg(any(feature = "std", all(feature = "alloc", target_has_atomic = "ptr")))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "std", all(feature = "alloc", target_has_atomic = "ptr")))))]
     <'a, T> Serialize for Cow<'a, T> where T: ?Sized + Serialize + ToOwned
 }
 
@@ -528,10 +528,10 @@ deref_impl! {
 /// This impl requires the [`"rc"`] Cargo feature of Serde.
 ///
 /// [`"rc"`]: https://serde.rs/feature-flags.html#-features-rc
-#[cfg(all(feature = "rc", any(feature = "std", feature = "alloc")))]
+#[cfg(all(feature = "rc", any(feature = "std", all(feature = "alloc", target_has_atomic = "ptr"))))]
 #[cfg_attr(
     docsrs,
-    doc(cfg(all(feature = "rc", any(feature = "std", feature = "alloc"))))
+    doc(cfg(all(feature = "rc", any(feature = "std", all(feature = "alloc", target_has_atomic = "ptr")))))
 )]
 impl<T> Serialize for RcWeak<T>
 where
@@ -548,10 +548,10 @@ where
 /// This impl requires the [`"rc"`] Cargo feature of Serde.
 ///
 /// [`"rc"`]: https://serde.rs/feature-flags.html#-features-rc
-#[cfg(all(feature = "rc", any(feature = "std", feature = "alloc")))]
+#[cfg(all(feature = "rc", any(feature = "std", all(feature = "alloc", target_has_atomic = "ptr"))))]
 #[cfg_attr(
     docsrs,
-    doc(cfg(all(feature = "rc", any(feature = "std", feature = "alloc"))))
+    doc(cfg(all(feature = "rc", any(feature = "std", all(feature = "alloc", target_has_atomic = "ptr")))))
 )]
 impl<T> Serialize for ArcWeak<T>
 where


### PR DESCRIPTION
This PR enables building serde for the `riscv32im-unknown-none-elf` target.

`cargo build -p serde --no-default-features --features="rc,alloc" --target riscv32im-unknown-none-elf`