### PR TITLE
serde_derive: replace `.fold(sum + expr)` with `sum_tokens`

### DIFF
--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -294,6 +294,7 @@ fn serialize_tuple_struct(
     }
 }
 
+/// `quote!(#init + #item + ...)`
 fn sum_tokens(init: TokenStream, iter: impl Iterator<Item = TokenStream>) -> TokenStream {
     let mut tokens = init;
     for item in iter {
@@ -355,18 +356,16 @@ fn serialize_struct_as_struct(
 
     let let_mut = mut_if(serialized_fields.peek().is_some() || tag_field_exists);
 
-    let len = serialized_fields
-        .map(|field| match field.attrs.skip_serializing_if() {
+    let len = sum_tokens(
+        quote!(#tag_field_exists as usize),
+        serialized_fields.map(|field| match field.attrs.skip_serializing_if() {
             None => quote!(1),
             Some(path) => {
                 let field_expr = get_member(params, field, &field.member);
                 quote!(if #path(#field_expr) { 0 } else { 1 })
             }
-        })
-        .fold(
-            quote!(#tag_field_exists as usize),
-            |sum, expr| quote!(#sum + #expr),
-        );
+        }),
+    );
 
     quote_block! {
         let #let_mut __serde_state = _serde::Serializer::serialize_struct(__serializer, #type_name, #len)?;
@@ -840,15 +839,16 @@ fn serialize_tuple_variant(
 
     let let_mut = mut_if(serialized_fields.peek().is_some());
 
-    let len = serialized_fields
-        .map(|(i, field)| match field.attrs.skip_serializing_if() {
+    let len = sum_tokens(
+        quote!(0),
+        serialized_fields.map(|(i, field)| match field.attrs.skip_serializing_if() {
             None => quote!(1),
             Some(path) => {
                 let field_expr = field_i(i);
                 quote!(if #path(#field_expr) { 0 } else { 1 })
             }
-        })
-        .fold(quote!(0), |sum, expr| quote!(#sum + #expr));
+        }),
+    );
 
     match context {
         TupleVariant::ExternallyTagged {
@@ -917,16 +917,17 @@ fn serialize_struct_variant(
 
     let let_mut = mut_if(serialized_fields.peek().is_some());
 
-    let len = serialized_fields
-        .map(|field| {
+    let len = sum_tokens(
+        quote!(0),
+        serialized_fields.map(|field| {
             let member = &field.member;
 
             match field.attrs.skip_serializing_if() {
                 Some(path) => quote!(if #path(#member) { 0 } else { 1 }),
                 None => quote!(1),
             }
-        })
-        .fold(quote!(0), |sum, expr| quote!(#sum + #expr));
+        }),
+    );
 
     match context {
         StructVariant::ExternallyTagged {


### PR DESCRIPTION
638 less llvm-lines

```
before: 139793
after:  139155
```

I think it changes the `TokenStream` behavior.

Edit: Maybe `Punctuated<_ , Plus>` would be better?

<img width="529" height="883" alt="behavior" src="https://github.com/user-attachments/assets/e23d0d9f-68e2-464f-a792-0dbea96d3e18" />
