### PR TITLE
Add WASI support for OsStr/OsString serialization

### DIFF
--- a/serde_core/src/de/impls.rs
+++ b/serde_core/src/de/impls.rs
@@ -1887,17 +1887,17 @@ forwarded_impl! {
 //
 //    #[derive(Deserialize)]
 //    #[serde(variant_identifier)]
-#[cfg(all(feature = "std", any(unix, windows)))]
+#[cfg(all(feature = "std", any(unix, windows, target_family = "wasi")))]
 variant_identifier! {
     OsStringKind (Unix; b"Unix"; 0, Windows; b"Windows"; 1)
     "`Unix` or `Windows`",
     OSSTR_VARIANTS
 }
 
-#[cfg(all(feature = "std", any(unix, windows)))]
+#[cfg(all(feature = "std", any(unix, windows, target_family = "wasi")))]
 struct OsStringVisitor;
 
-#[cfg(all(feature = "std", any(unix, windows)))]
+#[cfg(all(feature = "std", any(unix, windows, target_family = "wasi")))]
 impl<'de> Visitor<'de> for OsStringVisitor {
     type Value = OsString;
 
@@ -1920,6 +1920,21 @@ impl<'de> Visitor<'de> for OsStringVisitor {
         }
     }
 
+    #[cfg(target_family = "wasi")]
+    fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+    where
+        A: EnumAccess<'de>,
+    {
+        use std::os::wasi::ffi::OsStringExt;
+
+        match tri!(data.variant()) {
+            (OsStringKind::Unix, v) => v.newtype_variant().map(OsString::from_vec),
+            (OsStringKind::Windows, _) => Err(Error::custom(
+                "cannot deserialize Windows OS string on WASI",
+            )),
+        }
+    }
+
     #[cfg(windows)]
     fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
     where
@@ -1938,8 +1953,8 @@ impl<'de> Visitor<'de> for OsStringVisitor {
     }
 }
 
-#[cfg(all(feature = "std", any(unix, windows)))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "std", any(unix, windows)))))]
+#[cfg(all(feature = "std", any(unix, windows, target_family = "wasi")))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "std", any(unix, windows, target_family = "wasi")))))]
 impl<'de> Deserialize<'de> for OsString {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -1970,8 +1985,8 @@ forwarded_impl! {
 }
 
 forwarded_impl! {
-    #[cfg(all(feature = "std", any(unix, windows)))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "std", any(unix, windows)))))]
+    #[cfg(all(feature = "std", any(unix, windows, target_family = "wasi")))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "std", any(unix, windows, target_family = "wasi")))))]
     (), Box<OsStr>, OsString::into_boxed_os_str
 }
 

--- a/serde_core/src/ser/impls.rs
+++ b/serde_core/src/ser/impls.rs
@@ -928,8 +928,8 @@ impl Serialize for PathBuf {
     }
 }
 
-#[cfg(all(feature = "std", any(unix, windows)))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "std", any(unix, windows)))))]
+#[cfg(all(feature = "std", any(unix, windows, target_family = "wasi")))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "std", any(unix, windows, target_family = "wasi")))))]
 impl Serialize for OsStr {
     #[cfg(unix)]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -937,6 +937,15 @@ impl Serialize for OsStr {
         S: Serializer,
     {
         use std::os::unix::ffi::OsStrExt;
+        serializer.serialize_newtype_variant("OsString", 0, "Unix", self.as_bytes())
+    }
+
+    #[cfg(target_family = "wasi")]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use std::os::wasi::ffi::OsStrExt;
         serializer.serialize_newtype_variant("OsString", 0, "Unix", self.as_bytes())
     }
 
@@ -951,8 +960,8 @@ impl Serialize for OsStr {
     }
 }
 
-#[cfg(all(feature = "std", any(unix, windows)))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "std", any(unix, windows)))))]
+#[cfg(all(feature = "std", any(unix, windows, target_family = "wasi")))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "std", any(unix, windows, target_family = "wasi")))))]
 impl Serialize for OsString {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
Fixes #3020

This PR extends the OsStr/OsString Serialize/Deserialize implementations to support WASI targets.

WASI provides Unix-like OsStrExt APIs (same as std::os::unix::ffi::OsStrExt but under std::os::wasi::ffi), so the implementation follows the same pattern as Unix - serializing as bytes using the "Unix" variant.

## Changes
- Updated cfg guards from `any(unix, windows)` to `any(unix, windows, target_family = "wasi")`
- Added WASI-specific serialize/deserialize implementations using `std::os::wasi::ffi::OsStrExt`
- WASI treats OsStr the same as Unix (byte-based) rather than Windows (wide-char-based)

## Testing
Tested by verifying the code compiles for WASI targets (wasip1/p2) which previously failed.