### PR TITLE
serde_derive: fix ser/de inconsistency with skipped enum variants

### DIFF
--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -396,9 +396,12 @@ fn serialize_enum(params: &Parameters, variants: &[Variant], cattrs: &attr::Cont
 
     let mut arms: Vec<_> = variants
         .iter()
-        .enumerate()
-        .map(|(variant_index, variant)| {
-            serialize_variant(params, variant, variant_index as u32, cattrs)
+        .scan(0, |next_variant_index, variant| {
+            let variant_index = *next_variant_index;
+            if !variant.attrs.skip_serializing() {
+                *next_variant_index += 1;
+            }
+            Some(serialize_variant(params, variant, variant_index, cattrs))
         })
         .collect();
 


### PR DESCRIPTION
When serde_derive generates Serialize/Deserialize implementations for an enum with #[serde(skipped)] variants, it leaves a gap in the assigned `variant_index`es for the variants (i.e., includes skipped variants in the count) in the Serialize impl, but excludes skipped variants in the count in the Deserialize impl. This means that non-self-describing data formats that rely on variant indices instead of variant names cannot correctly serialize+deserialize enums with skipped variants.

This changes the generated Serialize impl to match the deserialize impl by excluding skipped variants from the count. This is also consistent with how #[serde(skip)] affects field indices in structs.

Fixes #2614

This is not covered by existing tests because the test suite only covers variant names, not variant indices (https://github.com/serde-deprecated/test/issues/21). As such, I'm not sure the best way to add test coverage for this particular case.