### PR TITLE
Fix deserializing adjacently tagged unit variants as sequences

### DIFF
--- a/serde_derive/src/de/enum_adjacently.rs
+++ b/serde_derive/src/de/enum_adjacently.rs
@@ -293,10 +293,8 @@ pub(super) fn deserialize(
                             },
                         ) {
                             _serde::#private::Ok(_serde::#private::Some(__ret)) => _serde::#private::Ok(__ret),
-                            // There is no second element.
-                            _serde::#private::Ok(_serde::#private::None) => {
-                                _serde::#private::Err(_serde::de::Error::invalid_length(1, &self))
-                            }
+                            // There is no second element; might be okay if the we have a unit variant.
+                            _serde::#private::Ok(_serde::#private::None) => #missing_content,
                             _serde::#private::Err(__err) => _serde::#private::Err(__err),
                         }
                     }


### PR DESCRIPTION
This behavior is copied from the map visitor where this was already fixed.

Partially addresses #1762 and https://github.com/3Hren/msgpack-rust/issues/250. Resolving the struct variant part of the issue will be more tricky due to its codepath involving the untagged variants logic where the current behavior is more desirable.