### PR TITLE
feat: implement Serialize/Deserialize for std::rc::UniqueRc

### DIFF
--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -106,6 +106,7 @@
 //
 //    https://github.com/serde-rs/serde/issues/812
 #![cfg_attr(all(feature = "unstable", docsrs), feature(never_type))]
+#![cfg_attr(all(feature = "unstable", docsrs), feature(unique_rc_arc))]
 #![allow(
     unknown_lints,
     bare_trait_objects,

--- a/serde_core/src/crate_root.rs
+++ b/serde_core/src/crate_root.rs
@@ -56,6 +56,16 @@ macro_rules! crate_root {
             #[cfg(all(feature = "rc", feature = "std"))]
             pub use std::sync::{Arc, Weak as ArcWeak};
 
+            #[cfg(all(
+                feature = "unstable",
+                feature = "rc",
+                feature = "alloc",
+                not(feature = "std")
+            ))]
+            pub use alloc::rc::UniqueRc;
+            #[cfg(all(feature = "unstable", feature = "rc", feature = "std"))]
+            pub use std::rc::UniqueRc;
+
             #[cfg(all(feature = "alloc", not(feature = "std")))]
             pub use alloc::collections::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, VecDeque};
             #[cfg(feature = "std")]

--- a/serde_core/src/de/impls.rs
+++ b/serde_core/src/de/impls.rs
@@ -2086,6 +2086,26 @@ box_forwarded_impl! {
     Arc
 }
 
+/// This impl requires the [`"rc"`] and `"unstable"` Cargo features of Serde.
+///
+/// [`"rc"`]: https://serde.rs/feature-flags.html#-features-rc
+#[cfg(all(feature = "unstable", feature = "rc", any(feature = "std", feature = "alloc")))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(all(feature = "unstable", feature = "rc", any(feature = "std", feature = "alloc"))))
+)]
+impl<'de, T> Deserialize<'de> for UniqueRc<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        T::deserialize(deserializer).map(UniqueRc::new)
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 impl<'de, T> Deserialize<'de> for Cell<T>

--- a/serde_core/src/lib.rs
+++ b/serde_core/src/lib.rs
@@ -46,6 +46,7 @@
 //
 //    https://github.com/serde-rs/serde/issues/812
 #![cfg_attr(feature = "unstable", feature(never_type))]
+#![cfg_attr(feature = "unstable", feature(unique_rc_arc))]
 #![allow(unknown_lints, bare_trait_objects, deprecated)]
 // Ignored clippy and clippy_pedantic lints
 #![allow(

--- a/serde_core/src/ser/impls.rs
+++ b/serde_core/src/ser/impls.rs
@@ -523,6 +523,18 @@ deref_impl! {
     <'a, T> Serialize for Cow<'a, T> where T: ?Sized + Serialize + ToOwned
 }
 
+deref_impl! {
+    /// This impl requires the [`"rc"`] and `"unstable"` Cargo features of Serde.
+    ///
+    /// [`"rc"`]: https://serde.rs/feature-flags.html#-features-rc
+    #[cfg(all(feature = "unstable", feature = "rc", any(feature = "std", feature = "alloc")))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(feature = "unstable", feature = "rc", any(feature = "std", feature = "alloc"))))
+    )]
+    <T> Serialize for UniqueRc<T> where T: ?Sized + Serialize
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 /// This impl requires the [`"rc"`] Cargo feature of Serde.

--- a/test_suite/tests/test_unstable.rs
+++ b/test_suite/tests/test_unstable.rs
@@ -1,5 +1,6 @@
 #![deny(warnings)]
 #![allow(clippy::derive_partial_eq_without_eq)]
+#![cfg_attr(feature = "unstable", feature(unique_rc_arc))]
 
 // This test target is convoluted with the actual #[test] in a separate file to
 // get it so that the stable compiler does not need to parse the code of the

--- a/test_suite/tests/unstable/mod.rs
+++ b/test_suite/tests/unstable/mod.rs
@@ -1,5 +1,6 @@
 use serde_derive::{Deserialize, Serialize};
-use serde_test::{assert_tokens, Token};
+use serde_test::{assert_de_tokens, assert_ser_tokens, assert_tokens, Token};
+use std::rc::UniqueRc;
 
 #[test]
 fn test_raw_identifiers() {
@@ -22,4 +23,14 @@ fn test_raw_identifiers() {
             Token::StructVariantEnd,
         ],
     );
+}
+
+#[test]
+fn test_unique_rc_ser() {
+    assert_ser_tokens(&UniqueRc::new(true), &[Token::Bool(true)]);
+}
+
+#[test]
+fn test_unique_rc_de() {
+    assert_de_tokens(&UniqueRc::new(true), &[Token::Bool(true)]);
 }


### PR DESCRIPTION
## Summary

Closes #3079 — adds `Serialize`/`Deserialize` impls for `std::rc::UniqueRc<T>`, mirroring the existing impls for `Rc<T>`/`Arc<T>`.

`UniqueRc` is gated behind the nightly-only `unique_rc_arc` feature (rust-lang/rust#112566), so it can't be added unconditionally the way `Rc`/`Arc` are. Instead this follows the same pattern serde already uses for other nightly-only APIs (e.g. `impl Serialize for !`, gated on `never_type`): the impls, the `UniqueRc` re-export in `crate_root.rs`, and the crate-level `#![feature(unique_rc_arc)]` are all gated behind serde's own `"unstable"` Cargo feature, in addition to the existing `"rc"` feature that covers `Rc`/`Arc`.

### Implementation notes

- **Serialize**: reuses the existing `deref_impl!` macro, same as `Rc`/`Arc` (`serde_core/src/ser/impls.rs`).
- **Deserialize**: can't reuse `box_forwarded_impl!` (used by `Rc`/`Arc`) because that macro requires `Box<T>: Deserialize<'de>` for `T: ?Sized`, but `UniqueRc<T>` requires `T: Sized` (there's no `UniqueRc<dyn Trait>`). Instead it deserializes `T` directly and wraps it with `UniqueRc::new` (confirmed `UniqueRc::new` only requires `T: Sized`, and `From<T> for UniqueRc<T>` exists, so this is the natural construction path — no unnecessary intermediate allocation via `Box`).

### Test plan

Since `UniqueRc` requires the nightly-only feature, straightforward `#[test]` functions referencing it can't live in `test_ser.rs`/`test_de.rs` (those compile on stable Rust too). Added roundtrip tests to `test_suite/tests/unstable/mod.rs` instead, following the existing pattern used for `test_raw_identifiers` (isolated behind `#[cfg(feature = "unstable")]` in `test_unstable.rs` so stable rustc never parses it).

Verified via Docker (`rustlang/rust:nightly`, since I don't have a local Rust toolchain):
- `cargo build` for `serde_core` with each of: `rc std` (no `unstable`), `unstable rc alloc` (no `std`), default features, `--all-features` — all succeed, confirming the existing `Rc`/`Arc`-only builds are unaffected.
- `cargo build --all-features` for `serde` crate — succeeds.
- `cd test_suite && cargo test --features unstable` — all tests pass, including the 2 new ones (`test_unique_rc_ser`, `test_unique_rc_de`).
- `cd test_suite && cargo test` (no `unstable` feature) — unaffected, `test_unstable.rs` compiles to 0 tests as expected.
- `cargo clippy --all-features` on `serde_core` — clean.
- `cargo fmt --check -p serde_core -p serde_test_suite` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code). I've reviewed and tested every change in this PR.