### PR TITLE
Pass is_human_readable for internal deserializer

### DIFF
--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -1040,6 +1040,7 @@ mod content {
     /// Not public API
     pub struct ContentDeserializer<'de, E> {
         content: Content<'de>,
+        is_human_readable: bool,
         err: PhantomData<E>,
     }
 
@@ -1089,12 +1090,16 @@ mod content {
         }
     }
 
-    fn visit_content_seq<'de, V, E>(content: Vec<Content<'de>>, visitor: V) -> Result<V::Value, E>
+    fn visit_content_seq<'de, V, E>(
+        content: Vec<Content<'de>>,
+        visitor: V,
+        is_human_readable: bool,
+    ) -> Result<V::Value, E>
     where
         V: Visitor<'de>,
         E: de::Error,
     {
-        let mut seq_visitor = SeqDeserializer::new(content);
+        let mut seq_visitor = SeqDeserializer::new(content, is_human_readable);
         let value = tri!(visitor.visit_seq(&mut seq_visitor));
         tri!(seq_visitor.end());
         Ok(value)
@@ -1103,12 +1108,13 @@ mod content {
     fn visit_content_map<'de, V, E>(
         content: Vec<(Content<'de>, Content<'de>)>,
         visitor: V,
+        is_human_readable: bool,
     ) -> Result<V::Value, E>
     where
         V: Visitor<'de>,
         E: de::Error,
     {
-        let mut map_visitor = MapDeserializer::new(content);
+        let mut map_visitor = MapDeserializer::new(content, is_human_readable);
         let value = tri!(visitor.visit_map(&mut map_visitor));
         tri!(map_visitor.end());
         Ok(value)
@@ -1122,6 +1128,10 @@ mod content {
         E: de::Error,
     {
         type Error = E;
+
+        fn is_human_readable(&self) -> bool {
+            self.is_human_readable
+        }
 
         fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where
@@ -1146,10 +1156,13 @@ mod content {
                 Content::Bytes(v) => visitor.visit_borrowed_bytes(v),
                 Content::Unit => visitor.visit_unit(),
                 Content::None => visitor.visit_none(),
-                Content::Some(v) => visitor.visit_some(ContentDeserializer::new(*v)),
-                Content::Newtype(v) => visitor.visit_newtype_struct(ContentDeserializer::new(*v)),
-                Content::Seq(v) => visit_content_seq(v, visitor),
-                Content::Map(v) => visit_content_map(v, visitor),
+                Content::Some(v) => {
+                    visitor.visit_some(ContentDeserializer::new(*v, self.is_human_readable))
+                }
+                Content::Newtype(v) => visitor
+                    .visit_newtype_struct(ContentDeserializer::new(*v, self.is_human_readable)),
+                Content::Seq(v) => visit_content_seq(v, visitor, self.is_human_readable),
+                Content::Map(v) => visit_content_map(v, visitor, self.is_human_readable),
             }
         }
 
@@ -1281,7 +1294,7 @@ mod content {
                 Content::Str(v) => visitor.visit_borrowed_str(v),
                 Content::ByteBuf(v) => visitor.visit_byte_buf(v),
                 Content::Bytes(v) => visitor.visit_borrowed_bytes(v),
-                Content::Seq(v) => visit_content_seq(v, visitor),
+                Content::Seq(v) => visit_content_seq(v, visitor, self.is_human_readable),
                 _ => Err(self.invalid_type(&visitor)),
             }
         }
@@ -1292,7 +1305,9 @@ mod content {
         {
             match self.content {
                 Content::None => visitor.visit_none(),
-                Content::Some(v) => visitor.visit_some(ContentDeserializer::new(*v)),
+                Content::Some(v) => {
+                    visitor.visit_some(ContentDeserializer::new(*v, self.is_human_readable))
+                }
                 Content::Unit => visitor.visit_unit(),
                 _ => visitor.visit_some(self),
             }
@@ -1357,7 +1372,8 @@ mod content {
             V: Visitor<'de>,
         {
             match self.content {
-                Content::Newtype(v) => visitor.visit_newtype_struct(ContentDeserializer::new(*v)),
+                Content::Newtype(v) => visitor
+                    .visit_newtype_struct(ContentDeserializer::new(*v, self.is_human_readable)),
                 _ => visitor.visit_newtype_struct(self),
             }
         }
@@ -1367,7 +1383,7 @@ mod content {
             V: Visitor<'de>,
         {
             match self.content {
-                Content::Seq(v) => visit_content_seq(v, visitor),
+                Content::Seq(v) => visit_content_seq(v, visitor, self.is_human_readable),
                 _ => Err(self.invalid_type(&visitor)),
             }
         }
@@ -1396,7 +1412,7 @@ mod content {
             V: Visitor<'de>,
         {
             match self.content {
-                Content::Map(v) => visit_content_map(v, visitor),
+                Content::Map(v) => visit_content_map(v, visitor, self.is_human_readable),
                 _ => Err(self.invalid_type(&visitor)),
             }
         }
@@ -1411,8 +1427,8 @@ mod content {
             V: Visitor<'de>,
         {
             match self.content {
-                Content::Seq(v) => visit_content_seq(v, visitor),
-                Content::Map(v) => visit_content_map(v, visitor),
+                Content::Seq(v) => visit_content_seq(v, visitor, self.is_human_readable),
+                Content::Map(v) => visit_content_map(v, visitor, self.is_human_readable),
                 _ => Err(self.invalid_type(&visitor)),
             }
         }
@@ -1456,7 +1472,7 @@ mod content {
                 }
             };
 
-            visitor.visit_enum(EnumDeserializer::new(variant, value))
+            visitor.visit_enum(EnumDeserializer::new(variant, value, self.is_human_readable))
         }
 
         fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -1493,9 +1509,10 @@ mod content {
 
     impl<'de, E> ContentDeserializer<'de, E> {
         /// private API, don't use
-        pub fn new(content: Content<'de>) -> Self {
+        pub fn new(content: Content<'de>, is_human_readable: bool) -> Self {
             ContentDeserializer {
                 content,
+                is_human_readable,
                 err: PhantomData,
             }
         }
@@ -1504,14 +1521,16 @@ mod content {
     struct SeqDeserializer<'de, E> {
         iter: <Vec<Content<'de>> as IntoIterator>::IntoIter,
         count: usize,
+        is_human_readable: bool,
         marker: PhantomData<E>,
     }
 
     impl<'de, E> SeqDeserializer<'de, E> {
-        fn new(content: Vec<Content<'de>>) -> Self {
+        fn new(content: Vec<Content<'de>>, is_human_readable: bool) -> Self {
             SeqDeserializer {
                 iter: content.into_iter(),
                 count: 0,
+                is_human_readable,
                 marker: PhantomData,
             }
         }
@@ -1573,7 +1592,8 @@ mod content {
             match self.iter.next() {
                 Some(value) => {
                     self.count += 1;
-                    seed.deserialize(ContentDeserializer::new(value)).map(Some)
+                    seed.deserialize(ContentDeserializer::new(value, self.is_human_readable))
+                        .map(Some)
                 }
                 None => Ok(None),
             }
@@ -1601,15 +1621,17 @@ mod content {
         iter: <Vec<(Content<'de>, Content<'de>)> as IntoIterator>::IntoIter,
         value: Option<Content<'de>>,
         count: usize,
+        is_human_readable: bool,
         error: PhantomData<E>,
     }
 
     impl<'de, E> MapDeserializer<'de, E> {
-        fn new(content: Vec<(Content<'de>, Content<'de>)>) -> Self {
+        fn new(content: Vec<(Content<'de>, Content<'de>)>, is_human_readable: bool) -> Self {
             MapDeserializer {
                 iter: content.into_iter(),
                 value: None,
                 count: 0,
+                is_human_readable,
                 error: PhantomData,
             }
         }
@@ -1700,7 +1722,8 @@ mod content {
             match self.next_pair() {
                 Some((key, value)) => {
                     self.value = Some(value);
-                    seed.deserialize(ContentDeserializer::new(key)).map(Some)
+                    seed.deserialize(ContentDeserializer::new(key, self.is_human_readable))
+                        .map(Some)
                 }
                 None => Ok(None),
             }
@@ -1714,7 +1737,7 @@ mod content {
             // Panic because this indicates a bug in the program rather than an
             // expected failure.
             let value = value.expect("MapAccess::next_value called before next_key");
-            seed.deserialize(ContentDeserializer::new(value))
+            seed.deserialize(ContentDeserializer::new(value, self.is_human_readable))
         }
 
         fn next_entry_seed<TK, TV>(
@@ -1728,8 +1751,14 @@ mod content {
         {
             match self.next_pair() {
                 Some((key, value)) => {
-                    let key = tri!(kseed.deserialize(ContentDeserializer::new(key)));
-                    let value = tri!(vseed.deserialize(ContentDeserializer::new(value)));
+                    let key = tri!(kseed.deserialize(ContentDeserializer::new(
+                        key,
+                        self.is_human_readable
+                    )));
+                    let value = tri!(vseed.deserialize(ContentDeserializer::new(
+                        value,
+                        self.is_human_readable
+                    )));
                     Ok(Some((key, value)))
                 }
                 None => Ok(None),
@@ -1754,7 +1783,7 @@ mod content {
         {
             match self.next_pair() {
                 Some((k, v)) => {
-                    let de = PairDeserializer(k, v, PhantomData);
+                    let de = PairDeserializer(k, v, self.is_human_readable, PhantomData);
                     seed.deserialize(de).map(Some)
                 }
                 None => Ok(None),
@@ -1766,7 +1795,7 @@ mod content {
         }
     }
 
-    struct PairDeserializer<'de, E>(Content<'de>, Content<'de>, PhantomData<E>);
+    struct PairDeserializer<'de, E>(Content<'de>, Content<'de>, bool, PhantomData<E>);
 
     #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'de, E> Deserializer<'de> for PairDeserializer<'de, E>
@@ -1792,7 +1821,7 @@ mod content {
         where
             V: Visitor<'de>,
         {
-            let mut pair_visitor = PairVisitor(Some(self.0), Some(self.1), PhantomData);
+            let mut pair_visitor = PairVisitor(Some(self.0), Some(self.1), self.2, PhantomData);
             let pair = tri!(visitor.visit_seq(&mut pair_visitor));
             if pair_visitor.1.is_none() {
                 Ok(pair)
@@ -1818,7 +1847,7 @@ mod content {
         }
     }
 
-    struct PairVisitor<'de, E>(Option<Content<'de>>, Option<Content<'de>>, PhantomData<E>);
+    struct PairVisitor<'de, E>(Option<Content<'de>>, Option<Content<'de>>, bool, PhantomData<E>);
 
     #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'de, E> SeqAccess<'de> for PairVisitor<'de, E>
@@ -1832,9 +1861,11 @@ mod content {
             T: DeserializeSeed<'de>,
         {
             if let Some(k) = self.0.take() {
-                seed.deserialize(ContentDeserializer::new(k)).map(Some)
+                seed.deserialize(ContentDeserializer::new(k, self.2))
+                    .map(Some)
             } else if let Some(v) = self.1.take() {
-                seed.deserialize(ContentDeserializer::new(v)).map(Some)
+                seed.deserialize(ContentDeserializer::new(v, self.2))
+                    .map(Some)
             } else {
                 Ok(None)
             }
@@ -1870,6 +1901,7 @@ mod content {
     {
         variant: Content<'de>,
         value: Option<Content<'de>>,
+        is_human_readable: bool,
         err: PhantomData<E>,
     }
 
@@ -1877,10 +1909,15 @@ mod content {
     where
         E: de::Error,
     {
-        pub fn new(variant: Content<'de>, value: Option<Content<'de>>) -> EnumDeserializer<'de, E> {
+        pub fn new(
+            variant: Content<'de>,
+            value: Option<Content<'de>>,
+            is_human_readable: bool,
+        ) -> EnumDeserializer<'de, E> {
             EnumDeserializer {
                 variant,
                 value,
+                is_human_readable,
                 err: PhantomData,
             }
         }
@@ -1900,10 +1937,14 @@ mod content {
         {
             let visitor = VariantDeserializer {
                 value: self.value,
+                is_human_readable: self.is_human_readable,
                 err: PhantomData,
             };
-            seed.deserialize(ContentDeserializer::new(self.variant))
-                .map(|v| (v, visitor))
+            seed.deserialize(ContentDeserializer::new(
+                self.variant,
+                self.is_human_readable,
+            ))
+            .map(|v| (v, visitor))
         }
     }
 
@@ -1912,6 +1953,7 @@ mod content {
         E: de::Error,
     {
         value: Option<Content<'de>>,
+        is_human_readable: bool,
         err: PhantomData<E>,
     }
 
@@ -1924,7 +1966,10 @@ mod content {
 
         fn unit_variant(self) -> Result<(), E> {
             match self.value {
-                Some(value) => de::Deserialize::deserialize(ContentDeserializer::new(value)),
+                Some(value) => de::Deserialize::deserialize(ContentDeserializer::new(
+                    value,
+                    self.is_human_readable,
+                )),
                 None => Ok(()),
             }
         }
@@ -1934,7 +1979,10 @@ mod content {
             T: de::DeserializeSeed<'de>,
         {
             match self.value {
-                Some(value) => seed.deserialize(ContentDeserializer::new(value)),
+                Some(value) => seed.deserialize(ContentDeserializer::new(
+                    value,
+                    self.is_human_readable,
+                )),
                 None => Err(de::Error::invalid_type(
                     de::Unexpected::UnitVariant,
                     &"newtype variant",
@@ -1947,9 +1995,10 @@ mod content {
             V: de::Visitor<'de>,
         {
             match self.value {
-                Some(Content::Seq(v)) => {
-                    de::Deserializer::deserialize_any(SeqDeserializer::new(v), visitor)
-                }
+                Some(Content::Seq(v)) => de::Deserializer::deserialize_any(
+                    SeqDeserializer::new(v, self.is_human_readable),
+                    visitor,
+                ),
                 Some(other) => Err(de::Error::invalid_type(
                     content_unexpected(&other),
                     &"tuple variant",
@@ -1970,12 +2019,14 @@ mod content {
             V: de::Visitor<'de>,
         {
             match self.value {
-                Some(Content::Map(v)) => {
-                    de::Deserializer::deserialize_any(MapDeserializer::new(v), visitor)
-                }
-                Some(Content::Seq(v)) => {
-                    de::Deserializer::deserialize_any(SeqDeserializer::new(v), visitor)
-                }
+                Some(Content::Map(v)) => de::Deserializer::deserialize_any(
+                    MapDeserializer::new(v, self.is_human_readable),
+                    visitor,
+                ),
+                Some(Content::Seq(v)) => de::Deserializer::deserialize_any(
+                    SeqDeserializer::new(v, self.is_human_readable),
+                    visitor,
+                ),
                 Some(other) => Err(de::Error::invalid_type(
                     content_unexpected(&other),
                     &"struct variant",
@@ -1991,6 +2042,7 @@ mod content {
     /// Not public API.
     pub struct ContentRefDeserializer<'a, 'de: 'a, E> {
         content: &'a Content<'de>,
+        is_human_readable: bool,
         err: PhantomData<E>,
     }
 
@@ -2043,12 +2095,13 @@ mod content {
     fn visit_content_seq_ref<'a, 'de, V, E>(
         content: &'a [Content<'de>],
         visitor: V,
+        is_human_readable: bool,
     ) -> Result<V::Value, E>
     where
         V: Visitor<'de>,
         E: de::Error,
     {
-        let mut seq_visitor = SeqRefDeserializer::new(content);
+        let mut seq_visitor = SeqRefDeserializer::new(content, is_human_readable);
         let value = tri!(visitor.visit_seq(&mut seq_visitor));
         tri!(seq_visitor.end());
         Ok(value)
@@ -2057,12 +2110,13 @@ mod content {
     fn visit_content_map_ref<'a, 'de, V, E>(
         content: &'a [(Content<'de>, Content<'de>)],
         visitor: V,
+        is_human_readable: bool,
     ) -> Result<V::Value, E>
     where
         V: Visitor<'de>,
         E: de::Error,
     {
-        let mut map_visitor = MapRefDeserializer::new(content);
+        let mut map_visitor = MapRefDeserializer::new(content, is_human_readable);
         let value = tri!(visitor.visit_map(&mut map_visitor));
         tri!(map_visitor.end());
         Ok(value)
@@ -2076,6 +2130,10 @@ mod content {
         E: de::Error,
     {
         type Error = E;
+
+        fn is_human_readable(&self) -> bool {
+            self.is_human_readable
+        }
 
         fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, E>
         where
@@ -2100,12 +2158,17 @@ mod content {
                 Content::Bytes(v) => visitor.visit_borrowed_bytes(v),
                 Content::Unit => visitor.visit_unit(),
                 Content::None => visitor.visit_none(),
-                Content::Some(ref v) => visitor.visit_some(ContentRefDeserializer::new(v)),
-                Content::Newtype(ref v) => {
-                    visitor.visit_newtype_struct(ContentRefDeserializer::new(v))
+                Content::Some(ref v) => {
+                    visitor.visit_some(ContentRefDeserializer::new(v, self.is_human_readable))
                 }
-                Content::Seq(ref v) => visit_content_seq_ref(v, visitor),
-                Content::Map(ref v) => visit_content_map_ref(v, visitor),
+                Content::Newtype(ref v) => visitor
+                    .visit_newtype_struct(ContentRefDeserializer::new(v, self.is_human_readable)),
+                Content::Seq(ref v) => {
+                    visit_content_seq_ref(v, visitor, self.is_human_readable)
+                }
+                Content::Map(ref v) => {
+                    visit_content_map_ref(v, visitor, self.is_human_readable)
+                }
             }
         }
 
@@ -2230,7 +2293,9 @@ mod content {
                 Content::Str(v) => visitor.visit_borrowed_str(v),
                 Content::ByteBuf(ref v) => visitor.visit_bytes(v),
                 Content::Bytes(v) => visitor.visit_borrowed_bytes(v),
-                Content::Seq(ref v) => visit_content_seq_ref(v, visitor),
+                Content::Seq(ref v) => {
+                    visit_content_seq_ref(v, visitor, self.is_human_readable)
+                }
                 _ => Err(self.invalid_type(&visitor)),
             }
         }
@@ -2250,7 +2315,9 @@ mod content {
             //      with_optional_field::*
             match *self.content {
                 Content::None => visitor.visit_none(),
-                Content::Some(ref v) => visitor.visit_some(ContentRefDeserializer::new(v)),
+                Content::Some(ref v) => {
+                    visitor.visit_some(ContentRefDeserializer::new(v, self.is_human_readable))
+                }
                 Content::Unit => visitor.visit_unit(),
                 // This case is to support data formats which do not encode an
                 // indication whether a value is optional. An example of such a
@@ -2291,9 +2358,8 @@ mod content {
             // Covered by tests/test_enum_untagged.rs
             //      newtype_struct
             match *self.content {
-                Content::Newtype(ref v) => {
-                    visitor.visit_newtype_struct(ContentRefDeserializer::new(v))
-                }
+                Content::Newtype(ref v) => visitor
+                    .visit_newtype_struct(ContentRefDeserializer::new(v, self.is_human_readable)),
                 // This case is to support data formats that encode newtype
                 // structs and their underlying data the same, with no
                 // indication whether a newtype wrapper was present. For example
@@ -2312,7 +2378,9 @@ mod content {
             V: Visitor<'de>,
         {
             match *self.content {
-                Content::Seq(ref v) => visit_content_seq_ref(v, visitor),
+                Content::Seq(ref v) => {
+                    visit_content_seq_ref(v, visitor, self.is_human_readable)
+                }
                 _ => Err(self.invalid_type(&visitor)),
             }
         }
@@ -2341,7 +2409,9 @@ mod content {
             V: Visitor<'de>,
         {
             match *self.content {
-                Content::Map(ref v) => visit_content_map_ref(v, visitor),
+                Content::Map(ref v) => {
+                    visit_content_map_ref(v, visitor, self.is_human_readable)
+                }
                 _ => Err(self.invalid_type(&visitor)),
             }
         }
@@ -2356,8 +2426,12 @@ mod content {
             V: Visitor<'de>,
         {
             match *self.content {
-                Content::Seq(ref v) => visit_content_seq_ref(v, visitor),
-                Content::Map(ref v) => visit_content_map_ref(v, visitor),
+                Content::Seq(ref v) => {
+                    visit_content_seq_ref(v, visitor, self.is_human_readable)
+                }
+                Content::Map(ref v) => {
+                    visit_content_map_ref(v, visitor, self.is_human_readable)
+                }
                 _ => Err(self.invalid_type(&visitor)),
             }
         }
@@ -2404,6 +2478,7 @@ mod content {
             visitor.visit_enum(EnumRefDeserializer {
                 variant,
                 value,
+                is_human_readable: self.is_human_readable,
                 err: PhantomData,
             })
         }
@@ -2441,9 +2516,10 @@ mod content {
 
     impl<'a, 'de, E> ContentRefDeserializer<'a, 'de, E> {
         /// private API, don't use
-        pub fn new(content: &'a Content<'de>) -> Self {
+        pub fn new(content: &'a Content<'de>, is_human_readable: bool) -> Self {
             ContentRefDeserializer {
                 content,
+                is_human_readable,
                 err: PhantomData,
             }
         }
@@ -2462,14 +2538,16 @@ mod content {
     struct SeqRefDeserializer<'a, 'de, E> {
         iter: <&'a [Content<'de>] as IntoIterator>::IntoIter,
         count: usize,
+        is_human_readable: bool,
         marker: PhantomData<E>,
     }
 
     impl<'a, 'de, E> SeqRefDeserializer<'a, 'de, E> {
-        fn new(content: &'a [Content<'de>]) -> Self {
+        fn new(content: &'a [Content<'de>], is_human_readable: bool) -> Self {
             SeqRefDeserializer {
                 iter: content.iter(),
                 count: 0,
+                is_human_readable,
                 marker: PhantomData,
             }
         }
@@ -2531,8 +2609,11 @@ mod content {
             match self.iter.next() {
                 Some(value) => {
                     self.count += 1;
-                    seed.deserialize(ContentRefDeserializer::new(value))
-                        .map(Some)
+                    seed.deserialize(ContentRefDeserializer::new(
+                        value,
+                        self.is_human_readable,
+                    ))
+                    .map(Some)
                 }
                 None => Ok(None),
             }
@@ -2547,15 +2628,20 @@ mod content {
         iter: <&'a [(Content<'de>, Content<'de>)] as IntoIterator>::IntoIter,
         value: Option<&'a Content<'de>>,
         count: usize,
+        is_human_readable: bool,
         error: PhantomData<E>,
     }
 
     impl<'a, 'de, E> MapRefDeserializer<'a, 'de, E> {
-        fn new(content: &'a [(Content<'de>, Content<'de>)]) -> Self {
+        fn new(
+            content: &'a [(Content<'de>, Content<'de>)],
+            is_human_readable: bool,
+        ) -> Self {
             MapRefDeserializer {
                 iter: content.iter(),
                 value: None,
                 count: 0,
+                is_human_readable,
                 error: PhantomData,
             }
         }
@@ -2646,7 +2732,8 @@ mod content {
             match self.next_pair() {
                 Some((key, value)) => {
                     self.value = Some(value);
-                    seed.deserialize(ContentRefDeserializer::new(key)).map(Some)
+                    seed.deserialize(ContentRefDeserializer::new(key, self.is_human_readable))
+                        .map(Some)
                 }
                 None => Ok(None),
             }
@@ -2660,7 +2747,7 @@ mod content {
             // Panic because this indicates a bug in the program rather than an
             // expected failure.
             let value = value.expect("MapAccess::next_value called before next_key");
-            seed.deserialize(ContentRefDeserializer::new(value))
+            seed.deserialize(ContentRefDeserializer::new(value, self.is_human_readable))
         }
 
         fn next_entry_seed<TK, TV>(
@@ -2674,8 +2761,14 @@ mod content {
         {
             match self.next_pair() {
                 Some((key, value)) => {
-                    let key = tri!(kseed.deserialize(ContentRefDeserializer::new(key)));
-                    let value = tri!(vseed.deserialize(ContentRefDeserializer::new(value)));
+                    let key = tri!(kseed.deserialize(ContentRefDeserializer::new(
+                        key,
+                        self.is_human_readable
+                    )));
+                    let value = tri!(vseed.deserialize(ContentRefDeserializer::new(
+                        value,
+                        self.is_human_readable
+                    )));
                     Ok(Some((key, value)))
                 }
                 None => Ok(None),
@@ -2700,7 +2793,7 @@ mod content {
         {
             match self.next_pair() {
                 Some((k, v)) => {
-                    let de = PairRefDeserializer(k, v, PhantomData);
+                    let de = PairRefDeserializer(k, v, self.is_human_readable, PhantomData);
                     seed.deserialize(de).map(Some)
                 }
                 None => Ok(None),
@@ -2712,7 +2805,12 @@ mod content {
         }
     }
 
-    struct PairRefDeserializer<'a, 'de, E>(&'a Content<'de>, &'a Content<'de>, PhantomData<E>);
+    struct PairRefDeserializer<'a, 'de, E>(
+        &'a Content<'de>,
+        &'a Content<'de>,
+        bool,
+        PhantomData<E>,
+    );
 
     #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
     impl<'a, 'de, E> Deserializer<'de> for PairRefDeserializer<'a, 'de, E>
@@ -2738,7 +2836,7 @@ mod content {
         where
             V: Visitor<'de>,
         {
-            let mut pair_visitor = PairRefVisitor(Some(self.0), Some(self.1), PhantomData);
+            let mut pair_visitor = PairRefVisitor(Some(self.0), Some(self.1), self.2, PhantomData);
             let pair = tri!(visitor.visit_seq(&mut pair_visitor));
             if pair_visitor.1.is_none() {
                 Ok(pair)
@@ -2767,6 +2865,7 @@ mod content {
     struct PairRefVisitor<'a, 'de, E>(
         Option<&'a Content<'de>>,
         Option<&'a Content<'de>>,
+        bool,
         PhantomData<E>,
     );
 
@@ -2782,9 +2881,11 @@ mod content {
             T: DeserializeSeed<'de>,
         {
             if let Some(k) = self.0.take() {
-                seed.deserialize(ContentRefDeserializer::new(k)).map(Some)
+                seed.deserialize(ContentRefDeserializer::new(k, self.2))
+                    .map(Some)
             } else if let Some(v) = self.1.take() {
-                seed.deserialize(ContentRefDeserializer::new(v)).map(Some)
+                seed.deserialize(ContentRefDeserializer::new(v, self.2))
+                    .map(Some)
             } else {
                 Ok(None)
             }
@@ -2807,6 +2908,7 @@ mod content {
     {
         variant: &'a Content<'de>,
         value: Option<&'a Content<'de>>,
+        is_human_readable: bool,
         err: PhantomData<E>,
     }
 
@@ -2824,10 +2926,14 @@ mod content {
         {
             let visitor = VariantRefDeserializer {
                 value: self.value,
+                is_human_readable: self.is_human_readable,
                 err: PhantomData,
             };
-            seed.deserialize(ContentRefDeserializer::new(self.variant))
-                .map(|v| (v, visitor))
+            seed.deserialize(ContentRefDeserializer::new(
+                self.variant,
+                self.is_human_readable,
+            ))
+            .map(|v| (v, visitor))
         }
     }
 
@@ -2836,6 +2942,7 @@ mod content {
         E: de::Error,
     {
         value: Option<&'a Content<'de>>,
+        is_human_readable: bool,
         err: PhantomData<E>,
     }
 
@@ -2848,7 +2955,10 @@ mod content {
 
         fn unit_variant(self) -> Result<(), E> {
             match self.value {
-                Some(value) => de::Deserialize::deserialize(ContentRefDeserializer::new(value)),
+                Some(value) => de::Deserialize::deserialize(ContentRefDeserializer::new(
+                    value,
+                    self.is_human_readable,
+                )),
                 // Covered by tests/test_annotations.rs
                 //      test_partially_untagged_adjacently_tagged_enum
                 // Covered by tests/test_enum_untagged.rs
@@ -2867,7 +2977,10 @@ mod content {
                 //      test_partially_untagged_enum_generic
                 // Covered by tests/test_enum_untagged.rs
                 //      newtype_enum::newtype
-                Some(value) => seed.deserialize(ContentRefDeserializer::new(value)),
+                Some(value) => seed.deserialize(ContentRefDeserializer::new(
+                    value,
+                    self.is_human_readable,
+                )),
                 None => Err(de::Error::invalid_type(
                     de::Unexpected::UnitVariant,
                     &"newtype variant",
@@ -2886,7 +2999,9 @@ mod content {
                 // Covered by tests/test_enum_untagged.rs
                 //      newtype_enum::tuple0
                 //      newtype_enum::tuple2
-                Some(Content::Seq(v)) => visit_content_seq_ref(v, visitor),
+                Some(Content::Seq(v)) => {
+                    visit_content_seq_ref(v, visitor, self.is_human_readable)
+                }
                 Some(other) => Err(de::Error::invalid_type(
                     content_unexpected(other),
                     &"tuple variant",
@@ -2909,11 +3024,15 @@ mod content {
             match self.value {
                 // Covered by tests/test_enum_untagged.rs
                 //      newtype_enum::struct_from_map
-                Some(Content::Map(v)) => visit_content_map_ref(v, visitor),
+                Some(Content::Map(v)) => {
+                    visit_content_map_ref(v, visitor, self.is_human_readable)
+                }
                 // Covered by tests/test_enum_untagged.rs
                 //      newtype_enum::struct_from_seq
                 //      newtype_enum::empty_struct_from_seq
-                Some(Content::Seq(v)) => visit_content_seq_ref(v, visitor),
+                Some(Content::Seq(v)) => {
+                    visit_content_seq_ref(v, visitor, self.is_human_readable)
+                }
                 Some(other) => Err(de::Error::invalid_type(
                     content_unexpected(other),
                     &"struct variant",
@@ -3184,6 +3303,7 @@ where
 pub struct FlatMapDeserializer<'a, 'de: 'a, E>(
     pub &'a mut Vec<Option<(Content<'de>, Content<'de>)>>,
     pub PhantomData<E>,
+    pub bool,
 );
 
 #[cfg(any(feature = "std", feature = "alloc"))]
@@ -3236,7 +3356,7 @@ where
     {
         for entry in self.0 {
             if let Some((key, value)) = flat_map_take_entry(entry, variants) {
-                return visitor.visit_enum(EnumDeserializer::new(key, Some(value)));
+                return visitor.visit_enum(EnumDeserializer::new(key, Some(value), self.2));
             }
         }
 
@@ -3253,6 +3373,7 @@ where
         visitor.visit_map(FlatMapAccess {
             iter: self.0.iter(),
             pending_content: None,
+            is_human_readable: self.2,
             _marker: PhantomData,
         })
     }
@@ -3270,6 +3391,7 @@ where
             iter: self.0.iter_mut(),
             pending_content: None,
             fields,
+            is_human_readable: self.2,
             _marker: PhantomData,
         })
     }
@@ -3344,6 +3466,7 @@ where
 struct FlatMapAccess<'a, 'de: 'a, E> {
     iter: slice::Iter<'a, Option<(Content<'de>, Content<'de>)>>,
     pending_content: Option<&'a Content<'de>>,
+    is_human_readable: bool,
     _marker: PhantomData<E>,
 }
 
@@ -3367,7 +3490,9 @@ where
                 // is going to be consumed. Borrowing here leaves the entry
                 // available for later flattened fields.
                 self.pending_content = Some(content);
-                return seed.deserialize(ContentRefDeserializer::new(key)).map(Some);
+                return seed
+                    .deserialize(ContentRefDeserializer::new(key, self.is_human_readable))
+                    .map(Some);
             }
         }
         Ok(None)
@@ -3378,7 +3503,9 @@ where
         T: DeserializeSeed<'de>,
     {
         match self.pending_content.take() {
-            Some(value) => seed.deserialize(ContentRefDeserializer::new(value)),
+            Some(value) => {
+                seed.deserialize(ContentRefDeserializer::new(value, self.is_human_readable))
+            }
             None => Err(Error::custom("value is missing")),
         }
     }
@@ -3389,6 +3516,7 @@ struct FlatStructAccess<'a, 'de: 'a, E> {
     iter: slice::IterMut<'a, Option<(Content<'de>, Content<'de>)>>,
     pending_content: Option<Content<'de>>,
     fields: &'static [&'static str],
+    is_human_readable: bool,
     _marker: PhantomData<E>,
 }
 
@@ -3407,7 +3535,9 @@ where
         for entry in self.iter.by_ref() {
             if let Some((key, content)) = flat_map_take_entry(entry, self.fields) {
                 self.pending_content = Some(content);
-                return seed.deserialize(ContentDeserializer::new(key)).map(Some);
+                return seed
+                    .deserialize(ContentDeserializer::new(key, self.is_human_readable))
+                    .map(Some);
             }
         }
         Ok(None)
@@ -3418,7 +3548,9 @@ where
         T: DeserializeSeed<'de>,
     {
         match self.pending_content.take() {
-            Some(value) => seed.deserialize(ContentDeserializer::new(value)),
+            Some(value) => {
+                seed.deserialize(ContentDeserializer::new(value, self.is_human_readable))
+            }
             None => Err(Error::custom("value is missing")),
         }
     }

--- a/serde_derive/src/de/enum_adjacently.rs
+++ b/serde_derive/src/de/enum_adjacently.rs
@@ -171,7 +171,7 @@ pub(super) fn deserialize(
                 marker: _serde::#private::PhantomData,
                 lifetime: _serde::#private::PhantomData,
             };
-            let __deserializer = _serde::#private::de::ContentDeserializer::<__A::Error>::new(__content);
+            let __deserializer = _serde::#private::de::ContentDeserializer::<__A::Error>::new(__content, self.__is_human_readable);
             let __ret = _serde::de::DeserializeSeed::deserialize(__seed, __deserializer)?;
             // Visit remaining keys, looking for duplicates.
             #visit_remaining_keys
@@ -208,6 +208,7 @@ pub(super) fn deserialize(
         struct __Visitor #de_impl_generics #where_clause {
             marker: _serde::#private::PhantomData<#this_type #ty_generics>,
             lifetime: _serde::#private::PhantomData<&#delife ()>,
+            __is_human_readable: bool,
         }
 
         #[automatically_derived]
@@ -311,6 +312,7 @@ pub(super) fn deserialize(
 
         #[doc(hidden)]
         const FIELDS: &'static [&'static str] = &[#tag, #content];
+        let __is_human_readable = _serde::Deserializer::is_human_readable(&__deserializer);
         _serde::Deserializer::deserialize_struct(
             __deserializer,
             #type_name,
@@ -318,6 +320,7 @@ pub(super) fn deserialize(
             __Visitor {
                 marker: _serde::#private::PhantomData::<#this_type #ty_generics>,
                 lifetime: _serde::#private::PhantomData,
+                __is_human_readable: __is_human_readable,
             },
         )
     }

--- a/serde_derive/src/de/enum_internally.rs
+++ b/serde_derive/src/de/enum_internally.rs
@@ -51,10 +51,11 @@ pub(super) fn deserialize(
 
         #variants_stmt
 
+        let __is_human_readable = _serde::Deserializer::is_human_readable(&__deserializer);
         let (__tag, __content) = _serde::Deserializer::deserialize_any(
             __deserializer,
             _serde::#private::de::TaggedContentVisitor::<__Field>::new(#tag, #expecting))?;
-        let __deserializer = _serde::#private::de::ContentDeserializer::<__D::Error>::new(__content);
+        let __deserializer = _serde::#private::de::ContentDeserializer::<__D::Error>::new(__content, __is_human_readable);
 
         match __tag {
             #(#variant_arms)*

--- a/serde_derive/src/de/enum_untagged.rs
+++ b/serde_derive/src/de/enum_untagged.rs
@@ -43,8 +43,9 @@ pub(super) fn deserialize(
 
     let private2 = private;
     quote_block! {
+        let __is_human_readable = _serde::Deserializer::is_human_readable(&__deserializer);
         let __content = _serde::de::DeserializeSeed::deserialize(_serde::#private::de::ContentVisitor::new(), __deserializer)?;
-        let __deserializer = _serde::#private::de::ContentRefDeserializer::<__D::Error>::new(&__content);
+        let __deserializer = _serde::#private::de::ContentRefDeserializer::<__D::Error>::new(&__content, __is_human_readable);
 
         #first_attempt
 

--- a/serde_derive/src/de/struct_.rs
+++ b/serde_derive/src/de/struct_.rs
@@ -108,10 +108,11 @@ pub(super) fn deserialize(
             impl #de_impl_generics _serde::de::DeserializeSeed<#delife> for __Visitor #de_ty_generics #where_clause {
                 type Value = #this_type #ty_generics;
 
-                fn deserialize<__D>(self, __deserializer: __D) -> _serde::#private::Result<Self::Value, __D::Error>
+                fn deserialize<__D>(mut self, __deserializer: __D) -> _serde::#private::Result<Self::Value, __D::Error>
                 where
                     __D: _serde::Deserializer<#delife>,
                 {
+                    self.__is_human_readable = _serde::Deserializer::is_human_readable(&__deserializer);
                     _serde::Deserializer::deserialize_map(__deserializer, self)
                 }
             }
@@ -130,14 +131,25 @@ pub(super) fn deserialize(
         })
     };
 
-    let visitor_expr = quote! {
-        __Visitor {
-            marker: _serde::#private::PhantomData::<#this_type #ty_generics>,
-            lifetime: _serde::#private::PhantomData,
+    let visitor_expr = if has_flatten {
+        quote! {
+            __Visitor {
+                marker: _serde::#private::PhantomData::<#this_type #ty_generics>,
+                lifetime: _serde::#private::PhantomData,
+                __is_human_readable: __is_human_readable,
+            }
+        }
+    } else {
+        quote! {
+            __Visitor {
+                marker: _serde::#private::PhantomData::<#this_type #ty_generics>,
+                lifetime: _serde::#private::PhantomData,
+            }
         }
     };
     let dispatch = match form {
         StructForm::Struct if has_flatten => quote! {
+            let __is_human_readable = _serde::Deserializer::is_human_readable(&__deserializer);
             _serde::Deserializer::deserialize_map(__deserializer, #visitor_expr)
         },
         StructForm::Struct => {
@@ -146,18 +158,43 @@ pub(super) fn deserialize(
                 _serde::Deserializer::deserialize_struct(__deserializer, #type_name, FIELDS, #visitor_expr)
             }
         }
-        StructForm::ExternallyTagged(_) if has_flatten => quote! {
-            _serde::de::VariantAccess::newtype_variant_seed(__variant, #visitor_expr)
-        },
+        StructForm::ExternallyTagged(_) if has_flatten => {
+            // __is_human_readable is not available here; it will be set in
+            // DeserializeSeed::deserialize before visit_map is called.
+            let visitor_expr_default = quote! {
+                __Visitor {
+                    marker: _serde::#private::PhantomData::<#this_type #ty_generics>,
+                    lifetime: _serde::#private::PhantomData,
+                    __is_human_readable: true,
+                }
+            };
+            quote! {
+                _serde::de::VariantAccess::newtype_variant_seed(__variant, #visitor_expr_default)
+            }
+        }
         StructForm::ExternallyTagged(_) => quote! {
             _serde::de::VariantAccess::struct_variant(__variant, FIELDS, #visitor_expr)
         },
+        StructForm::InternallyTagged(_) if has_flatten => quote! {
+            let __is_human_readable = _serde::Deserializer::is_human_readable(&__deserializer);
+            _serde::Deserializer::deserialize_any(__deserializer, #visitor_expr)
+        },
         StructForm::InternallyTagged(_) => quote! {
+            _serde::Deserializer::deserialize_any(__deserializer, #visitor_expr)
+        },
+        StructForm::Untagged(_) if has_flatten => quote! {
+            let __is_human_readable = _serde::Deserializer::is_human_readable(&__deserializer);
             _serde::Deserializer::deserialize_any(__deserializer, #visitor_expr)
         },
         StructForm::Untagged(_) => quote! {
             _serde::Deserializer::deserialize_any(__deserializer, #visitor_expr)
         },
+    };
+
+    let is_human_readable_field = if has_flatten {
+        Some(quote! { __is_human_readable: bool, })
+    } else {
+        None
     };
 
     quote_block! {
@@ -167,6 +204,7 @@ pub(super) fn deserialize(
         struct __Visitor #de_impl_generics #where_clause {
             marker: _serde::#private::PhantomData<#this_type #ty_generics>,
             lifetime: _serde::#private::PhantomData<&#delife ()>,
+            #is_human_readable_field
         }
 
         #[automatically_derived]
@@ -224,6 +262,7 @@ fn deserialize_map(
     // Collect contents for flatten fields into a buffer
     let let_collect = if has_flatten {
         Some(quote! {
+            let __is_human_readable = self.__is_human_readable;
             let mut __collect = _serde::#private::Vec::<_serde::#private::Option<(
                 _serde::#private::de::Content,
                 _serde::#private::de::Content
@@ -340,7 +379,8 @@ fn deserialize_map(
                 let #name: #field_ty = #func(
                     _serde::#private::de::FlatMapDeserializer(
                         &mut __collect,
-                        _serde::#private::PhantomData))?;
+                        _serde::#private::PhantomData,
+                        __is_human_readable))?;
             }
         });
 

--- a/test_suite/tests/regression/issue2172.rs
+++ b/test_suite/tests/regression/issue2172.rs
@@ -1,0 +1,70 @@
+// Untagged enum deserializing expects human-readable representation even with
+// non human-readable data formats.
+//
+// https://github.com/serde-rs/serde/issues/2172
+
+use serde_derive::{Deserialize, Serialize};
+use serde_test::{assert_tokens, Configure, Token};
+
+/// Type that serializes as a string when human-readable, or as bytes when compact.
+#[derive(Debug, PartialEq)]
+struct HrBytes(Vec<u8>);
+
+impl serde::Serialize for HrBytes {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        if serializer.is_human_readable() {
+            hex_encode(&self.0).serialize(serializer)
+        } else {
+            self.0.serialize(serializer)
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for HrBytes {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        if deserializer.is_human_readable() {
+            let s = String::deserialize(deserializer)?;
+            hex_decode(&s).map(HrBytes).map_err(serde::de::Error::custom)
+        } else {
+            Vec::deserialize(deserializer).map(HrBytes)
+        }
+    }
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+fn hex_decode(s: &str) -> Result<Vec<u8>, String> {
+    (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).map_err(|e| e.to_string()))
+        .collect()
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+enum Untagged {
+    Hr(HrBytes),
+}
+
+#[test]
+fn human_readable() {
+    assert_tokens(
+        &Untagged::Hr(HrBytes(vec![1, 2])).readable(),
+        &[Token::Str("0102")],
+    );
+}
+
+#[test]
+fn compact() {
+    assert_tokens(
+        &Untagged::Hr(HrBytes(vec![1, 2])).compact(),
+        &[
+            Token::Seq { len: Some(2) },
+            Token::U8(1),
+            Token::U8(2),
+            Token::SeqEnd,
+        ],
+    );
+}

--- a/test_suite/tests/regression/issue2565.rs
+++ b/test_suite/tests/regression/issue2565.rs
@@ -1,5 +1,5 @@
 use serde_derive::{Deserialize, Serialize};
-use serde_test::{assert_tokens, Token};
+use serde_test::{assert_tokens, Configure, Token};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 enum Enum {
@@ -33,7 +33,7 @@ fn simple_variant() {
 #[test]
 fn flatten_variant() {
     assert_tokens(
-        &Enum::Flatten { flatten: (), a: 42 },
+        &Enum::Flatten { flatten: (), a: 42 }.readable(),
         &[
             Token::NewtypeVariant {
                 name: "Enum",

--- a/test_suite/tests/regression/issue2704.rs
+++ b/test_suite/tests/regression/issue2704.rs
@@ -1,0 +1,78 @@
+// human_readable flag does not get carried through #[serde(flatten)].
+//
+// https://github.com/serde-rs/serde/issues/2704
+
+use serde_derive::{Deserialize, Serialize};
+use serde_test::{assert_tokens, Configure, Token};
+
+/// Type that serializes as a string when human-readable, or as a u32 when compact.
+#[derive(Debug, PartialEq)]
+struct HrU32(u32);
+
+impl serde::Serialize for HrU32 {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        if serializer.is_human_readable() {
+            self.0.to_string().serialize(serializer)
+        } else {
+            self.0.serialize(serializer)
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for HrU32 {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        if deserializer.is_human_readable() {
+            let s = String::deserialize(deserializer)?;
+            s.parse().map(HrU32).map_err(serde::de::Error::custom)
+        } else {
+            u32::deserialize(deserializer).map(HrU32)
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct Inner {
+    value: HrU32,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct Outer {
+    #[serde(flatten)]
+    inner: Inner,
+}
+
+#[test]
+fn human_readable() {
+    assert_tokens(
+        &Outer {
+            inner: Inner {
+                value: HrU32(42),
+            },
+        }
+        .readable(),
+        &[
+            Token::Map { len: None },
+            Token::Str("value"),
+            Token::Str("42"),
+            Token::MapEnd,
+        ],
+    );
+}
+
+#[test]
+fn compact() {
+    assert_tokens(
+        &Outer {
+            inner: Inner {
+                value: HrU32(42),
+            },
+        }
+        .compact(),
+        &[
+            Token::Map { len: None },
+            Token::Str("value"),
+            Token::U32(42),
+            Token::MapEnd,
+        ],
+    );
+}

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -15,7 +15,7 @@ use serde::ser::{Serialize, Serializer};
 use serde_derive::{Deserialize, Serialize};
 use serde_test::{
     assert_de_tokens, assert_de_tokens_error, assert_ser_tokens, assert_ser_tokens_error,
-    assert_tokens, Token,
+    assert_tokens, Configure, Readable, Token,
 };
 use std::collections::{BTreeMap, HashMap};
 use std::convert::TryFrom;
@@ -1593,7 +1593,7 @@ fn test_collect_other() {
     let mut extra = HashMap::new();
     extra.insert("c".into(), 3);
     assert_tokens(
-        &CollectOther { a: 1, b: 2, extra },
+        &CollectOther { a: 1, b: 2, extra }.readable(),
         &[
             Token::Map { len: None },
             Token::Str("a"),
@@ -1621,7 +1621,7 @@ fn test_partially_untagged_enum() {
 
     let data = Lambda(0, Box::new(App(Box::new(Var(0)), Box::new(Var(0)))));
     assert_tokens(
-        &data,
+        &data.readable(),
         &[
             Token::TupleVariant {
                 name: "Exp",
@@ -1663,10 +1663,10 @@ fn test_partially_untagged_enum_generic() {
     type MyE = E<(), bool, u32>;
     use E::*;
 
-    assert_tokens::<MyE>(&B(true), &[Token::Bool(true)]);
+    assert_tokens(&B::<(), bool, u32>(true).readable(), &[Token::Bool(true)]);
 
-    assert_tokens::<MyE>(
-        &A(5),
+    assert_tokens(
+        &A::<(), bool, u32>(5).readable(),
         &[
             Token::NewtypeVariant {
                 name: "E",
@@ -1679,7 +1679,7 @@ fn test_partially_untagged_enum_generic() {
 
 #[test]
 fn test_partially_untagged_enum_desugared() {
-    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
     enum Test {
         A(u32, u32),
         B(u32),
@@ -1720,9 +1720,9 @@ fn test_partially_untagged_enum_desugared() {
     }
 
     fn assert_tokens_desugared(value: Test, tokens: &[Token]) {
-        assert_tokens(&value, tokens);
+        assert_tokens(&value.clone().readable(), tokens);
         let desugared: TestUntagged = value.into();
-        assert_tokens(&desugared, tokens);
+        assert_tokens(&desugared.readable(), tokens);
     }
 
     assert_tokens_desugared(
@@ -1777,7 +1777,7 @@ fn test_partially_untagged_internally_tagged_enum() {
     let data = Data::A;
 
     assert_de_tokens(
-        &data,
+        &data.readable(),
         &[
             Token::Map { len: None },
             Token::Str("t"),
@@ -1788,7 +1788,7 @@ fn test_partially_untagged_internally_tagged_enum() {
 
     let data = Data::Var(42);
 
-    assert_de_tokens(&data, &[Token::U32(42)]);
+    assert_de_tokens(&data.readable(), &[Token::U32(42)]);
 
     // TODO test error output
 }
@@ -1983,7 +1983,8 @@ mod flatten {
                 },
                 second: Second { f: 3 },
                 z: 4,
-            },
+            }
+            .readable(),
             &[
                 Token::Map { len: None },
                 Token::Str("y"),
@@ -2021,7 +2022,8 @@ mod flatten {
                 },
                 second: Second { f: 3 },
                 z: 4,
-            },
+            }
+            .readable(),
             &[
                 Token::Map { len: None },
                 Token::Str("y"),
@@ -2080,7 +2082,8 @@ mod flatten {
                     second.insert("x".to_owned(), "X".to_owned());
                     second
                 },
-            },
+            }
+            .readable(),
             &[
                 Token::Map { len: None },
                 Token::Str("x"),
@@ -2105,7 +2108,8 @@ mod flatten {
             &Outer {
                 outer: "foo".into(),
                 inner: "bar".into(),
-            },
+            }
+            .readable(),
             &[
                 Token::Map { len: None },
                 Token::Str("outer"),
@@ -2113,7 +2117,7 @@ mod flatten {
             ],
             "can only flatten structs and maps (got a string)",
         );
-        assert_de_tokens_error::<Outer>(
+        assert_de_tokens_error::<Readable<Outer>>(
             &[
                 Token::Map { len: None },
                 Token::Str("outer"),
@@ -2141,7 +2145,7 @@ mod flatten {
             foo: HashMap<String, u32>,
         }
 
-        assert_de_tokens_error::<Outer>(
+        assert_de_tokens_error::<Readable<Outer>>(
             &[
                 Token::Struct {
                     name: "Outer",
@@ -2181,7 +2185,8 @@ mod flatten {
                 name: "peter".into(),
                 age: 3,
                 mapping,
-            },
+            }
+            .readable(),
             &[
                 Token::Map { len: None },
                 Token::Str("name"),
@@ -2218,7 +2223,7 @@ mod flatten {
         let mut owned_map = HashMap::new();
         owned_map.insert("x".to_string(), 42u32);
         assert_tokens(
-            &A { t: owned_map },
+            &A { t: owned_map }.readable(),
             &[
                 Token::Map { len: None },
                 Token::Str("x"),
@@ -2232,7 +2237,8 @@ mod flatten {
         assert_ser_tokens(
             &B {
                 t: borrowed_map.clone(),
-            },
+            }
+            .readable(),
             &[
                 Token::Map { len: None },
                 Token::BorrowedStr("x"),
@@ -2242,7 +2248,7 @@ mod flatten {
         );
 
         assert_de_tokens(
-            &B { t: borrowed_map },
+            &B { t: borrowed_map }.readable(),
             &[
                 Token::Map { len: None },
                 Token::BorrowedStr("x"),
@@ -2256,7 +2262,8 @@ mod flatten {
         assert_ser_tokens(
             &C {
                 t: borrowed_map.clone(),
-            },
+            }
+            .readable(),
             &[
                 Token::Map { len: None },
                 Token::Seq { len: Some(1) },
@@ -2268,7 +2275,7 @@ mod flatten {
         );
 
         assert_de_tokens(
-            &C { t: borrowed_map },
+            &C { t: borrowed_map }.readable(),
             &[
                 Token::Map { len: None },
                 Token::BorrowedBytes(b"x"),
@@ -2297,7 +2304,7 @@ mod flatten {
         }
 
         assert_tokens(
-            &Outer::Tuple(1.2, 3),
+            &Outer::Tuple(1.2, 3).readable(),
             &[
                 Token::TupleVariant {
                     name: "Outer",
@@ -2312,7 +2319,8 @@ mod flatten {
         assert_tokens(
             &Outer::Flatten {
                 nested: Nested { a: 1, b: 2 },
-            },
+            }
+            .readable(),
             &[
                 Token::NewtypeVariant {
                     name: "Outer",
@@ -2352,7 +2360,8 @@ mod flatten {
             &Outer {
                 inner1: Some(Inner1 { inner1: 1 }),
                 inner2: Some(Inner2 { inner2: 2 }),
-            },
+            }
+            .readable(),
             &[
                 Token::Map { len: None },
                 Token::Str("inner1"),
@@ -2367,7 +2376,8 @@ mod flatten {
             &Outer {
                 inner1: Some(Inner1 { inner1: 1 }),
                 inner2: None,
-            },
+            }
+            .readable(),
             &[
                 Token::Map { len: None },
                 Token::Str("inner1"),
@@ -2380,7 +2390,8 @@ mod flatten {
             &Outer {
                 inner1: None,
                 inner2: Some(Inner2 { inner2: 2 }),
-            },
+            }
+            .readable(),
             &[
                 Token::Map { len: None },
                 Token::Str("inner2"),
@@ -2393,7 +2404,8 @@ mod flatten {
             &Outer {
                 inner1: None,
                 inner2: None,
-            },
+            }
+            .readable(),
             &[Token::Map { len: None }, Token::MapEnd],
         );
     }
@@ -2407,12 +2419,12 @@ mod flatten {
         }
 
         assert_de_tokens(
-            &Outer { inner: IgnoredAny },
+            &Outer { inner: IgnoredAny }.readable(),
             &[Token::Map { len: None }, Token::MapEnd],
         );
 
         assert_de_tokens(
-            &Outer { inner: IgnoredAny },
+            &Outer { inner: IgnoredAny }.readable(),
             &[
                 Token::Struct {
                     name: "DoNotMatter",
@@ -2474,7 +2486,7 @@ mod flatten {
         };
 
         assert_de_tokens(
-            &s,
+            &s.readable(),
             &[
                 Token::Map { len: None },
                 Token::Str("inner"),
@@ -2501,7 +2513,8 @@ mod flatten {
                     a4: 4,
                 },
                 b: 7,
-            },
+            }
+            .readable(),
             &[
                 Token::Struct {
                     name: "Outer",
@@ -2527,7 +2540,8 @@ mod flatten {
                     a4: 4,
                 },
                 b: 7,
-            },
+            }
+            .readable(),
             &[
                 Token::Struct {
                     name: "Outer",
@@ -2562,7 +2576,8 @@ mod flatten {
                 &Response {
                     data: (),
                     status: 0,
-                },
+                }
+                .readable(),
                 &[
                     Token::Map { len: None },
                     Token::Str("status"),
@@ -2588,7 +2603,8 @@ mod flatten {
                 &Response {
                     data: Unit,
                     status: 0,
-                },
+                }
+                .readable(),
                 &[
                     Token::Map { len: None },
                     Token::Str("status"),
@@ -2628,7 +2644,7 @@ mod flatten {
                 };
 
                 assert_tokens(
-                    &data,
+                    &data.readable(),
                     &[
                         Token::NewtypeVariant {
                             name: "Data",
@@ -2644,7 +2660,7 @@ mod flatten {
                 );
             }
 
-            #[derive(Debug, PartialEq, Serialize, Deserialize)]
+            #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
             struct Flatten {
                 #[serde(flatten)]
                 data: Enum,
@@ -2653,7 +2669,7 @@ mod flatten {
                 extra: HashMap<String, String>,
             }
 
-            #[derive(Debug, PartialEq, Serialize, Deserialize)]
+            #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
             enum Enum {
                 Unit,
                 Newtype(HashMap<String, String>),
@@ -2668,7 +2684,7 @@ mod flatten {
                     extra: HashMap::from_iter([("extra_key".into(), "extra value".into())]),
                 };
                 assert_tokens(
-                    &value,
+                    &value.clone().readable(),
                     &[
                         Token::Map { len: None },
                         // data
@@ -2681,7 +2697,7 @@ mod flatten {
                     ],
                 );
                 assert_de_tokens(
-                    &value,
+                    &value.readable(),
                     &[
                         Token::Map { len: None },
                         // extra
@@ -2702,7 +2718,7 @@ mod flatten {
                     extra: HashMap::from_iter([("extra_key".into(), "extra value".into())]),
                 };
                 assert_tokens(
-                    &value,
+                    &value.clone().readable(),
                     &[
                         Token::Map { len: None },
                         // data
@@ -2718,7 +2734,7 @@ mod flatten {
                     ],
                 );
                 assert_de_tokens(
-                    &value,
+                    &value.readable(),
                     &[
                         Token::Map { len: None },
                         // extra
@@ -2745,7 +2761,7 @@ mod flatten {
                     extra: HashMap::from_iter([("extra_key".into(), "extra value".into())]),
                 };
                 assert_tokens(
-                    &value,
+                    &value.clone().readable(),
                     &[
                         Token::Map { len: None },
                         // data
@@ -2761,7 +2777,7 @@ mod flatten {
                     ],
                 );
                 assert_de_tokens(
-                    &value,
+                    &value.readable(),
                     &[
                         Token::Map { len: None },
                         // extra
@@ -2791,7 +2807,7 @@ mod flatten {
                     extra: HashMap::from_iter([("extra_key".into(), "extra value".into())]),
                 };
                 assert_de_tokens(
-                    &value,
+                    &value.clone().readable(),
                     &[
                         Token::Map { len: None },
                         // data
@@ -2807,7 +2823,7 @@ mod flatten {
                     ],
                 );
                 assert_de_tokens(
-                    &value,
+                    &value.readable(),
                     &[
                         Token::Map { len: None },
                         // extra
@@ -2837,7 +2853,7 @@ mod flatten {
                     extra: HashMap::from_iter([("extra_key".into(), "extra value".into())]),
                 };
                 assert_tokens(
-                    &value,
+                    &value.clone().readable(),
                     &[
                         Token::Map { len: None },
                         // data
@@ -2858,7 +2874,7 @@ mod flatten {
                     ],
                 );
                 assert_de_tokens(
-                    &value,
+                    &value.readable(),
                     &[
                         Token::Map { len: None },
                         // extra
@@ -2884,7 +2900,7 @@ mod flatten {
         mod adjacently_tagged {
             use super::*;
 
-            #[derive(Debug, PartialEq, Serialize, Deserialize)]
+            #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
             struct Flatten {
                 outer: u32,
 
@@ -2892,10 +2908,10 @@ mod flatten {
                 data: NewtypeWrapper,
             }
 
-            #[derive(Debug, PartialEq, Serialize, Deserialize)]
+            #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
             struct NewtypeWrapper(pub Enum);
 
-            #[derive(Debug, PartialEq, Serialize, Deserialize)]
+            #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
             #[serde(tag = "tag", content = "content")]
             enum Enum {
                 Unit,
@@ -2903,7 +2919,7 @@ mod flatten {
                 Struct { index: u32, value: u32 },
             }
 
-            #[derive(Debug, PartialEq, Serialize, Deserialize)]
+            #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
             struct NewtypeVariant {
                 value: u32,
             }
@@ -2916,7 +2932,7 @@ mod flatten {
                 };
                 // Field order: outer, [tag]
                 assert_tokens(
-                    &value,
+                    &value.clone().readable(),
                     &[
                         Token::Map { len: None },
                         // outer
@@ -2934,7 +2950,7 @@ mod flatten {
                 );
                 // Field order: [tag], outer
                 assert_de_tokens(
-                    &value,
+                    &value.clone().readable(),
                     &[
                         Token::Map { len: None },
                         // tag
@@ -2952,7 +2968,7 @@ mod flatten {
                 );
                 // Field order: outer, [tag, content]
                 assert_de_tokens(
-                    &value,
+                    &value.clone().readable(),
                     &[
                         Token::Map { len: None },
                         // outer
@@ -2972,7 +2988,7 @@ mod flatten {
                 );
                 // Field order: outer, [content, tag]
                 assert_de_tokens(
-                    &value,
+                    &value.clone().readable(),
                     &[
                         Token::Map { len: None },
                         // outer
@@ -2992,7 +3008,7 @@ mod flatten {
                 );
                 // Field order: [tag, content], outer
                 assert_de_tokens(
-                    &value,
+                    &value.clone().readable(),
                     &[
                         Token::Map { len: None },
                         // tag
@@ -3012,7 +3028,7 @@ mod flatten {
                 );
                 // Field order: [content, tag], outer
                 assert_de_tokens(
-                    &value,
+                    &value.clone().readable(),
                     &[
                         Token::Map { len: None },
                         // content
@@ -3032,7 +3048,7 @@ mod flatten {
                 );
                 // Field order: [tag], outer, [content]
                 assert_de_tokens(
-                    &value,
+                    &value.clone().readable(),
                     &[
                         Token::Map { len: None },
                         // tag
@@ -3052,7 +3068,7 @@ mod flatten {
                 );
                 // Field order: [content], outer, [tag]
                 assert_de_tokens(
-                    &value,
+                    &value.readable(),
                     &[
                         Token::Map { len: None },
                         // content
@@ -3080,7 +3096,7 @@ mod flatten {
                 };
                 // Field order: outer, [tag, content]
                 assert_tokens(
-                    &value,
+                    &value.clone().readable(),
                     &[
                         Token::Map { len: None },
                         // outer
@@ -3106,7 +3122,7 @@ mod flatten {
                 );
                 // Field order: outer, [content, tag]
                 assert_de_tokens(
-                    &value,
+                    &value.clone().readable(),
                     &[
                         Token::Map { len: None },
                         // outer
@@ -3132,7 +3148,7 @@ mod flatten {
                 );
                 // Field order: [tag, content], outer
                 assert_de_tokens(
-                    &value,
+                    &value.clone().readable(),
                     &[
                         Token::Map { len: None },
                         // tag
@@ -3158,7 +3174,7 @@ mod flatten {
                 );
                 // Field order: [content, tag], outer
                 assert_de_tokens(
-                    &value,
+                    &value.clone().readable(),
                     &[
                         Token::Map { len: None },
                         // content
@@ -3184,7 +3200,7 @@ mod flatten {
                 );
                 // Field order: [tag], outer, [content]
                 assert_de_tokens(
-                    &value,
+                    &value.clone().readable(),
                     &[
                         Token::Map { len: None },
                         // tag
@@ -3210,7 +3226,7 @@ mod flatten {
                 );
                 // Field order: [content], outer, [tag]
                 assert_de_tokens(
-                    &value,
+                    &value.readable(),
                     &[
                         Token::Map { len: None },
                         // content
@@ -3247,7 +3263,7 @@ mod flatten {
                 };
                 // Field order: outer, [tag, content]
                 assert_tokens(
-                    &value,
+                    &value.clone().readable(),
                     &[
                         Token::Map { len: None },
                         // outer
@@ -3275,7 +3291,7 @@ mod flatten {
                 );
                 // Field order: outer, [content, tag]
                 assert_de_tokens(
-                    &value,
+                    &value.clone().readable(),
                     &[
                         Token::Map { len: None },
                         // outer
@@ -3303,7 +3319,7 @@ mod flatten {
                 );
                 // Field order: [tag, content], outer
                 assert_de_tokens(
-                    &value,
+                    &value.clone().readable(),
                     &[
                         Token::Map { len: None },
                         // tag
@@ -3331,7 +3347,7 @@ mod flatten {
                 );
                 // Field order: [content, tag], outer
                 assert_de_tokens(
-                    &value,
+                    &value.clone().readable(),
                     &[
                         Token::Map { len: None },
                         // content
@@ -3359,7 +3375,7 @@ mod flatten {
                 );
                 // Field order: [tag], outer, [content]
                 assert_de_tokens(
-                    &value,
+                    &value.clone().readable(),
                     &[
                         Token::Map { len: None },
                         // tag
@@ -3387,7 +3403,7 @@ mod flatten {
                 );
                 // Field order: [content], outer, [tag]
                 assert_de_tokens(
-                    &value,
+                    &value.readable(),
                     &[
                         Token::Map { len: None },
                         // content
@@ -3421,7 +3437,7 @@ mod flatten {
 
             #[test]
             fn structs() {
-                #[derive(Debug, PartialEq, Serialize, Deserialize)]
+                #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
                 struct Flatten {
                     #[serde(flatten)]
                     x: X,
@@ -3429,14 +3445,14 @@ mod flatten {
                     y: Y,
                 }
 
-                #[derive(Debug, PartialEq, Serialize, Deserialize)]
+                #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
                 #[serde(tag = "typeX")]
                 enum X {
                     A { a: i32 },
                     B { b: i32 },
                 }
 
-                #[derive(Debug, PartialEq, Serialize, Deserialize)]
+                #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
                 #[serde(tag = "typeY")]
                 enum Y {
                     C { c: i32 },
@@ -3448,7 +3464,7 @@ mod flatten {
                     y: Y::D { d: 2 },
                 };
                 assert_tokens(
-                    &value,
+                    &value.clone().readable(),
                     &[
                         Token::Map { len: None },
                         // x
@@ -3465,7 +3481,7 @@ mod flatten {
                     ],
                 );
                 assert_de_tokens(
-                    &value,
+                    &value.readable(),
                     &[
                         Token::Map { len: None },
                         // y
@@ -3485,7 +3501,7 @@ mod flatten {
 
             #[test]
             fn unit_enum_with_unknown_fields() {
-                #[derive(Debug, PartialEq, Serialize, Deserialize)]
+                #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
                 struct Flatten {
                     #[serde(flatten)]
                     x: X,
@@ -3493,13 +3509,13 @@ mod flatten {
                     y: Y,
                 }
 
-                #[derive(Debug, PartialEq, Serialize, Deserialize)]
+                #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
                 #[serde(tag = "typeX")]
                 enum X {
                     A,
                 }
 
-                #[derive(Debug, PartialEq, Serialize, Deserialize)]
+                #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
                 #[serde(tag = "typeY")]
                 enum Y {
                     B { c: u32 },
@@ -3510,7 +3526,7 @@ mod flatten {
                     y: Y::B { c: 0 },
                 };
                 assert_tokens(
-                    &value,
+                    &value.clone().readable(),
                     &[
                         Token::Map { len: None },
                         // x
@@ -3525,7 +3541,7 @@ mod flatten {
                     ],
                 );
                 assert_de_tokens(
-                    &value,
+                    &value.readable(),
                     &[
                         Token::Map { len: None },
                         // y
@@ -3562,7 +3578,8 @@ mod flatten {
                 assert_tokens(
                     &Flatten {
                         data: Enum::Struct { a: 0 },
-                    },
+                    }
+                    .readable(),
                     &[
                         Token::Map { len: None },
                         Token::Str("a"),

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -1660,7 +1660,6 @@ fn test_partially_untagged_enum_generic() {
         type Assoc2 = bool;
     }
 
-    type MyE = E<(), bool, u32>;
     use E::*;
 
     assert_tokens(&B::<(), bool, u32>(true).readable(), &[Token::Bool(true)]);

--- a/test_suite/tests/test_enum_adjacently_tagged.rs
+++ b/test_suite/tests/test_enum_adjacently_tagged.rs
@@ -7,9 +7,11 @@
 )]
 
 use serde_derive::{Deserialize, Serialize};
-use serde_test::{assert_de_tokens, assert_de_tokens_error, assert_tokens, Token};
+use serde_test::{
+    assert_de_tokens, assert_de_tokens_error, assert_tokens, Configure, Readable, Token,
+};
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "t", content = "c")]
 enum AdjacentlyTagged<T> {
     Unit,
@@ -25,7 +27,7 @@ mod unit {
     fn map_str_tag_only() {
         // Map: tag only
         assert_tokens(
-            &AdjacentlyTagged::Unit::<u8>,
+            &AdjacentlyTagged::Unit::<u8>.readable(),
             &[
                 Token::Struct {
                     name: "AdjacentlyTagged",
@@ -42,7 +44,7 @@ mod unit {
 
         // Map: tag only and incorrect hint for number of elements
         assert_de_tokens(
-            &AdjacentlyTagged::Unit::<u8>,
+            &AdjacentlyTagged::Unit::<u8>.readable(),
             &[
                 Token::Struct {
                     name: "AdjacentlyTagged",
@@ -62,7 +64,7 @@ mod unit {
     fn map_int_tag_only() {
         // Map: tag (as number) only
         assert_de_tokens(
-            &AdjacentlyTagged::Unit::<u8>,
+            &AdjacentlyTagged::Unit::<u8>.readable(),
             &[
                 Token::Struct {
                     name: "AdjacentlyTagged",
@@ -82,7 +84,7 @@ mod unit {
     fn map_bytes_tag_only() {
         // Map: tag only
         assert_de_tokens(
-            &AdjacentlyTagged::Unit::<u8>,
+            &AdjacentlyTagged::Unit::<u8>.readable(),
             &[
                 Token::Struct {
                     name: "AdjacentlyTagged",
@@ -99,7 +101,7 @@ mod unit {
 
         // Map: tag only
         assert_de_tokens(
-            &AdjacentlyTagged::Unit::<u8>,
+            &AdjacentlyTagged::Unit::<u8>.readable(),
             &[
                 Token::Struct {
                     name: "AdjacentlyTagged",
@@ -119,7 +121,7 @@ mod unit {
     fn map_str_tag_content() {
         // Map: tag + content
         assert_de_tokens(
-            &AdjacentlyTagged::Unit::<u8>,
+            &AdjacentlyTagged::Unit::<u8>.readable(),
             &[
                 Token::Struct {
                     name: "AdjacentlyTagged",
@@ -137,7 +139,7 @@ mod unit {
         );
         // Map: content + tag
         assert_de_tokens(
-            &AdjacentlyTagged::Unit::<u8>,
+            &AdjacentlyTagged::Unit::<u8>.readable(),
             &[
                 Token::Struct {
                     name: "AdjacentlyTagged",
@@ -156,7 +158,7 @@ mod unit {
 
         // Map: tag + content + excess fields (f, g, h)
         assert_de_tokens(
-            &AdjacentlyTagged::Unit::<u8>,
+            &AdjacentlyTagged::Unit::<u8>.readable(),
             &[
                 Token::Struct {
                     name: "AdjacentlyTagged",
@@ -184,7 +186,7 @@ mod unit {
     fn map_int_tag_content() {
         // Map: tag (as number) + content (as number)
         assert_de_tokens(
-            &AdjacentlyTagged::Unit::<u8>,
+            &AdjacentlyTagged::Unit::<u8>.readable(),
             &[
                 Token::Struct {
                     name: "AdjacentlyTagged",
@@ -203,7 +205,7 @@ mod unit {
 
         // Map: content (as number) + tag (as number)
         assert_de_tokens(
-            &AdjacentlyTagged::Unit::<u8>,
+            &AdjacentlyTagged::Unit::<u8>.readable(),
             &[
                 Token::Struct {
                     name: "AdjacentlyTagged",
@@ -225,7 +227,7 @@ mod unit {
     fn map_bytes_tag_content() {
         // Map: tag + content
         assert_de_tokens(
-            &AdjacentlyTagged::Unit::<u8>,
+            &AdjacentlyTagged::Unit::<u8>.readable(),
             &[
                 Token::Struct {
                     name: "AdjacentlyTagged",
@@ -244,7 +246,7 @@ mod unit {
 
         // Map: content + tag
         assert_de_tokens(
-            &AdjacentlyTagged::Unit::<u8>,
+            &AdjacentlyTagged::Unit::<u8>.readable(),
             &[
                 Token::Struct {
                     name: "AdjacentlyTagged",
@@ -266,7 +268,7 @@ mod unit {
     fn seq_tag_content() {
         // Seq: tag and content
         assert_de_tokens(
-            &AdjacentlyTagged::Unit::<u8>,
+            &AdjacentlyTagged::Unit::<u8>.readable(),
             &[
                 Token::Seq { len: Some(2) },
                 Token::UnitVariant {
@@ -280,7 +282,7 @@ mod unit {
 
         // Seq: tag (as string) and content
         assert_de_tokens(
-            &AdjacentlyTagged::Unit::<u8>,
+            &AdjacentlyTagged::Unit::<u8>.readable(),
             &[
                 Token::Seq { len: None },
                 Token::Str("Unit"), // tag
@@ -291,7 +293,7 @@ mod unit {
 
         // Seq: tag (as borrowed string) and content
         assert_de_tokens(
-            &AdjacentlyTagged::Unit::<u8>,
+            &AdjacentlyTagged::Unit::<u8>.readable(),
             &[
                 Token::Seq { len: None },
                 Token::BorrowedStr("Unit"), // tag
@@ -309,7 +311,7 @@ mod newtype {
     fn map_tag_only() {
         // optional newtype with no content field
         assert_de_tokens(
-            &AdjacentlyTagged::Newtype::<Option<u8>>(None),
+            &AdjacentlyTagged::Newtype::<Option<u8>>(None).readable(),
             &[
                 Token::Struct {
                     name: "AdjacentlyTagged",
@@ -331,7 +333,7 @@ mod newtype {
 
         // Map: tag + content
         assert_tokens(
-            &value,
+            &value.clone().readable(),
             &[
                 Token::Struct {
                     name: "AdjacentlyTagged",
@@ -350,7 +352,7 @@ mod newtype {
 
         // Map: content + tag
         assert_de_tokens(
-            &value,
+            &value.readable(),
             &[
                 Token::Struct {
                     name: "AdjacentlyTagged",
@@ -374,7 +376,7 @@ mod newtype {
 
         // Seq: tag and content
         assert_de_tokens(
-            &value,
+            &value.clone().readable(),
             &[
                 Token::Seq { len: Some(2) },
                 Token::UnitVariant {
@@ -388,7 +390,7 @@ mod newtype {
 
         // Seq: tag (as string) and content
         assert_de_tokens(
-            &value,
+            &value.clone().readable(),
             &[
                 Token::Seq { len: None },
                 Token::Str("Newtype"), // tag
@@ -399,7 +401,7 @@ mod newtype {
 
         // Seq: tag (as borrowed string) and content
         assert_de_tokens(
-            &value,
+            &value.readable(),
             &[
                 Token::Seq { len: None },
                 Token::BorrowedStr("Newtype"), // tag
@@ -416,7 +418,7 @@ fn newtype_with_newtype() {
     struct NewtypeStruct(u32);
 
     assert_de_tokens(
-        &AdjacentlyTagged::Newtype(NewtypeStruct(5)),
+        &AdjacentlyTagged::Newtype(NewtypeStruct(5)).readable(),
         &[
             Token::Struct {
                 name: "AdjacentlyTagged",
@@ -446,7 +448,7 @@ mod tuple {
 
         // Map: tag + content
         assert_tokens(
-            &value,
+            &value.clone().readable(),
             &[
                 Token::Struct {
                     name: "AdjacentlyTagged",
@@ -468,7 +470,7 @@ mod tuple {
 
         // Map: content + tag
         assert_de_tokens(
-            &value,
+            &value.readable(),
             &[
                 Token::Struct {
                     name: "AdjacentlyTagged",
@@ -495,7 +497,7 @@ mod tuple {
 
         // Seq: tag + content
         assert_de_tokens(
-            &value,
+            &value.readable(),
             &[
                 Token::Seq { len: Some(2) },
                 Token::UnitVariant {
@@ -521,7 +523,7 @@ mod struct_ {
 
         // Map: tag + content
         assert_tokens(
-            &value,
+            &value.clone().readable(),
             &[
                 Token::Struct {
                     name: "AdjacentlyTagged",
@@ -546,7 +548,7 @@ mod struct_ {
 
         // Map: content + tag
         assert_de_tokens(
-            &value,
+            &value.readable(),
             &[
                 Token::Struct {
                     name: "AdjacentlyTagged",
@@ -576,7 +578,7 @@ mod struct_ {
 
         // Seq: tag + content
         assert_de_tokens(
-            &value,
+            &value.readable(),
             &[
                 Token::Seq { len: Some(2) },
                 Token::UnitVariant {
@@ -619,7 +621,7 @@ fn struct_with_flatten() {
     };
 
     assert_tokens(
-        &data,
+        &data.readable(),
         &[
             Token::Struct {
                 name: "Data",
@@ -651,18 +653,18 @@ fn expecting_message() {
         AdjacentlyTagged,
     }
 
-    assert_de_tokens_error::<Enum>(
+    assert_de_tokens_error::<Readable<Enum>>(
         &[Token::Str("AdjacentlyTagged")],
         r#"invalid type: string "AdjacentlyTagged", expected something strange..."#,
     );
 
-    assert_de_tokens_error::<Enum>(
+    assert_de_tokens_error::<Readable<Enum>>(
         &[Token::Map { len: None }, Token::Unit],
         r#"invalid type: unit value, expected "tag", "content", or other ignored fields"#,
     );
 
     // Check that #[serde(expecting = "...")] doesn't affect variant identifier error message
-    assert_de_tokens_error::<Enum>(
+    assert_de_tokens_error::<Readable<Enum>>(
         &[Token::Map { len: None }, Token::Str("tag"), Token::Unit],
         "invalid type: unit value, expected variant of enum Enum",
     );
@@ -682,7 +684,7 @@ fn partially_untagged() {
     let data = Data::A(7);
 
     assert_de_tokens(
-        &data,
+        &data.readable(),
         &[
             Token::Map { len: None },
             Token::Str("t"),
@@ -695,7 +697,7 @@ fn partially_untagged() {
 
     let data = Data::Var(42);
 
-    assert_de_tokens(&data, &[Token::U32(42)]);
+    assert_de_tokens(&data.readable(), &[Token::U32(42)]);
 
     // TODO test error output
 }
@@ -709,7 +711,7 @@ fn deny_unknown_fields() {
     }
 
     assert_de_tokens(
-        &AdjacentlyTagged::Unit,
+        &AdjacentlyTagged::Unit.readable(),
         &[
             Token::Struct {
                 name: "AdjacentlyTagged",
@@ -726,7 +728,7 @@ fn deny_unknown_fields() {
         ],
     );
 
-    assert_de_tokens_error::<AdjacentlyTagged>(
+    assert_de_tokens_error::<Readable<AdjacentlyTagged>>(
         &[
             Token::Struct {
                 name: "AdjacentlyTagged",
@@ -744,7 +746,7 @@ fn deny_unknown_fields() {
         r#"invalid value: string "h", expected "t" or "c""#,
     );
 
-    assert_de_tokens_error::<AdjacentlyTagged>(
+    assert_de_tokens_error::<Readable<AdjacentlyTagged>>(
         &[
             Token::Struct {
                 name: "AdjacentlyTagged",
@@ -755,7 +757,7 @@ fn deny_unknown_fields() {
         r#"invalid value: string "h", expected "t" or "c""#,
     );
 
-    assert_de_tokens_error::<AdjacentlyTagged>(
+    assert_de_tokens_error::<Readable<AdjacentlyTagged>>(
         &[
             Token::Struct {
                 name: "AdjacentlyTagged",
@@ -768,7 +770,7 @@ fn deny_unknown_fields() {
         r#"invalid value: string "h", expected "t" or "c""#,
     );
 
-    assert_de_tokens_error::<AdjacentlyTagged>(
+    assert_de_tokens_error::<Readable<AdjacentlyTagged>>(
         &[
             Token::Struct {
                 name: "AdjacentlyTagged",
@@ -784,7 +786,7 @@ fn deny_unknown_fields() {
         r#"invalid value: integer `3`, expected "t" or "c""#,
     );
 
-    assert_de_tokens_error::<AdjacentlyTagged>(
+    assert_de_tokens_error::<Readable<AdjacentlyTagged>>(
         &[
             Token::Struct {
                 name: "AdjacentlyTagged",

--- a/test_suite/tests/test_enum_internally_tagged.rs
+++ b/test_suite/tests/test_enum_internally_tagged.rs
@@ -9,22 +9,24 @@
 mod bytes;
 
 use serde_derive::{Deserialize, Serialize};
-use serde_test::{assert_de_tokens, assert_de_tokens_error, assert_tokens, Token};
+use serde_test::{
+    assert_de_tokens, assert_de_tokens_error, assert_tokens, Configure, Readable, Token,
+};
 use std::collections::BTreeMap;
 use std::iter::FromIterator;
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 struct Unit;
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 struct Newtype(BTreeMap<String, String>);
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 struct Struct {
     f: u8,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 enum Enum {
     Unit,
     Newtype(u8),
@@ -32,7 +34,7 @@ enum Enum {
     Struct { f: u8 },
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "tag")]
 enum InternallyTagged {
     Unit,
@@ -49,7 +51,7 @@ enum InternallyTagged {
 #[test]
 fn unit() {
     assert_tokens(
-        &InternallyTagged::Unit,
+        &InternallyTagged::Unit.readable(),
         &[
             Token::Struct {
                 name: "InternallyTagged",
@@ -61,7 +63,7 @@ fn unit() {
         ],
     );
     assert_de_tokens(
-        &InternallyTagged::Unit,
+        &InternallyTagged::Unit.readable(),
         &[
             Token::Struct {
                 name: "InternallyTagged",
@@ -74,7 +76,7 @@ fn unit() {
     );
 
     assert_de_tokens(
-        &InternallyTagged::Unit,
+        &InternallyTagged::Unit.readable(),
         &[
             Token::Map { len: Some(1) },
             Token::Str("tag"),
@@ -83,7 +85,7 @@ fn unit() {
         ],
     );
     assert_de_tokens(
-        &InternallyTagged::Unit,
+        &InternallyTagged::Unit.readable(),
         &[
             Token::Map { len: Some(1) },
             Token::BorrowedStr("tag"),
@@ -93,7 +95,7 @@ fn unit() {
     );
 
     assert_de_tokens(
-        &InternallyTagged::Unit,
+        &InternallyTagged::Unit.readable(),
         &[
             Token::Seq { len: Some(1) },
             Token::Str("Unit"), // tag
@@ -101,7 +103,7 @@ fn unit() {
         ],
     );
     assert_de_tokens(
-        &InternallyTagged::Unit,
+        &InternallyTagged::Unit.readable(),
         &[
             Token::Seq { len: Some(1) },
             Token::BorrowedStr("Unit"), // tag
@@ -115,7 +117,7 @@ fn newtype_unit() {
     let value = InternallyTagged::NewtypeUnit(());
 
     assert_tokens(
-        &value,
+        &value.clone().readable(),
         &[
             Token::Map { len: Some(1) },
             Token::Str("tag"),
@@ -124,7 +126,7 @@ fn newtype_unit() {
         ],
     );
     assert_de_tokens(
-        &value,
+        &value.clone().readable(),
         &[
             Token::Map { len: Some(1) },
             Token::BorrowedStr("tag"),
@@ -134,7 +136,7 @@ fn newtype_unit() {
     );
 
     assert_de_tokens(
-        &value,
+        &value.clone().readable(),
         &[
             Token::Struct {
                 name: "InternallyTagged",
@@ -146,7 +148,7 @@ fn newtype_unit() {
         ],
     );
     assert_de_tokens(
-        &value,
+        &value.readable(),
         &[
             Token::Struct {
                 name: "InternallyTagged",
@@ -164,7 +166,7 @@ fn newtype_unit_struct() {
     let value = InternallyTagged::NewtypeUnitStruct(Unit);
 
     assert_tokens(
-        &value,
+        &value.clone().readable(),
         &[
             Token::Map { len: Some(1) },
             Token::Str("tag"),
@@ -173,7 +175,7 @@ fn newtype_unit_struct() {
         ],
     );
     assert_de_tokens(
-        &value,
+        &value.clone().readable(),
         &[
             Token::Map { len: Some(1) },
             Token::BorrowedStr("tag"),
@@ -183,7 +185,7 @@ fn newtype_unit_struct() {
     );
 
     assert_de_tokens(
-        &value,
+        &value.clone().readable(),
         &[
             Token::Struct {
                 name: "InternallyTagged",
@@ -195,7 +197,7 @@ fn newtype_unit_struct() {
         ],
     );
     assert_de_tokens(
-        &value,
+        &value.clone().readable(),
         &[
             Token::Struct {
                 name: "InternallyTagged",
@@ -208,7 +210,7 @@ fn newtype_unit_struct() {
     );
 
     assert_de_tokens(
-        &value,
+        &value.clone().readable(),
         &[
             Token::Seq { len: Some(1) },
             Token::Str("NewtypeUnitStruct"), // tag
@@ -216,7 +218,7 @@ fn newtype_unit_struct() {
         ],
     );
     assert_de_tokens(
-        &value,
+        &value.readable(),
         &[
             Token::Seq { len: Some(1) },
             Token::BorrowedStr("NewtypeUnitStruct"), // tag
@@ -228,7 +230,7 @@ fn newtype_unit_struct() {
 #[test]
 fn newtype_newtype() {
     assert_tokens(
-        &InternallyTagged::NewtypeNewtype(Newtype(BTreeMap::new())),
+        &InternallyTagged::NewtypeNewtype(Newtype(BTreeMap::new())).readable(),
         &[
             Token::Map { len: Some(1) },
             Token::Str("tag"),
@@ -244,7 +246,7 @@ fn newtype_map() {
 
     // Special case: empty map
     assert_tokens(
-        &value,
+        &value.clone().readable(),
         &[
             Token::Map { len: Some(1) },
             Token::Str("tag"),
@@ -253,7 +255,7 @@ fn newtype_map() {
         ],
     );
     assert_de_tokens(
-        &value,
+        &value.readable(),
         &[
             Token::Map { len: Some(1) },
             Token::BorrowedStr("tag"),
@@ -269,7 +271,7 @@ fn newtype_map() {
 
     // Special case: tag field ("tag") is the first field
     assert_tokens(
-        &value,
+        &value.clone().readable(),
         &[
             Token::Map { len: Some(2) },
             Token::Str("tag"),
@@ -280,7 +282,7 @@ fn newtype_map() {
         ],
     );
     assert_de_tokens(
-        &value,
+        &value.clone().readable(),
         &[
             Token::Map { len: Some(2) },
             Token::BorrowedStr("tag"),
@@ -293,7 +295,7 @@ fn newtype_map() {
 
     // General case: tag field ("tag") is not the first field
     assert_de_tokens(
-        &value,
+        &value.clone().readable(),
         &[
             Token::Map { len: Some(2) },
             Token::Str("field"),
@@ -304,7 +306,7 @@ fn newtype_map() {
         ],
     );
     assert_de_tokens(
-        &value,
+        &value.readable(),
         &[
             Token::Map { len: Some(2) },
             Token::BorrowedStr("field"),
@@ -315,7 +317,7 @@ fn newtype_map() {
         ],
     );
 
-    assert_de_tokens_error::<InternallyTagged>(
+    assert_de_tokens_error::<Readable<InternallyTagged>>(
         &[
             Token::Seq { len: Some(2) },
             Token::Str("NewtypeMap"), // tag
@@ -333,7 +335,7 @@ fn newtype_struct() {
 
     // Special case: tag field ("tag") is the first field
     assert_tokens(
-        &value,
+        &value.clone().readable(),
         &[
             Token::Struct {
                 name: "Struct",
@@ -347,7 +349,7 @@ fn newtype_struct() {
         ],
     );
     assert_de_tokens(
-        &value,
+        &value.clone().readable(),
         &[
             Token::Struct {
                 name: "Struct",
@@ -363,7 +365,7 @@ fn newtype_struct() {
 
     // General case: tag field ("tag") is not the first field
     assert_de_tokens(
-        &value,
+        &value.clone().readable(),
         &[
             Token::Struct {
                 name: "Struct",
@@ -377,7 +379,7 @@ fn newtype_struct() {
         ],
     );
     assert_de_tokens(
-        &value,
+        &value.clone().readable(),
         &[
             Token::Struct {
                 name: "Struct",
@@ -392,7 +394,7 @@ fn newtype_struct() {
     );
 
     assert_de_tokens(
-        &value,
+        &value.clone().readable(),
         &[
             Token::Seq { len: Some(2) },
             Token::Str("NewtypeStruct"), // tag
@@ -401,7 +403,7 @@ fn newtype_struct() {
         ],
     );
     assert_de_tokens(
-        &value,
+        &value.readable(),
         &[
             Token::Seq { len: Some(2) },
             Token::BorrowedStr("NewtypeStruct"), // tag
@@ -420,7 +422,7 @@ mod newtype_enum {
 
         // Special case: tag field ("tag") is the first field
         assert_tokens(
-            &value,
+            &value.clone().readable(),
             &[
                 Token::Map { len: Some(2) },
                 Token::Str("tag"),
@@ -431,7 +433,7 @@ mod newtype_enum {
             ],
         );
         assert_de_tokens(
-            &value,
+            &value.clone().readable(),
             &[
                 Token::Map { len: Some(2) },
                 Token::BorrowedStr("tag"),
@@ -444,7 +446,7 @@ mod newtype_enum {
 
         // General case: tag field ("tag") is not the first field
         assert_de_tokens(
-            &value,
+            &value.clone().readable(),
             &[
                 Token::Map { len: Some(2) },
                 Token::Str("Unit"),
@@ -455,7 +457,7 @@ mod newtype_enum {
             ],
         );
         assert_de_tokens(
-            &value,
+            &value.readable(),
             &[
                 Token::Map { len: Some(2) },
                 Token::BorrowedStr("Unit"),
@@ -473,7 +475,7 @@ mod newtype_enum {
 
         // Special case: tag field ("tag") is the first field
         assert_tokens(
-            &value,
+            &value.clone().readable(),
             &[
                 Token::Map { len: Some(2) },
                 Token::Str("tag"),
@@ -484,7 +486,7 @@ mod newtype_enum {
             ],
         );
         assert_de_tokens(
-            &value,
+            &value.clone().readable(),
             &[
                 Token::Map { len: Some(2) },
                 Token::BorrowedStr("tag"),
@@ -497,7 +499,7 @@ mod newtype_enum {
 
         // General case: tag field ("tag") is not the first field
         assert_de_tokens(
-            &value,
+            &value.clone().readable(),
             &[
                 Token::Map { len: Some(2) },
                 Token::Str("Newtype"),
@@ -508,7 +510,7 @@ mod newtype_enum {
             ],
         );
         assert_de_tokens(
-            &value,
+            &value.readable(),
             &[
                 Token::Map { len: Some(2) },
                 Token::BorrowedStr("Newtype"),
@@ -526,7 +528,7 @@ mod newtype_enum {
 
         // Special case: tag field ("tag") is the first field
         assert_tokens(
-            &value,
+            &value.clone().readable(),
             &[
                 Token::Map { len: Some(2) },
                 Token::Str("tag"),
@@ -543,7 +545,7 @@ mod newtype_enum {
             ],
         );
         assert_de_tokens(
-            &value,
+            &value.clone().readable(),
             &[
                 Token::Map { len: Some(2) },
                 Token::BorrowedStr("tag"),
@@ -565,7 +567,7 @@ mod newtype_enum {
         // Content::Seq case
         // via ContentDeserializer::deserialize_enum
         assert_de_tokens(
-            &value,
+            &value.clone().readable(),
             &[
                 Token::Map { len: Some(2) },
                 Token::Str("Tuple"),
@@ -582,7 +584,7 @@ mod newtype_enum {
             ],
         );
         assert_de_tokens(
-            &value,
+            &value.readable(),
             &[
                 Token::Map { len: Some(2) },
                 Token::BorrowedStr("Tuple"),
@@ -606,7 +608,7 @@ mod newtype_enum {
 
         // Special case: tag field ("tag") is the first field
         assert_tokens(
-            &value,
+            &value.clone().readable(),
             &[
                 Token::Map { len: Some(2) },
                 Token::Str("tag"),
@@ -623,7 +625,7 @@ mod newtype_enum {
             ],
         );
         assert_de_tokens(
-            &value,
+            &value.clone().readable(),
             &[
                 Token::Map { len: Some(2) },
                 Token::BorrowedStr("tag"),
@@ -645,7 +647,7 @@ mod newtype_enum {
         // Content::Map case
         // via ContentDeserializer::deserialize_enum
         assert_de_tokens(
-            &value,
+            &value.clone().readable(),
             &[
                 Token::Map { len: Some(2) },
                 Token::Str("Struct"),
@@ -662,7 +664,7 @@ mod newtype_enum {
             ],
         );
         assert_de_tokens(
-            &value,
+            &value.clone().readable(),
             &[
                 Token::Map { len: Some(2) },
                 Token::BorrowedStr("Struct"),
@@ -681,7 +683,7 @@ mod newtype_enum {
 
         // Special case: tag field ("tag") is the first field
         assert_de_tokens(
-            &value,
+            &value.clone().readable(),
             &[
                 Token::Map { len: Some(2) },
                 Token::Str("tag"),
@@ -694,7 +696,7 @@ mod newtype_enum {
             ],
         );
         assert_de_tokens(
-            &value,
+            &value.clone().readable(),
             &[
                 Token::Map { len: Some(2) },
                 Token::BorrowedStr("tag"),
@@ -712,7 +714,7 @@ mod newtype_enum {
         // Content::Seq case
         // via ContentDeserializer::deserialize_enum
         assert_de_tokens(
-            &value,
+            &value.clone().readable(),
             &[
                 Token::Map { len: Some(2) },
                 Token::Str("Struct"),
@@ -725,7 +727,7 @@ mod newtype_enum {
             ],
         );
         assert_de_tokens(
-            &value,
+            &value.readable(),
             &[
                 Token::Map { len: Some(2) },
                 Token::BorrowedStr("Struct"),
@@ -746,7 +748,7 @@ fn struct_() {
 
     // Special case: tag field ("tag") is the first field
     assert_tokens(
-        &value,
+        &value.clone().readable(),
         &[
             Token::Struct {
                 name: "InternallyTagged",
@@ -760,7 +762,7 @@ fn struct_() {
         ],
     );
     assert_de_tokens(
-        &value,
+        &value.clone().readable(),
         &[
             Token::Struct {
                 name: "InternallyTagged",
@@ -776,7 +778,7 @@ fn struct_() {
 
     // General case: tag field ("tag") is not the first field
     assert_de_tokens(
-        &value,
+        &value.clone().readable(),
         &[
             Token::Struct {
                 name: "InternallyTagged",
@@ -790,7 +792,7 @@ fn struct_() {
         ],
     );
     assert_de_tokens(
-        &value,
+        &value.clone().readable(),
         &[
             Token::Struct {
                 name: "InternallyTagged",
@@ -806,7 +808,7 @@ fn struct_() {
 
     // Special case: tag field ("tag") is the first field
     assert_de_tokens(
-        &value,
+        &value.clone().readable(),
         &[
             Token::Map { len: Some(2) },
             Token::Str("tag"),
@@ -817,7 +819,7 @@ fn struct_() {
         ],
     );
     assert_de_tokens(
-        &value,
+        &value.clone().readable(),
         &[
             Token::Map { len: Some(2) },
             Token::BorrowedStr("tag"),
@@ -830,7 +832,7 @@ fn struct_() {
 
     // General case: tag field ("tag") is not the first field
     assert_de_tokens(
-        &value,
+        &value.clone().readable(),
         &[
             Token::Map { len: Some(2) },
             Token::Str("a"),
@@ -841,7 +843,7 @@ fn struct_() {
         ],
     );
     assert_de_tokens(
-        &value,
+        &value.clone().readable(),
         &[
             Token::Map { len: Some(2) },
             Token::BorrowedStr("a"),
@@ -853,7 +855,7 @@ fn struct_() {
     );
 
     assert_de_tokens(
-        &value,
+        &value.clone().readable(),
         &[
             Token::Seq { len: Some(2) },
             Token::Str("Struct"), // tag
@@ -862,7 +864,7 @@ fn struct_() {
         ],
     );
     assert_de_tokens(
-        &value,
+        &value.readable(),
         &[
             Token::Seq { len: Some(2) },
             Token::BorrowedStr("Struct"), // tag
@@ -878,7 +880,7 @@ mod struct_enum {
     #[test]
     fn unit() {
         assert_de_tokens(
-            &Enum::Unit,
+            &Enum::Unit.readable(),
             &[
                 Token::Enum { name: "Enum" },
                 Token::BorrowedStr("Unit"),
@@ -890,7 +892,7 @@ mod struct_enum {
 
         // Special case: tag field ("tag") is the first field
         assert_tokens(
-            &value,
+            &value.clone().readable(),
             &[
                 Token::Struct {
                     name: "InternallyTagged",
@@ -906,7 +908,7 @@ mod struct_enum {
             ],
         );
         assert_de_tokens(
-            &value,
+            &value.clone().readable(),
             &[
                 Token::Struct {
                     name: "InternallyTagged",
@@ -924,7 +926,7 @@ mod struct_enum {
 
         // General case: tag field ("tag") is not the first field
         assert_de_tokens(
-            &value,
+            &value.clone().readable(),
             &[
                 Token::Struct {
                     name: "InternallyTagged",
@@ -940,7 +942,7 @@ mod struct_enum {
             ],
         );
         assert_de_tokens(
-            &value,
+            &value.clone().readable(),
             &[
                 Token::Struct {
                     name: "InternallyTagged",
@@ -958,7 +960,7 @@ mod struct_enum {
 
         // Special case: tag field ("tag") is the first field
         assert_de_tokens(
-            &value,
+            &value.clone().readable(),
             &[
                 Token::Map { len: Some(2) },
                 Token::Str("tag"),
@@ -971,7 +973,7 @@ mod struct_enum {
             ],
         );
         assert_de_tokens(
-            &value,
+            &value.clone().readable(),
             &[
                 Token::Map { len: Some(2) },
                 Token::BorrowedStr("tag"),
@@ -986,7 +988,7 @@ mod struct_enum {
 
         // General case: tag field ("tag") is not the first field
         assert_de_tokens(
-            &value,
+            &value.clone().readable(),
             &[
                 Token::Map { len: Some(2) },
                 Token::Str("enum_"),
@@ -999,7 +1001,7 @@ mod struct_enum {
             ],
         );
         assert_de_tokens(
-            &value,
+            &value.clone().readable(),
             &[
                 Token::Map { len: Some(2) },
                 Token::BorrowedStr("enum_"),
@@ -1013,7 +1015,7 @@ mod struct_enum {
         );
 
         assert_de_tokens(
-            &value,
+            &value.clone().readable(),
             &[
                 Token::Seq { len: Some(2) },
                 Token::Str("StructEnum"),     // tag
@@ -1024,7 +1026,7 @@ mod struct_enum {
             ],
         );
         assert_de_tokens(
-            &value,
+            &value.readable(),
             &[
                 Token::Seq { len: Some(2) },
                 Token::BorrowedStr("StructEnum"), // tag
@@ -1039,12 +1041,12 @@ mod struct_enum {
 
 #[test]
 fn wrong_tag() {
-    assert_de_tokens_error::<InternallyTagged>(
+    assert_de_tokens_error::<Readable<InternallyTagged>>(
         &[Token::Map { len: Some(0) }, Token::MapEnd],
         "missing field `tag`",
     );
 
-    assert_de_tokens_error::<InternallyTagged>(
+    assert_de_tokens_error::<Readable<InternallyTagged>>(
         &[
             Token::Map { len: Some(1) },
             Token::Str("tag"),
@@ -1080,7 +1082,7 @@ fn untagged_variant() {
     }
 
     assert_de_tokens(
-        &InternallyTagged::Tagged { a: 1 },
+        &InternallyTagged::Tagged { a: 1 }.readable(),
         &[
             Token::Map { len: Some(2) },
             Token::Str("tag"),
@@ -1092,7 +1094,7 @@ fn untagged_variant() {
     );
 
     assert_tokens(
-        &InternallyTagged::Tagged { a: 1 },
+        &InternallyTagged::Tagged { a: 1 }.readable(),
         &[
             Token::Struct {
                 name: "InternallyTagged",
@@ -1110,7 +1112,8 @@ fn untagged_variant() {
         &InternallyTagged::Untagged {
             tag: "Foo".to_owned(),
             b: 2,
-        },
+        }
+        .readable(),
         &[
             Token::Map { len: Some(2) },
             Token::Str("tag"),
@@ -1125,7 +1128,8 @@ fn untagged_variant() {
         &InternallyTagged::Untagged {
             tag: "Foo".to_owned(),
             b: 2,
-        },
+        }
+        .readable(),
         &[
             Token::Struct {
                 name: "InternallyTagged",
@@ -1143,7 +1147,8 @@ fn untagged_variant() {
         &InternallyTagged::Untagged {
             tag: "Tagged".to_owned(),
             b: 2,
-        },
+        }
+        .readable(),
         &[
             Token::Struct {
                 name: "InternallyTagged",
@@ -1178,7 +1183,8 @@ mod string_and_bytes {
         assert_de_tokens(
             &InternallyTagged::String {
                 string: "\0".to_owned(),
-            },
+            }
+            .readable(),
             &[
                 Token::Struct {
                     name: "String",
@@ -1195,7 +1201,8 @@ mod string_and_bytes {
         assert_de_tokens(
             &InternallyTagged::String {
                 string: "\0".to_owned(),
-            },
+            }
+            .readable(),
             &[
                 Token::Struct {
                     name: "String",
@@ -1215,7 +1222,8 @@ mod string_and_bytes {
         assert_de_tokens(
             &InternallyTagged::String {
                 string: "\0".to_owned(),
-            },
+            }
+            .readable(),
             &[
                 Token::Struct {
                     name: "String",
@@ -1232,7 +1240,8 @@ mod string_and_bytes {
         assert_de_tokens(
             &InternallyTagged::String {
                 string: "\0".to_owned(),
-            },
+            }
+            .readable(),
             &[
                 Token::Struct {
                     name: "String",
@@ -1250,7 +1259,7 @@ mod string_and_bytes {
     #[test]
     fn bytes_from_string() {
         assert_de_tokens(
-            &InternallyTagged::Bytes { bytes: vec![0] },
+            &InternallyTagged::Bytes { bytes: vec![0] }.readable(),
             &[
                 Token::Struct {
                     name: "Bytes",
@@ -1265,7 +1274,7 @@ mod string_and_bytes {
         );
 
         assert_de_tokens(
-            &InternallyTagged::Bytes { bytes: vec![0] },
+            &InternallyTagged::Bytes { bytes: vec![0] }.readable(),
             &[
                 Token::Struct {
                     name: "Bytes",
@@ -1283,7 +1292,7 @@ mod string_and_bytes {
     #[test]
     fn bytes_from_bytes() {
         assert_de_tokens(
-            &InternallyTagged::Bytes { bytes: vec![0] },
+            &InternallyTagged::Bytes { bytes: vec![0] }.readable(),
             &[
                 Token::Struct {
                     name: "Bytes",
@@ -1298,7 +1307,7 @@ mod string_and_bytes {
         );
 
         assert_de_tokens(
-            &InternallyTagged::Bytes { bytes: vec![0] },
+            &InternallyTagged::Bytes { bytes: vec![0] }.readable(),
             &[
                 Token::Struct {
                     name: "Bytes",
@@ -1316,7 +1325,7 @@ mod string_and_bytes {
     #[test]
     fn bytes_from_seq() {
         assert_de_tokens(
-            &InternallyTagged::Bytes { bytes: vec![0] },
+            &InternallyTagged::Bytes { bytes: vec![0] }.readable(),
             &[
                 Token::Struct {
                     name: "Bytes",
@@ -1343,7 +1352,7 @@ fn borrow() {
     }
 
     assert_tokens(
-        &Input::Package { name: "borrowed" },
+        &Input::Package { name: "borrowed" }.readable(),
         &[
             Token::Struct {
                 name: "Input",
@@ -1378,7 +1387,7 @@ fn with_skipped_conflict() {
     let data = Data::C { t: String::new() };
 
     assert_tokens(
-        &data,
+        &data.readable(),
         &[
             Token::Struct {
                 name: "Data",
@@ -1414,7 +1423,7 @@ fn containing_flatten() {
     };
 
     assert_tokens(
-        &data,
+        &data.readable(),
         &[
             Token::Map { len: None },
             Token::Str("tag"),
@@ -1433,7 +1442,7 @@ fn unit_variant_with_unknown_fields() {
     let value = InternallyTagged::Unit;
 
     assert_de_tokens(
-        &value,
+        &value.readable(),
         &[
             Token::Map { len: None },
             Token::Str("tag"),
@@ -1445,7 +1454,7 @@ fn unit_variant_with_unknown_fields() {
     );
 
     // Unknown elements are not allowed in sequences
-    assert_de_tokens_error::<InternallyTagged>(
+    assert_de_tokens_error::<Readable<InternallyTagged>>(
         &[
             Token::Seq { len: None },
             Token::Str("Unit"), // tag
@@ -1465,13 +1474,13 @@ fn expecting_message() {
         InternallyTagged,
     }
 
-    assert_de_tokens_error::<Enum>(
+    assert_de_tokens_error::<Readable<Enum>>(
         &[Token::Str("InternallyTagged")],
         r#"invalid type: string "InternallyTagged", expected something strange..."#,
     );
 
     // Check that #[serde(expecting = "...")] doesn't affect variant identifier error message
-    assert_de_tokens_error::<Enum>(
+    assert_de_tokens_error::<Readable<Enum>>(
         &[Token::Map { len: None }, Token::Str("tag"), Token::Unit],
         "invalid type: unit value, expected variant identifier",
     );

--- a/test_suite/tests/test_enum_untagged.rs
+++ b/test_suite/tests/test_enum_untagged.rs
@@ -9,7 +9,9 @@
 mod bytes;
 
 use serde_derive::{Deserialize, Serialize};
-use serde_test::{assert_de_tokens, assert_de_tokens_error, assert_tokens, Token};
+use serde_test::{
+    assert_de_tokens, assert_de_tokens_error, assert_tokens, Configure, Readable, Token,
+};
 use std::collections::BTreeMap;
 
 #[test]
@@ -26,7 +28,7 @@ fn complex() {
     }
 
     assert_tokens(
-        &Untagged::A { a: 1 },
+        &Untagged::A { a: 1 }.readable(),
         &[
             Token::Struct {
                 name: "Untagged",
@@ -39,7 +41,7 @@ fn complex() {
     );
 
     assert_tokens(
-        &Untagged::B { b: 2 },
+        &Untagged::B { b: 2 }.readable(),
         &[
             Token::Struct {
                 name: "Untagged",
@@ -53,14 +55,14 @@ fn complex() {
 
     // Serializes to unit, deserializes from either depending on format's
     // preference.
-    assert_tokens(&Untagged::C, &[Token::Unit]);
-    assert_de_tokens(&Untagged::C, &[Token::None]);
+    assert_tokens(&Untagged::C.readable(), &[Token::Unit]);
+    assert_de_tokens(&Untagged::C.readable(), &[Token::None]);
 
-    assert_tokens(&Untagged::D(4), &[Token::U8(4)]);
-    assert_tokens(&Untagged::E("e".to_owned()), &[Token::Str("e")]);
+    assert_tokens(&Untagged::D(4).readable(), &[Token::U8(4)]);
+    assert_tokens(&Untagged::E("e".to_owned()).readable(), &[Token::Str("e")]);
 
     assert_tokens(
-        &Untagged::F(1, 2),
+        &Untagged::F(1, 2).readable(),
         &[
             Token::Tuple { len: 2 },
             Token::U8(1),
@@ -69,12 +71,12 @@ fn complex() {
         ],
     );
 
-    assert_de_tokens_error::<Untagged>(
+    assert_de_tokens_error::<Readable<Untagged>>(
         &[Token::Tuple { len: 1 }, Token::U8(1), Token::TupleEnd],
         "data did not match any variant of untagged enum Untagged",
     );
 
-    assert_de_tokens_error::<Untagged>(
+    assert_de_tokens_error::<Readable<Untagged>>(
         &[
             Token::Tuple { len: 3 },
             Token::U8(1),
@@ -99,7 +101,7 @@ fn newtype_unit_and_empty_map() {
     }
 
     assert_tokens(
-        &Message::Map(BTreeMap::new()),
+        &Message::Map(BTreeMap::new()).readable(),
         &[Token::Map { len: Some(0) }, Token::MapEnd],
     );
 }
@@ -117,11 +119,9 @@ fn newtype_struct() {
         Null,
     }
 
-    let value = E::Newtype(NewtypeStruct(5));
-
     // Content::Newtype case
     assert_tokens(
-        &value,
+        &E::Newtype(NewtypeStruct(5)).readable(),
         &[
             Token::NewtypeStruct {
                 name: "NewtypeStruct",
@@ -131,7 +131,7 @@ fn newtype_struct() {
     );
 
     // _ case
-    assert_de_tokens(&value, &[Token::U32(5)]);
+    assert_de_tokens(&E::Newtype(NewtypeStruct(5)).readable(), &[Token::U32(5)]);
 }
 
 mod newtype_enum {
@@ -157,7 +157,7 @@ mod newtype_enum {
     #[test]
     fn unit() {
         assert_tokens(
-            &Outer::Inner(Inner::Unit),
+            &Outer::Inner(Inner::Unit).readable(),
             &[Token::UnitVariant {
                 name: "Inner",
                 variant: "Unit",
@@ -169,7 +169,7 @@ mod newtype_enum {
     #[test]
     fn newtype() {
         assert_tokens(
-            &Outer::Inner(Inner::Newtype(1)),
+            &Outer::Inner(Inner::Newtype(1)).readable(),
             &[
                 Token::NewtypeVariant {
                     name: "Inner",
@@ -184,7 +184,7 @@ mod newtype_enum {
     #[test]
     fn tuple0() {
         assert_tokens(
-            &Outer::Inner(Inner::Tuple0()),
+            &Outer::Inner(Inner::Tuple0()).readable(),
             &[
                 Token::TupleVariant {
                     name: "Inner",
@@ -200,7 +200,7 @@ mod newtype_enum {
     #[test]
     fn tuple2() {
         assert_tokens(
-            &Outer::Inner(Inner::Tuple2(1, 1)),
+            &Outer::Inner(Inner::Tuple2(1, 1)).readable(),
             &[
                 Token::TupleVariant {
                     name: "Inner",
@@ -219,7 +219,7 @@ mod newtype_enum {
     #[test]
     fn struct_from_map() {
         assert_tokens(
-            &Outer::Inner(Inner::Struct { f: 1 }),
+            &Outer::Inner(Inner::Struct { f: 1 }).readable(),
             &[
                 Token::StructVariant {
                     name: "Inner",
@@ -238,7 +238,7 @@ mod newtype_enum {
     #[test]
     fn struct_from_seq() {
         assert_de_tokens(
-            &Outer::Inner(Inner::Struct { f: 1 }),
+            &Outer::Inner(Inner::Struct { f: 1 }).readable(),
             &[
                 Token::Map { len: Some(1) },
                 // tag
@@ -258,7 +258,7 @@ mod newtype_enum {
     #[test]
     fn empty_struct_from_map() {
         assert_de_tokens(
-            &Outer::Inner(Inner::EmptyStruct {}),
+            &Outer::Inner(Inner::EmptyStruct {}).readable(),
             &[
                 Token::Map { len: Some(1) },
                 // tag
@@ -277,7 +277,7 @@ mod newtype_enum {
     #[test]
     fn empty_struct_from_seq() {
         assert_de_tokens(
-            &Outer::Inner(Inner::EmptyStruct {}),
+            &Outer::Inner(Inner::EmptyStruct {}).readable(),
             &[
                 Token::Map { len: Some(1) },
                 // tag
@@ -305,7 +305,7 @@ mod with_optional_field {
     #[test]
     fn some() {
         assert_tokens(
-            &Enum::Struct { optional: Some(42) },
+            &Enum::Struct { optional: Some(42) }.readable(),
             &[
                 Token::Struct {
                     name: "Enum",
@@ -322,7 +322,7 @@ mod with_optional_field {
     #[test]
     fn some_without_marker() {
         assert_de_tokens(
-            &Enum::Struct { optional: Some(42) },
+            &Enum::Struct { optional: Some(42) }.readable(),
             &[
                 Token::Struct {
                     name: "Enum",
@@ -338,7 +338,7 @@ mod with_optional_field {
     #[test]
     fn none() {
         assert_tokens(
-            &Enum::Struct { optional: None },
+            &Enum::Struct { optional: None }.readable(),
             &[
                 Token::Struct {
                     name: "Enum",
@@ -354,7 +354,7 @@ mod with_optional_field {
     #[test]
     fn unit() {
         assert_de_tokens(
-            &Enum::Struct { optional: None },
+            &Enum::Struct { optional: None }.readable(),
             &[
                 Token::Map { len: None },
                 Token::Str("optional"),
@@ -382,7 +382,8 @@ fn string_and_bytes() {
     assert_de_tokens(
         &Untagged::String {
             string: "\0".to_owned(),
-        },
+        }
+        .readable(),
         &[
             Token::Struct {
                 name: "Untagged",
@@ -397,7 +398,8 @@ fn string_and_bytes() {
     assert_de_tokens(
         &Untagged::String {
             string: "\0".to_owned(),
-        },
+        }
+        .readable(),
         &[
             Token::Struct {
                 name: "Untagged",
@@ -412,7 +414,8 @@ fn string_and_bytes() {
     assert_de_tokens(
         &Untagged::String {
             string: "\0".to_owned(),
-        },
+        }
+        .readable(),
         &[
             Token::Struct {
                 name: "Untagged",
@@ -427,7 +430,8 @@ fn string_and_bytes() {
     assert_de_tokens(
         &Untagged::String {
             string: "\0".to_owned(),
-        },
+        }
+        .readable(),
         &[
             Token::Struct {
                 name: "Untagged",
@@ -440,7 +444,7 @@ fn string_and_bytes() {
     );
 
     assert_de_tokens(
-        &Untagged::Bytes { bytes: vec![0] },
+        &Untagged::Bytes { bytes: vec![0] }.readable(),
         &[
             Token::Struct {
                 name: "Untagged",
@@ -453,7 +457,7 @@ fn string_and_bytes() {
     );
 
     assert_de_tokens(
-        &Untagged::Bytes { bytes: vec![0] },
+        &Untagged::Bytes { bytes: vec![0] }.readable(),
         &[
             Token::Struct {
                 name: "Untagged",
@@ -466,7 +470,7 @@ fn string_and_bytes() {
     );
 
     assert_de_tokens(
-        &Untagged::Bytes { bytes: vec![0] },
+        &Untagged::Bytes { bytes: vec![0] }.readable(),
         &[
             Token::Struct {
                 name: "Untagged",
@@ -479,7 +483,7 @@ fn string_and_bytes() {
     );
 
     assert_de_tokens(
-        &Untagged::Bytes { bytes: vec![0] },
+        &Untagged::Bytes { bytes: vec![0] }.readable(),
         &[
             Token::Struct {
                 name: "Untagged",
@@ -492,7 +496,7 @@ fn string_and_bytes() {
     );
 
     assert_de_tokens(
-        &Untagged::Bytes { bytes: vec![0] },
+        &Untagged::Bytes { bytes: vec![0] }.readable(),
         &[
             Token::Struct {
                 name: "Untagged",
@@ -530,7 +534,7 @@ fn contains_flatten() {
     };
 
     assert_tokens(
-        &data,
+        &data.readable(),
         &[
             Token::Map { len: None },
             Token::Str("a"),
@@ -560,7 +564,8 @@ fn contains_flatten_with_integer_key() {
                 map.insert(100, "BTreeMap".to_owned());
                 map
             },
-        },
+        }
+        .readable(),
         &[
             Token::Map { len: None },
             Token::U64(100),
@@ -579,5 +584,5 @@ fn expecting_message() {
         Untagged,
     }
 
-    assert_de_tokens_error::<Enum>(&[Token::Str("Untagged")], "something strange...");
+    assert_de_tokens_error::<Readable<Enum>>(&[Token::Str("Untagged")], "something strange...");
 }

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -7,7 +7,7 @@
 )]
 
 use serde_derive::{Deserialize, Serialize};
-use serde_test::{assert_de_tokens, assert_ser_tokens, assert_tokens, Token};
+use serde_test::{assert_de_tokens, assert_ser_tokens, assert_tokens, Configure, Token};
 use std::marker::PhantomData;
 
 // That tests that the derived Serialize implementation doesn't trigger
@@ -622,7 +622,7 @@ fn test_internally_tagged_struct_with_flattened_field() {
     }
 
     assert_tokens(
-        &Struct { flat: Enum::A(0) },
+        &Struct { flat: Enum::A(0) }.readable(),
         &[
             Token::Map { len: None },
             Token::Str("tag_struct"),
@@ -639,7 +639,7 @@ fn test_internally_tagged_struct_with_flattened_field() {
     );
 
     assert_de_tokens(
-        &Struct { flat: Enum::A(0) },
+        &Struct { flat: Enum::A(0) }.readable(),
         &[
             Token::Map { len: None },
             Token::Str("tag_enum"),


### PR DESCRIPTION
The internal deserializer does not honor `is_human_readable` flag, which leads to numerous problems (basically `is_human_readable=false` are semi-usable). This PR simply passes the flag through all machinery, exactly as it were in #1919. However, now there are two open issues here which are not closed for a reason apparently.

Resolves #2172, resolves #2704