### PR TITLE
Add serde(explicit_tags) attribute

### DIFF
--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -173,6 +173,7 @@ pub struct Container {
     /// Error message generated when type can't be deserialized
     expecting: Option<String>,
     non_exhaustive: bool,
+    explicit_tags: bool,
 }
 
 /// Styles of representing an enum.
@@ -258,6 +259,7 @@ impl Container {
         let mut variant_identifier = BoolAttr::none(cx, VARIANT_IDENTIFIER);
         let mut serde_path = Attr::none(cx, CRATE);
         let mut expecting = Attr::none(cx, EXPECTING);
+        let mut explicit_tags = BoolAttr::none(cx, EXPLICIT_TAGS);
         let mut non_exhaustive = false;
 
         for attr in &item.attrs {
@@ -491,6 +493,9 @@ impl Container {
                     if let Some(s) = get_lit_str(cx, EXPECTING, &meta)? {
                         expecting.set(&meta.path, s.value());
                     }
+                } else if meta.path == EXPLICIT_TAGS {
+                    // #[serde(explicit_tags)]
+                    explicit_tags.set_true(meta.path);
                 } else {
                     let path = meta.path.to_token_stream().to_string().replace(' ', "");
                     return Err(
@@ -542,6 +547,7 @@ impl Container {
             is_packed,
             expecting: expecting.get(),
             non_exhaustive,
+            explicit_tags: explicit_tags.get(),
         }
     }
 
@@ -622,6 +628,10 @@ impl Container {
 
     pub fn non_exhaustive(&self) -> bool {
         self.non_exhaustive
+    }
+
+    pub fn explicit_tags(&self) -> bool {
+        self.explicit_tags
     }
 }
 

--- a/serde_derive/src/internals/symbol.rs
+++ b/serde_derive/src/internals/symbol.rs
@@ -14,6 +14,7 @@ pub const DENY_UNKNOWN_FIELDS: Symbol = Symbol("deny_unknown_fields");
 pub const DESERIALIZE: Symbol = Symbol("deserialize");
 pub const DESERIALIZE_WITH: Symbol = Symbol("deserialize_with");
 pub const EXPECTING: Symbol = Symbol("expecting");
+pub const EXPLICIT_TAGS: Symbol = Symbol("explicit_tags");
 pub const FIELD_IDENTIFIER: Symbol = Symbol("field_identifier");
 pub const FLATTEN: Symbol = Symbol("flatten");
 pub const FROM: Symbol = Symbol("from");


### PR DESCRIPTION
Closes #2763.

- [x] Serialization
- [x] Deserialization
- [x] Externally tagged
- [ ] Any other tagging methods (do all apply? I don't think postcard supports all)
- [ ] Proper error handling
- [ ] Tests

Does this approach look good? I'm not great with proc macros and this is my first time contributing to serde.

This makes the following work:

```rust
use serde::{Deserialize, Serialize};

#[derive(Debug, PartialEq, Serialize, Deserialize)]
#[repr(i8)]
#[serde(explicit_tags)]
pub enum Foo {
    Zero,
    One,
    Five = 5,
    Six,
    Ten(u32) = 10,
    Twenty { value: u32 } = 20,
    // Invalid = -1,
    // error:    ^^ unsupported expression for enum discriminant (Serialize)
    //
    // Deserialize panics with "message: unsupported discriminant expression"
}

#[cfg(test)]
mod tests {
    use super::*;

    fn t(value: Foo, expected: &[u8]) {
        let serialized = postcard::to_allocvec(&value).unwrap();
        assert_eq!(serialized, expected);

        let deserialized = postcard::from_bytes::<Foo>(&serialized);
        assert_eq!(deserialized, Ok(value));
    }

    #[test]
    fn test_name() {
        t(Foo::Zero, &[0]);
        t(Foo::One, &[1]);
        t(Foo::Five, &[5]);
        t(Foo::Six, &[6]);
        t(Foo::Ten(42), &[10, 42]);
        t(Foo::Twenty { value: 84 }, &[20, 84]);
    }
}
```