### PR TITLE
Allow only one unit variant in untagged enums

### DIFF
--- a/test_suite/tests/ui/enum-representation/untagged-with-muliple-units.rs
+++ b/test_suite/tests/ui/enum-representation/untagged-with-muliple-units.rs
@@ -1,0 +1,29 @@
+use serde_derive::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum E1 {
+    Unit1,
+    Tuple1(usize),
+    Unit2,
+    Struct {},
+    #[serde(skip_serializing)]
+    Unit3,
+    #[serde(skip_deserializing)]
+    Unit4,
+}
+
+#[derive(Serialize)]
+#[serde(untagged)]
+enum E2 {
+    Unit1,
+    Tuple1(usize),
+    Unit2,
+    Struct {},
+    #[serde(skip_serializing)]
+    Unit3,
+    #[serde(skip_deserializing)]
+    Unit4,
+}
+
+fn main() {}

--- a/test_suite/tests/ui/enum-representation/untagged-with-muliple-units.stderr
+++ b/test_suite/tests/ui/enum-representation/untagged-with-muliple-units.stderr
@@ -1,0 +1,12 @@
+error: untagged enums can contain only one unit variant. Use #[serde(skip_deserializing)] if you really want several unit variants
+ --> tests/ui/enum-representation/untagged-with-muliple-units.rs:8:5
+  |
+8 |     Unit2,
+  |     ^^^^^
+
+error: untagged enums can contain only one unit variant. Use #[serde(skip_deserializing)] if you really want several unit variants
+  --> tests/ui/enum-representation/untagged-with-muliple-units.rs:10:5
+   |
+10 | /     #[serde(skip_serializing)]
+11 | |     Unit3,
+   | |_________^


### PR DESCRIPTION
We cannot distinguish between them when deserialize, so prohibit that to protect from possible errors.

If you really need several unit variants, mark all of them except one with `#[serde(skip_deserializing)]`.

Several units still are allowed for serialization, because that will allow to add to the enums new preferred unit variant and deprecate the old without breaking changes. Both (new and old) would be serialized to the same value, but deserialization will get you only new variant.