### PR TITLE
Patch serde_core at workspace level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ resolver = "2"
 
 [patch.crates-io]
 serde = { path = "serde" }
+serde_core = { path = "serde_core" }
 
 [workspace.dependencies]
 proc-macro2 = { version = "1.0.74", default-features = false }


### PR DESCRIPTION
Without this, there end up being 2 incompatible `serde_core` versions, one from crates.io used by dependencies such as serde_json and trybuild, and one from the local repo.

```console
error[E0277]: the trait bound `cargo::Metadata: serde::Deserialize<'de>` is not satisfied
    --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/trybuild-1.0.111/src/cargo.rs:183:5
     |
 183 |     serde_json::from_slice(&output.stdout).map_err(|err| {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
     |
help: the trait `serde_core::de::Deserialize<'_>` is not implemented for `cargo::Metadata`
    --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/trybuild-1.0.111/src/cargo.rs:14:1
     |
  14 | pub(crate) struct Metadata {
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^
     = note: for local types consider adding `#[derive(serde::Deserialize)]` to your `cargo::Metadata` type
     = note: for types from other crates check whether the crate offers a `serde` feature flag
note: there are multiple different versions of crate `serde_core` in the dependency graph
    --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/serde_core-1.0.220/src/de/mod.rs:555:1
     |
 555 | pub trait Deserialize<'de>: Sized {
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this is the required trait
     |
    ::: $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/trybuild-1.0.111/src/dependencies.rs:10:5
     |
  10 | use serde_json::Value;
     |     ---------- one version of crate `serde_core` used here, as a dependency of crate `serde_json`
     |
    ::: $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/trybuild-1.0.111/src/cargo.rs:13:10
     |
  13 | #[derive(Deserialize)]
     |          ----------- one version of crate `serde_core` used here, as a dependency of crate `serde`
  14 | pub(crate) struct Metadata {
     | -------------------------- this type doesn't implement the required trait
     |
    ::: serde_core/src/de/value.rs:1879:5
     |
1879 |     pub trait Pair {
     |     -------------- this is the found trait
     = help: you can use `cargo tree` to explore your dependency tree
note: required by a bound in `serde_json::from_slice`
    --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/serde_json-1.0.144/src/de.rs:2657:8
     |
2655 | pub fn from_slice<'a, T>(v: &'a [u8]) -> Result<T>
     |        ---------- required by a bound in this function
2656 | where
2657 |     T: de::Deserialize<'a>,
     |        ^^^^^^^^^^^^^^^^^^^ required by this bound in `from_slice`
```