### PR TITLE
Reject struct field names that collide with #[serde(tag)]

### DIFF
--- a/serde_derive/src/internals/check.rs
+++ b/serde_derive/src/internals/check.rs
@@ -294,57 +294,91 @@ fn check_variant_skip_attrs(cx: &Ctxt, cont: &Container) {
     }
 }
 
-// The tag of an internally-tagged struct variant must not be the same as either
-// one of its fields, as this would result in duplicate keys in the serialized
-// output and/or ambiguity in the to-be-deserialized input.
+// The tag of an internally-tagged enum variant or named struct must not be the
+// same as either one of its fields, as this would result in duplicate keys in
+// the serialized output and/or ambiguity in the to-be-deserialized input.
 fn check_internal_tag_field_name_conflict(cx: &Ctxt, cont: &Container) {
-    let variants = match &cont.data {
-        Data::Enum(variants) => variants,
-        Data::Struct(_, _) => return,
-    };
-
     let tag = match cont.attrs.tag() {
         TagType::Internal { tag } => tag.as_str(),
         TagType::External | TagType::Adjacent { .. } | TagType::None => return,
     };
 
-    let diagnose_conflict = || {
-        cx.error_spanned_by(
-            cont.original,
-            format!("variant field name `{}` conflicts with internal tag", tag),
-        );
-    };
-
-    for variant in variants {
-        match variant.style {
-            Style::Struct => {
-                if variant.attrs.untagged() {
-                    continue;
-                }
-                for field in &variant.fields {
-                    let check_ser =
-                        !(field.attrs.skip_serializing() || variant.attrs.skip_serializing());
-                    let check_de =
-                        !(field.attrs.skip_deserializing() || variant.attrs.skip_deserializing());
-                    let name = field.attrs.name();
-                    let ser_name = name.serialize_name();
-
-                    if check_ser && ser_name.value == tag {
-                        diagnose_conflict();
-                        return;
-                    }
-
-                    for de_name in field.attrs.aliases() {
-                        if check_de && de_name.value == tag {
-                            diagnose_conflict();
-                            return;
+    match &cont.data {
+        Data::Enum(variants) => {
+            for variant in variants {
+                match variant.style {
+                    Style::Struct => {
+                        if variant.attrs.untagged() {
+                            continue;
+                        }
+                        for field in &variant.fields {
+                            // Flattened fields do not appear under their own
+                            // name in the serialized form.
+                            if field.attrs.flatten() {
+                                continue;
+                            }
+                            let check_ser = !(field.attrs.skip_serializing()
+                                || variant.attrs.skip_serializing());
+                            let check_de = !(field.attrs.skip_deserializing()
+                                || variant.attrs.skip_deserializing());
+                            if field_conflicts_with_internal_tag(field, tag, check_ser, check_de) {
+                                cx.error_spanned_by(
+                                    cont.original,
+                                    format!(
+                                        "variant field name `{}` conflicts with internal tag",
+                                        tag
+                                    ),
+                                );
+                                return;
+                            }
                         }
                     }
+                    Style::Unit | Style::Newtype | Style::Tuple => {}
                 }
             }
-            Style::Unit | Style::Newtype | Style::Tuple => {}
+        }
+        Data::Struct(Style::Struct, fields) => {
+            for field in fields {
+                // Flattened fields do not appear under their own name in the
+                // serialized form (e.g. tag = "data" with #[serde(flatten)] data).
+                if field.attrs.flatten() {
+                    continue;
+                }
+                let check_ser = !field.attrs.skip_serializing();
+                let check_de = !field.attrs.skip_deserializing();
+                if field_conflicts_with_internal_tag(field, tag, check_ser, check_de) {
+                    cx.error_spanned_by(
+                        cont.original,
+                        format!("field name `{}` conflicts with internal tag", tag),
+                    );
+                    return;
+                }
+            }
+        }
+        Data::Struct(Style::Unit | Style::Newtype | Style::Tuple, _) => {}
+    }
+}
+
+fn field_conflicts_with_internal_tag(
+    field: &Field,
+    tag: &str,
+    check_ser: bool,
+    check_de: bool,
+) -> bool {
+    let name = field.attrs.name();
+    let ser_name = name.serialize_name();
+
+    if check_ser && ser_name.value == tag {
+        return true;
+    }
+
+    for de_name in field.attrs.aliases() {
+        if check_de && de_name.value == tag {
+            return true;
         }
     }
+
+    false
 }
 
 // In the case of adjacently-tagged enums, the type and the contents tag must

--- a/test_suite/tests/ui/conflict/internal-tag-struct-alias.rs
+++ b/test_suite/tests/ui/conflict/internal-tag-struct-alias.rs
@@ -1,0 +1,10 @@
+use serde_derive::Serialize;
+
+#[derive(Serialize)]
+#[serde(tag = "conflict")]
+struct S {
+    #[serde(alias = "conflict")]
+    x: (),
+}
+
+fn main() {}

--- a/test_suite/tests/ui/conflict/internal-tag-struct-alias.stderr
+++ b/test_suite/tests/ui/conflict/internal-tag-struct-alias.stderr
@@ -1,0 +1,9 @@
+error: field name `conflict` conflicts with internal tag
+ --> tests/ui/conflict/internal-tag-struct-alias.rs:4:1
+  |
+4 | / #[serde(tag = "conflict")]
+5 | | struct S {
+6 | |     #[serde(alias = "conflict")]
+7 | |     x: (),
+8 | | }
+  | |_^

--- a/test_suite/tests/ui/conflict/internal-tag-struct.rs
+++ b/test_suite/tests/ui/conflict/internal-tag-struct.rs
@@ -1,0 +1,10 @@
+use serde_derive::Serialize;
+
+#[derive(Serialize)]
+#[serde(tag = "conflict")]
+struct S {
+    #[serde(rename = "conflict")]
+    x: (),
+}
+
+fn main() {}

--- a/test_suite/tests/ui/conflict/internal-tag-struct.stderr
+++ b/test_suite/tests/ui/conflict/internal-tag-struct.stderr
@@ -1,0 +1,9 @@
+error: field name `conflict` conflicts with internal tag
+ --> tests/ui/conflict/internal-tag-struct.rs:4:1
+  |
+4 | / #[serde(tag = "conflict")]
+5 | | struct S {
+6 | |     #[serde(rename = "conflict")]
+7 | |     x: (),
+8 | | }
+  | |_^


### PR DESCRIPTION
## Summary

Reject named-struct field (and alias) names that collide with `#[serde(tag = "...")]`, matching the existing check for enum struct variants.

## Problem

Enums with an internal tag already error at derive time when a field serialize name or alias equals the tag:

```text
error: variant field name `conflict` conflicts with internal tag
```

Named structs with the same attribute skipped that check. Serialize injects the type name under the tag key, then also emits the colliding field, which produces duplicate keys and breaks round-trips.

```rust
#[derive(Serialize)]
#[serde(tag = "type")]
struct S {
    #[serde(rename = "type")]
    x: i32,
}
// Was: {"type":"S","type":0}
// Deserialize of that JSON fails: invalid type string for i32
```

This early return for structs has been present since the internal-tag field conflict check was introduced (2018).

## Change

- Extend `check_internal_tag_field_name_conflict` to named structs (`Style::Struct`)
- Skip flattened fields (they never appear under their own name; e.g. `tag = "data"` with `#[serde(flatten)] data`)
- Share the rename/alias comparison helper with the enum path
- UI tests: `internal-tag-struct.rs` and `internal-tag-struct-alias.rs` next to the existing enum cases

## Validation

```diff
+ Red: without the fix, colliding struct derives successfully (bug present)
+ Green: with the fix, derive errors with `field name \`conflict\` conflicts with internal tag`
+ cargo +nightly test --test compiletest ui  (120 UI cases, including new ones)
+ cargo +nightly test --test test_macros test_internally_tagged_struct_with_flattened_field
```

Flatten + tag with a matching field name still compiles (regression covered by the flatten skip).
