### PR TITLE
Deserialize Option<T> in place when T needs drop

### DIFF
--- a/serde_core/src/crate_root.rs
+++ b/serde_core/src/crate_root.rs
@@ -25,6 +25,7 @@ macro_rules! crate_root {
             pub use self::core::ops::{Bound, Range, RangeFrom, RangeInclusive, RangeTo};
             pub use self::core::result;
             pub use self::core::time::Duration;
+            pub use self::core::mem::needs_drop;
 
             #[cfg(all(feature = "alloc", not(feature = "std")))]
             pub use alloc::borrow::{Cow, ToOwned};

--- a/serde_core/src/de/impls.rs
+++ b/serde_core/src/de/impls.rs
@@ -913,6 +913,62 @@ where
     }
 }
 
+struct OptionInPlaceVisitor<'a, T>(&'a mut Option<T>);
+
+impl<'a, 'de, T> Visitor<'de> for OptionInPlaceVisitor<'a, T>
+where
+    T: Deserialize<'de>,
+{
+    type Value = ();
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("option")
+    }
+
+    #[inline]
+    fn visit_unit<E>(self) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        *self.0 = None;
+        Ok(())
+    }
+
+    #[inline]
+    fn visit_none<E>(self) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        *self.0 = None;
+        Ok(())
+    }
+
+    #[inline]
+    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        match self.0 {
+            Some(place) => tri!(T::deserialize_in_place(deserializer, place)),
+            None => *self.0 = Some(tri!(T::deserialize(deserializer))),
+        };
+        Ok(())
+    }
+
+    fn __private_visit_untagged_option<D>(self, deserializer: D) -> Result<Self::Value, ()>
+    where
+        D: Deserializer<'de>,
+    {
+        match self.0 {
+            Some(place) => if T::deserialize_in_place(deserializer, place).is_err() {
+                *self.0 = None;
+            },
+            None => *self.0 = T::deserialize(deserializer).ok(),
+        };
+        Ok(())
+    }
+}
+
 impl<'de, T> Deserialize<'de> for Option<T>
 where
     T: Deserialize<'de>,
@@ -926,11 +982,21 @@ where
         })
     }
 
-    // The Some variant's repr is opaque, so we can't play cute tricks with its
-    // tag to have deserialize_in_place build the content in place unconditionally.
-    //
-    // FIXME: investigate whether branching on the old value being Some to
-    // deserialize_in_place the value is profitable (probably data-dependent?)
+    fn deserialize_in_place<D>(deserializer: D, place: &mut Self) -> Result<(), D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // The Some variant's repr is opaque, so we can't play cute tricks with its
+        // tag to have deserialize_in_place build the content in place unconditionally.
+
+        if needs_drop::<T>() {
+            tri!(deserializer.deserialize_option(OptionInPlaceVisitor(place)));
+            Ok(())
+        } else {
+            *place = tri!(Deserialize::deserialize(deserializer));
+            Ok(())
+        }
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Needing Drop should be good enough to estimate whether branching on the old value is profitable or not: a quick check on Deserialize impl's of the crate show that it holds for all of them. And if not, the Drop impl might be more costly than the added branch anyway.
And for the [std::mem::needs_drop](https://doc.rust-lang.org/std/mem/fn.needs_drop.html) check, since it's const since 1.36, it should be elided 