### PR TITLE
Implement `#[serde(with = "...")]` for containers

### DIFF
--- a/test_suite/tests/ui/with-container/incorrect_type.rs
+++ b/test_suite/tests/ui/with-container/incorrect_type.rs
@@ -1,0 +1,26 @@
+use serde_derive::{Deserialize, Serialize};
+
+mod w {
+    use serde::{Deserializer, Serializer};
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(_: D) -> Result<(), D::Error> {
+        unimplemented!()
+    }
+    pub fn serialize<T, S: Serializer>(_: S) -> Result<S::Ok, S::Error> {
+        unimplemented!()
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(with = "w")]
+struct W(u8);
+
+#[derive(Serialize, Deserialize)]
+#[serde(serialize_with = "w::serialize")]
+struct S(u8);
+
+#[derive(Serialize, Deserialize)]
+#[serde(deserialize_with = "w::deserialize")]
+struct D(u8);
+
+fn main() {}

--- a/test_suite/tests/ui/with-container/incorrect_type.stderr
+++ b/test_suite/tests/ui/with-container/incorrect_type.stderr
@@ -1,0 +1,111 @@
+error[E0277]: the trait bound `&W: serde::Serializer` is not satisfied
+  --> tests/ui/with-container/incorrect_type.rs:14:10
+   |
+14 | #[derive(Serialize, Deserialize)]
+   |          ^^^^^^^^^ the trait `Serializer` is not implemented for `&W`
+15 | #[serde(with = "w")]
+   |                --- required by a bound introduced by this call
+   |
+help: the trait `Serializer` is implemented for `&mut Formatter<'a>`
+  --> $WORKSPACE/serde_core/src/ser/fmt.rs
+   |
+   | impl<'a> Serializer for &mut fmt::Formatter<'a> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `w::serialize`
+  --> tests/ui/with-container/incorrect_type.rs:9:28
+   |
+ 9 |     pub fn serialize<T, S: Serializer>(_: S) -> Result<S::Ok, S::Error> {
+   |                            ^^^^^^^^^^ required by this bound in `serialize`
+
+error[E0061]: this function takes 1 argument but 2 arguments were supplied
+  --> tests/ui/with-container/incorrect_type.rs:15:16
+   |
+14 | #[derive(Serialize, Deserialize)]
+   |          --------- unexpected argument #2 of type `__S`
+15 | #[serde(with = "w")]
+   |                ^^^
+   |
+note: function defined here
+  --> tests/ui/with-container/incorrect_type.rs:9:12
+   |
+ 9 |     pub fn serialize<T, S: Serializer>(_: S) -> Result<S::Ok, S::Error> {
+   |            ^^^^^^^^^
+
+error[E0277]: the trait bound `&W: serde::Serializer` is not satisfied
+  --> tests/ui/with-container/incorrect_type.rs:15:16
+   |
+15 | #[serde(with = "w")]
+   |                ^^^ the trait `Serializer` is not implemented for `&W`
+   |
+help: the trait `Serializer` is implemented for `&mut Formatter<'a>`
+  --> $WORKSPACE/serde_core/src/ser/fmt.rs
+   |
+   | impl<'a> Serializer for &mut fmt::Formatter<'a> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> tests/ui/with-container/incorrect_type.rs:15:16
+   |
+14 | #[derive(Serialize, Deserialize)]
+   |                     ----------- expected `Result<W, <__D as Deserializer<'de>>::Error>` because of return type
+15 | #[serde(with = "w")]
+   |                ^^^ expected `Result<W, ...>`, found `Result<(), ...>`
+   |
+   = note: expected enum `Result<W, <__D as Deserializer<'de>>::Error>`
+              found enum `Result<(), <__D as Deserializer<'_>>::Error>`
+
+error[E0277]: the trait bound `&S: serde::Serializer` is not satisfied
+  --> tests/ui/with-container/incorrect_type.rs:18:10
+   |
+18 | #[derive(Serialize, Deserialize)]
+   |          ^^^^^^^^^ the trait `Serializer` is not implemented for `&S`
+19 | #[serde(serialize_with = "w::serialize")]
+   |                          -------------- required by a bound introduced by this call
+   |
+help: the trait `Serializer` is implemented for `&mut Formatter<'a>`
+  --> $WORKSPACE/serde_core/src/ser/fmt.rs
+   |
+   | impl<'a> Serializer for &mut fmt::Formatter<'a> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `w::serialize`
+  --> tests/ui/with-container/incorrect_type.rs:9:28
+   |
+ 9 |     pub fn serialize<T, S: Serializer>(_: S) -> Result<S::Ok, S::Error> {
+   |                            ^^^^^^^^^^ required by this bound in `serialize`
+
+error[E0061]: this function takes 1 argument but 2 arguments were supplied
+  --> tests/ui/with-container/incorrect_type.rs:19:26
+   |
+18 | #[derive(Serialize, Deserialize)]
+   |          --------- unexpected argument #2 of type `__S`
+19 | #[serde(serialize_with = "w::serialize")]
+   |                          ^^^^^^^^^^^^^^
+   |
+note: function defined here
+  --> tests/ui/with-container/incorrect_type.rs:9:12
+   |
+ 9 |     pub fn serialize<T, S: Serializer>(_: S) -> Result<S::Ok, S::Error> {
+   |            ^^^^^^^^^
+
+error[E0277]: the trait bound `&S: serde::Serializer` is not satisfied
+  --> tests/ui/with-container/incorrect_type.rs:19:26
+   |
+19 | #[serde(serialize_with = "w::serialize")]
+   |                          ^^^^^^^^^^^^^^ the trait `Serializer` is not implemented for `&S`
+   |
+help: the trait `Serializer` is implemented for `&mut Formatter<'a>`
+  --> $WORKSPACE/serde_core/src/ser/fmt.rs
+   |
+   | impl<'a> Serializer for &mut fmt::Formatter<'a> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> tests/ui/with-container/incorrect_type.rs:23:28
+   |
+22 | #[derive(Serialize, Deserialize)]
+   |                     ----------- expected `Result<D, <__D as Deserializer<'de>>::Error>` because of return type
+23 | #[serde(deserialize_with = "w::deserialize")]
+   |                            ^^^^^^^^^^^^^^^^ expected `Result<D, ...>`, found `Result<(), ...>`
+   |
+   = note: expected enum `Result<D, <__D as Deserializer<'de>>::Error>`
+              found enum `Result<(), <__D as Deserializer<'_>>::Error>`


### PR DESCRIPTION
Fixes #1118, at least the original request. I understand some people wanted finalizers / some other kind of thing, this does not address that but I can't really see how it would be incompatible with doing that as well later. On the `de` side, this is just another implementation for `deserialize_body`, like from/try_from/transparent. **Edit:** indeed, seems compatible with https://github.com/serde-rs/serde/pull/2891, which runs straight after `deserialize_body`.

I submit this PR out of light frustration, from the 100 times in the last decade that I have tried to write `#[serde(with)]` on a container and it hasn't existed. `serde(with)` modules and functions are fantastic and very reusable, and there's a whole ecosystem built around them, but they come with the silly caveat that they do not work on containers. It's silly because the pattern [works on a single-variant enum](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=3d195508e7382ed1470c5129b94711c8), which is really just a struct, but not a struct that happens to be a container. It's an attribute that could work anywhere and function identically, but doesn't. So I think this is long overdue.

I came to this specifically after trying to tweak the serialization for a whole lot of `bitflags` flags. V2 of bitflags changed the serialization format to a string representation `"A | B"`, which I have gripes with as a default, but ok. The only way to change to integer serialization for all of the bitflags is to `impl Serialize` and `impl Deserialize` on all of them, which is a lot of boilerplate. There's [bitflags-serde-legacy](https://github.com/KodrAus/bitflags-serde-legacy), which would be much easier to use if only `#[serde(with)]` worked on containers. With this functionality, you can just write a serde-with module that's generic over `T: bitflags::Flags`, and you're done.

Would need docs at https://serde.rs/container-attrs.html 