### PR TITLE
docs: modify serde yaml repo

### DIFF
--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -68,7 +68,7 @@
 //! [JSON]: https://github.com/serde-rs/json
 //! [Postcard]: https://github.com/jamesmunns/postcard
 //! [CBOR]: https://github.com/enarx/ciborium
-//! [YAML]: https://github.com/dtolnay/serde-yaml
+//! [YAML]: https://github.com/yaml/yaml-serde
 //! [MessagePack]: https://github.com/3Hren/msgpack-rust
 //! [TOML]: https://docs.rs/toml
 //! [Pickle]: https://github.com/birkenfeld/serde-pickle


### PR DESCRIPTION
Hi!

the [`serde-yaml`](https://github.com/dtolnay/serde-yaml) crate is now unmaintained since Mar 25, 2024.

A new crate, [`yaml-serde`](https://github.com/yaml/yaml-serde), which is a fork of the original `serde-yaml` is now available.

This PR updates the link in the docs.