### PR TITLE
Deserialize Option from value deserializers as Some

### DIFF
--- a/serde_core/src/de/value.rs
+++ b/serde_core/src/de/value.rs
@@ -46,6 +46,24 @@ macro_rules! impl_copy_clone {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// A value deserializer always holds a value that is present, so deserializing
+// it as an `Option` must produce `Some`. Forwarding `deserialize_option` to
+// `deserialize_any` would instead make the visitor receive the held value
+// directly, which fails for `Option<T>` with "invalid type ..., expected
+// option".
+macro_rules! deserialize_option_some {
+    () => {
+        fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: de::Visitor<'de>,
+        {
+            visitor.visit_some(self)
+        }
+    };
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 /// A minimal representation of all possible errors that can occur using the
 /// `IntoDeserializer` trait.
 #[derive(Clone, PartialEq)]
@@ -291,9 +309,11 @@ macro_rules! primitive_deserializer {
 
             forward_to_deserialize_any! {
                 bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str
-                string bytes byte_buf option unit unit_struct newtype_struct seq
+                string bytes byte_buf unit unit_struct newtype_struct seq
                 tuple tuple_struct map struct enum identifier ignored_any
             }
+
+            deserialize_option_some!();
 
             fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
             where
@@ -378,9 +398,11 @@ where
 
     forward_to_deserialize_any! {
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
-        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        bytes byte_buf unit unit_struct newtype_struct seq tuple
         tuple_struct map struct identifier ignored_any
     }
+
+    deserialize_option_some!();
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
@@ -499,9 +521,11 @@ where
 
     forward_to_deserialize_any! {
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
-        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        bytes byte_buf unit unit_struct newtype_struct seq tuple
         tuple_struct map struct identifier ignored_any
     }
+
+    deserialize_option_some!();
 }
 
 impl<'de, 'a, E> IntoDeserializer<'de, E> for StrDeserializer<'a, E>
@@ -589,9 +613,11 @@ where
 
     forward_to_deserialize_any! {
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
-        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        bytes byte_buf unit unit_struct newtype_struct seq tuple
         tuple_struct map struct identifier ignored_any
     }
+
+    deserialize_option_some!();
 }
 
 impl<'de, E> IntoDeserializer<'de, E> for BorrowedStrDeserializer<'de, E>
@@ -703,9 +729,11 @@ where
 
     forward_to_deserialize_any! {
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
-        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        bytes byte_buf unit unit_struct newtype_struct seq tuple
         tuple_struct map struct identifier ignored_any
     }
+
+    deserialize_option_some!();
 }
 
 #[cfg(any(feature = "std", feature = "alloc"))]
@@ -823,9 +851,11 @@ where
 
     forward_to_deserialize_any! {
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
-        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        bytes byte_buf unit unit_struct newtype_struct seq tuple
         tuple_struct map struct identifier ignored_any
     }
+
+    deserialize_option_some!();
 }
 
 #[cfg(any(feature = "std", feature = "alloc"))]
@@ -912,9 +942,11 @@ where
 
     forward_to_deserialize_any! {
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
-        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        bytes byte_buf unit unit_struct newtype_struct seq tuple
         tuple_struct map struct enum identifier ignored_any
     }
+
+    deserialize_option_some!();
 }
 
 impl<'de, 'a, E> IntoDeserializer<'de, E> for BytesDeserializer<'a, E>
@@ -971,9 +1003,11 @@ where
 
     forward_to_deserialize_any! {
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
-        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        bytes byte_buf unit unit_struct newtype_struct seq tuple
         tuple_struct map struct enum identifier ignored_any
     }
+
+    deserialize_option_some!();
 }
 
 impl<'de, E> IntoDeserializer<'de, E> for BorrowedBytesDeserializer<'de, E>
@@ -1061,9 +1095,11 @@ where
 
     forward_to_deserialize_any! {
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
-        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        bytes byte_buf unit unit_struct newtype_struct seq tuple
         tuple_struct map struct enum identifier ignored_any
     }
+
+    deserialize_option_some!();
 }
 
 impl<'de, I, T, E> IntoDeserializer<'de, E> for SeqDeserializer<I, E>
@@ -1205,9 +1241,11 @@ where
 
     forward_to_deserialize_any! {
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
-        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        bytes byte_buf unit unit_struct newtype_struct seq tuple
         tuple_struct map struct enum identifier ignored_any
     }
+
+    deserialize_option_some!();
 }
 
 impl<'de, A> IntoDeserializer<'de, A::Error> for SeqAccessDeserializer<A>
@@ -1330,9 +1368,11 @@ where
 
     forward_to_deserialize_any! {
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
-        bytes byte_buf option unit unit_struct newtype_struct tuple_struct map
+        bytes byte_buf unit unit_struct newtype_struct tuple_struct map
         struct enum identifier ignored_any
     }
+
+    deserialize_option_some!();
 }
 
 impl<'de, I, E> IntoDeserializer<'de, E> for MapDeserializer<'de, I, E>
@@ -1484,9 +1524,11 @@ where
 
     forward_to_deserialize_any! {
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
-        bytes byte_buf option unit unit_struct newtype_struct tuple_struct map
+        bytes byte_buf unit unit_struct newtype_struct tuple_struct map
         struct enum identifier ignored_any
     }
+
+    deserialize_option_some!();
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
@@ -1646,9 +1688,11 @@ where
 
     forward_to_deserialize_any! {
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
-        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        bytes byte_buf unit unit_struct newtype_struct seq tuple
         tuple_struct map struct identifier ignored_any
     }
+
+    deserialize_option_some!();
 }
 
 impl<'de, A> IntoDeserializer<'de, A::Error> for MapAccessDeserializer<A>
@@ -1710,9 +1754,11 @@ where
 
     forward_to_deserialize_any! {
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
-        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        bytes byte_buf unit unit_struct newtype_struct seq tuple
         tuple_struct map struct enum identifier ignored_any
     }
+
+    deserialize_option_some!();
 }
 
 impl<'de, A> IntoDeserializer<'de, A::Error> for EnumAccessDeserializer<A>

--- a/test_suite/tests/test_value.rs
+++ b/test_suite/tests/test_value.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::derive_partial_eq_without_eq, clippy::similar_names)]
 
-use serde::de::value::{self, MapAccessDeserializer};
+use serde::de::value::{self, MapAccessDeserializer, MapDeserializer};
 use serde::de::{Deserialize, Deserializer, IntoDeserializer, MapAccess, Visitor};
 use serde_derive::Deserialize;
 use serde_test::{assert_de_tokens, Token};
@@ -91,5 +91,38 @@ fn test_map_access_to_enum() {
             Token::MapEnd,
             Token::MapEnd,
         ],
+    );
+}
+
+#[test]
+fn test_option_from_value_deserializer() {
+    // A value deserializer holding a present value must deserialize into
+    // `Option<T>` as `Some(value)`, not error with "invalid type ..., expected
+    // option".
+    let de = IntoDeserializer::<value::Error>::into_deserializer("value");
+    let opt = Option::<String>::deserialize(de).unwrap();
+    assert_eq!(opt, Some("value".to_owned()));
+
+    let de = IntoDeserializer::<value::Error>::into_deserializer(7u32);
+    let opt = Option::<u32>::deserialize(de).unwrap();
+    assert_eq!(opt, Some(7));
+}
+
+#[test]
+fn test_map_deserializer_optional_field() {
+    // Regression test for https://github.com/serde-rs/serde/issues/3050
+    #[derive(Debug, PartialEq, Deserialize)]
+    struct Map {
+        optional: Option<String>,
+    }
+
+    let iter = [("optional", "value")].into_iter();
+    let de = MapDeserializer::<_, value::Error>::new(iter);
+    let map = Map::deserialize(de).unwrap();
+    assert_eq!(
+        map,
+        Map {
+            optional: Some("value".to_owned()),
+        },
     );
 }


### PR DESCRIPTION
The value deserializers in `serde::de::value` (the ones you get from `IntoDeserializer`, including `MapDeserializer`) forward `deserialize_option` to `deserialize_any`. `deserialize_any` hands the held value straight to the visitor, so for an `Option<T>` target it ends up calling `visit_str`/`visit_u32`/etc. on the option visitor, which only knows `visit_some`/`visit_none`. The result is a spurious error:

```
invalid type: string "value", expected option
```

Minimal repro (from #3050):

```rust
use serde::Deserialize;
use serde::de::value::{Error, MapDeserializer};

#[derive(Debug, Deserialize)]
struct Map {
    optional: Option<String>,
}

let iter = [("optional", "value")].into_iter();
let de = MapDeserializer::<_, Error>::new(iter);
Map::deserialize(de); // Err: invalid type: string "value", expected option
```

A value deserializer always wraps a value that is present, so deserializing it as an option must yield `Some`. This implements `deserialize_option` as `visitor.visit_some(self)` for the scalar, string, bytes, seq, map, and enum value deserializers, matching how self-describing format deserializers (serde_json, toml, ...) behave. `UnitDeserializer` still returns `visit_none`, and the uninhabited `NeverDeserializer` is left unchanged.

Added two regression tests in `test_value.rs`: a direct `IntoDeserializer` -> `Option<T>` case and the exact `MapDeserializer` reproduction from the issue. Ran `cargo fmt --check`, `cargo clippy -p serde_core`, `cargo test -p serde_core`, and the relevant `test_suite` integration tests (stable and `cargo +nightly --features unstable`); all clean.

Fixes #3050.
