### PR TITLE
Feat: Add   independent_number  support for   rename_all  attributes

### DIFF
--- a/serde_derive/src/internals/attr.rs
+++ b/serde_derive/src/internals/attr.rs
@@ -138,6 +138,7 @@ fn unraw(ident: &Ident) -> Ident {
 pub struct RenameAllRules {
     pub serialize: RenameRule,
     pub deserialize: RenameRule,
+    pub independent_number: Option<bool>,
 }
 
 impl RenameAllRules {
@@ -147,6 +148,7 @@ impl RenameAllRules {
         Self {
             serialize: self.serialize.or(other_rules.serialize),
             deserialize: self.deserialize.or(other_rules.deserialize),
+            independent_number: self.independent_number.or(other_rules.independent_number),
         }
     }
 }
@@ -244,6 +246,7 @@ impl Container {
         let mut rename_all_de_rule = Attr::none(cx, RENAME_ALL);
         let mut rename_all_fields_ser_rule = Attr::none(cx, RENAME_ALL_FIELDS);
         let mut rename_all_fields_de_rule = Attr::none(cx, RENAME_ALL_FIELDS);
+        let mut independent_number = Attr::none(cx, INDEPENDENT_NUMBER);
         let mut ser_bound = Attr::none(cx, BOUND);
         let mut de_bound = Attr::none(cx, BOUND);
         let mut untagged = BoolAttr::none(cx, UNTAGGED);
@@ -490,6 +493,13 @@ impl Container {
                     if let Some(s) = get_lit_str(cx, EXPECTING, &meta)? {
                         expecting.set(&meta.path, s.value());
                     }
+                } else if meta.path == INDEPENDENT_NUMBER {
+                    if meta.input.peek(Token![=]) {
+                        let lit: syn::LitBool = meta.value()?.parse()?;
+                        independent_number.set(&meta.path, lit.value);
+                    } else {
+                        independent_number.set(&meta.path, true);
+                    }
                 } else {
                     let path = meta.path.to_token_stream().to_string().replace(' ', "");
                     return Err(
@@ -516,6 +526,7 @@ impl Container {
             }
         }
 
+        let independent_number = independent_number.get();
         Container {
             name: MultiName::from_attrs(Name::from(&unraw(&item.ident)), ser_name, de_name, None),
             transparent: transparent.get(),
@@ -524,10 +535,12 @@ impl Container {
             rename_all_rules: RenameAllRules {
                 serialize: rename_all_ser_rule.get().unwrap_or(RenameRule::None),
                 deserialize: rename_all_de_rule.get().unwrap_or(RenameRule::None),
+                independent_number,
             },
             rename_all_fields_rules: RenameAllRules {
                 serialize: rename_all_fields_ser_rule.get().unwrap_or(RenameRule::None),
                 deserialize: rename_all_fields_de_rule.get().unwrap_or(RenameRule::None),
+                independent_number,
             },
             ser_bound: ser_bound.get(),
             de_bound: de_bound.get(),
@@ -753,6 +766,7 @@ impl Variant {
         let mut skip_serializing = BoolAttr::none(cx, SKIP_SERIALIZING);
         let mut rename_all_ser_rule = Attr::none(cx, RENAME_ALL);
         let mut rename_all_de_rule = Attr::none(cx, RENAME_ALL);
+        let mut variant_independent_number = Attr::none(cx, INDEPENDENT_NUMBER);
         let mut ser_bound = Attr::none(cx, BOUND);
         let mut de_bound = Attr::none(cx, BOUND);
         let mut other = BoolAttr::none(cx, OTHER);
@@ -879,6 +893,13 @@ impl Variant {
                     }
                 } else if meta.path == UNTAGGED {
                     untagged.set_true(&meta.path);
+                } else if meta.path == INDEPENDENT_NUMBER {
+                    if meta.input.peek(Token![=]) {
+                        let lit: syn::LitBool = meta.value()?.parse()?;
+                        variant_independent_number.set(&meta.path, lit.value);
+                    } else {
+                        variant_independent_number.set(&meta.path, true);
+                    }
                 } else {
                     let path = meta.path.to_token_stream().to_string().replace(' ', "");
                     return Err(
@@ -901,6 +922,7 @@ impl Variant {
             rename_all_rules: RenameAllRules {
                 serialize: rename_all_ser_rule.get().unwrap_or(RenameRule::None),
                 deserialize: rename_all_de_rule.get().unwrap_or(RenameRule::None),
+                independent_number: variant_independent_number.get(),
             },
             ser_bound: ser_bound.get(),
             de_bound: de_bound.get(),
@@ -923,14 +945,16 @@ impl Variant {
     }
 
     pub fn rename_by_rules(&mut self, rules: RenameAllRules) {
+        let ind = rules.independent_number.unwrap_or(false);
         if !self.name.serialize_renamed {
-            self.name.serialize.value =
-                rules.serialize.apply_to_variant(&self.name.serialize.value);
+            self.name.serialize.value = rules
+                .serialize
+                .apply_to_variant(&self.name.serialize.value, ind);
         }
         if !self.name.deserialize_renamed {
             self.name.deserialize.value = rules
                 .deserialize
-                .apply_to_variant(&self.name.deserialize.value);
+                .apply_to_variant(&self.name.deserialize.value, ind);
         }
         self.name
             .deserialize_aliases
@@ -1270,13 +1294,16 @@ impl Field {
     }
 
     pub fn rename_by_rules(&mut self, rules: RenameAllRules) {
+        let ind = rules.independent_number.unwrap_or(false);
         if !self.name.serialize_renamed {
-            self.name.serialize.value = rules.serialize.apply_to_field(&self.name.serialize.value);
+            self.name.serialize.value = rules
+                .serialize
+                .apply_to_field(&self.name.serialize.value, ind);
         }
         if !self.name.deserialize_renamed {
             self.name.deserialize.value = rules
                 .deserialize
-                .apply_to_field(&self.name.deserialize.value);
+                .apply_to_field(&self.name.deserialize.value, ind);
         }
         self.name
             .deserialize_aliases

--- a/serde_derive/src/internals/case.rs
+++ b/serde_derive/src/internals/case.rs
@@ -54,7 +54,7 @@ impl RenameRule {
     }
 
     /// Apply a renaming rule to an enum variant, returning the version expected in the source.
-    pub fn apply_to_variant(self, variant: &str) -> String {
+    pub fn apply_to_variant(self, variant: &str, independent_number: bool) -> String {
         match self {
             None | PascalCase => variant.to_owned(),
             LowerCase => variant.to_ascii_lowercase(),
@@ -62,26 +62,39 @@ impl RenameRule {
             CamelCase => variant[..1].to_ascii_lowercase() + &variant[1..],
             SnakeCase => {
                 let mut snake = String::new();
-                for (i, ch) in variant.char_indices() {
-                    if i > 0 && ch.is_uppercase() {
-                        snake.push('_');
+                let mut prev_ch: Option<char> = Option::None;
+                for ch in variant.chars() {
+                    if let Some(prev) = prev_ch {
+                        let mut needs_underscore = ch.is_uppercase();
+                        if independent_number && !needs_underscore {
+                            needs_underscore = (prev.is_ascii_digit() && ch.is_ascii_alphabetic())
+                                || (prev.is_ascii_alphabetic() && ch.is_ascii_digit());
+                        }
+                        if needs_underscore {
+                            snake.push('_');
+                        }
                     }
                     snake.push(ch.to_ascii_lowercase());
+                    prev_ch = Some(ch);
                 }
                 snake
             }
-            ScreamingSnakeCase => SnakeCase.apply_to_variant(variant).to_ascii_uppercase(),
-            KebabCase => SnakeCase.apply_to_variant(variant).replace('_', "-"),
+            ScreamingSnakeCase => SnakeCase
+                .apply_to_variant(variant, independent_number)
+                .to_ascii_uppercase(),
+            KebabCase => SnakeCase
+                .apply_to_variant(variant, independent_number)
+                .replace('_', "-"),
             ScreamingKebabCase => ScreamingSnakeCase
-                .apply_to_variant(variant)
+                .apply_to_variant(variant, independent_number)
                 .replace('_', "-"),
         }
     }
 
     /// Apply a renaming rule to a struct field, returning the version expected in the source.
-    pub fn apply_to_field(self, field: &str) -> String {
+    pub fn apply_to_field(self, field: &str, independent_number: bool) -> String {
         match self {
-            None | LowerCase | SnakeCase => field.to_owned(),
+            None | LowerCase => field.to_owned(),
             UpperCase => field.to_ascii_uppercase(),
             PascalCase => {
                 let mut pascal = String::new();
@@ -99,12 +112,50 @@ impl RenameRule {
                 pascal
             }
             CamelCase => {
-                let pascal = PascalCase.apply_to_field(field);
+                let pascal = PascalCase.apply_to_field(field, independent_number);
                 pascal[..1].to_ascii_lowercase() + &pascal[1..]
             }
-            ScreamingSnakeCase => field.to_ascii_uppercase(),
-            KebabCase => field.replace('_', "-"),
-            ScreamingKebabCase => ScreamingSnakeCase.apply_to_field(field).replace('_', "-"),
+            SnakeCase => {
+                if independent_number {
+                    let mut snake = String::new();
+                    let mut prev_ch: Option<char> = Option::None;
+                    for ch in field.chars() {
+                        if let Some(prev) = prev_ch {
+                            let mut needs_underscore = ch.is_uppercase();
+                            if !needs_underscore {
+                                needs_underscore = (prev.is_ascii_digit()
+                                    && ch.is_ascii_alphabetic())
+                                    || (prev.is_ascii_alphabetic() && ch.is_ascii_digit());
+                            }
+                            if needs_underscore {
+                                snake.push('_');
+                            }
+                        }
+                        snake.push(ch.to_ascii_lowercase());
+                        prev_ch = Some(ch);
+                    }
+                    snake
+                } else {
+                    field.to_owned()
+                }
+            }
+            ScreamingSnakeCase => {
+                if independent_number {
+                    SnakeCase.apply_to_field(field, true).to_ascii_uppercase()
+                } else {
+                    field.to_ascii_uppercase()
+                }
+            }
+            KebabCase => {
+                if independent_number {
+                    SnakeCase.apply_to_field(field, true).replace('_', "-")
+                } else {
+                    field.replace('_', "-")
+                }
+            }
+            ScreamingKebabCase => ScreamingSnakeCase
+                .apply_to_field(field, independent_number)
+                .replace('_', "-"),
         }
     }
 
@@ -155,19 +206,40 @@ fn rename_variants() {
         ("A", "a", "A", "a", "a", "A", "a", "A"),
         ("Z42", "z42", "Z42", "z42", "z42", "Z42", "z42", "Z42"),
     ] {
-        assert_eq!(None.apply_to_variant(original), original);
-        assert_eq!(LowerCase.apply_to_variant(original), lower);
-        assert_eq!(UpperCase.apply_to_variant(original), upper);
-        assert_eq!(PascalCase.apply_to_variant(original), original);
-        assert_eq!(CamelCase.apply_to_variant(original), camel);
-        assert_eq!(SnakeCase.apply_to_variant(original), snake);
-        assert_eq!(ScreamingSnakeCase.apply_to_variant(original), screaming);
-        assert_eq!(KebabCase.apply_to_variant(original), kebab);
+        assert_eq!(None.apply_to_variant(original, false), original);
+        assert_eq!(LowerCase.apply_to_variant(original, false), lower);
+        assert_eq!(UpperCase.apply_to_variant(original, false), upper);
+        assert_eq!(PascalCase.apply_to_variant(original, false), original);
+        assert_eq!(CamelCase.apply_to_variant(original, false), camel);
+        assert_eq!(SnakeCase.apply_to_variant(original, false), snake);
         assert_eq!(
-            ScreamingKebabCase.apply_to_variant(original),
+            ScreamingSnakeCase.apply_to_variant(original, false),
+            screaming
+        );
+        assert_eq!(KebabCase.apply_to_variant(original, false), kebab);
+        assert_eq!(
+            ScreamingKebabCase.apply_to_variant(original, false),
             screaming_kebab
         );
     }
+
+    // Test independent_number = true
+    assert_eq!(
+        SnakeCase.apply_to_variant("Have1Apple", true),
+        "have_1_apple"
+    );
+    assert_eq!(
+        KebabCase.apply_to_variant("Have1Apple", true),
+        "have-1-apple"
+    );
+    assert_eq!(
+        ScreamingSnakeCase.apply_to_variant("Have1Apple", true),
+        "HAVE_1_APPLE"
+    );
+    assert_eq!(
+        ScreamingKebabCase.apply_to_variant("Have1Apple", true),
+        "HAVE-1-APPLE"
+    );
 }
 
 #[test]
@@ -188,13 +260,31 @@ fn rename_fields() {
         ("a", "A", "A", "a", "A", "a", "A"),
         ("z42", "Z42", "Z42", "z42", "Z42", "z42", "Z42"),
     ] {
-        assert_eq!(None.apply_to_field(original), original);
-        assert_eq!(UpperCase.apply_to_field(original), upper);
-        assert_eq!(PascalCase.apply_to_field(original), pascal);
-        assert_eq!(CamelCase.apply_to_field(original), camel);
-        assert_eq!(SnakeCase.apply_to_field(original), original);
-        assert_eq!(ScreamingSnakeCase.apply_to_field(original), screaming);
-        assert_eq!(KebabCase.apply_to_field(original), kebab);
-        assert_eq!(ScreamingKebabCase.apply_to_field(original), screaming_kebab);
+        assert_eq!(None.apply_to_field(original, false), original);
+        assert_eq!(UpperCase.apply_to_field(original, false), upper);
+        assert_eq!(PascalCase.apply_to_field(original, false), pascal);
+        assert_eq!(CamelCase.apply_to_field(original, false), camel);
+        assert_eq!(SnakeCase.apply_to_field(original, false), original);
+        assert_eq!(
+            ScreamingSnakeCase.apply_to_field(original, false),
+            screaming
+        );
+        assert_eq!(KebabCase.apply_to_field(original, false), kebab);
+        assert_eq!(
+            ScreamingKebabCase.apply_to_field(original, false),
+            screaming_kebab
+        );
     }
+
+    // Test independent_number = true on fields
+    assert_eq!(SnakeCase.apply_to_field("have1Apple", true), "have_1_apple");
+    assert_eq!(SnakeCase.apply_to_field("have1apple", true), "have_1_apple");
+    assert_eq!(
+        KebabCase.apply_to_field("have1_apple", true),
+        "have-1-apple"
+    );
+    assert_eq!(
+        ScreamingSnakeCase.apply_to_field("have1apple", true),
+        "HAVE_1_APPLE"
+    );
 }

--- a/serde_derive/src/internals/symbol.rs
+++ b/serde_derive/src/internals/symbol.rs
@@ -19,6 +19,7 @@ pub const FLATTEN: Symbol = Symbol("flatten");
 pub const FROM: Symbol = Symbol("from");
 pub const GETTER: Symbol = Symbol("getter");
 pub const INTO: Symbol = Symbol("into");
+pub const INDEPENDENT_NUMBER: Symbol = Symbol("independent_number");
 pub const NON_EXHAUSTIVE: Symbol = Symbol("non_exhaustive");
 pub const OTHER: Symbol = Symbol("other");
 pub const REMOTE: Symbol = Symbol("remote");

--- a/test_suite/tests/test_macros.rs
+++ b/test_suite/tests/test_macros.rs
@@ -835,6 +835,54 @@ fn test_rename_all_fields() {
 }
 
 #[test]
+fn test_independent_number() {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    #[serde(rename_all = "snake_case", independent_number)]
+    enum E {
+        Have1Apple,
+        Get2Bananas,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    #[serde(rename_all = "kebab-case", independent_number)]
+    struct S {
+        have1_apple: bool,
+        get2_bananas: bool,
+    }
+
+    assert_tokens(
+        &E::Have1Apple,
+        &[Token::UnitVariant {
+            name: "E",
+            variant: "have_1_apple",
+        }],
+    );
+
+    assert_tokens(
+        &E::Get2Bananas,
+        &[Token::UnitVariant {
+            name: "E",
+            variant: "get_2_bananas",
+        }],
+    );
+
+    assert_tokens(
+        &S {
+            have1_apple: true,
+            get2_bananas: false,
+        },
+        &[
+            Token::Struct { name: "S", len: 2 },
+            Token::Str("have-1-apple"),
+            Token::Bool(true),
+            Token::Str("get-2-bananas"),
+            Token::Bool(false),
+            Token::StructEnd,
+        ],
+    );
+}
+
+#[test]
 fn test_packed_struct_can_derive_serialize() {
     #[derive(Copy, Clone, Serialize)]
     #[repr(packed, C)]


### PR DESCRIPTION
**Description**

Right now, when Serde converts identifiers between cases, numbers get grouped with whatever letters sit next to them. `Have1Apple` under `snake_case` becomes `have1_apple`, for example. I ran into a case where the target API expected numbers as their own segment instead (`have_1_apple`), and there wasn't a way to get that out of the existing rename rules.

This adds an opt-in `independent_number` flag for `rename_all` and `rename_all_fields` that treats digits as their own boundary, so numbers get split away from the surrounding letters instead of sticking to them.

**Example Usage:**

```rust
#[derive(Serialize)]
#[serde(rename_all = "snake_case", independent_number)]
pub enum Chapter {
    Have1Apple, // -> "have_1_apple"
}

#[derive(Serialize)]
#[serde(rename_all = "kebab-case", independent_number)]
struct Item {
    get2_bananas: bool, // -> "get-2-bananas"
}
```

**Changes:**

- Parses the new `independent_number` attribute in `serde_derive`.
- `RenameRule`'s `SnakeCase` matching now checks for digit/letter boundaries when the flag is set.
- Carries over automatically to `ScreamingSnakeCase`, `KebabCase`, and `ScreamingKebabCase`, so it doesn't need to be set per case style.
- Leaving the flag off keeps the old behavior untouched, so this is fully backwards compatible.
- Added unit and integration tests in `test_macros.rs` covering the new behavior.

**Related Issues**

_(Closes #3074)_