### PR TITLE
Mark every trait impl for a private type with do_not_recommend

### DIFF
--- a/serde/build.rs
+++ b/serde/build.rs
@@ -14,12 +14,19 @@ fn main() {
     };
 
     if minor >= 77 {
+        println!("cargo:rustc-check-cfg=cfg(no_diagnostic_namespace)");
         println!("cargo:rustc-check-cfg=cfg(no_serde_derive)");
     }
 
     // Current minimum supported version of serde_derive crate is Rust 1.61.
     if minor < 61 {
         println!("cargo:rustc-cfg=no_serde_derive");
+    }
+
+    // Support for the `#[diagnostic]` tool attribute namespace
+    // https://blog.rust-lang.org/2024/05/02/Rust-1.78.0.html#diagnostic-attributes
+    if minor < 78 {
+        println!("cargo:rustc-cfg=no_diagnostic_namespace");
     }
 }
 

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -28,6 +28,7 @@ where
 {
     struct MissingFieldDeserializer<E>(&'static str, PhantomData<E>);
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'de, E> Deserializer<'de> for MissingFieldDeserializer<E>
     where
         E: Error,
@@ -67,6 +68,7 @@ where
 {
     struct CowStrVisitor;
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'a> Visitor<'a> for CowStrVisitor {
         type Value = Cow<'a, str>;
 
@@ -140,6 +142,7 @@ where
 {
     struct CowBytesVisitor;
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'a> Visitor<'a> for CowBytesVisitor {
         type Value = Cow<'a, [u8]>;
 
@@ -294,6 +297,7 @@ mod content {
         }
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'de> DeserializeSeed<'de> for ContentVisitor<'de> {
         type Value = Content<'de>;
 
@@ -305,6 +309,7 @@ mod content {
         }
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'de> Visitor<'de> for ContentVisitor<'de> {
         type Value = Content<'de>;
 
@@ -530,6 +535,7 @@ mod content {
         }
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'de> DeserializeSeed<'de> for TagOrContentVisitor<'de> {
         type Value = TagOrContent<'de>;
 
@@ -543,6 +549,7 @@ mod content {
         }
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'de> Visitor<'de> for TagOrContentVisitor<'de> {
         type Value = TagOrContent<'de>;
 
@@ -824,6 +831,7 @@ mod content {
         }
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'de, T> Visitor<'de> for TaggedContentVisitor<T>
     where
         T: Deserialize<'de>,
@@ -894,6 +902,7 @@ mod content {
         pub content: &'static str,
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'de> DeserializeSeed<'de> for TagOrContentFieldVisitor {
         type Value = TagOrContentField;
 
@@ -905,6 +914,7 @@ mod content {
         }
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'de> Visitor<'de> for TagOrContentFieldVisitor {
         type Value = TagOrContentField;
 
@@ -971,6 +981,7 @@ mod content {
         pub content: &'static str,
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'de> DeserializeSeed<'de> for TagContentOtherFieldVisitor {
         type Value = TagContentOtherField;
 
@@ -982,6 +993,7 @@ mod content {
         }
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'de> Visitor<'de> for TagContentOtherFieldVisitor {
         type Value = TagContentOtherField;
 
@@ -1104,6 +1116,7 @@ mod content {
 
     /// Used when deserializing an internally tagged enum because the content
     /// will be used exactly once.
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'de, E> Deserializer<'de> for ContentDeserializer<'de, E>
     where
         E: de::Error,
@@ -1523,6 +1536,7 @@ mod content {
         }
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'de, E> Deserializer<'de> for SeqDeserializer<'de, E>
     where
         E: de::Error,
@@ -1545,6 +1559,7 @@ mod content {
         }
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'de, E> SeqAccess<'de> for SeqDeserializer<'de, E>
     where
         E: de::Error,
@@ -1571,6 +1586,7 @@ mod content {
 
     struct ExpectedInSeq(usize);
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl Expected for ExpectedInSeq {
         fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
             if self.0 == 1 {
@@ -1630,6 +1646,7 @@ mod content {
         }
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'de, E> Deserializer<'de> for MapDeserializer<'de, E>
     where
         E: de::Error,
@@ -1669,6 +1686,7 @@ mod content {
         }
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'de, E> MapAccess<'de> for MapDeserializer<'de, E>
     where
         E: de::Error,
@@ -1723,6 +1741,7 @@ mod content {
         }
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'de, E> SeqAccess<'de> for MapDeserializer<'de, E>
     where
         E: de::Error,
@@ -1749,6 +1768,7 @@ mod content {
 
     struct PairDeserializer<'de, E>(Content<'de>, Content<'de>, PhantomData<E>);
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'de, E> Deserializer<'de> for PairDeserializer<'de, E>
     where
         E: de::Error,
@@ -1800,6 +1820,7 @@ mod content {
 
     struct PairVisitor<'de, E>(Option<Content<'de>>, Option<Content<'de>>, PhantomData<E>);
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'de, E> SeqAccess<'de> for PairVisitor<'de, E>
     where
         E: de::Error,
@@ -1832,6 +1853,7 @@ mod content {
 
     struct ExpectedInMap(usize);
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl Expected for ExpectedInMap {
         fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
             if self.0 == 1 {
@@ -1864,6 +1886,7 @@ mod content {
         }
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'de, E> de::EnumAccess<'de> for EnumDeserializer<'de, E>
     where
         E: de::Error,
@@ -1892,6 +1915,7 @@ mod content {
         err: PhantomData<E>,
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'de, E> de::VariantAccess<'de> for VariantDeserializer<'de, E>
     where
         E: de::Error,
@@ -2046,6 +2070,7 @@ mod content {
 
     /// Used when deserializing an untagged enum because the content may need
     /// to be used more than once.
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'de, 'a, E> Deserializer<'de> for ContentRefDeserializer<'a, 'de, E>
     where
         E: de::Error,
@@ -2424,8 +2449,10 @@ mod content {
         }
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'a, 'de: 'a, E> Copy for ContentRefDeserializer<'a, 'de, E> {}
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'a, 'de: 'a, E> Clone for ContentRefDeserializer<'a, 'de, E> {
         fn clone(&self) -> Self {
             *self
@@ -2467,6 +2494,7 @@ mod content {
         }
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'a, 'de, E> Deserializer<'de> for SeqRefDeserializer<'a, 'de, E>
     where
         E: de::Error,
@@ -2489,6 +2517,7 @@ mod content {
         }
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'a, 'de, E> SeqAccess<'de> for SeqRefDeserializer<'a, 'de, E>
     where
         E: de::Error,
@@ -2563,6 +2592,7 @@ mod content {
         }
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'a, 'de, E> Deserializer<'de> for MapRefDeserializer<'a, 'de, E>
     where
         E: de::Error,
@@ -2602,6 +2632,7 @@ mod content {
         }
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'a, 'de, E> MapAccess<'de> for MapRefDeserializer<'a, 'de, E>
     where
         E: de::Error,
@@ -2656,6 +2687,7 @@ mod content {
         }
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'a, 'de, E> SeqAccess<'de> for MapRefDeserializer<'a, 'de, E>
     where
         E: de::Error,
@@ -2682,6 +2714,7 @@ mod content {
 
     struct PairRefDeserializer<'a, 'de, E>(&'a Content<'de>, &'a Content<'de>, PhantomData<E>);
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'a, 'de, E> Deserializer<'de> for PairRefDeserializer<'a, 'de, E>
     where
         E: de::Error,
@@ -2737,6 +2770,7 @@ mod content {
         PhantomData<E>,
     );
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'a, 'de, E> SeqAccess<'de> for PairRefVisitor<'a, 'de, E>
     where
         E: de::Error,
@@ -2776,6 +2810,7 @@ mod content {
         err: PhantomData<E>,
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'de, 'a, E> de::EnumAccess<'de> for EnumRefDeserializer<'a, 'de, E>
     where
         E: de::Error,
@@ -2804,6 +2839,7 @@ mod content {
         err: PhantomData<E>,
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'de, 'a, E> de::VariantAccess<'de> for VariantRefDeserializer<'a, 'de, E>
     where
         E: de::Error,
@@ -2890,6 +2926,7 @@ mod content {
         }
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'de, E> de::IntoDeserializer<'de, E> for ContentDeserializer<'de, E>
     where
         E: de::Error,
@@ -2901,6 +2938,7 @@ mod content {
         }
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'de, 'a, E> de::IntoDeserializer<'de, E> for ContentRefDeserializer<'a, 'de, E>
     where
         E: de::Error,
@@ -2930,6 +2968,7 @@ mod content {
         }
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'de, 'a> Visitor<'de> for InternallyTaggedUnitVisitor<'a> {
         type Value = ();
 
@@ -2975,6 +3014,7 @@ mod content {
         }
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'de, 'a> Visitor<'de> for UntaggedUnitVisitor<'a> {
         type Value = ();
 
@@ -3022,6 +3062,7 @@ pub trait IdentifierDeserializer<'de, E: Error> {
 
 pub struct Borrowed<'de, T: 'de + ?Sized>(pub &'de T);
 
+#[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
 impl<'de, E> IdentifierDeserializer<'de, E> for u64
 where
     E: Error,
@@ -3038,6 +3079,7 @@ pub struct StrDeserializer<'a, E> {
     marker: PhantomData<E>,
 }
 
+#[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
 impl<'de, 'a, E> Deserializer<'de> for StrDeserializer<'a, E>
 where
     E: Error,
@@ -3063,6 +3105,7 @@ pub struct BorrowedStrDeserializer<'de, E> {
     marker: PhantomData<E>,
 }
 
+#[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
 impl<'de, E> Deserializer<'de> for BorrowedStrDeserializer<'de, E>
 where
     E: Error,
@@ -3083,6 +3126,7 @@ where
     }
 }
 
+#[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
 impl<'a, E> IdentifierDeserializer<'a, E> for &'a str
 where
     E: Error,
@@ -3097,6 +3141,7 @@ where
     }
 }
 
+#[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
 impl<'de, E> IdentifierDeserializer<'de, E> for Borrowed<'de, str>
 where
     E: Error,
@@ -3111,6 +3156,7 @@ where
     }
 }
 
+#[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
 impl<'a, E> IdentifierDeserializer<'a, E> for &'a [u8]
 where
     E: Error,
@@ -3122,6 +3168,7 @@ where
     }
 }
 
+#[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
 impl<'de, E> IdentifierDeserializer<'de, E> for Borrowed<'de, [u8]>
 where
     E: Error,
@@ -3164,6 +3211,7 @@ macro_rules! forward_to_deserialize_other {
 }
 
 #[cfg(any(feature = "std", feature = "alloc"))]
+#[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
 impl<'a, 'de, E> Deserializer<'de> for FlatMapDeserializer<'a, 'de, E>
 where
     E: Error,
@@ -3300,6 +3348,7 @@ struct FlatMapAccess<'a, 'de: 'a, E> {
 }
 
 #[cfg(any(feature = "std", feature = "alloc"))]
+#[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
 impl<'a, 'de, E> MapAccess<'de> for FlatMapAccess<'a, 'de, E>
 where
     E: Error,
@@ -3344,6 +3393,7 @@ struct FlatStructAccess<'a, 'de: 'a, E> {
 }
 
 #[cfg(any(feature = "std", feature = "alloc"))]
+#[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
 impl<'a, 'de, E> MapAccess<'de> for FlatStructAccess<'a, 'de, E>
 where
     E: Error,
@@ -3407,6 +3457,7 @@ pub struct AdjacentlyTaggedEnumVariantVisitor<F> {
     fields_enum: PhantomData<F>,
 }
 
+#[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
 impl<'de, F> Visitor<'de> for AdjacentlyTaggedEnumVariantVisitor<F>
 where
     F: Deserialize<'de>,
@@ -3427,6 +3478,7 @@ where
     }
 }
 
+#[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
 impl<'de, F> DeserializeSeed<'de> for AdjacentlyTaggedEnumVariantSeed<F>
 where
     F: Deserialize<'de>,

--- a/serde/src/private/ser.rs
+++ b/serde/src/private/ser.rs
@@ -58,6 +58,7 @@ enum Unsupported {
     Enum,
 }
 
+#[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
 impl Display for Unsupported {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         match *self {
@@ -89,6 +90,7 @@ where
     }
 }
 
+#[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
 impl<S> Serializer for TaggedSerializer<S>
 where
     S: Serializer,
@@ -355,6 +357,7 @@ mod content {
         }
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<M> ser::SerializeTupleVariant for SerializeTupleVariantAsMapValue<M>
     where
         M: ser::SerializeMap,
@@ -395,6 +398,7 @@ mod content {
         }
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<M> ser::SerializeStructVariant for SerializeStructVariantAsMapValue<M>
     where
         M: ser::SerializeMap,
@@ -462,6 +466,7 @@ mod content {
         ),
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl Serialize for Content {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
@@ -554,6 +559,7 @@ mod content {
         }
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<E> Serializer for ContentSerializer<E>
     where
         E: ser::Error,
@@ -765,6 +771,7 @@ mod content {
         error: PhantomData<E>,
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<E> ser::SerializeSeq for SerializeSeq<E>
     where
         E: ser::Error,
@@ -791,6 +798,7 @@ mod content {
         error: PhantomData<E>,
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<E> ser::SerializeTuple for SerializeTuple<E>
     where
         E: ser::Error,
@@ -818,6 +826,7 @@ mod content {
         error: PhantomData<E>,
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<E> ser::SerializeTupleStruct for SerializeTupleStruct<E>
     where
         E: ser::Error,
@@ -847,6 +856,7 @@ mod content {
         error: PhantomData<E>,
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<E> ser::SerializeTupleVariant for SerializeTupleVariant<E>
     where
         E: ser::Error,
@@ -879,6 +889,7 @@ mod content {
         error: PhantomData<E>,
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<E> ser::SerializeMap for SerializeMap<E>
     where
         E: ser::Error,
@@ -930,6 +941,7 @@ mod content {
         error: PhantomData<E>,
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<E> ser::SerializeStruct for SerializeStruct<E>
     where
         E: ser::Error,
@@ -959,6 +971,7 @@ mod content {
         error: PhantomData<E>,
     }
 
+    #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<E> ser::SerializeStructVariant for SerializeStructVariant<E>
     where
         E: ser::Error,
@@ -1003,6 +1016,7 @@ where
 }
 
 #[cfg(any(feature = "std", feature = "alloc"))]
+#[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
 impl<'a, M> Serializer for FlatMapSerializer<'a, M>
 where
     M: SerializeMap + 'a,
@@ -1184,6 +1198,7 @@ where
 pub struct FlatMapSerializeMap<'a, M: 'a>(&'a mut M);
 
 #[cfg(any(feature = "std", feature = "alloc"))]
+#[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
 impl<'a, M> ser::SerializeMap for FlatMapSerializeMap<'a, M>
 where
     M: SerializeMap + 'a,
@@ -1222,6 +1237,7 @@ where
 pub struct FlatMapSerializeStruct<'a, M: 'a>(&'a mut M);
 
 #[cfg(any(feature = "std", feature = "alloc"))]
+#[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
 impl<'a, M> ser::SerializeStruct for FlatMapSerializeStruct<'a, M>
 where
     M: SerializeMap + 'a,
@@ -1263,6 +1279,7 @@ where
 }
 
 #[cfg(any(feature = "std", feature = "alloc"))]
+#[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
 impl<'a, M> ser::SerializeTupleVariant for FlatMapSerializeTupleVariantAsMapValue<'a, M>
 where
     M: SerializeMap + 'a,
@@ -1309,6 +1326,7 @@ where
 }
 
 #[cfg(any(feature = "std", feature = "alloc"))]
+#[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
 impl<'a, M> ser::SerializeStructVariant for FlatMapSerializeStructVariantAsMapValue<'a, M>
 where
     M: SerializeMap + 'a,
@@ -1339,6 +1357,7 @@ pub struct AdjacentlyTaggedEnumVariant {
     pub variant_name: &'static str,
 }
 
+#[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
 impl Serialize for AdjacentlyTaggedEnumVariant {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -1352,6 +1371,7 @@ impl Serialize for AdjacentlyTaggedEnumVariant {
 // that is not recognized.
 pub struct CannotSerializeVariant<T>(pub T);
 
+#[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
 impl<T> Display for CannotSerializeVariant<T>
 where
     T: Debug,

--- a/serde_core/src/private/doc.rs
+++ b/serde_core/src/private/doc.rs
@@ -8,6 +8,7 @@ use crate::ser;
 #[derive(Debug)]
 pub struct Error;
 
+#[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
 impl ser::Error for Error {
     fn custom<T>(_: T) -> Self
     where
@@ -18,12 +19,14 @@ impl ser::Error for Error {
 }
 
 #[cfg(feature = "std")]
+#[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
 impl error::Error for Error {
     fn description(&self) -> &str {
         unimplemented!()
     }
 }
 
+#[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
 impl Display for Error {
     fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {
         unimplemented!()

--- a/serde_core/src/private/seed.rs
+++ b/serde_core/src/private/seed.rs
@@ -5,6 +5,7 @@ use crate::de::{Deserialize, DeserializeSeed, Deserializer};
 /// Wraps a mutable reference and calls deserialize_in_place on it.
 pub struct InPlaceSeed<'a, T: 'a>(pub &'a mut T);
 
+#[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
 impl<'a, 'de, T> DeserializeSeed<'de> for InPlaceSeed<'a, T>
 where
     T: Deserialize<'de>,

--- a/test_suite/tests/ui/with/incorrect_type.stderr
+++ b/test_suite/tests/ui/with/incorrect_type.stderr
@@ -6,10 +6,7 @@ error[E0277]: the trait bound `&u8: serde::Serializer` is not satisfied
 15 | struct W(#[serde(with = "w")] u8, u8);
    |                         --- required by a bound introduced by this call
    |
-   = help: the following other types implement trait `Serializer`:
-             &mut Formatter<'a>
-             FlatMapSerializer<'a, M>
-             _::_serde::__private::ser::content::ContentSerializer<E>
+   = help: the trait `Serializer` is implemented for `&mut Formatter<'a>`
 note: required by a bound in `w::serialize`
   --> tests/ui/with/incorrect_type.rs:9:28
    |
@@ -36,10 +33,7 @@ error[E0277]: the trait bound `&u8: serde::Serializer` is not satisfied
 15 | struct W(#[serde(with = "w")] u8, u8);
    |                         ^^^ the trait `Serializer` is not implemented for `&u8`
    |
-   = help: the following other types implement trait `Serializer`:
-             &mut Formatter<'a>
-             FlatMapSerializer<'a, M>
-             _::_serde::__private::ser::content::ContentSerializer<E>
+   = help: the trait `Serializer` is implemented for `&mut Formatter<'a>`
 
 error[E0308]: `?` operator has incompatible types
   --> tests/ui/with/incorrect_type.rs:15:25
@@ -57,10 +51,7 @@ error[E0277]: the trait bound `&u8: serde::Serializer` is not satisfied
 18 | struct S(#[serde(serialize_with = "w::serialize")] u8, u8);
    |                                   -------------- required by a bound introduced by this call
    |
-   = help: the following other types implement trait `Serializer`:
-             &mut Formatter<'a>
-             FlatMapSerializer<'a, M>
-             _::_serde::__private::ser::content::ContentSerializer<E>
+   = help: the trait `Serializer` is implemented for `&mut Formatter<'a>`
 note: required by a bound in `w::serialize`
   --> tests/ui/with/incorrect_type.rs:9:28
    |
@@ -87,10 +78,7 @@ error[E0277]: the trait bound `&u8: serde::Serializer` is not satisfied
 18 | struct S(#[serde(serialize_with = "w::serialize")] u8, u8);
    |                                   ^^^^^^^^^^^^^^ the trait `Serializer` is not implemented for `&u8`
    |
-   = help: the following other types implement trait `Serializer`:
-             &mut Formatter<'a>
-             FlatMapSerializer<'a, M>
-             _::_serde::__private::ser::content::ContentSerializer<E>
+   = help: the trait `Serializer` is implemented for `&mut Formatter<'a>`
 
 error[E0308]: `?` operator has incompatible types
   --> tests/ui/with/incorrect_type.rs:21:37


### PR DESCRIPTION
Rustc was suggesting these private types in diagnostics, with paths like `_::_serde::__private::ser::content::ContentSerializer<E>`.