### PR TITLE
Fixes Default Literals | Issue #368

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -206,7 +206,7 @@ fn build_generics(cont: &Container, borrowed: &BorrowedLifetimes) -> syn::Generi
                     &generics,
                     &parse_quote!(_serde::#private::Default),
                 ),
-                attr::Default::None | attr::Default::Path(_) => generics,
+                attr::Default::None | attr::Default::Path(_) | attr::Default::Expr(_) => generics,
             };
 
             let delife = borrowed.de_lifetime();
@@ -409,6 +409,7 @@ fn deserialize_transparent(cont: &Container, params: &Parameters) -> Fragment {
                 // on the #[serde(default = "...")]
                 //                          ^^^^^
                 attr::Default::Path(path) => quote_spanned!(path.span()=> #path()),
+                attr::Default::Expr(expr) => quote_spanned!(expr.span()=> #expr),
                 attr::Default::None => quote!(_serde::#private::PhantomData),
             };
             quote!(#member: #value)
@@ -537,7 +538,7 @@ fn deserialize_seq(
         attr::Default::Path(path) => Some(quote_spanned!(path.span()=>
             let __default: Self::Value = #path();
         )),
-        attr::Default::None => {
+        attr::Default::None | attr::Default::Expr(_) => {
             // We don't need the default value, to prevent an unused variable warning
             // we'll leave the line empty.
             None
@@ -626,7 +627,7 @@ fn deserialize_seq_in_place(
         attr::Default::Path(path) => Some(quote_spanned!(path.span()=>
             let __default: #this_type #ty_generics = #path();
         )),
-        attr::Default::None => {
+        attr::Default::None | attr::Default::Expr(_) => {
             // We don't need the default value, to prevent an unused variable warning
             // we'll leave the line empty.
             None
@@ -777,6 +778,9 @@ fn expr_is_missing(field: &Field, cattrs: &attr::Container) -> Fragment {
             //                          ^^^^^
             return Fragment::Expr(quote_spanned!(path.span()=> #path()));
         }
+        attr::Default::Expr(expr) => {
+            return Fragment::Expr(quote_spanned!(expr.span()=> #expr));
+        }
         attr::Default::None => { /* below */ }
     }
 
@@ -785,6 +789,7 @@ fn expr_is_missing(field: &Field, cattrs: &attr::Container) -> Fragment {
             let member = &field.member;
             return quote_expr!(__default.#member);
         }
+        attr::Default::Expr(_) => unreachable!("default_expr is not supported on containers"),
         attr::Default::None => { /* below */ }
     }
 
@@ -824,6 +829,9 @@ fn expr_is_missing_seq(
             //                          ^^^^^
             return quote_spanned!(path.span()=> #assign_to #path());
         }
+        attr::Default::Expr(expr) => {
+            return quote_spanned!(expr.span()=> #assign_to #expr);
+        }
         attr::Default::None => { /* below */ }
     }
 
@@ -832,6 +840,7 @@ fn expr_is_missing_seq(
             let member = &field.member;
             quote!(#assign_to __default.#member)
         }
+        attr::Default::Expr(_) => unreachable!("default_expr is not supported on containers"),
         attr::Default::None => quote!(
             return _serde::#private::Err(_serde::de::Error::invalid_length(#index, &#expecting))
         ),

--- a/serde_derive/src/de/struct_.rs
+++ b/serde_derive/src/de/struct_.rs
@@ -383,7 +383,7 @@ fn deserialize_map(
         attr::Default::Path(path) => Some(quote_spanned!(path.span()=>
             let __default: Self::Value = #path();
         )),
-        attr::Default::None => {
+        attr::Default::None | attr::Default::Expr(_) => {
             // We don't need the default value, to prevent an unused variable warning
             // we'll leave the line empty.
             None
@@ -648,7 +648,7 @@ fn deserialize_map_in_place(
         attr::Default::Path(path) => Some(quote_spanned!(path.span()=>
             let __default: #this_type #ty_generics = #path();
         )),
-        attr::Default::None => {
+        attr::Default::None | attr::Default::Expr(_) => {
             // We don't need the default value, to prevent an unused variable warning
             // we'll leave the line empty.
             None

--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -999,13 +999,15 @@ pub enum Default {
     Default,
     /// The default is given by this function.
     Path(syn::ExprPath),
+    /// The default is given by this expression.
+    Expr(syn::Expr),
 }
 
 impl Default {
     pub fn is_none(&self) -> bool {
         match self {
             Default::None => true,
-            Default::Default | Default::Path(_) => false,
+            Default::Default | Default::Path(_) | Default::Expr(_) => false,
         }
     }
 }
@@ -1027,6 +1029,7 @@ impl Field {
         let mut skip_deserializing = BoolAttr::none(cx, SKIP_DESERIALIZING);
         let mut skip_serializing_if = Attr::none(cx, SKIP_SERIALIZING_IF);
         let mut default = Attr::none(cx, DEFAULT);
+        let mut default_expr = Attr::none(cx, DEFAULT_EXPR);
         let mut serialize_with = Attr::none(cx, SERIALIZE_WITH);
         let mut deserialize_with = Attr::none(cx, DESERIALIZE_WITH);
         let mut ser_bound = Attr::none(cx, BOUND);
@@ -1096,6 +1099,10 @@ impl Field {
                         // #[serde(default)]
                         default.set(&meta.path, Default::Default);
                     }
+                } else if meta.path == DEFAULT_EXPR {
+                    // #[serde(default_expr = ...)]
+                    let expr = parse_lit_into_expr(cx, DEFAULT_EXPR, &meta)?;
+                    default_expr.set_opt(&meta.path, expr.map(Default::Expr));
                 } else if meta.path == SKIP_SERIALIZING {
                     // #[serde(skip_serializing)]
                     skip_serializing.set_true(&meta.path);
@@ -1188,9 +1195,24 @@ impl Field {
         // If skip_deserializing, initialize the field to Default::default() unless a
         // different default is specified by `#[serde(default = "...")]` on
         // ourselves or our container (e.g. the struct we are in).
-        if container_default.is_none() && skip_deserializing.0.value.is_some() {
+        if container_default.is_none()
+            && skip_deserializing.0.value.is_some()
+            && default_expr.value.is_none()
+        {
             default.set_if_none(Default::Default);
         }
+
+        let default = match (default.get_with_tokens(), default_expr.get_with_tokens()) {
+            (Some((default_tokens, default)), Some((default_expr_tokens, _))) => {
+                let msg = "a field may have only one of: #[serde(default)], \
+                           #[serde(default = \"...\")], or #[serde(default_expr = ...)]";
+                cx.error_spanned_by(default_tokens, msg);
+                cx.error_spanned_by(default_expr_tokens, msg);
+                default
+            }
+            (Some((_, default)), None) | (None, Some((_, default))) => default,
+            (None, None) => Default::None,
+        };
 
         let mut borrowed_lifetimes = borrowed_lifetimes.get().unwrap_or_default();
         if !borrowed_lifetimes.is_empty() {
@@ -1249,7 +1271,7 @@ impl Field {
             skip_serializing: skip_serializing.get(),
             skip_deserializing: skip_deserializing.get(),
             skip_serializing_if: skip_serializing_if.get(),
-            default: default.get().unwrap_or(Default::None),
+            default,
             serialize_with: serialize_with.get(),
             deserialize_with: deserialize_with.get(),
             ser_bound: ser_bound.get(),
@@ -1492,6 +1514,24 @@ fn parse_lit_into_expr_path(
             None
         }
     })
+}
+
+fn parse_lit_into_expr(
+    cx: &Ctxt,
+    attr_name: Symbol,
+    meta: &ParseNestedMeta,
+) -> syn::Result<Option<syn::Expr>> {
+    let input = meta.value()?;
+    match input.parse::<syn::Expr>() {
+        Ok(expr) => Ok(Some(expr)),
+        Err(err) => {
+            cx.error_spanned_by(
+                meta.path.clone(),
+                format!("failed to parse expression for `{}`: {}", attr_name, err),
+            );
+            Ok(None)
+        }
+    }
 }
 
 fn parse_lit_into_where(

--- a/serde_derive/src/internals/symbol.rs
+++ b/serde_derive/src/internals/symbol.rs
@@ -10,6 +10,7 @@ pub const BOUND: Symbol = Symbol("bound");
 pub const CONTENT: Symbol = Symbol("content");
 pub const CRATE: Symbol = Symbol("crate");
 pub const DEFAULT: Symbol = Symbol("default");
+pub const DEFAULT_EXPR: Symbol = Symbol("default_expr");
 pub const DENY_UNKNOWN_FIELDS: Symbol = Symbol("deny_unknown_fields");
 pub const DESERIALIZE: Symbol = Symbol("deserialize");
 pub const DESERIALIZE_WITH: Symbol = Symbol("deserialize_with");

--- a/test_suite/tests/test_annotations.rs
+++ b/test_suite/tests/test_annotations.rs
@@ -106,6 +106,35 @@ struct DefaultTupleStruct<A, B, C>(
 where
     C: MyDefault;
 
+#[derive(Debug, PartialEq, Deserialize)]
+struct DefaultExprStruct {
+    #[serde(default_expr = 0)]
+    int: u32,
+    #[serde(default_expr = 0.1)]
+    rate: f32,
+    #[serde(default_expr = true)]
+    enabled: bool,
+    #[serde(default_expr = Some(5))]
+    limit: Option<u32>,
+    #[serde(default_expr = Vec::new())]
+    items: Vec<String>,
+    #[serde(default_expr = "localhost".to_string())]
+    host: String,
+}
+
+#[derive(Debug, PartialEq, Deserialize)]
+struct DefaultExprTupleStruct(
+    #[serde(default_expr = 7)] u32,
+    #[serde(default_expr = String::new())] String,
+);
+
+#[derive(Debug, PartialEq, Deserialize)]
+struct SkipWithExpr {
+    present: u32,
+    #[serde(skip_deserializing, default_expr = 99u32)]
+    skipped: u32,
+}
+
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 struct CollectOther {
     a: u32,
@@ -188,6 +217,60 @@ fn test_default_tuple() {
             },
             Token::I32(1),
             Token::TupleStructEnd,
+        ],
+    );
+}
+
+#[test]
+fn test_default_expr_struct() {
+    assert_de_tokens(
+        &DefaultExprStruct {
+            int: 0,
+            rate: 0.1,
+            enabled: true,
+            limit: Some(5),
+            items: Vec::new(),
+            host: "localhost".to_string(),
+        },
+        &[
+            Token::Struct {
+                name: "DefaultExprStruct",
+                len: 6,
+            },
+            Token::StructEnd,
+        ],
+    );
+}
+
+#[test]
+fn test_default_expr_tuple() {
+    assert_de_tokens(
+        &DefaultExprTupleStruct(7, String::new()),
+        &[
+            Token::TupleStruct {
+                name: "DefaultExprTupleStruct",
+                len: 2,
+            },
+            Token::TupleStructEnd,
+        ],
+    );
+}
+
+#[test]
+fn test_skip_with_expr() {
+    assert_de_tokens(
+        &SkipWithExpr {
+            present: 1,
+            skipped: 99,
+        },
+        &[
+            Token::Struct {
+                name: "SkipWithExpr",
+                len: 1,
+            },
+            Token::Str("present"),
+            Token::U32(1),
+            Token::StructEnd,
         ],
     );
 }

--- a/test_suite/tests/ui/default-expr/conflict.rs
+++ b/test_suite/tests/ui/default-expr/conflict.rs
@@ -1,0 +1,9 @@
+use serde_derive::Deserialize;
+
+#[derive(Deserialize)]
+struct Conflict {
+    #[serde(default, default_expr = 1)]
+    value: u32,
+}
+
+fn main() {}

--- a/test_suite/tests/ui/default-expr/conflict.stderr
+++ b/test_suite/tests/ui/default-expr/conflict.stderr
@@ -1,0 +1,11 @@
+error: a field may have only one of: #[serde(default)], #[serde(default = "...")], or #[serde(default_expr = ...)]
+ --> tests/ui/default-expr/conflict.rs:5:13
+  |
+5 |     #[serde(default, default_expr = 1)]
+  |             ^^^^^^^
+
+error: a field may have only one of: #[serde(default)], #[serde(default = "...")], or #[serde(default_expr = ...)]
+ --> tests/ui/default-expr/conflict.rs:5:22
+  |
+5 |     #[serde(default, default_expr = 1)]
+  |                      ^^^^^^^^^^^^

--- a/test_suite/tests/ui/default-expr/conflict_path.rs
+++ b/test_suite/tests/ui/default-expr/conflict_path.rs
@@ -1,0 +1,9 @@
+use serde_derive::Deserialize;
+
+#[derive(Deserialize)]
+struct ConflictPath {
+    #[serde(default = "u32::default", default_expr = 1)]
+    value: u32,
+}
+
+fn main() {}

--- a/test_suite/tests/ui/default-expr/conflict_path.stderr
+++ b/test_suite/tests/ui/default-expr/conflict_path.stderr
@@ -1,0 +1,11 @@
+error: a field may have only one of: #[serde(default)], #[serde(default = "...")], or #[serde(default_expr = ...)]
+ --> tests/ui/default-expr/conflict_path.rs:5:13
+  |
+5 |     #[serde(default = "u32::default", default_expr = 1)]
+  |             ^^^^^^^
+
+error: a field may have only one of: #[serde(default)], #[serde(default = "...")], or #[serde(default_expr = ...)]
+ --> tests/ui/default-expr/conflict_path.rs:5:39
+  |
+5 |     #[serde(default = "u32::default", default_expr = 1)]
+  |                                       ^^^^^^^^^^^^

--- a/test_suite/tests/ui/default-expr/type_mismatch.rs
+++ b/test_suite/tests/ui/default-expr/type_mismatch.rs
@@ -1,0 +1,12 @@
+// Tests that a type mismatch in default_expr is caught by Rust (no implicit coercion).
+// "abc" is &'static str, not String — Serde must not convert it automatically.
+
+use serde_derive::Deserialize;
+
+#[derive(Deserialize)]
+struct TypeMismatch {
+    #[serde(default_expr = "abc")]
+    host: String,
+}
+
+fn main() {}

--- a/test_suite/tests/ui/default-expr/type_mismatch.stderr
+++ b/test_suite/tests/ui/default-expr/type_mismatch.stderr
@@ -1,0 +1,30 @@
+error[E0308]: `match` arms have incompatible types
+ --> tests/ui/default-expr/type_mismatch.rs:8:28
+  |
+6 | #[derive(Deserialize)]
+  |          -----------
+  |          |
+  |          this is found to be of type `String`
+  |          `match` arms have incompatible types
+7 | struct TypeMismatch {
+8 |     #[serde(default_expr = "abc")]
+  |                            ^^^^^ expected `String`, found `&str`
+  |
+help: try using a conversion method
+  |
+8 |     #[serde(default_expr = "abc".to_string())]
+  |                                 ++++++++++++
+
+error[E0308]: mismatched types
+ --> tests/ui/default-expr/type_mismatch.rs:8:28
+  |
+6 | #[derive(Deserialize)]
+  |          ----------- expected due to the type of this binding
+7 | struct TypeMismatch {
+8 |     #[serde(default_expr = "abc")]
+  |                            ^^^^^ expected `String`, found `&str`
+  |
+help: try using a conversion method
+  |
+8 |     #[serde(default_expr = "abc".to_string())]
+  |                                 ++++++++++++


### PR DESCRIPTION
[Serde_Default_Expression.pdf](https://github.com/user-attachments/files/27863411/Serde_Default_Expression.pdf)

[serde_default_expr_implementation_report.docx](https://github.com/user-attachments/files/27863408/serde_default_expr_implementation_report.docx)

Adds a new field-level attribute, `default_expr`, that allows an arbitrary 
Rust expression to be used as a missing-field default during deserialization, 
without requiring a dedicated helper function.

## Motivation
The existing `default = "path"` form requires a named callable, forcing 
boilerplate for trivial defaults like literals or simple constructors. 
`default_expr` eliminates that overhead while keeping semantics explicit 
and avoiding overload of the existing `default` attribute.

## Changes
- `symbol.rs`: introduce the `DEFAULT_EXPR` symbol
- `attr.rs`: parse `default_expr` as `syn::Expr`; extend `Default` enum 
  with `Expr(syn::Expr)`; enforce single-default-source conflict rule
- `de.rs`: emit expression directly in missing-field branches via 
  `quote_spanned!`; no `Default` bound added for `default_expr`
- `de/struct_.rs`: exhaustive match coverage for new `Default::Expr` variant

## Tests
- Runtime: `test_default_expr_struct`, `test_default_expr_tuple`, 
  `test_skip_with_expr`
- Compile-fail (nightly): `conflict.rs`, `conflict_path.rs`, 
  `type_mismatch.rs`

More in depth documents have been attached. It goes over the game plan and then the implementation that was followed.
