### PR TITLE
Remove `actually_private::T`

### DIFF
--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -1226,10 +1226,7 @@ pub trait Deserializer<'de>: Sized {
     // Not public API.
     #[cfg(all(not(no_serde_derive), any(feature = "std", feature = "alloc")))]
     #[doc(hidden)]
-    fn __deserialize_content<V>(
-        self,
-        visitor: V,
-    ) -> Result<crate::__private::de::Content<'de>, Self::Error>
+    fn __deserialize_content<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de, Value = crate::__private::de::Content<'de>>,
     {

--- a/serde/src/de/mod.rs
+++ b/serde/src/de/mod.rs
@@ -1228,7 +1228,6 @@ pub trait Deserializer<'de>: Sized {
     #[doc(hidden)]
     fn __deserialize_content<V>(
         self,
-        _: crate::actually_private::T,
         visitor: V,
     ) -> Result<crate::__private::de::Content<'de>, Self::Error>
     where

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -340,8 +340,3 @@ extern crate serde_derive;
 #[cfg(feature = "serde_derive")]
 #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
 pub use serde_derive::{Deserialize, Serialize};
-
-#[cfg(all(not(no_serde_derive), any(feature = "std", feature = "alloc")))]
-mod actually_private {
-    pub struct T;
-}

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -208,7 +208,6 @@ mod content {
 
     use crate::lib::*;
 
-    use crate::actually_private;
     use crate::de::value::{MapDeserializer, SeqDeserializer};
     use crate::de::{
         self, size_hint, Deserialize, DeserializeSeed, Deserializer, EnumAccess, Expected,
@@ -298,7 +297,7 @@ mod content {
             // Untagged and internally tagged enums are only supported in
             // self-describing formats.
             let visitor = ContentVisitor { value: PhantomData };
-            deserializer.__deserialize_content(actually_private::T, visitor)
+            deserializer.__deserialize_content(visitor)
         }
     }
 
@@ -1498,11 +1497,7 @@ mod content {
             visitor.visit_unit()
         }
 
-        fn __deserialize_content<V>(
-            self,
-            _: actually_private::T,
-            visitor: V,
-        ) -> Result<Content<'de>, Self::Error>
+        fn __deserialize_content<V>(self, visitor: V) -> Result<Content<'de>, Self::Error>
         where
             V: Visitor<'de, Value = Content<'de>>,
         {
@@ -2091,11 +2086,7 @@ mod content {
             visitor.visit_unit()
         }
 
-        fn __deserialize_content<V>(
-            self,
-            _: actually_private::T,
-            visitor: V,
-        ) -> Result<Content<'de>, Self::Error>
+        fn __deserialize_content<V>(self, visitor: V) -> Result<Content<'de>, Self::Error>
         where
             V: Visitor<'de, Value = Content<'de>>,
         {

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -1497,7 +1497,7 @@ mod content {
             visitor.visit_unit()
         }
 
-        fn __deserialize_content<V>(self, visitor: V) -> Result<Content<'de>, Self::Error>
+        fn __deserialize_content<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where
             V: Visitor<'de, Value = Content<'de>>,
         {
@@ -2086,7 +2086,7 @@ mod content {
             visitor.visit_unit()
         }
 
-        fn __deserialize_content<V>(self, visitor: V) -> Result<Content<'de>, Self::Error>
+        fn __deserialize_content<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where
             V: Visitor<'de, Value = Content<'de>>,
         {


### PR DESCRIPTION
> This sounds like a change we could do on master and consider in isolation from this PR

As posted by @oli-obk in https://github.com/serde-rs/serde/pull/2608#discussion_r1810195461, this PR removes `actually_private::T` type from signature of the hidden `Deserializer::__deserialize_content` method, like `Visitor::__private_visit_untagged_option` does not have such guard:
https://github.com/serde-rs/serde/blob/2130ba57885357b56e7087e164a33be0288371e4/serde/src/de/mod.rs#L1679-L1687

This guard just makes life harder in some cases without real benefits. If you use private API you already understand consequences and them can be totally acceptable, especially if you depend on the specific version