### PR TITLE
docs: add NOTICE with copyright for dual-licensed crates

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,3 @@
+Serde
+Copyright 2014 David Tolnay
+Copyright 2014 Erick Tryzelaar


### PR DESCRIPTION
## Summary
- Adds a root `NOTICE` file with copyright attribution for Serde's authors
- Satisfies MIT and Apache-2.0 requirements for downstream legal review

Fixes #3051

## Test plan
- [ ] NOTICE file present at repository root