### PR TITLE
Match untagged unit variant against an empty map or seq

### DIFF
--- a/serde/src/private/de.rs
+++ b/serde/src/private/de.rs
@@ -3039,6 +3039,34 @@ mod content {
         {
             Ok(())
         }
+
+        // An empty seq is treated as unit so that a unit variant of an untagged
+        // enum is reachable for formats that present "no data" as an empty seq.
+        // A non-empty seq must not be silently accepted as a unit variant.
+        fn visit_seq<A>(self, mut seq: A) -> Result<(), A::Error>
+        where
+            A: SeqAccess<'de>,
+        {
+            match tri!(seq.next_element::<IgnoredAny>()) {
+                None => Ok(()),
+                Some(_) => Err(de::Error::invalid_type(Unexpected::Seq, &self)),
+            }
+        }
+
+        // An empty map is treated as unit so that a unit variant of an untagged
+        // enum is reachable. This is what makes a unit variant work behind
+        // `flatten`, where the absence of fields is presented as an empty map
+        // rather than as unit. See https://github.com/serde-rs/serde/issues/1374
+        // A non-empty map must not be silently accepted as a unit variant.
+        fn visit_map<A>(self, mut map: A) -> Result<(), A::Error>
+        where
+            A: MapAccess<'de>,
+        {
+            match tri!(map.next_key::<IgnoredAny>()) {
+                None => Ok(()),
+                Some(_) => Err(de::Error::invalid_type(Unexpected::Map, &self)),
+            }
+        }
     }
 }
 

--- a/test_suite/tests/test_enum_untagged.rs
+++ b/test_suite/tests/test_enum_untagged.rs
@@ -570,6 +570,109 @@ fn contains_flatten_with_integer_key() {
     );
 }
 
+// https://github.com/serde-rs/serde/issues/1374
+//
+// A unit variant of an untagged enum must be reachable when the input is an
+// empty map (or empty seq), not only when it is `unit`/`none`. This shows up in
+// particular together with `flatten`, where "no remaining fields" is presented
+// to the enum as an empty map rather than as a unit.
+#[test]
+fn unit_variant_from_empty_map() {
+    #[derive(Debug, PartialEq, Deserialize)]
+    #[serde(untagged)]
+    enum Untagged {
+        NonEmpty { key: u16 },
+        Empty,
+    }
+
+    // Empty map falls through the struct variant and matches the unit variant.
+    assert_de_tokens(
+        &Untagged::Empty,
+        &[Token::Map { len: Some(0) }, Token::MapEnd],
+    );
+
+    // Empty seq matches the unit variant as well.
+    assert_de_tokens(
+        &Untagged::Empty,
+        &[Token::Seq { len: Some(0) }, Token::SeqEnd],
+    );
+
+    // The struct variant still wins when its fields are present.
+    assert_de_tokens(
+        &Untagged::NonEmpty { key: 12 },
+        &[
+            Token::Map { len: Some(1) },
+            Token::Str("key"),
+            Token::U16(12),
+            Token::MapEnd,
+        ],
+    );
+
+    // A non-empty map that does not match the struct variant must not be
+    // silently swallowed by the unit variant.
+    assert_de_tokens_error::<Untagged>(
+        &[
+            Token::Map { len: Some(1) },
+            Token::Str("unknown"),
+            Token::U16(12),
+            Token::MapEnd,
+        ],
+        "data did not match any variant of untagged enum Untagged",
+    );
+}
+
+#[test]
+fn flatten_unit_variant() {
+    #[derive(Debug, PartialEq, Deserialize)]
+    struct Container {
+        other: u16,
+        #[serde(flatten)]
+        inner: DeEnum,
+    }
+
+    #[derive(Debug, PartialEq, Deserialize)]
+    #[serde(untagged)]
+    enum DeEnum {
+        NonEmpty(NonEmpty),
+        Empty,
+    }
+
+    #[derive(Debug, PartialEq, Deserialize)]
+    struct NonEmpty {
+        key: u16,
+    }
+
+    // Flattened field present -> non-empty variant.
+    assert_de_tokens(
+        &Container {
+            other: 12,
+            inner: DeEnum::NonEmpty(NonEmpty { key: 34 }),
+        },
+        &[
+            Token::Map { len: None },
+            Token::Str("other"),
+            Token::U16(12),
+            Token::Str("key"),
+            Token::U16(34),
+            Token::MapEnd,
+        ],
+    );
+
+    // Flattened field absent -> the empty unit variant, instead of failing.
+    assert_de_tokens(
+        &Container {
+            other: 12,
+            inner: DeEnum::Empty,
+        },
+        &[
+            Token::Map { len: None },
+            Token::Str("other"),
+            Token::U16(12),
+            Token::MapEnd,
+        ],
+    );
+}
+
 #[test]
 fn expecting_message() {
     #[derive(Deserialize)]


### PR DESCRIPTION
Fixes #1374

Generated by Claude:

## Problem

A unit variant of a `#[serde(untagged)]` enum was only reachable when the
buffered content was `unit`/`none`. When the content was an empty map (or empty
seq), the variant could not be matched and deserialization failed — even though
a unit variant logically represents "no data".

This is most visible together with `#[serde(flatten)]`. When a flattened field
has no remaining keys, the flattened enum is handed an **empty map**, not a
unit, so a unit variant behind `flatten` was impossible to reach:

```rust
#[derive(Deserialize)]
struct Container {
    other: u16,
    #[serde(flatten)]
    inner: DeEnum,
}

#[derive(Deserialize)]
#[serde(untagged)]
enum DeEnum {
    NonEmpty(NonEmpty),
    Empty, // <-- never matched when the flattened fields are absent
}

#[derive(Deserialize)]
struct NonEmpty {
    key: u16,
}
```

Deserializing input that lacks `key` failed with *"data did not match any
variant"* instead of producing `DeEnum::Empty`. The documented workaround was to
replace the unit variant `Empty` with an empty struct variant `Empty {}`.

## Cause

Untagged enums buffer the input into a `Content` and try each variant via
`ContentRefDeserializer`. A unit variant is deserialized through
`UntaggedUnitVisitor`, which only implemented `visit_unit` and `visit_none`. For
`Content::Map([])`, `deserialize_any` dispatches to `visit_map`, hitting the
default `visit_map` and erroring with *"invalid type: map, expected unit
variant"*.

## Fix

Teach `UntaggedUnitVisitor` to accept an **empty** map or **empty** seq as unit.
A **non-empty** map or seq is still rejected (`invalid_type`), so data is never
silently dropped when a preceding variant fails for an unrelated reason.

## Tests

Added two tests in `test_suite/tests/test_enum_untagged.rs`:

- `unit_variant_from_empty_map` — an empty map/seq matches the unit variant; the
  struct variant still wins when its fields are present; a non-empty unknown map
  still fails (no silent data loss).
- `flatten_unit_variant` — the exact scenario from the issue, with a flattened
  untagged enum.

Both tests fail before the change and pass after it. The full `serde_test_suite`
is green and `cargo clippy` is clean.