### PR TITLE
Remove InPlaceSeed public re-export

### DIFF
--- a/serde_core/src/de/mod.rs
+++ b/serde_core/src/de/mod.rs
@@ -122,7 +122,6 @@ mod ignored_any;
 mod impls;
 
 pub use self::ignored_any::IgnoredAny;
-pub use crate::private::InPlaceSeed;
 #[cfg(all(not(feature = "std"), no_core_error))]
 #[doc(no_inline)]
 pub use crate::std_error::Error as StdError;


### PR DESCRIPTION
This struct was added into `serde_core::de` by https://github.com/serde-rs/serde/pull/2608 when it was not previously exposed by `serde::de`. I saw this in the review and tried to remove it in #2962/#2969 but 5ac3d84d999532a26ee036620fdc84760ba05c45 was incomplete.

I am not opposed to exposing a helper in some form, maybe even this form, just not silently as part of an unrelated refactor. It would need a dedicated PR with use case.

`deserialize_in_place` is niche functionality so it is unlikely that someone has immediately come to rely on the `InPlaceSeed` type since then.