### PR TITLE
serde_derive: Fix panic in camelCase field rename for empty names

### DIFF
--- a/serde_derive/src/internals/case.rs
+++ b/serde_derive/src/internals/case.rs
@@ -100,6 +100,9 @@ impl RenameRule {
             }
             CamelCase => {
                 let pascal = PascalCase.apply_to_field(field);
+                if pascal.is_empty() {
+                    return field.to_owned();
+                }
                 pascal[..1].to_ascii_lowercase() + &pascal[1..]
             }
             ScreamingSnakeCase => field.to_ascii_uppercase(),
@@ -187,6 +190,7 @@ fn rename_fields() {
         ),
         ("a", "A", "A", "a", "A", "a", "A"),
         ("z42", "Z42", "Z42", "z42", "Z42", "z42", "Z42"),
+        ("", "", "", "", "", "", ""),
     ] {
         assert_eq!(None.apply_to_field(original), original);
         assert_eq!(UpperCase.apply_to_field(original), upper);


### PR DESCRIPTION
## Summary
- Guard `camelCase` field renaming when PascalCase yields an empty string (e.g. empty or underscore-only identifiers), avoiding an out-of-bounds slice panic.
- Extend `rename_fields` unit test with an empty field name case.

## Test plan
- `cargo test -p serde_derive rename_fields`