### PR TITLE
Make unexpected() public

### DIFF
--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -263,7 +263,7 @@ mod content {
         }
 
         #[cold]
-        fn unexpected(&self) -> Unexpected {
+        pub fn unexpected(&self) -> Unexpected {
             match *self {
                 Content::Bool(b) => Unexpected::Bool(b),
                 Content::U8(n) => Unexpected::Unsigned(n as u64),


### PR DESCRIPTION
Make `unexpected()` public to allow deserialization using Content as an intermediate state. This allows you to complete your requirements with less code.


The following code, When `type` is omitted, it is expected to be deserialized as A. 

```rs

#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
#[serde(tag = "type")]
pub enum Foo {
   A(A),
   B(B),
   C(C),
}


impl<'de> serde::Deserialize<'de> for Foo {
    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
    where
        D: serde::Deserializer<'de>,
    {
        use serde::__private::de::Content;
        use serde::de;

        let content = Content::deserialize(deserializer)?;

        let Content::Map(mut map) = content else {
            return Err(de::Error::invalid_type(content.unexpected(), &"map"));
        };

        let typ = map
            .iter()
            .map(|(n, _)| n)
            .enumerate()
            .filter(|(_, n)| matches!(n.as_str(), Some(s) if s == "type"))
            .map(|(i, _)| i)
            .next()
            .map(|i| map.remove(i))
            .map(|(_, v)| v);

        let typ = typ.as_ref().and_then(|t| t.as_str()).unwrap_or_default();

        let deserializer = Content::Map(map).into_deserializer();

        const A: &'static str = "A";
        const B: &'static str = "B";
        const C: &'static str = "C";

        const VARIANTS: &'static [&'static str] = &[A, B, C];

        Ok(match typ {
            A | "" => Self::A(serde::Deserialize::deserialize(deserializer)?),
            B => Self::B(serde::Deserialize::deserialize(deserializer)?),
            C => Self::C(serde::Deserialize::deserialize(deserializer)?),
            typ => {
                return Err(de::Error::unknown_variant(typ, VARIANTS))?;
            }
        })
    }
}
```