### PR TITLE
docs: fix missing article in Error::custom doc comment

### DIFF
--- a/serde_core/src/de/mod.rs
+++ b/serde_core/src/de/mod.rs
@@ -163,7 +163,7 @@ macro_rules! declare_error_trait {
             )
         )]
         pub trait Error: Sized $(+ $($supertrait)::+)* {
-            /// Raised when there is general error when deserializing a type.
+            /// Raised when there is a general error when deserializing a type.
             ///
             /// The message should not be capitalized and should not end with a period.
             ///


### PR DESCRIPTION

**Repo:** serde-rs/serde (⭐ 10000)
**Type:** docs
**Files changed:** 1
**Lines:** +1/-1

## What
Fixes a small grammar issue in the rustdoc for the `Error` trait in `serde_core::de`. The sentence "Raised when there is general error when deserializing a type." was missing the article "a"; it now reads "Raised when there is a general error when deserializing a type."

## Why
This doc comment is rendered on docs.rs for the widely-used `serde::de::Error` trait. The missing article makes the sentence ungrammatical. Fixing it improves the quality of user-facing documentation at zero runtime cost and with no API surface change.

## Testing
Documentation-only change; no code paths are affected. Reviewers can verify by reading the diff in `serde_core/src/de/mod.rs` around line 166. `cargo doc` would render the corrected text.

## Risk
Low — pure doc-comment typo fix, single-line change.
