### PR TITLE
serde_derive: include variant error details in untagged enum

### DIFF
--- a/serde_derive/src/de/enum_untagged.rs
+++ b/serde_derive/src/de/enum_untagged.rs
@@ -25,16 +25,18 @@ pub(super) fn deserialize(
     cattrs: &attr::Container,
     first_attempt: Option<TokenStream>,
 ) -> Fragment {
-    let attempts = variants
+    let active_variants = variants
         .iter()
         .filter(|variant| !variant.attrs.skip_deserializing())
+        .collect::<Vec<_>>();
+    let attempts = active_variants
+        .iter()
         .map(|variant| Expr(deserialize_variant(params, variant, cattrs)));
-    // TODO this message could be better by saving the errors from the failed
-    // attempts. The heuristic used by TOML was to count the number of fields
-    // processed before an error, and use the error that happened after the
-    // largest number of fields. I'm not sure I like that. Maybe it would be
-    // better to save all the errors and combine them into one message that
-    // explains why none of the variants matched.
+    let variant_names = active_variants
+        .iter()
+        .map(|variant| variant.ident.to_string())
+        .collect::<Vec<_>>();
+
     let fallthrough_msg = format!(
         "data did not match any variant of untagged enum {}",
         params.type_name()
@@ -48,13 +50,22 @@ pub(super) fn deserialize(
 
         #first_attempt
 
+        let mut __errors = std::vec::Vec::new();
+
         #(
-            if let _serde::#private2::Ok(__ok) = #attempts {
-                return _serde::#private2::Ok(__ok);
+            match #attempts {
+                _serde::#private2::Ok(__ok) => return _serde::#private2::Ok(__ok),
+                _serde::#private2::Err(__err) => {__errors.push((#variant_names, __err));}
             }
         )*
 
-        _serde::#private::Err(_serde::de::Error::custom(#fallthrough_msg))
+        let mut __error_msg = std::string::String::from(#fallthrough_msg);
+        __error_msg.push_str(":");
+        for (__name, __e) in __errors {
+            use _serde::#private::fmt::Write;
+            let _ = core::write!(&mut __error_msg, "\n  - {__name}: {__e}");
+        }
+        _serde::#private::Err(_serde::de::Error::custom(__error_msg))
     }
 }
 

--- a/test_suite/tests/test_enum_untagged.rs
+++ b/test_suite/tests/test_enum_untagged.rs
@@ -71,7 +71,13 @@ fn complex() {
 
     assert_de_tokens_error::<Untagged>(
         &[Token::Tuple { len: 1 }, Token::U8(1), Token::TupleEnd],
-        "data did not match any variant of untagged enum Untagged",
+        "data did not match any variant of untagged enum Untagged:\n\
+            \x20 - A: invalid type: sequence, expected struct variant Untagged::A\n\
+            \x20 - B: invalid type: sequence, expected struct variant Untagged::B\n\
+            \x20 - C: invalid type: sequence, expected unit variant Untagged::C\n\
+            \x20 - D: invalid type: sequence, expected u8\n\
+            \x20 - E: invalid type: sequence, expected a string\n\
+            \x20 - F: invalid length 1, expected tuple variant Untagged::F with 2 elements",
     );
 
     assert_de_tokens_error::<Untagged>(
@@ -82,7 +88,13 @@ fn complex() {
             Token::U8(3),
             Token::TupleEnd,
         ],
-        "data did not match any variant of untagged enum Untagged",
+        "data did not match any variant of untagged enum Untagged:\n\
+            \x20 - A: invalid type: sequence, expected struct variant Untagged::A\n\
+            \x20 - B: invalid type: sequence, expected struct variant Untagged::B\n\
+            \x20 - C: invalid type: sequence, expected unit variant Untagged::C\n\
+            \x20 - D: invalid type: sequence, expected u8\n\
+            \x20 - E: invalid type: sequence, expected a string\n\
+            \x20 - F: invalid length 3, expected 2 elements in sequence",
     );
 }
 
@@ -579,5 +591,9 @@ fn expecting_message() {
         Untagged,
     }
 
-    assert_de_tokens_error::<Enum>(&[Token::Str("Untagged")], "something strange...");
+    assert_de_tokens_error::<Enum>(
+        &[Token::Str("Untagged")],
+        "something strange...:\n\
+        \x20 - Untagged: invalid type: string \"Untagged\", expected unit variant Enum::Untagged",
+    );
 }


### PR DESCRIPTION
deserialization errors

- Enhances error reporting for untagged enums (#[serde(untagged)]) by capturing and appending the deserialization error of each failed variant to the fallthrough error message, rather than returning only a generic failure message.

- Fixes #3083