### PR TITLE
No longer macro_use integer128 module

### DIFF
--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -234,7 +234,6 @@ pub use serde_core::{
     de, forward_to_deserialize_any, ser, Deserialize, Deserializer, Serialize, Serializer,
 };
 
-#[macro_use]
 mod integer128;
 
 // Used by generated code and doc tests. Not public API.


### PR DESCRIPTION
The `#[macro_use]` attribute makes the module's macros usable from inside the same crate. This used to be needed when Serde contained invocations of `serde_if_integer128!` prior to #2600, but no longer.

The macro remains usable from outside of the crate.