### PR TITLE
feat: allow disabling floats

### DIFF
--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -36,7 +36,11 @@ rustdoc-args = [
 ### FEATURES #################################################################
 
 [features]
-default = ["std"]
+default = ["std", "floats"]
+
+# Provide serialization support for floats
+# Disable this when running in embedded environments that do not support floating point numbers
+floats = ["serde_core/floats"]
 
 # Provide derive(Serialize, Deserialize) macros.
 derive = ["serde_derive"]

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -198,6 +198,7 @@ macro_rules! crate_root {
                 pub use std::*;
             }
 
+            #[cfg(feature = "floats")]
             pub use self::core::{f32, f64};
             pub use self::core::{ptr, str};
 

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -274,6 +274,10 @@ mod content {
             Content::U16(n) => Unexpected::Unsigned(n as u64),
             Content::U32(n) => Unexpected::Unsigned(n as u64),
             Content::U64(n) => Unexpected::Unsigned(n),
+            #[cfg(feature = "floats")]
+            Content::F32(n) => Unexpected::Float(n as f64),
+            #[cfg(feature = "floats")]
+            Content::F64(n) => Unexpected::Float(n),
             Content::I8(n) => Unexpected::Signed(n as i64),
             Content::I16(n) => Unexpected::Signed(n as i64),
             Content::I32(n) => Unexpected::Signed(n as i64),

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -240,6 +240,10 @@ mod content {
             Content::U16(n) => Content::U16(*n),
             Content::U32(n) => Content::U32(*n),
             Content::U64(n) => Content::U64(*n),
+            #[cfg(feature = "floats")]
+            Content::F32(n) => Content::F32(*n),
+            #[cfg(feature = "floats")]
+            Content::F64(n) => Content::F64(*n),
             Content::I8(n) => Content::I8(*n),
             Content::I16(n) => Content::I16(*n),
             Content::I32(n) => Content::I32(*n),
@@ -1100,6 +1104,10 @@ mod content {
                 Content::U16(v) => visitor.visit_u16(v),
                 Content::U32(v) => visitor.visit_u32(v),
                 Content::U64(v) => visitor.visit_u64(v),
+                #[cfg(feature = "floats")]
+                Content::F32(v) => visitor.visit_f32(v),
+                #[cfg(feature = "floats")]
+                Content::F64(v) => visitor.visit_f64(v),
                 Content::I8(v) => visitor.visit_i8(v),
                 Content::I16(v) => visitor.visit_i16(v),
                 Content::I32(v) => visitor.visit_i32(v),

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -50,7 +50,7 @@ where
         }
 
         serde_core::forward_to_deserialize_any! {
-            bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+            bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 char str string
             bytes byte_buf unit unit_struct newtype_struct seq tuple
             tuple_struct map struct enum identifier ignored_any
         }
@@ -240,8 +240,6 @@ mod content {
             Content::I16(n) => Content::I16(*n),
             Content::I32(n) => Content::I32(*n),
             Content::I64(n) => Content::I64(*n),
-            Content::F32(f) => Content::F32(*f),
-            Content::F64(f) => Content::F64(*f),
             Content::Char(c) => Content::Char(*c),
             Content::String(s) => Content::String(s.clone()),
             Content::Str(s) => Content::Str(*s),
@@ -272,8 +270,6 @@ mod content {
             Content::I16(n) => Unexpected::Signed(n as i64),
             Content::I32(n) => Unexpected::Signed(n as i64),
             Content::I64(n) => Unexpected::Signed(n),
-            Content::F32(f) => Unexpected::Float(f as f64),
-            Content::F64(f) => Unexpected::Float(f),
             Content::Char(c) => Unexpected::Char(c),
             Content::String(ref s) => Unexpected::Str(s),
             Content::Str(s) => Unexpected::Str(s),
@@ -378,20 +374,6 @@ mod content {
             F: de::Error,
         {
             Ok(Content::U64(value))
-        }
-
-        fn visit_f32<F>(self, value: f32) -> Result<Self::Value, F>
-        where
-            F: de::Error,
-        {
-            Ok(Content::F32(value))
-        }
-
-        fn visit_f64<F>(self, value: f64) -> Result<Self::Value, F>
-        where
-            F: de::Error,
-        {
-            Ok(Content::F64(value))
         }
 
         fn visit_char<F>(self, value: char) -> Result<Self::Value, F>
@@ -638,23 +620,6 @@ mod content {
                 .map(TagOrContent::Content)
         }
 
-        fn visit_f32<F>(self, value: f32) -> Result<Self::Value, F>
-        where
-            F: de::Error,
-        {
-            ContentVisitor::new()
-                .visit_f32(value)
-                .map(TagOrContent::Content)
-        }
-
-        fn visit_f64<F>(self, value: f64) -> Result<Self::Value, F>
-        where
-            F: de::Error,
-        {
-            ContentVisitor::new()
-                .visit_f64(value)
-                .map(TagOrContent::Content)
-        }
 
         fn visit_char<F>(self, value: char) -> Result<Self::Value, F>
         where
@@ -1074,8 +1039,6 @@ mod content {
             V: Visitor<'de>,
         {
             match self.content {
-                Content::F32(v) => visitor.visit_f32(v),
-                Content::F64(v) => visitor.visit_f64(v),
                 Content::U8(v) => visitor.visit_u8(v),
                 Content::U16(v) => visitor.visit_u16(v),
                 Content::U32(v) => visitor.visit_u32(v),
@@ -1137,8 +1100,6 @@ mod content {
                 Content::I16(v) => visitor.visit_i16(v),
                 Content::I32(v) => visitor.visit_i32(v),
                 Content::I64(v) => visitor.visit_i64(v),
-                Content::F32(v) => visitor.visit_f32(v),
-                Content::F64(v) => visitor.visit_f64(v),
                 Content::Char(v) => visitor.visit_char(v),
                 Content::String(v) => visitor.visit_string(v),
                 Content::Str(v) => visitor.visit_borrowed_str(v),
@@ -1219,19 +1180,6 @@ mod content {
             self.deserialize_integer(visitor)
         }
 
-        fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-        where
-            V: Visitor<'de>,
-        {
-            self.deserialize_float(visitor)
-        }
-
-        fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-        where
-            V: Visitor<'de>,
-        {
-            self.deserialize_float(visitor)
-        }
 
         fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where
@@ -1553,7 +1501,7 @@ mod content {
         }
 
         serde_core::forward_to_deserialize_any! {
-            bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+            bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 char str string
             bytes byte_buf option unit unit_struct newtype_struct seq tuple
             tuple_struct map struct enum identifier ignored_any
         }
@@ -1680,7 +1628,7 @@ mod content {
         }
 
         serde_core::forward_to_deserialize_any! {
-            bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+            bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 char str string
             bytes byte_buf option unit unit_struct newtype_struct tuple_struct map
             struct enum identifier ignored_any
         }
@@ -1776,7 +1724,7 @@ mod content {
         type Error = E;
 
         serde_core::forward_to_deserialize_any! {
-            bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+            bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 char str string
             bytes byte_buf option unit unit_struct newtype_struct tuple_struct map
             struct enum identifier ignored_any
         }
@@ -2025,8 +1973,6 @@ mod content {
             V: Visitor<'de>,
         {
             match *self.content {
-                Content::F32(v) => visitor.visit_f32(v),
-                Content::F64(v) => visitor.visit_f64(v),
                 Content::U8(v) => visitor.visit_u8(v),
                 Content::U16(v) => visitor.visit_u16(v),
                 Content::U32(v) => visitor.visit_u32(v),
@@ -2091,8 +2037,6 @@ mod content {
                 Content::I16(v) => visitor.visit_i16(v),
                 Content::I32(v) => visitor.visit_i32(v),
                 Content::I64(v) => visitor.visit_i64(v),
-                Content::F32(v) => visitor.visit_f32(v),
-                Content::F64(v) => visitor.visit_f64(v),
                 Content::Char(v) => visitor.visit_char(v),
                 Content::String(ref v) => visitor.visit_str(v),
                 Content::Str(v) => visitor.visit_borrowed_str(v),
@@ -2175,19 +2119,6 @@ mod content {
             self.deserialize_integer(visitor)
         }
 
-        fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-        where
-            V: Visitor<'de>,
-        {
-            self.deserialize_float(visitor)
-        }
-
-        fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-        where
-            V: Visitor<'de>,
-        {
-            self.deserialize_float(visitor)
-        }
 
         fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where
@@ -2511,7 +2442,7 @@ mod content {
         }
 
         serde_core::forward_to_deserialize_any! {
-            bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+            bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 char str string
             bytes byte_buf option unit unit_struct newtype_struct seq tuple
             tuple_struct map struct enum identifier ignored_any
         }
@@ -2626,7 +2557,7 @@ mod content {
         }
 
         serde_core::forward_to_deserialize_any! {
-            bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+            bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 char str string
             bytes byte_buf option unit unit_struct newtype_struct tuple_struct map
             struct enum identifier ignored_any
         }
@@ -2722,7 +2653,7 @@ mod content {
         type Error = E;
 
         serde_core::forward_to_deserialize_any! {
-            bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+            bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 char str string
             bytes byte_buf option unit unit_struct newtype_struct tuple_struct map
             struct enum identifier ignored_any
         }
@@ -3094,7 +3025,7 @@ where
     }
 
     serde_core::forward_to_deserialize_any! {
-        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 char str string
         bytes byte_buf option unit unit_struct newtype_struct seq tuple
         tuple_struct map struct enum identifier ignored_any
     }
@@ -3120,7 +3051,7 @@ where
     }
 
     serde_core::forward_to_deserialize_any! {
-        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 char str string
         bytes byte_buf option unit unit_struct newtype_struct seq tuple
         tuple_struct map struct enum identifier ignored_any
     }
@@ -3326,8 +3257,6 @@ where
         deserialize_u16()
         deserialize_u32()
         deserialize_u64()
-        deserialize_f32()
-        deserialize_f64()
         deserialize_char()
         deserialize_str()
         deserialize_string()

--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -54,6 +54,10 @@ where
             bytes byte_buf unit unit_struct newtype_struct seq tuple
             tuple_struct map struct enum identifier ignored_any
         }
+        #[cfg(feature = "floats")]
+        serde_core::forward_to_deserialize_any! {
+            f32 f64
+        }
     }
 
     let deserializer = MissingFieldDeserializer(field, PhantomData);
@@ -1437,6 +1441,22 @@ mod content {
             let _ = visitor;
             Ok(self.content)
         }
+        #[cfg(feature = "floats")]
+        fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            self.deserialize_float(visitor)
+        }
+
+        #[cfg(feature = "floats")]
+        fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            self.deserialize_float(visitor)
+        }
+
     }
 
     impl<'de, E> ContentDeserializer<'de, E> {
@@ -1504,6 +1524,10 @@ mod content {
             bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 char str string
             bytes byte_buf option unit unit_struct newtype_struct seq tuple
             tuple_struct map struct enum identifier ignored_any
+        }
+        #[cfg(feature = "floats")]
+        serde_core::forward_to_deserialize_any! {
+            f32 f64
         }
     }
 
@@ -1632,6 +1656,10 @@ mod content {
             bytes byte_buf option unit unit_struct newtype_struct tuple_struct map
             struct enum identifier ignored_any
         }
+        #[cfg(feature = "floats")]
+        serde_core::forward_to_deserialize_any! {
+            f32 f64
+        }
     }
 
     #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
@@ -1727,6 +1755,10 @@ mod content {
             bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 char str string
             bytes byte_buf option unit unit_struct newtype_struct tuple_struct map
             struct enum identifier ignored_any
+        }
+        #[cfg(feature = "floats")]
+        serde_core::forward_to_deserialize_any! {
+            f32 f64
         }
 
         fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -2050,6 +2082,10 @@ mod content {
                 }
                 Content::Seq(ref v) => visit_content_seq_ref(v, visitor),
                 Content::Map(ref v) => visit_content_map_ref(v, visitor),
+                #[cfg(feature = "floats")]
+                Content::F32(v) => visitor.visit_f32(v),
+                #[cfg(feature = "floats")]
+                Content::F64(v) => visitor.visit_f64(v),
             }
         }
 
@@ -2119,6 +2155,21 @@ mod content {
             self.deserialize_integer(visitor)
         }
 
+
+        #[cfg(feature = "floats")]
+        fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            self.deserialize_float(visitor)
+        }
+        #[cfg(feature = "floats")]
+        fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            self.deserialize_float(visitor)
+        }
 
         fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where
@@ -2446,6 +2497,10 @@ mod content {
             bytes byte_buf option unit unit_struct newtype_struct seq tuple
             tuple_struct map struct enum identifier ignored_any
         }
+        #[cfg(feature = "floats")]
+        serde_core::forward_to_deserialize_any! {
+            f32 f64
+        }
     }
 
     #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
@@ -2561,6 +2616,10 @@ mod content {
             bytes byte_buf option unit unit_struct newtype_struct tuple_struct map
             struct enum identifier ignored_any
         }
+        #[cfg(feature = "floats")]
+        serde_core::forward_to_deserialize_any! {
+            f32 f64
+        }
     }
 
     #[cfg_attr(not(no_diagnostic_namespace), diagnostic::do_not_recommend)]
@@ -2658,6 +2717,10 @@ mod content {
             struct enum identifier ignored_any
         }
 
+        #[cfg(feature = "floats")]
+        serde_core::forward_to_deserialize_any! {
+            f32 f64
+        }
         fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where
             V: Visitor<'de>,
@@ -3029,6 +3092,11 @@ where
         bytes byte_buf option unit unit_struct newtype_struct seq tuple
         tuple_struct map struct enum identifier ignored_any
     }
+
+    #[cfg(feature = "floats")]
+    serde_core::forward_to_deserialize_any! {
+        f32 f64
+    }
 }
 
 pub struct BorrowedStrDeserializer<'de, E> {
@@ -3054,6 +3122,10 @@ where
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 char str string
         bytes byte_buf option unit unit_struct newtype_struct seq tuple
         tuple_struct map struct enum identifier ignored_any
+    }
+    #[cfg(feature = "floats")]
+    serde_core::forward_to_deserialize_any! {
+        f32 f64
     }
 }
 
@@ -3266,6 +3338,11 @@ where
         deserialize_tuple(usize)
         deserialize_tuple_struct(&'static str, usize)
         deserialize_identifier()
+    }
+    #[cfg(feature = "floats")]
+    forward_to_deserialize_other! {
+        deserialize_f32()
+        deserialize_f64()
     }
 }
 

--- a/serde/src/private/ser.rs
+++ b/serde/src/private/ser.rs
@@ -487,7 +487,9 @@ mod content {
                 Content::I16(i) => serializer.serialize_i16(i),
                 Content::I32(i) => serializer.serialize_i32(i),
                 Content::I64(i) => serializer.serialize_i64(i),
+                #[cfg(feature = "floats")]
                 Content::F32(f) => serializer.serialize_f32(f),
+                #[cfg(feature = "floats")]
                 Content::F64(f) => serializer.serialize_f64(f),
                 Content::Char(c) => serializer.serialize_char(c),
                 Content::String(ref s) => serializer.serialize_str(s),
@@ -1073,11 +1075,12 @@ where
     fn serialize_u64(self, _: u64) -> Result<Self::Ok, Self::Error> {
         Err(Self::bad_type(Unsupported::Integer))
     }
-
+    #[cfg(feature = "floats")]
     fn serialize_f32(self, _: f32) -> Result<Self::Ok, Self::Error> {
         Err(Self::bad_type(Unsupported::Float))
     }
 
+    #[cfg(feature = "floats")]
     fn serialize_f64(self, _: f64) -> Result<Self::Ok, Self::Error> {
         Err(Self::bad_type(Unsupported::Float))
     }

--- a/serde/src/private/ser.rs
+++ b/serde/src/private/ser.rs
@@ -46,6 +46,7 @@ struct TaggedSerializer<S> {
 enum Unsupported {
     Boolean,
     Integer,
+    #[cfg(feature = "floats")]
     Float,
     Char,
     String,
@@ -64,6 +65,7 @@ impl Display for Unsupported {
         match *self {
             Unsupported::Boolean => formatter.write_str("a boolean"),
             Unsupported::Integer => formatter.write_str("an integer"),
+            #[cfg(feature = "floats")]
             Unsupported::Float => formatter.write_str("a float"),
             Unsupported::Char => formatter.write_str("a char"),
             Unsupported::String => formatter.write_str("a string"),
@@ -150,10 +152,12 @@ where
         Err(self.bad_type(Unsupported::Integer))
     }
 
+    #[cfg(feature = "floats")]
     fn serialize_f32(self, _: f32) -> Result<Self::Ok, Self::Error> {
         Err(self.bad_type(Unsupported::Float))
     }
 
+    #[cfg(feature = "floats")]
     fn serialize_f64(self, _: f64) -> Result<Self::Ok, Self::Error> {
         Err(self.bad_type(Unsupported::Float))
     }

--- a/serde/src/private/ser.rs
+++ b/serde/src/private/ser.rs
@@ -439,8 +439,9 @@ mod content {
         I16(i16),
         I32(i32),
         I64(i64),
-
+        #[cfg(feature = "floats")]
         F32(f32),
+        #[cfg(feature = "floats")]
         F64(f64),
 
         Char(char),

--- a/serde/src/private/ser.rs
+++ b/serde/src/private/ser.rs
@@ -614,11 +614,12 @@ mod content {
         fn serialize_u64(self, v: u64) -> Result<Content, E> {
             Ok(Content::U64(v))
         }
-
+        #[cfg(feature = "floats")]
         fn serialize_f32(self, v: f32) -> Result<Content, E> {
             Ok(Content::F32(v))
         }
 
+        #[cfg(feature = "floats")]
         fn serialize_f64(self, v: f64) -> Result<Content, E> {
             Ok(Content::F64(v))
         }

--- a/serde_core/Cargo.toml
+++ b/serde_core/Cargo.toml
@@ -43,7 +43,11 @@ serde_derive = { version = "=1.0.228", path = "../serde_derive" }
 ### FEATURES #################################################################
 
 [features]
-default = ["std", "result"]
+default = ["std", "result", "floats"]
+
+# Provide serialization support for floats
+# Disable this when running in embedded environments that do not support floating point numbers
+floats = []
 
 # Provide impls for common standard library types like Vec<T> and HashMap<K, V>.
 # Requires a dependency on the Rust standard library.

--- a/serde_core/src/crate_root.rs
+++ b/serde_core/src/crate_root.rs
@@ -11,6 +11,7 @@ macro_rules! crate_root {
                 pub use std::*;
             }
 
+            #[cfg(feature = "floats")]
             pub use self::core::{f32, f64};
             pub use self::core::{iter, num, str};
 

--- a/serde_core/src/de/ignored_any.rs
+++ b/serde_core/src/de/ignored_any.rs
@@ -148,6 +148,7 @@ impl<'de> Visitor<'de> for IgnoredAny {
     }
 
     #[inline]
+    #[cfg(feature = "floats")]
     fn visit_f64<E>(self, x: f64) -> Result<Self::Value, E> {
         let _ = x;
         Ok(IgnoredAny)

--- a/serde_core/src/de/impls.rs
+++ b/serde_core/src/de/impls.rs
@@ -219,6 +219,7 @@ macro_rules! num_as_self {
     };
 }
 
+#[cfg(feature = "floats")]
 macro_rules! num_as_copysign_self {
     ($ty:ident : $visit:ident) => {
         #[inline]
@@ -447,6 +448,7 @@ impl_deserialize_num! {
     uint_to_self!(u32:visit_u32 u64:visit_u64);
 }
 
+#[cfg(feature = "floats")]
 impl_deserialize_num! {
     f32, deserialize_f32
     num_self!(f32:visit_f32);
@@ -455,6 +457,7 @@ impl_deserialize_num! {
     num_as_self!(u8:visit_u8 u16:visit_u16 u32:visit_u32 u64:visit_u64);
 }
 
+#[cfg(feature = "floats")]
 impl_deserialize_num! {
     f64, deserialize_f64
     num_self!(f64:visit_f64);

--- a/serde_core/src/de/mod.rs
+++ b/serde_core/src/de/mod.rs
@@ -349,6 +349,7 @@ pub enum Unexpected<'a> {
 
     /// The input contained a floating point `f32` or `f64` that was not
     /// expected.
+    #[cfg(feature = "floats")]
     Float(f64),
 
     /// The input contained a `char` that was not expected.
@@ -405,6 +406,7 @@ impl<'a> fmt::Display for Unexpected<'a> {
             Bool(b) => write!(formatter, "boolean `{}`", b),
             Unsigned(i) => write!(formatter, "integer `{}`", i),
             Signed(i) => write!(formatter, "integer `{}`", i),
+            #[cfg(feature = "floats")]
             Float(f) => write!(formatter, "floating point `{}`", WithDecimalPoint(f)),
             Char(c) => write!(formatter, "character `{}`", c),
             Str(s) => write!(formatter, "string {:?}", s),
@@ -1028,11 +1030,13 @@ pub trait Deserializer<'de>: Sized {
     }
 
     /// Hint that the `Deserialize` type is expecting a `f32` value.
+    #[cfg(feature = "floats")]
     fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>;
 
     /// Hint that the `Deserialize` type is expecting a `f64` value.
+    #[cfg(feature = "floats")]
     fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>;
@@ -1481,6 +1485,7 @@ pub trait Visitor<'de>: Sized {
     /// The default implementation forwards to [`visit_f64`].
     ///
     /// [`visit_f64`]: #method.visit_f64
+    #[cfg(feature = "floats")]
     fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E>
     where
         E: Error,
@@ -1491,6 +1496,7 @@ pub trait Visitor<'de>: Sized {
     /// The input contains an `f64`.
     ///
     /// The default implementation fails with a type error.
+    #[cfg(feature = "floats")]
     fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
     where
         E: Error,
@@ -2354,8 +2360,10 @@ impl Display for OneOf {
     }
 }
 
+#[cfg(feature = "floats")]
 struct WithDecimalPoint(f64);
 
+#[cfg(feature = "floats")]
 impl Display for WithDecimalPoint {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         struct LookForDecimalPoint<'f, 'a> {

--- a/serde_core/src/de/value.rs
+++ b/serde_core/src/de/value.rs
@@ -337,7 +337,9 @@ primitive_deserializer!(u16, "a `u16`.", U16Deserializer, visit_u16);
 primitive_deserializer!(u64, "a `u64`.", U64Deserializer, visit_u64);
 primitive_deserializer!(u128, "a `u128`.", U128Deserializer, visit_u128);
 primitive_deserializer!(usize, "a `usize`.", UsizeDeserializer, visit_u64 as u64);
+#[cfg(feature = "floats")]
 primitive_deserializer!(f32, "an `f32`.", F32Deserializer, visit_f32);
+#[cfg(feature = "floats")]
 primitive_deserializer!(f64, "an `f64`.", F64Deserializer, visit_f64);
 primitive_deserializer!(char, "a `char`.", CharDeserializer, visit_char);
 
@@ -1060,9 +1062,13 @@ where
     }
 
     forward_to_deserialize_any! {
-        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 char str string
         bytes byte_buf option unit unit_struct newtype_struct seq tuple
         tuple_struct map struct enum identifier ignored_any
+    }
+    #[cfg(feature = "floats")]
+    forward_to_deserialize_any! {
+        f32 f64
     }
 }
 

--- a/serde_core/src/macros.rs
+++ b/serde_core/src/macros.rs
@@ -171,9 +171,11 @@ macro_rules! forward_to_deserialize_any_helper {
         forward_to_deserialize_any_method!{deserialize_u128<$l, $v>()}
     };
     (f32<$l:tt, $v:ident>) => {
+        #[cfg(feature = "floats")]
         forward_to_deserialize_any_method!{deserialize_f32<$l, $v>()}
     };
     (f64<$l:tt, $v:ident>) => {
+        #[cfg(feature = "floats")]
         forward_to_deserialize_any_method!{deserialize_f64<$l, $v>()}
     };
     (char<$l:tt, $v:ident>) => {

--- a/serde_core/src/private/content.rs
+++ b/serde_core/src/private/content.rs
@@ -14,7 +14,10 @@ pub enum Content<'de> {
     U16(u16),
     U32(u32),
     U64(u64),
-
+    #[cfg(feature = "floats")]
+    F32(f32),
+    #[cfg(feature = "floats")]
+    F64(f64),
     I8(i8),
     I16(i16),
     I32(i32),

--- a/serde_core/src/private/content.rs
+++ b/serde_core/src/private/content.rs
@@ -19,10 +19,6 @@ pub enum Content<'de> {
     I16(i16),
     I32(i32),
     I64(i64),
-
-    F32(f32),
-    F64(f64),
-
     Char(char),
     String(String),
     Str(&'de str),

--- a/serde_core/src/ser/fmt.rs
+++ b/serde_core/src/ser/fmt.rs
@@ -58,11 +58,14 @@ impl<'a> Serializer for &mut fmt::Formatter<'a> {
         serialize_u32: u32,
         serialize_u64: u64,
         serialize_u128: u128,
-        serialize_f32: f32,
-        serialize_f64: f64,
         serialize_char: char,
         serialize_str: &str,
         serialize_unit_struct: &'static str,
+    }
+    #[cfg(feature = "floats")]
+    fmt_primitives! {
+        serialize_f32: f32,
+        serialize_f64: f64,
     }
 
     fn serialize_unit_variant(

--- a/serde_core/src/ser/impls.rs
+++ b/serde_core/src/ser/impls.rs
@@ -31,7 +31,9 @@ primitive_impl!(u16, serialize_u16);
 primitive_impl!(u32, serialize_u32);
 primitive_impl!(u64, serialize_u64);
 primitive_impl!(u128, serialize_u128);
+#[cfg(feature = "floats")]
 primitive_impl!(f32, serialize_f32);
+#[cfg(feature = "floats")]
 primitive_impl!(f64, serialize_f64);
 primitive_impl!(char, serialize_char);
 

--- a/serde_core/src/ser/mod.rs
+++ b/serde_core/src/ser/mod.rs
@@ -660,6 +660,7 @@ pub trait Serializer: Sized {
     ///     }
     /// }
     /// ```
+    #[cfg(feature = "floats")]
     fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error>;
 
     /// Serialize an `f64` value.
@@ -678,6 +679,7 @@ pub trait Serializer: Sized {
     ///     }
     /// }
     /// ```
+    #[cfg(feature = "floats")]
     fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error>;
 
     /// Serialize a character.


### PR DESCRIPTION
This pull request adds a new `floats` feature that allows serde to be used in environments where floating point numbers are not available, in my case, it is the linux kernel, i'm coding a linux module in rust and it doesn't support floating point numbers.
It's a really straight forward fix, I just added a floats feature and added `#[cfg(feature = "floats")]` everywhere floats are used