### PR TITLE
Fix panic due to string slicing at char boundary

### DIFF
--- a/serde_derive/src/internals/case.rs
+++ b/serde_derive/src/internals/case.rs
@@ -59,7 +59,13 @@ impl RenameRule {
             None | PascalCase => variant.to_owned(),
             LowerCase => variant.to_ascii_lowercase(),
             UpperCase => variant.to_ascii_uppercase(),
-            CamelCase => variant[..1].to_ascii_lowercase() + &variant[1..],
+            CamelCase => {
+                if let Some(first) = variant.get(..1) {
+                    first.to_ascii_lowercase() + &variant[1..]
+                } else {
+                    variant.to_owned()
+                }
+            }
             SnakeCase => {
                 let mut snake = String::new();
                 for (i, ch) in variant.char_indices() {
@@ -100,7 +106,11 @@ impl RenameRule {
             }
             CamelCase => {
                 let pascal = PascalCase.apply_to_field(field);
-                pascal[..1].to_ascii_lowercase() + &pascal[1..]
+                if let Some(first) = pascal.get(..1) {
+                    first.to_ascii_lowercase() + &pascal[1..]
+                } else {
+                    pascal
+                }
             }
             ScreamingSnakeCase => field.to_ascii_uppercase(),
             KebabCase => field.replace('_', "-"),

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -657,10 +657,7 @@ fn test_rename_all() {
     #[serde(rename_all = "snake_case")]
     enum E {
         #[serde(rename_all = "camelCase")]
-        Serialize {
-            serialize: bool,
-            serialize_seq: bool,
-        },
+        Ändern { ändern: bool, serialize_seq: bool },
         #[serde(rename_all = "kebab-case")]
         SerializeSeq {
             serialize: bool,
@@ -688,17 +685,17 @@ fn test_rename_all() {
     }
 
     assert_tokens(
-        &E::Serialize {
-            serialize: true,
+        &E::Ändern {
+            ändern: true,
             serialize_seq: true,
         },
         &[
             Token::StructVariant {
                 name: "E",
-                variant: "serialize",
+                variant: "Ändern",
                 len: 2,
             },
-            Token::Str("serialize"),
+            Token::Str("ändern"),
             Token::Bool(true),
             Token::Str("serializeSeq"),
             Token::Bool(true),


### PR DESCRIPTION
This is a alternative solution to fix #2953 than #3024 by continuing to just support ASCII but not panic in this unwanted case.

Since this only makes code that didn't compile before compile now I would not consider this a breaking change.