### PR TITLE
Support `rc` on targets without pointer atomics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,10 @@ jobs:
       - run: cd serde && cargo build --no-default-features
       - run: cd serde && cargo build --no-default-features --features alloc
       - run: cd serde && cargo build --no-default-features --features rc,alloc
+      - run: rustup target add thumbv6m-none-eabi
+        if: matrix.os != 'windows'
+      - run: cd test_suite/no_atomic && cargo build --target thumbv6m-none-eabi
+        if: matrix.os != 'windows'
       - run: cd serde && cargo build --no-default-features --features unstable
       - run: cd serde_core && cargo test --features rc,unstable
       - run: cd test_suite/no_std && cargo build

--- a/serde_core/src/crate_root.rs
+++ b/serde_core/src/crate_root.rs
@@ -51,9 +51,18 @@ macro_rules! crate_root {
             #[cfg(all(feature = "rc", feature = "std"))]
             pub use std::rc::{Rc, Weak as RcWeak};
 
-            #[cfg(all(feature = "rc", feature = "alloc", not(feature = "std")))]
+            #[cfg(all(
+                feature = "rc",
+                feature = "alloc",
+                not(feature = "std"),
+                any(no_target_has_atomic, target_has_atomic = "ptr")
+            ))]
             pub use alloc::sync::{Arc, Weak as ArcWeak};
-            #[cfg(all(feature = "rc", feature = "std"))]
+            #[cfg(all(
+                feature = "rc",
+                feature = "std",
+                any(no_target_has_atomic, target_has_atomic = "ptr")
+            ))]
             pub use std::sync::{Arc, Weak as ArcWeak};
 
             #[cfg(all(feature = "alloc", not(feature = "std")))]

--- a/serde_core/src/de/impls.rs
+++ b/serde_core/src/de/impls.rs
@@ -2000,7 +2000,11 @@ where
 #[cfg(all(feature = "rc", any(feature = "std", feature = "alloc")))]
 #[cfg_attr(
     docsrs,
-    doc(cfg(all(feature = "rc", any(feature = "std", feature = "alloc"))))
+    doc(cfg(all(
+        feature = "rc",
+        any(feature = "std", feature = "alloc"),
+        target_has_atomic = "ptr"
+    )))
 )]
 impl<'de, T> Deserialize<'de> for RcWeak<T>
 where
@@ -2019,7 +2023,11 @@ where
 /// `Weak<T>` has a reference count of 0 and cannot be upgraded.
 ///
 /// [`"rc"`]: https://serde.rs/feature-flags.html#-features-rc
-#[cfg(all(feature = "rc", any(feature = "std", feature = "alloc")))]
+#[cfg(all(
+    feature = "rc",
+    any(feature = "std", feature = "alloc"),
+    any(no_target_has_atomic, target_has_atomic = "ptr")
+))]
 #[cfg_attr(
     docsrs,
     doc(cfg(all(feature = "rc", any(feature = "std", feature = "alloc"))))
@@ -2069,7 +2077,14 @@ box_forwarded_impl! {
     ///
     /// [`"rc"`]: https://serde.rs/feature-flags.html#-features-rc
     #[cfg(all(feature = "rc", any(feature = "std", feature = "alloc")))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "rc", any(feature = "std", feature = "alloc")))))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(
+            feature = "rc",
+            any(feature = "std", feature = "alloc"),
+            target_has_atomic = "ptr"
+        )))
+    )]
     Rc
 }
 
@@ -2081,7 +2096,11 @@ box_forwarded_impl! {
     /// will end up with a strong count of 1.
     ///
     /// [`"rc"`]: https://serde.rs/feature-flags.html#-features-rc
-    #[cfg(all(feature = "rc", any(feature = "std", feature = "alloc")))]
+    #[cfg(all(
+        feature = "rc",
+        any(feature = "std", feature = "alloc"),
+        any(no_target_has_atomic, target_has_atomic = "ptr")
+    ))]
     #[cfg_attr(docsrs, doc(cfg(all(feature = "rc", any(feature = "std", feature = "alloc")))))]
     Arc
 }

--- a/serde_core/src/ser/impls.rs
+++ b/serde_core/src/ser/impls.rs
@@ -499,7 +499,14 @@ deref_impl! {
     ///
     /// [`"rc"`]: https://serde.rs/feature-flags.html#-features-rc
     #[cfg(all(feature = "rc", any(feature = "std", feature = "alloc")))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "rc", any(feature = "std", feature = "alloc")))))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(
+            feature = "rc",
+            any(feature = "std", feature = "alloc"),
+            target_has_atomic = "ptr"
+        )))
+    )]
     <T> Serialize for Rc<T> where T: ?Sized + Serialize
 }
 
@@ -512,7 +519,11 @@ deref_impl! {
     /// repeated data.
     ///
     /// [`"rc"`]: https://serde.rs/feature-flags.html#-features-rc
-    #[cfg(all(feature = "rc", any(feature = "std", feature = "alloc")))]
+    #[cfg(all(
+        feature = "rc",
+        any(feature = "std", feature = "alloc"),
+        any(no_target_has_atomic, target_has_atomic = "ptr")
+    ))]
     #[cfg_attr(docsrs, doc(cfg(all(feature = "rc", any(feature = "std", feature = "alloc")))))]
     <T> Serialize for Arc<T> where T: ?Sized + Serialize
 }
@@ -531,7 +542,11 @@ deref_impl! {
 #[cfg(all(feature = "rc", any(feature = "std", feature = "alloc")))]
 #[cfg_attr(
     docsrs,
-    doc(cfg(all(feature = "rc", any(feature = "std", feature = "alloc"))))
+    doc(cfg(all(
+        feature = "rc",
+        any(feature = "std", feature = "alloc"),
+        target_has_atomic = "ptr"
+    )))
 )]
 impl<T> Serialize for RcWeak<T>
 where
@@ -548,7 +563,11 @@ where
 /// This impl requires the [`"rc"`] Cargo feature of Serde.
 ///
 /// [`"rc"`]: https://serde.rs/feature-flags.html#-features-rc
-#[cfg(all(feature = "rc", any(feature = "std", feature = "alloc")))]
+#[cfg(all(
+    feature = "rc",
+    any(feature = "std", feature = "alloc"),
+    any(no_target_has_atomic, target_has_atomic = "ptr")
+))]
 #[cfg_attr(
     docsrs,
     doc(cfg(all(feature = "rc", any(feature = "std", feature = "alloc"))))

--- a/test_suite/no_atomic/.gitignore
+++ b/test_suite/no_atomic/.gitignore
@@ -1,0 +1,2 @@
+/target/
+/Cargo.lock

--- a/test_suite/no_atomic/Cargo.toml
+++ b/test_suite/no_atomic/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "serde_no_atomic_test"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+serde = { path = "../../serde", default-features = false, features = ["alloc", "rc"] }
+
+[workspace]

--- a/test_suite/no_atomic/src/lib.rs
+++ b/test_suite/no_atomic/src/lib.rs
@@ -1,0 +1,20 @@
+#![no_std]
+
+extern crate alloc;
+
+use alloc::{
+    borrow::Cow,
+    rc::{Rc, Weak},
+};
+
+fn assert_serialize<T: serde::Serialize>() {}
+fn assert_deserialize<T: for<'de> serde::Deserialize<'de>>() {}
+
+pub fn assert_non_atomic_rc_impls() {
+    assert_serialize::<Rc<u8>>();
+    assert_deserialize::<Rc<u8>>();
+    assert_serialize::<Weak<u8>>();
+    assert_deserialize::<Weak<u8>>();
+    assert_serialize::<Cow<'static, str>>();
+    assert_deserialize::<Cow<'static, str>>();
+}


### PR DESCRIPTION
The `rc` feature currently imports and implements both `Rc` and `Arc`, which prevents `no_std` builds on targets without pointer atomics even when downstream code only uses `Rc`.

Keep the `Rc` implementations available and gate only `Arc`/`Weak<Arc>` using Serde's existing `no_target_has_atomic` compatibility path. A compile-only fixture verifies `Rc`, `Weak<Rc>`, and `Cow` on `thumbv6m-none-eabi`.

This is a narrower alternative to #2924: `Cow`, `Rc`, and `Weak<Rc>` remain unchanged.