### PR TITLE
Change serde_core's html_root_url to docs.rs/serde_core

### DIFF
--- a/serde_core/src/lib.rs
+++ b/serde_core/src/lib.rs
@@ -35,7 +35,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 // Serde types in rustdoc of other crates get linked to here.
-#![doc(html_root_url = "https://docs.rs/serde/1.0.222")]
+#![doc(html_root_url = "https://docs.rs/serde_core/1.0.222")]
 // Support using Serde without the standard library!
 #![cfg_attr(not(feature = "std"), no_std)]
 // Show which crate feature enables conditionally compiled APIs in documentation.


### PR DESCRIPTION
Fixes https://github.com/serde-rs/serde/issues/2977.

Maybe it would be possible to redirect trait definitions from docs.rs/serde_core to docs.rs/serde as the canonical location using something like this in `--html-in-header`:

```html
<script>
  url_regex = /^https:\/\/docs\.rs\/serde_core\/([^\/]+)\/serde_core\/(.+)$/;
  serde_redirect = window.location.href.replace(url_regex, "https://docs.rs/serde/$1/serde/$2");
  if (serde_redirect !== window.location.href) {
    window.location.replace(serde_redirect);
  }
</script>
```