### PR TITLE
Add support for unstable `core::range` types `Range`, `RangeFrom`, and `RangeInclusive`

### DIFF
--- a/serde_core/src/de/impls.rs
+++ b/serde_core/src/de/impls.rs
@@ -2440,6 +2440,20 @@ where
     }
 }
 
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+impl<'de, Idx> Deserialize<'de> for core::range::Range<Idx>
+where
+    Idx: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(tri!(Range::deserialize(deserializer)).into())
+    }
+}
+
 impl<'de, Idx> Deserialize<'de> for RangeInclusive<Idx>
 where
     Idx: Deserialize<'de>,
@@ -2457,6 +2471,20 @@ where
             },
         ));
         Ok(RangeInclusive::new(start, end))
+    }
+}
+
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+impl<'de, Idx> Deserialize<'de> for core::range::RangeInclusive<Idx>
+where
+    Idx: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(tri!(RangeInclusive::deserialize(deserializer)).into())
     }
 }
 
@@ -2616,6 +2644,20 @@ where
             },
         ));
         Ok(start..)
+    }
+}
+
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+impl<'de, Idx> Deserialize<'de> for core::range::RangeFrom<Idx>
+where
+    Idx: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(tri!(RangeFrom::deserialize(deserializer)).into())
     }
 }
 

--- a/serde_core/src/lib.rs
+++ b/serde_core/src/lib.rs
@@ -45,7 +45,7 @@
 // discussion of these features please refer to this issue:
 //
 //    https://github.com/serde-rs/serde/issues/812
-#![cfg_attr(feature = "unstable", feature(never_type))]
+#![cfg_attr(feature = "unstable", feature(never_type, new_range_api))]
 #![allow(unknown_lints, bare_trait_objects, deprecated)]
 // Ignored clippy and clippy_pedantic lints
 #![allow(

--- a/serde_core/src/ser/impls.rs
+++ b/serde_core/src/ser/impls.rs
@@ -260,9 +260,44 @@ where
     }
 }
 
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+impl<Idx> Serialize for core::range::Range<Idx>
+where
+    Idx: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use super::SerializeStruct;
+        let mut state = tri!(serializer.serialize_struct("Range", 2));
+        tri!(state.serialize_field("start", &self.start));
+        tri!(state.serialize_field("end", &self.end));
+        state.end()
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 impl<Idx> Serialize for RangeFrom<Idx>
+where
+    Idx: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use super::SerializeStruct;
+        let mut state = tri!(serializer.serialize_struct("RangeFrom", 1));
+        tri!(state.serialize_field("start", &self.start));
+        state.end()
+    }
+}
+
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+impl<Idx> Serialize for core::range::RangeFrom<Idx>
 where
     Idx: Serialize,
 {
@@ -291,6 +326,25 @@ where
         let mut state = tri!(serializer.serialize_struct("RangeInclusive", 2));
         tri!(state.serialize_field("start", &self.start()));
         tri!(state.serialize_field("end", &self.end()));
+        state.end()
+    }
+}
+
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+impl<Idx> Serialize for core::range::RangeInclusive<Idx>
+where
+    Idx: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use super::SerializeStruct;
+        let mut state = tri!(serializer.serialize_struct("RangeInclusive", 2));
+        tri!(state.serialize_field("start", &self.start));
+        // We serialize this as "end" instead of "last" for parity with the original RangeInclusive
+        tri!(state.serialize_field("end", &self.last));
         state.end()
     }
 }


### PR DESCRIPTION
Closes #3004 

Deserialization for a range type uses its stable counterpart's `deserialize` followed by `.into()` since that seemed the simplest way to go about it.
Serialized ranges are identical and can be deserialized into either one.
This change enables `new_range_api` in `serde_core` when the `unstable` feature is enabled. I think this would require updating #812?