### PR TITLE
Unify access to the serde namespace

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -27,7 +27,6 @@ pub fn expand_derive_deserialize(input: &mut syn::DeriveInput) -> syn::Result<To
     let (de_impl_generics, _, ty_generics, where_clause) = split_with_de_lifetime(&params);
     let body = Stmts(deserialize_body(&cont, &params));
     let delife = params.borrowed.de_lifetime();
-    let serde = cont.attrs.serde_path();
 
     let impl_block = if let Some(remote) = cont.attrs.remote() {
         let vis = &input.vis;
@@ -35,9 +34,9 @@ pub fn expand_derive_deserialize(input: &mut syn::DeriveInput) -> syn::Result<To
         quote! {
             #[automatically_derived]
             impl #de_impl_generics #ident #ty_generics #where_clause {
-                #vis fn deserialize<__D>(__deserializer: __D) -> #serde::__private::Result<#remote #ty_generics, __D::Error>
+                #vis fn deserialize<__D>(__deserializer: __D) -> _serde::__private::Result<#remote #ty_generics, __D::Error>
                 where
-                    __D: #serde::Deserializer<#delife>,
+                    __D: _serde::Deserializer<#delife>,
                 {
                     #used
                     #body
@@ -49,10 +48,10 @@ pub fn expand_derive_deserialize(input: &mut syn::DeriveInput) -> syn::Result<To
 
         quote! {
             #[automatically_derived]
-            impl #de_impl_generics #serde::Deserialize<#delife> for #ident #ty_generics #where_clause {
-                fn deserialize<__D>(__deserializer: __D) -> #serde::__private::Result<Self, __D::Error>
+            impl #de_impl_generics _serde::Deserialize<#delife> for #ident #ty_generics #where_clause {
+                fn deserialize<__D>(__deserializer: __D) -> _serde::__private::Result<Self, __D::Error>
                 where
-                    __D: #serde::Deserializer<#delife>,
+                    __D: _serde::Deserializer<#delife>,
                 {
                     #body
                 }

--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -3,14 +3,13 @@ use crate::internals::symbol::*;
 use crate::internals::{ungroup, Ctxt};
 use proc_macro2::{Spacing, Span, TokenStream, TokenTree};
 use quote::ToTokens;
-use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::iter::FromIterator;
 use syn::meta::ParseNestedMeta;
 use syn::parse::ParseStream;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
-use syn::{parse_quote, token, Ident, Lifetime, Token};
+use syn::{token, Ident, Lifetime, Token};
 
 // This module handles parsing of `#[serde(...)]` attributes. The entrypoints
 // are `attr::Container::from_ast`, `attr::Variant::from_ast`, and
@@ -607,11 +606,6 @@ impl Container {
 
     pub fn custom_serde_path(&self) -> Option<&syn::Path> {
         self.serde_path.as_ref()
-    }
-
-    pub fn serde_path(&self) -> Cow<syn::Path> {
-        self.custom_serde_path()
-            .map_or_else(|| Cow::Owned(parse_quote!(_serde)), Cow::Borrowed)
     }
 
     /// Error message generated when type can't be deserialized.

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -23,7 +23,6 @@ pub fn expand_derive_serialize(input: &mut syn::DeriveInput) -> syn::Result<Toke
     let params = Parameters::new(&cont);
     let (impl_generics, ty_generics, where_clause) = params.generics.split_for_impl();
     let body = Stmts(serialize_body(&cont, &params));
-    let serde = cont.attrs.serde_path();
 
     let impl_block = if let Some(remote) = cont.attrs.remote() {
         let vis = &input.vis;
@@ -31,9 +30,9 @@ pub fn expand_derive_serialize(input: &mut syn::DeriveInput) -> syn::Result<Toke
         quote! {
             #[automatically_derived]
             impl #impl_generics #ident #ty_generics #where_clause {
-                #vis fn serialize<__S>(__self: &#remote #ty_generics, __serializer: __S) -> #serde::__private::Result<__S::Ok, __S::Error>
+                #vis fn serialize<__S>(__self: &#remote #ty_generics, __serializer: __S) -> _serde::__private::Result<__S::Ok, __S::Error>
                 where
-                    __S: #serde::Serializer,
+                    __S: _serde::Serializer,
                 {
                     #used
                     #body
@@ -43,10 +42,10 @@ pub fn expand_derive_serialize(input: &mut syn::DeriveInput) -> syn::Result<Toke
     } else {
         quote! {
             #[automatically_derived]
-            impl #impl_generics #serde::Serialize for #ident #ty_generics #where_clause {
-                fn serialize<__S>(&self, __serializer: __S) -> #serde::__private::Result<__S::Ok, __S::Error>
+            impl #impl_generics _serde::Serialize for #ident #ty_generics #where_clause {
+                fn serialize<__S>(&self, __serializer: __S) -> _serde::__private::Result<__S::Ok, __S::Error>
                 where
-                    __S: #serde::Serializer,
+                    __S: _serde::Serializer,
                 {
                     #body
                 }


### PR DESCRIPTION
In other places `_serde` name is used to access the `serde` crate, so will be defined and can be use there