### PR TITLE
Guard IgnoredAny against unbounded recursion

### DIFF
--- a/serde_core/src/de/ignored_any.rs
+++ b/serde_core/src/de/ignored_any.rs
@@ -1,7 +1,8 @@
 use crate::lib::*;
 
 use crate::de::{
-    Deserialize, Deserializer, EnumAccess, Error, MapAccess, SeqAccess, VariantAccess, Visitor,
+    Deserialize, DeserializeSeed, Deserializer, EnumAccess, Error, MapAccess, SeqAccess,
+    VariantAccess, Visitor,
 };
 
 /// An efficient way of discarding data from a deserializer.
@@ -110,69 +111,123 @@ use crate::de::{
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
 pub struct IgnoredAny;
 
-impl<'de> Visitor<'de> for IgnoredAny {
-    type Value = IgnoredAny;
+// Bound the recursion so that ignoring an already constructed, deeply nested
+// structure errors out rather than exhausting the stack and aborting.
+const RECURSION_LIMIT: u32 = 128;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("anything at all")
-    }
+// The scalar visits are the same whether or not recursion depth is being
+// tracked, so both `IgnoredAny` and `IgnoredAnyDepth` share them from here.
+macro_rules! ignored_scalars {
+    () => {
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("anything at all")
+        }
 
+        #[inline]
+        fn visit_bool<E>(self, x: bool) -> Result<Self::Value, E> {
+            let _ = x;
+            Ok(IgnoredAny)
+        }
+
+        #[inline]
+        fn visit_i64<E>(self, x: i64) -> Result<Self::Value, E> {
+            let _ = x;
+            Ok(IgnoredAny)
+        }
+
+        #[inline]
+        fn visit_i128<E>(self, x: i128) -> Result<Self::Value, E> {
+            let _ = x;
+            Ok(IgnoredAny)
+        }
+
+        #[inline]
+        fn visit_u64<E>(self, x: u64) -> Result<Self::Value, E> {
+            let _ = x;
+            Ok(IgnoredAny)
+        }
+
+        #[inline]
+        fn visit_u128<E>(self, x: u128) -> Result<Self::Value, E> {
+            let _ = x;
+            Ok(IgnoredAny)
+        }
+
+        #[inline]
+        fn visit_f64<E>(self, x: f64) -> Result<Self::Value, E> {
+            let _ = x;
+            Ok(IgnoredAny)
+        }
+
+        #[inline]
+        fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+        where
+            E: Error,
+        {
+            let _ = s;
+            Ok(IgnoredAny)
+        }
+
+        #[inline]
+        fn visit_bytes<E>(self, bytes: &[u8]) -> Result<Self::Value, E>
+        where
+            E: Error,
+        {
+            let _ = bytes;
+            Ok(IgnoredAny)
+        }
+
+        #[inline]
+        fn visit_none<E>(self) -> Result<Self::Value, E> {
+            Ok(IgnoredAny)
+        }
+
+        #[inline]
+        fn visit_unit<E>(self) -> Result<Self::Value, E> {
+            Ok(IgnoredAny)
+        }
+    };
+}
+
+#[derive(Copy, Clone)]
+struct IgnoredAnyDepth(u32);
+
+impl IgnoredAnyDepth {
     #[inline]
-    fn visit_bool<E>(self, x: bool) -> Result<Self::Value, E> {
-        let _ = x;
-        Ok(IgnoredAny)
-    }
-
-    #[inline]
-    fn visit_i64<E>(self, x: i64) -> Result<Self::Value, E> {
-        let _ = x;
-        Ok(IgnoredAny)
-    }
-
-    #[inline]
-    fn visit_i128<E>(self, x: i128) -> Result<Self::Value, E> {
-        let _ = x;
-        Ok(IgnoredAny)
-    }
-
-    #[inline]
-    fn visit_u64<E>(self, x: u64) -> Result<Self::Value, E> {
-        let _ = x;
-        Ok(IgnoredAny)
-    }
-
-    #[inline]
-    fn visit_u128<E>(self, x: u128) -> Result<Self::Value, E> {
-        let _ = x;
-        Ok(IgnoredAny)
-    }
-
-    #[inline]
-    fn visit_f64<E>(self, x: f64) -> Result<Self::Value, E> {
-        let _ = x;
-        Ok(IgnoredAny)
-    }
-
-    #[inline]
-    fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+    fn descend<E>(&self) -> Result<u32, E>
     where
         E: Error,
     {
-        let _ = s;
-        Ok(IgnoredAny)
+        match self.0.checked_sub(1) {
+            Some(remaining) => Ok(remaining),
+            None => Err(E::custom("recursion limit exceeded")),
+        }
     }
+}
+
+impl<'de> DeserializeSeed<'de> for IgnoredAnyDepth {
+    type Value = IgnoredAny;
 
     #[inline]
-    fn visit_none<E>(self) -> Result<Self::Value, E> {
-        Ok(IgnoredAny)
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_ignored_any(self)
     }
+}
+
+impl<'de> Visitor<'de> for IgnoredAnyDepth {
+    type Value = IgnoredAny;
+
+    ignored_scalars!();
 
     #[inline]
     fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
     where
         D: Deserializer<'de>,
     {
-        IgnoredAny::deserialize(deserializer)
+        deserializer.deserialize_ignored_any(self)
     }
 
     #[inline]
@@ -180,12 +235,7 @@ impl<'de> Visitor<'de> for IgnoredAny {
     where
         D: Deserializer<'de>,
     {
-        IgnoredAny::deserialize(deserializer)
-    }
-
-    #[inline]
-    fn visit_unit<E>(self) -> Result<Self::Value, E> {
-        Ok(IgnoredAny)
+        deserializer.deserialize_ignored_any(self)
     }
 
     #[inline]
@@ -193,7 +243,8 @@ impl<'de> Visitor<'de> for IgnoredAny {
     where
         A: SeqAccess<'de>,
     {
-        while let Some(IgnoredAny) = tri!(seq.next_element()) {
+        let seed = IgnoredAnyDepth(tri!(self.descend()));
+        while tri!(seq.next_element_seed(seed)).is_some() {
             // Gobble
         }
         Ok(IgnoredAny)
@@ -204,18 +255,10 @@ impl<'de> Visitor<'de> for IgnoredAny {
     where
         A: MapAccess<'de>,
     {
-        while let Some((IgnoredAny, IgnoredAny)) = tri!(map.next_entry()) {
-            // Gobble
+        let depth = tri!(self.descend());
+        while tri!(map.next_key::<IgnoredAny>()).is_some() {
+            tri!(map.next_value_seed(IgnoredAnyDepth(depth)));
         }
-        Ok(IgnoredAny)
-    }
-
-    #[inline]
-    fn visit_bytes<E>(self, bytes: &[u8]) -> Result<Self::Value, E>
-    where
-        E: Error,
-    {
-        let _ = bytes;
         Ok(IgnoredAny)
     }
 
@@ -223,7 +266,55 @@ impl<'de> Visitor<'de> for IgnoredAny {
     where
         A: EnumAccess<'de>,
     {
-        tri!(data.variant::<IgnoredAny>()).1.newtype_variant()
+        let depth = tri!(self.descend());
+        tri!(data.variant::<IgnoredAny>())
+            .1
+            .newtype_variant_seed(IgnoredAnyDepth(depth))
+    }
+}
+
+impl<'de> Visitor<'de> for IgnoredAny {
+    type Value = IgnoredAny;
+
+    ignored_scalars!();
+
+    #[inline]
+    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_ignored_any(IgnoredAnyDepth(RECURSION_LIMIT))
+    }
+
+    #[inline]
+    fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_ignored_any(IgnoredAnyDepth(RECURSION_LIMIT))
+    }
+
+    #[inline]
+    fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        IgnoredAnyDepth(RECURSION_LIMIT).visit_seq(seq)
+    }
+
+    #[inline]
+    fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        IgnoredAnyDepth(RECURSION_LIMIT).visit_map(map)
+    }
+
+    fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+    where
+        A: EnumAccess<'de>,
+    {
+        IgnoredAnyDepth(RECURSION_LIMIT).visit_enum(data)
     }
 }
 

--- a/test_suite/tests/test_ignored_any.rs
+++ b/test_suite/tests/test_ignored_any.rs
@@ -7,6 +7,7 @@ use serde::de::{
 };
 use serde::forward_to_deserialize_any;
 use serde_derive::Deserialize;
+use std::iter;
 
 #[derive(PartialEq, Debug, Deserialize)]
 enum Target {
@@ -105,4 +106,43 @@ fn test_deserialize_enum() {
     IgnoredAny::deserialize(Enum("Newtype")).unwrap();
     IgnoredAny::deserialize(Enum("Tuple")).unwrap();
     IgnoredAny::deserialize(Enum("Struct")).unwrap();
+}
+
+// A deserializer that nests single-element sequences without itself recursing,
+// so the recursion happens entirely inside IgnoredAny.
+struct Nested(u32);
+
+impl<'de> Deserializer<'de> for Nested {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.0 {
+            0 => visitor.visit_unit(),
+            remaining => visitor.visit_seq(SeqDeserializer::new(iter::once(Nested(remaining - 1)))),
+        }
+    }
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct map struct enum identifier ignored_any
+    }
+}
+
+impl<'de> IntoDeserializer<'de, Error> for Nested {
+    type Deserializer = Self;
+
+    fn into_deserializer(self) -> Self {
+        self
+    }
+}
+
+// Regression test for https://github.com/serde-rs/serde/issues/3023.
+#[test]
+fn test_ignored_any_recursion_limit() {
+    IgnoredAny::deserialize(Nested(64)).unwrap();
+    IgnoredAny::deserialize(Nested(100_000)).unwrap_err();
 }


### PR DESCRIPTION
Deserializing a deeply nested value into `IgnoredAny` recurses once per level of nesting. When the deserializer forwards `deserialize_ignored_any` to a recursive `deserialize_any` (rather than short-circuiting it, as `serde_json::Value` does), this exhausts the thread stack and aborts the process.

This threads a recursion depth through an internal seed so that `IgnoredAny` returns a deserialization error once a depth limit is reached instead of overflowing the stack.

Closes #3023.