### PR TITLE
Add RemoteSerialize and RemoteDeserialize traits.

### DIFF
--- a/serde_core/src/de/mod.rs
+++ b/serde_core/src/de/mod.rs
@@ -120,8 +120,11 @@ pub mod value;
 
 mod ignored_any;
 mod impls;
+mod remote;
 
 pub use self::ignored_any::IgnoredAny;
+pub use self::remote::RemoteDeserialize;
+
 #[cfg(all(not(feature = "std"), no_core_error))]
 #[doc(no_inline)]
 pub use crate::std_error::Error as StdError;
@@ -131,7 +134,6 @@ pub use core::error::Error as StdError;
 #[cfg(feature = "std")]
 #[doc(no_inline)]
 pub use std::error::Error as StdError;
-
 ////////////////////////////////////////////////////////////////////////////////
 
 macro_rules! declare_error_trait {

--- a/serde_core/src/de/remote.rs
+++ b/serde_core/src/de/remote.rs
@@ -1,0 +1,9 @@
+use crate::Deserializer;
+
+/// TODO
+pub trait RemoteDeserialize<'de, Remote> where Remote: Sized {
+    /// TODO
+    fn deserialize<D>(deserializer: D) -> Result<Remote, D::Error>
+    where
+        D: Deserializer<'de>;
+}

--- a/serde_core/src/ser/mod.rs
+++ b/serde_core/src/ser/mod.rs
@@ -112,9 +112,10 @@ use crate::lib::*;
 mod fmt;
 mod impls;
 mod impossible;
+mod remote;
 
 pub use self::impossible::Impossible;
-
+pub use self::remote::RemoteSerialize;
 #[cfg(all(not(feature = "std"), no_core_error))]
 #[doc(no_inline)]
 pub use crate::std_error::Error as StdError;

--- a/serde_core/src/ser/remote.rs
+++ b/serde_core/src/ser/remote.rs
@@ -1,0 +1,9 @@
+use crate::Serializer;
+
+/// TODO
+pub trait RemoteSerialize<Remote> {
+    /// TODO
+    fn serialize<S>(origin: &Remote, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer;
+}

--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -46,13 +46,24 @@ pub fn expand_derive_deserialize(input: &mut syn::DeriveInput) -> syn::Result<To
         quote! {
             #[automatically_derived]
             #allow_deprecated
-            impl #de_impl_generics #ident #ty_generics #where_clause {
-                #vis fn deserialize<__D>(__deserializer: __D) -> _serde::#private::Result<#remote #ty_generics, __D::Error>
+            impl #de_impl_generics _serde::de::RemoteDeserialize<#delife, #remote #ty_generics> for #ident #ty_generics #where_clause {
+                fn deserialize<__D>(__deserializer: __D) -> _serde::#private::Result<#remote #ty_generics, __D::Error>
                 where
                     __D: _serde::Deserializer<#delife>,
                 {
                     #used
                     #body
+                }
+            }
+
+            #[automatically_derived]
+            #allow_deprecated
+            impl #de_impl_generics #ident #ty_generics #where_clause {
+                #vis fn deserialize<__D>(__deserializer: __D) -> _serde::#private::Result<#remote #ty_generics, __D::Error>
+                where
+                    __D: _serde::Deserializer<#delife>,
+                {
+                    <#ident #ty_generics as _serde::de::RemoteDeserialize::<#delife, #remote #ty_generics>>::deserialize(__deserializer)
                 }
             }
         }

--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -32,13 +32,24 @@ pub fn expand_derive_serialize(input: &mut syn::DeriveInput) -> syn::Result<Toke
         quote! {
             #[automatically_derived]
             #allow_deprecated
-            impl #impl_generics #ident #ty_generics #where_clause {
-                #vis fn serialize<__S>(__self: &#remote #ty_generics, __serializer: __S) -> _serde::#private::Result<__S::Ok, __S::Error>
+            impl #impl_generics _serde::ser::RemoteSerialize<#remote #ty_generics> for #ident #ty_generics #where_clause {
+                fn serialize<__S>(__self: &#remote #ty_generics, __serializer: __S) -> _serde::#private::Result<__S::Ok, __S::Error>
                 where
                     __S: _serde::Serializer,
                 {
                     #used
                     #body
+                }
+            }
+
+            #[automatically_derived]
+            #allow_deprecated
+            impl #impl_generics #ident #ty_generics #where_clause {
+                #vis fn serialize<__S>(__self: &#remote #ty_generics, __serializer: __S) -> _serde::#private::Result<__S::Ok, __S::Error>
+                where
+                    __S: _serde::Serializer,
+                {
+                    <#ident #ty_generics as _serde::ser::RemoteSerialize::<#remote #ty_generics>>::serialize(__self, __serializer)
                 }
             }
         }


### PR DESCRIPTION
See #2898 for rationale.

To maintain backward compatibility with current associated functions, I've kept them and delegated the implementation to the trait method.